### PR TITLE
fix: keep system prompt byte-stable for prefix cache

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -187,9 +187,20 @@ function prepareAnthropic(
         processedMessages = turn.messages;
         rebuiltMessages = coreToAnthropic(turn.messages);
 
-        systemOut = injectSystem(parsed, turn.nudge, opts);
+        systemOut = injectSystem(parsed, opts);
         if (opts.compress.injectTool) {
             toolsOut = injectTool(parsed.tools);
+        }
+        // Nudge as a separate trailing user message (cache-friendly): the
+        // system block stays byte-stable so the prefix cache survives.
+        if (turn.nudge?.shouldInject) {
+            try {
+                const rendered = renderNudgeText(turn.nudge);
+                if (rendered.text) {
+                    rebuiltMessages = [...rebuiltMessages, { role: "user", content: rendered.text }];
+                }
+            } catch {
+            }
         }
     } catch (err) {
         log("warn", `[${sessionId}] kernel transform failed, forwarding unchanged: ${String(err)}`);
@@ -231,18 +242,27 @@ function prepareOpenai(
         processedMessages = turn.messages;
         rebuiltMessages = coreToOpenai(turn.messages);
 
+        // ONLY the static compress prompt goes into the system message — the
+        // system prompt is the prefix-cache anchor and must be byte-stable
+        // across turns. The nudge (which changes every turn: token count,
+        // growth %, dynamic example) is appended as a trailing user message
+        // instead, mirroring pai-acp's design. Putting the nudge in system
+        // would invalidate the cache every turn.
         const sysParts: string[] = [];
         if (shouldInject) sysParts.push(buildCompressSystemPrompt());
-        if (turn.nudge?.shouldInject && shouldInject) {
-            try {
-                const rendered = renderNudgeText(turn.nudge);
-                if (rendered.text) sysParts.push(rendered.text);
-            } catch {
-            }
-        }
         rebuiltMessages = injectOpenaiSystem(rebuiltMessages, sysParts);
         if (shouldInject) {
             toolsOut = injectOpenaiTool(parsed.tools);
+        }
+        // Nudge as a separate trailing user message (cache-friendly).
+        if (turn.nudge?.shouldInject && shouldInject) {
+            try {
+                const rendered = renderNudgeText(turn.nudge);
+                if (rendered.text) {
+                    rebuiltMessages = [...rebuiltMessages, { role: "user", content: rendered.text }];
+                }
+            } catch {
+            }
         }
     } catch (err) {
         log("warn", `[${sessionId}] kernel transform failed, forwarding unchanged: ${String(err)}`);
@@ -255,19 +275,15 @@ function prepareOpenai(
 
 function injectSystem(
     parsed: AnthropicRequestBody,
-    nudge: NudgeDecision | undefined,
     opts: ProxyOptions,
 ): string | AnthropicRequestBody["system"] {
+    // ONLY the static compress prompt goes into the system block — it is the
+    // prefix-cache anchor and must stay byte-stable across turns. The nudge
+    // (which changes every turn) is appended as a trailing user message by
+    // the caller (prepareAnthropic), never merged into system.
     const baseText = extractSystem(parsed.system);
     const parts: string[] = [];
     if (opts.compress.injectTool) parts.push(buildCompressSystemPrompt());
-    if (nudge?.shouldInject) {
-        try {
-            const rendered = renderNudgeText(nudge);
-            if (rendered.text) parts.push(rendered.text);
-        } catch {
-        }
-    }
     if (parts.length === 0) return parsed.system;
     const full = baseText ? `${baseText}\n\n---\n\n${parts.join("\n\n")}` : parts.join("\n\n");
     return buildSystem(full, parsed.system);


### PR DESCRIPTION
## Problem

Cache hit rate collapsed to ~0% across turns. Root cause: the nudge (which changes every turn — token count, growth %, dynamic compress example) was merged into the **system prompt**. The system prompt is the prefix-cache anchor; any byte change at its tail invalidates the entire cached prefix.

## Reproduce

Before fix, consecutive requests saw `system_len` jump every turn:
```
system_len=17501 → 23432 → 17501 → ...
```

## Fix

Mirror pai-acp's design: the system block carries ONLY the static compress prompt (byte-stable); the nudge is appended as a separate trailing user message.

```
system_len=16871 → 16871 → 16871   ✅ stable
```

## Changes
- `injectSystem()`: drop nudge param, only inject static compress prompt
- `prepareOpenai()`: append nudge as trailing `{role:user}` message
- `prepareAnthropic()`: append nudge as trailing `{role:user}` message

## Verification
- typecheck ✅ / 79 tests ✅ / build ✅
- end-to-end verified: system_len constant across 3 consecutive turns