### PR TITLE
Use kernel renderTags:"text-only" + forbid tag echoing in prompt

### DIFF
--- a/src/compress-tool.ts
+++ b/src/compress-tool.ts
@@ -100,7 +100,7 @@ ${HOW_TO_COMPRESS_RULES}
 
 ACP TAGS
 
-Each message in the conversation is annotated with a <acp tokens="2.1K" type="tool:bash">m00175</acp> tag showing its reference ID, approximate token size, and content type. Use these annotations to assess which messages are consuming the most context and prioritize compression accordingly. The token size is approximate — treat it as a relative guide, not an exact count.
+Each message in the conversation is annotated with a <acp tokens="2.1K" type="tool:bash">m00175</acp> tag showing its reference ID, approximate token size, and content type. These tags are system metadata injected by the proxy. NEVER echo, repeat, or reference these XML tags in your responses — the tags must not appear in your output. Use only the ref ID (e.g. m00005) inside compress calls, never the XML wrapper. The token size is approximate — treat it as a relative guide, not an exact count.
 
 TOOLS
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -176,16 +176,6 @@ async function handle(
     await forward(req, res, opts, outBody, prepared, core, reqConfig, log);
 }
 
-const ACP_TAG_RE = /^\x3cacp [^>]*\x3e[^\x3c]*\x3c\/acp\x3e\n?/;
-
-function stripToolTags(messages: CoreMessage[]): void {
-    for (const m of messages) {
-        if (m.contentType === "tool-call" || m.contentType === "tool-result") {
-            m.text = (m.text ?? "").replace(ACP_TAG_RE, "");
-        }
-    }
-}
-
 function prepareAnthropic(
     bodyBuffer: Buffer,
     req: http.IncomingMessage,
@@ -208,9 +198,8 @@ function prepareAnthropic(
     try {
         const { msgs } = anthropicToCore(parsed);
         const tokenCount = estimateTokensFast(msgs.map((m) => m.text ?? "").join("\n"));
-        const turn = core.processTurn({ messages: msgs, state: session.state, config, tokenCount });
+        const turn = core.processTurn({ messages: msgs, state: session.state, config, tokenCount, renderTags: "text-only" });
         session.state = turn.state;
-        stripToolTags(turn.messages);
         processedMessages = applyCondense(turn.messages, opts, session);
         rebuiltMessages = coreToAnthropic(processedMessages);
 
@@ -263,9 +252,8 @@ function prepareOpenai(
     try {
         const { msgs } = openaiToCore(parsed);
         const tokenCount = estimateTokensFast(msgs.map((m) => m.text ?? "").join("\n"));
-        const turn = core.processTurn({ messages: msgs, state: session.state, config, tokenCount });
+        const turn = core.processTurn({ messages: msgs, state: session.state, config, tokenCount, renderTags: "text-only" });
         session.state = turn.state;
-        stripToolTags(turn.messages);
         processedMessages = applyCondense(turn.messages, opts, session);
         rebuiltMessages = coreToOpenai(processedMessages);
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -176,6 +176,20 @@ async function handle(
     await forward(req, res, opts, outBody, prepared, core, reqConfig, log);
 }
 
+const ACP_TAG_MARK = "\x3cacp ";
+
+function diagTagSummary(messages: CoreMessage[], sessionId: string, strategy: string): string {
+    let textTagged = 0;
+    let toolTagged = 0;
+    for (const m of messages) {
+        const hasTag = (m.text ?? "").includes(ACP_TAG_MARK);
+        if (!hasTag) continue;
+        if (m.contentType === "tool-call" || m.contentType === "tool-result") toolTagged++;
+        else textTagged++;
+    }
+    return `[${sessionId}] processTurn: ${messages.length} msgs, renderTags=${strategy}, ${textTagged} text tagged, ${toolTagged} tool tagged (should be 0 with text-only)`;
+}
+
 function prepareAnthropic(
     bodyBuffer: Buffer,
     req: http.IncomingMessage,
@@ -200,6 +214,7 @@ function prepareAnthropic(
         const tokenCount = estimateTokensFast(msgs.map((m) => m.text ?? "").join("\n"));
         const turn = core.processTurn({ messages: msgs, state: session.state, config, tokenCount, renderTags: "text-only" });
         session.state = turn.state;
+        log("info", diagTagSummary(turn.messages, sessionId, "text-only"));
         processedMessages = applyCondense(turn.messages, opts, session);
         rebuiltMessages = coreToAnthropic(processedMessages);
 
@@ -254,6 +269,7 @@ function prepareOpenai(
         const tokenCount = estimateTokensFast(msgs.map((m) => m.text ?? "").join("\n"));
         const turn = core.processTurn({ messages: msgs, state: session.state, config, tokenCount, renderTags: "text-only" });
         session.state = turn.state;
+        log("info", diagTagSummary(turn.messages, sessionId, "text-only"));
         processedMessages = applyCondense(turn.messages, opts, session);
         rebuiltMessages = coreToOpenai(processedMessages);
 
@@ -414,11 +430,23 @@ async function forward(
                 { url: upstreamUrl, headers: reqHeaders },
             );
             for await (const chunk of loop) {
+                {
+                    const s = chunk.toString("utf8");
+                    if (s.includes("\x3cacp ") || s.includes("\x3c/acp")) {
+                        log("warn", `[${prepared.session.id}] tag echo: openai response stream contains <acp tag`);
+                    }
+                }
                 if (!res.write(chunk)) await new Promise<void>((r) => res.once("drain", () => r()));
             }
         } else {
             const rewriter = rewriteSseStream(streamToRead, ctx);
             for await (const chunk of rewriter) {
+                {
+                    const s = chunk.toString("utf8");
+                    if (s.includes("\x3cacp ") || s.includes("\x3c/acp")) {
+                        log("warn", `[${prepared.session.id}] tag echo: anthropic response stream contains <acp tag`);
+                    }
+                }
                 if (!res.write(chunk)) await new Promise<void>((r) => res.once("drain", () => r()));
             }
         }

--- a/src/stream-openai.ts
+++ b/src/stream-openai.ts
@@ -197,6 +197,9 @@ export function rewriteOpenaiJsonResponse(body: unknown, ctx: RewriteCtx): unkno
             }
         }
     }
+    if (existingText && (existingText.includes("\x3cacp ") || existingText.includes("\x3c/acp"))) {
+        ctx.log(`[warn: tag echo] non-stream openai output contains <acp tag: ${existingText.slice(0, 120).replace(/\n/g, " ")}`);
+    }
     if (!converted) return body;
     const note = noteParts.join("\n");
     msg.content = existingText ? `${existingText}\n${note}` : note;

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -94,6 +94,10 @@ function routeEvent(
             if (typeof partial === "string") st.json += partial;
             return NOOP;
         }
+        const dt = (d as { delta?: { text?: string } }).delta;
+        if (dt?.text && (dt.text.includes("\x3cacp ") || dt.text.includes("\x3c/acp"))) {
+            ctx.log(`[warn: tag echo] model emitted <acp tag in text delta: ${dt.text.slice(0, 120).replace(/\n/g, " ")}`);
+        }
         return emitEvent(ev);
     }
     if (t === "content_block_stop") {
@@ -230,6 +234,12 @@ export function rewriteJsonResponse(body: unknown, ctx: RewriteCtx): unknown {
     }
     b.content = newContent;
     if (converted && !sawRealToolUse) b.stop_reason = "end_turn";
+    for (const blk of newContent) {
+        const t = (blk as { type?: string; text?: string }).text;
+        if (typeof t === "string" && (t.includes("\x3cacp ") || t.includes("\x3c/acp"))) {
+            ctx.log(`[warn: tag echo] non-stream model output contains <acp tag: ${t.slice(0, 120).replace(/\n/g, " ")}`);
+        }
+    }
     return body;
 }
 


### PR DESCRIPTION
Two changes keeping <acp> tags out of model output.

## 1. server.ts — kernel-driven tag strategy replaces proxy hack
Pass `renderTags: "text-only"` to `processTurn` (both Anthropic + OpenAI paths). Requires acp-kernel PR#38 (`RenderStrategy` three-state). The render-refs node now leaves tool messages (tool-call args / tool-result content) pristine — no tag injected — so structured JSON is never corrupted. Refs are still assigned to every message (assignRefsNode runs unconditionally), so compress ranges still work.

**Removes** the `stripToolTags` hack: `ACP_TAG_RE` constant + `stripToolTags()` function + 2 call sites. Tag stripping was proxy-side post-processing doing what the kernel should do. Now the kernel does it cleanly via `renderTags`.

## 2. compress-tool.ts — forbid tag echoing in prompt
The ACP TAGS prompt section previously said 'Use these annotations to assess which messages are consuming the most context' — this encouraged the model to focus on the tags, and it started reproducing the tag syntax in its output (observed as `</acip>` typos in replies).

New wording: tags are system metadata injected by the proxy; **NEVER echo, repeat, or reference these XML tags in responses**; use only the ref ID inside compress calls, never the XML wrapper.

## Tags never reach the client
Tags exist only on the proxy→provider request path. Provider responses stream back to the client untouched. This PR ensures they also don't leak into the model's *generated* text.

## Depends on
acp-kernel PR#38 (RenderStrategy). Node_modules overlay used locally for testing; npm bump pending.