### PR TITLE
fix: address all code review findings (condense, routing, session-id, dead code)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [master]
   pull_request:
-    branches: [main]
+    branches: [master]
 
 jobs:
   test:

--- a/src/anthropic.ts
+++ b/src/anthropic.ts
@@ -1,4 +1,5 @@
 import type { CoreMessage } from "acp-kernel";
+import { hashId } from "./util.js";
 
 export type AnthropicTextBlock = { type: "text"; text: string; cache_control?: unknown };
 export type AnthropicToolUse = {
@@ -190,7 +191,7 @@ export function deriveSessionId(body: AnthropicRequestBody, headerValue?: string
     if (headerValue && headerValue.trim()) return headerValue.trim();
     const firstUser = body.messages.find((m) => m.role === "user");
     const seed = firstUser ? JSON.stringify(firstUser.content).slice(0, 200) : "default";
-    return hash(seed);
+    return hashId(seed);
 }
 
 function safeStringify(v: unknown): string {
@@ -208,13 +209,4 @@ function safeParse(s: string | undefined): unknown {
     } catch {
         return {};
     }
-}
-
-function hash(s: string): string {
-    let h = 2166136261;
-    for (let i = 0; i < s.length; i++) {
-        h ^= s.charCodeAt(i);
-        h = Math.imul(h, 16777619);
-    }
-    return (h >>> 0).toString(36);
 }

--- a/src/openai.ts
+++ b/src/openai.ts
@@ -1,5 +1,6 @@
 import type { CoreMessage } from "acp-kernel";
 import { condenseOldToolResults, type CondenseOptions, type CondenseResult } from "./anthropic.js";
+import { hashId } from "./util.js";
 
 export type OpenAIContentPart =
     | { type: "text"; text: string }
@@ -131,13 +132,6 @@ export function coreToOpenai(messages: CoreMessage[]): OpenAIMessage[] {
     return out;
 }
 
-export function extractOpenaiSystem(messages: OpenAIMessage[]): string {
-    return messages
-        .filter((m) => m.role === "system" || m.role === "developer")
-        .map((m) => stringContent(m.content))
-        .join("\n\n");
-}
-
 export function injectOpenaiSystem(messages: OpenAIMessage[], parts: string[]): OpenAIMessage[] {
     if (parts.length === 0) return messages;
     const extra = parts.join("\n\n");
@@ -152,34 +146,11 @@ export function injectOpenaiSystem(messages: OpenAIMessage[], parts: string[]): 
 
 export { condenseOldToolResults, type CondenseOptions, type CondenseResult };
 
-export function validateToolPairing(messages: OpenAIMessage[]): { ok: boolean; details: string[] } {
-    const callIds = new Set<string>();
-    const resultIds = new Set<string>();
-    for (const m of messages) {
-        if (m.role === "assistant" && Array.isArray(m.tool_calls)) {
-            for (const tc of m.tool_calls) {
-                if (tc.id) callIds.add(tc.id);
-            }
-        }
-        if (m.role === "tool" && m.tool_call_id) {
-            resultIds.add(m.tool_call_id);
-        }
-    }
-    const details: string[] = [];
-    for (const id of callIds) {
-        if (!resultIds.has(id)) details.push(`orphan tool_call ${id} (no result)`);
-    }
-    for (const id of resultIds) {
-        if (!callIds.has(id)) details.push(`orphan tool_result ${id} (no call)`);
-    }
-    return { ok: details.length === 0, details };
-}
-
 export function deriveSessionIdOpenai(body: OpenAIRequestBody, headerValue?: string): string {
     if (headerValue && headerValue.trim()) return headerValue.trim();
     const firstUser = body.messages.find((m) => m.role === "user");
     const seed = firstUser ? stringContent(firstUser.content).slice(0, 200) : "default";
-    return hash(seed);
+    return hashId(seed);
 }
 
 function stringContent(content: OpenAIMessage["content"]): string {
@@ -191,13 +162,4 @@ function stringContent(content: OpenAIMessage["content"]): string {
             .join("\n");
     }
     return "";
-}
-
-function hash(s: string): string {
-    let h = 2166136261;
-    for (let i = 0; i < s.length; i++) {
-        h ^= s.charCodeAt(i);
-        h = Math.imul(h, 16777619);
-    }
-    return (h >>> 0).toString(36);
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,6 +16,8 @@ import {
     coreToOpenai,
     injectOpenaiSystem,
     deriveSessionIdOpenai,
+    condenseOldToolResults,
+    type CondenseOptions,
     type OpenAIRequestBody,
     type OpenAITool,
 } from "./openai.js";
@@ -101,6 +103,31 @@ type Prepared = {
     compressInjected: boolean;
 };
 
+/**
+ * Apply condense to the kernel-processed messages and record stats on the
+ * session. Previously `opts.condense` and `condenseOldToolResults` were wired
+ * into config but never invoked — leaving a whole feature as dead code. This
+ * is the single integration point for both protocols.
+ */
+function applyCondense(
+    messages: CoreMessage[],
+    opts: ProxyOptions,
+    session: Session,
+): CoreMessage[] {
+    const condenseOpts: CondenseOptions = {
+        enabled: opts.condense.enabled,
+        keepRecent: opts.condense.keepRecentToolResults,
+        minChars: opts.condense.minCharsToCondense,
+        maxKeptChars: opts.condense.maxKeptChars,
+    };
+    const { messages: out, condensedCount, charsSaved } = condenseOldToolResults(messages, condenseOpts);
+    if (condensedCount > 0) {
+        session.condensedToolResults += condensedCount;
+        session.tokensSaved += Math.ceil(charsSaved / 4);
+    }
+    return out;
+}
+
 async function handle(
     req: http.IncomingMessage,
     res: http.ServerResponse,
@@ -184,8 +211,8 @@ function prepareAnthropic(
         const turn = core.processTurn({ messages: msgs, state: session.state, config, tokenCount });
         session.state = turn.state;
         stripToolTags(turn.messages);
-        processedMessages = turn.messages;
-        rebuiltMessages = coreToAnthropic(turn.messages);
+        processedMessages = applyCondense(turn.messages, opts, session);
+        rebuiltMessages = coreToAnthropic(processedMessages);
 
         systemOut = injectSystem(parsed, opts);
         if (opts.compress.injectTool) {
@@ -239,8 +266,8 @@ function prepareOpenai(
         const turn = core.processTurn({ messages: msgs, state: session.state, config, tokenCount });
         session.state = turn.state;
         stripToolTags(turn.messages);
-        processedMessages = turn.messages;
-        rebuiltMessages = coreToOpenai(turn.messages);
+        processedMessages = applyCondense(turn.messages, opts, session);
+        rebuiltMessages = coreToOpenai(processedMessages);
 
         // ONLY the static compress prompt goes into the system message — the
         // system prompt is the prefix-cache anchor and must be byte-stable
@@ -354,10 +381,16 @@ async function forward(
         res.end();
         return;
     }
+    // We only rewrite when THIS request actually had the compress tool
+    // injected (per-request). For the OpenAI title-gen path
+    // (`compressInjected === false`) we must NOT route the stream into a
+    // rewriter — `rewriteSseStream` below is the *Anthropic* SSE rewriter
+    // and would mishandle OpenAI `choices[].delta` events. Plain passthrough
+    // is correct there.
     const useRewriter =
         prepared !== null &&
-        prepared.processedMessages.length > 0 &&
-        opts.compress.injectTool;
+        prepared.compressInjected &&
+        prepared.processedMessages.length > 0;
     if (!useRewriter || prepared === null) {
         await pipeThrough(upstream.body, res);
         return;
@@ -378,15 +411,7 @@ async function forward(
             streamToRead = a;
             dumpRaw = dumpStreamToFile(b, opts.dumpSse, `${Date.now()}-${prepared.session.id}-raw.sse`);
         }
-        const ctx: RewriteCtx = {
-            core,
-            config,
-            messages: prepared.processedMessages,
-            session: prepared.session,
-            log: (msg: string) => log("info", `[${prepared.session.id}] ${msg}`),
-            debug: opts.debug,
-        };
-        if (prepared.protocol === "openai" && prepared.compressInjected) {
+        if (prepared.protocol === "openai") {
             const parsedReq = JSON.parse(typeof body === "string" ? body : body.toString("utf8"));
             const reqHeaders: Record<string, string> = {};
             for (const [k, v] of Object.entries(headers)) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,22 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Cryptographic hash of a string, truncated to a 64-bit id (16 hex chars).
+ *
+ * Used for session-id derivation. The seed is the first user message content,
+ * which is stable across turns within one conversation (the conversation grows
+ * but its first message doesn't change) — so this produces a *deterministic*
+ * session id that lets the proxy accumulate compression state across turns for
+ * clients that don't send an explicit `x-acp-session` header.
+ *
+ * Determinism is a deliberate trade-off: it enables session continuity at the
+ * cost that two *different* conversations that happen to share an opening
+ * message will collapse onto the same session. The mitigation for that case is
+ * for multi-agent setups to send an explicit `x-acp-session` header (see
+ * README). Using SHA-256 (vs the previous 32-bit FNV-1a) drops the accidental
+ * birthday-collision probability to negligible levels while preserving the
+ * same-content → same-id invariant.
+ */
+export function hashId(s: string): string {
+    return createHash("sha256").update(s, "utf8").digest("hex").slice(0, 16);
+}


### PR DESCRIPTION
## Summary

Addresses all findings from a full codebase review.

## Changes

### 🔴 condense was dead code (wired in)
`config.ts` parsed `ACP_CONDENSE_ENABLED` / `ACP_KEEP_RECENT_TOOL_RESULTS` / `ACP_MIN_CHARS_TO_CONDENSE` / `ACP_MAX_KEPT_CHARS` into `opts.condense`, but `server.ts` **never called** `condenseOldToolResults()`. The entire feature — plus `session.condensedToolResults` / `session.tokensSaved` (always 0 in `/__acp/stats`) — was inert.

**Fix:** New `applyCondense()` helper in `server.ts`, invoked after `stripToolTags` in both `prepareAnthropic` and `prepareOpenai`. Session stats now increment correctly.

### 🟠 OpenAI streaming routing bug (fixed)
`forward()` keyed `useRewriter` on the **global** `opts.compress.injectTool` flag. When per-request `compressInjected=false` (OpenAI title-gen: `maxTokens<=200 || messages.length<=2`), the OpenAI SSE stream was routed into `rewriteSseStream` — which is the **Anthropic** SSE rewriter (`content_block_*` / `message_delta`). It would mishandle OpenAI `choices[].delta` events.

**Fix:** `useRewriter` now keys on the **per-request** `prepared.compressInjected`. Title-gen falls through to plain `pipeThrough` (correct — no rewriting needed).

### 🟠 Session-id collision risk (hardened)
`deriveSessionId` / `deriveSessionIdOpenai` used a 32-bit FNV-1a hash of the first user message. Lookalike opening messages would collide, cross-contaminating compression state for concurrent agents.

**Fix:** Replaced with `hashId()` = SHA-256 truncated to 16 hex chars (64-bit). Determinism is preserved (required for cross-turn session continuity — same content → same id), while birthday-collision probability drops to negligible. Multi-agent setups should still use the explicit `x-acp-session` header (documented).

### 🟡 Cleanup
- **Duplicate `ctx` declaration** in `forward()` — removed the inner shadow.
- **Duplicate `hash()`** — identical FNV-1a in both `anthropic.ts` and `openai.ts`; consolidated into new `src/util.ts:hashId()`.
- **Dead exports removed** — `extractOpenaiSystem` and `validateToolPairing` (`openai.ts`) had zero callers in src or tests.
- **Comment block** documenting the streaming routing logic so the Anthropic-only else-branch is clearly intentional.

## Test plan
- [x] `tsc --noEmit` — clean (0 errors)
- [x] `node --import tsx --test tests/*.test.ts` — **79/79 pass**
- [x] Existing `deriveSessionId is stable for same first message` test still passes (hashId is deterministic)
- [x] condense tests unaffected (test the function directly)
