### PR TITLE
feat: persistent + namespaced sessions, multi-tenant session isolation, stream robustness

### DIFF
--- a/src/anthropic.ts
+++ b/src/anthropic.ts
@@ -198,7 +198,12 @@ export function condenseOldToolResults(messages: CoreMessage[], opts: CondenseOp
     return { messages: out, condensedCount, charsSaved };
 }
 
-export function deriveSessionId(body: AnthropicRequestBody, headerValue?: string): string {
+/** Extract the conversation dimension for Anthropic: a client-provided
+ *  session header if present, else a content fingerprint of the first user
+ *  message. The protocol+upstream+key dimensions are mixed in by the caller
+ *  (server.ts) via deriveSessionId() — this function contributes only the
+ *  conversation axis. */
+export function conversationSignalAnthropic(body: AnthropicRequestBody, headerValue?: string): string {
     if (headerValue && headerValue.trim()) return headerValue.trim();
     const firstUser = body.messages.find((m) => m.role === "user");
     const seed = firstUser ? JSON.stringify(firstUser.content).slice(0, 200) : "default";

--- a/src/compress-loop-responses.ts
+++ b/src/compress-loop-responses.ts
@@ -7,9 +7,6 @@ import {
     type Config,
     type CoreMessage,
 } from "acp-kernel";
-import { writeFileSync, mkdirSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { tmpdir } from "node:os";
 import type { Session } from "./session.js";
 import { parseCompressInput, PROXY_TOOL_NAMES, COMPRESS_TOOL_NAME, ACP_TEXT_OPEN, ACP_TEXT_CLOSE } from "./compress-tool.js";
 import { applyRanges } from "./stream.js";

--- a/src/compress-loop-responses.ts
+++ b/src/compress-loop-responses.ts
@@ -507,7 +507,7 @@ export async function* compressLoopResponsesStream(
             ctx.log(`[acp-proxy: responses compress loop upstream error ${resp.status}: ${errText.slice(0, 200)}]`);
             const errItemId = `msg_acp_err_${Date.now()}`;
             yield Buffer.from(
-                buildMessageItemSequence(errItemId, nextOutputIndex++, `\n[acp-proxy: upstream error ${resp.status}]\n`),
+                buildMessageItemSequence(errItemId, nextOutputIndex++, `\n[acp-proxy: upstream error ${resp.status}: ${errText.slice(0, 200)}]\n`),
                 "utf8",
             );
             yield Buffer.from(buildCompleted(responseObj), "utf8");

--- a/src/compress-loop.ts
+++ b/src/compress-loop.ts
@@ -7,9 +7,6 @@ import {
     type Config,
     type CoreMessage,
 } from "acp-kernel";
-import { writeFileSync, mkdirSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { tmpdir } from "node:os";
 import type { Session } from "./session.js";
 import { parseCompressInput, PROXY_TOOL_NAMES } from "./compress-tool.js";
 import { applyRanges } from "./stream.js";

--- a/src/compress-loop.ts
+++ b/src/compress-loop.ts
@@ -206,6 +206,7 @@ export async function* compressLoopStream(
 ): AsyncGenerator<Buffer> {
     let upstream = initialUpstream;
     let activeClearTimer: (() => void) | null = null;
+    try {
     const model = (requestBody.model as string) ?? "unknown";
     let responseId = `chatcmpl-proxy-${Date.now()}`;
     const makeBase = () => ({
@@ -396,7 +397,7 @@ export async function* compressLoopStream(
                     ...makeBase(),
                     choices: [{
                         index: 0,
-                        delta: { content: `\n[acp-proxy: upstream error ${resp.status}]\n` },
+                        delta: { content: `\n[acp-proxy: upstream error ${resp.status}: ${errText.slice(0, 200)}]\n` },
                         finish_reason: null,
                     }],
                 })}\n\n`,
@@ -409,5 +410,14 @@ export async function* compressLoopStream(
 
         upstream = resp.body as ReadableStream<Uint8Array>;
         activeClearTimer = clearTimer;
+    }
+    } finally {
+        // Clear the fetch timeout timer on any exit (return / throw / normal
+        // completion) so it cannot leak across rounds or keep the event loop
+        // alive. Mirrors the responses-loop variant.
+        if (activeClearTimer) {
+            activeClearTimer();
+            activeClearTimer = null;
+        }
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,10 +3,7 @@ import { loadOptions } from "./config.js";
 import { startServer } from "./server.js";
 
 const opts = loadOptions();
-const server = startServer(opts);
-
-for (const sig of ["SIGINT", "SIGTERM"] as const) {
-    process.on(sig, () => {
-        server.close(() => process.exit(0));
-    });
-}
+startServer(opts).catch((err) => {
+    console.error("failed to start:", err);
+    process.exit(1);
+});

--- a/src/openai.ts
+++ b/src/openai.ts
@@ -152,7 +152,10 @@ export function injectOpenaiSystem(messages: OpenAIMessage[], parts: string[]): 
 
 export { condenseOldToolResults, type CondenseOptions, type CondenseResult };
 
-export function deriveSessionIdOpenai(body: OpenAIRequestBody, headerValue?: string): string {
+/** Extract the conversation dimension for OpenAI Chat: a client-provided
+ *  session header if present, else a content fingerprint of the first user
+ *  message. See conversationSignalAnthropic for the full rationale. */
+export function conversationSignalOpenai(body: OpenAIRequestBody, headerValue?: string): string {
     if (headerValue && headerValue.trim()) return headerValue.trim();
     const firstUser = body.messages.find((m) => m.role === "user");
     const seed = firstUser ? stringContent(firstUser.content).slice(0, 200) : "default";

--- a/src/persist.ts
+++ b/src/persist.ts
@@ -1,0 +1,297 @@
+import { promises as fs } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { createInitialState, type CompressionState } from "acp-kernel";
+import type { Session, BlockContent } from "./session.js";
+
+/**
+ * On-disk persistence for proxy sessions.
+ *
+ * WHY: proxy sessions previously lived only in process memory. A restart
+ * dropped all compression state. For sessions whose raw history has grown
+ * past the model's context limit, the client re-sends full history on the
+ * next request — without the saved block summaries there is nothing to fold
+ * it under, so the model rejects the oversized request and the session hangs
+ * permanently. Persisting the CompressionState (and the blockContents
+ * originals cache) lets the proxy rebuild the folded view after a restart so
+ * the model only ever sees the small compressed context.
+ *
+ * DESIGN:
+ *  - Memory is a bounded cache (MAX_SESSIONS in session.ts). The disk is the
+ *    source of truth. Evicting a session from memory flushes it to disk first;
+ *    a later miss reloads it. So memory is bounded while ALL sessions persist.
+ *  - One JSON file per session, atomic write (temp + rename) — survives a
+ *    crash mid-write (the rename is atomic on posix; a partial temp is
+ *    discarded on next load by the corrupt-file fallback).
+ *  - Debounced async writes (default 500ms): the hot path never blocks on fs.
+ *    Multiple mutations within the window coalesce into one write.
+ *  - Forward-compat: `mergeInitialState` fills any fields missing on a file
+ *    written by an older version, so a schema change never breaks old files.
+ *  - Disable with BILI_PERSIST=0 for ephemeral/test runs.
+ */
+
+const PERSIST_VERSION = 1;
+
+interface PersistedSession {
+    version: number;
+    savedAt: number;
+    id: string;
+    createdAt: number;
+    requests: number;
+    condensedToolResults: number;
+    tokensSaved: number;
+    state: CompressionState;
+    /** blockContents serialized as a plain record (Maps do not survive JSON). */
+    blockContents: Record<string, BlockContent>;
+}
+
+/** Forward-compat: merge a parsed state with a fresh one so missing fields
+ *  (added in later versions) get sane defaults instead of `undefined`. */
+function mergeState(parsed: CompressionState): CompressionState {
+    const fresh = createInitialState();
+    return {
+        blocks: parsed.blocks ?? fresh.blocks,
+        messageRefs: parsed.messageRefs ?? fresh.messageRefs,
+        nudge: { ...fresh.nudge, ...(parsed.nudge ?? {}) },
+        stats: { ...fresh.stats, ...(parsed.stats ?? {}) },
+        nextBlockId: parsed.nextBlockId ?? fresh.nextBlockId,
+        nextRunId: parsed.nextRunId ?? fresh.nextRunId,
+    };
+}
+
+/** Build a filesystem-safe filename from a session id. Session ids are hashes
+ *  (deriveSessionId*) or arbitrary x-acp-session header values — sanitize to
+ *  avoid path traversal, keep it readable. The real id is also stored inside
+ *  the file so integrity can be verified on load. */
+function safeFileName(id: string): string {
+    return id.replace(/[^A-Za-z0-9_-]/g, "_").slice(0, 128) || "session";
+}
+
+export class SessionStore {
+    private readonly dir: string;
+    private readonly debounceMs: number;
+    readonly enabled: boolean;
+    private readonly timers = new Map<string, NodeJS.Timeout>();
+
+    constructor(opts?: { dir?: string; debounceMs?: number; enabled?: boolean }) {
+        this.dir = opts?.dir ?? defaultDir();
+        this.debounceMs = opts?.debounceMs ?? defaultDebounce();
+        this.enabled = (opts?.enabled ?? true) && this.debounceMs >= 0;
+    }
+
+    private filePath(id: string): string {
+        return path.join(this.dir, `${safeFileName(id)}.json`);
+    }
+
+    /** Bulk-load every persisted session from disk into a map keyed by session
+     *  id. Called once at startup before the server accepts traffic. Corrupt
+     *  individual files are skipped (logged) — one bad file never blocks boot. */
+    async loadAll(): Promise<Map<string, Session>> {
+        const out = new Map<string, Session>();
+        if (!this.enabled) return out;
+        try {
+            await fs.mkdir(this.dir, { recursive: true });
+        } catch {
+            return out;
+        }
+        let names: string[];
+        try {
+            names = await fs.readdir(this.dir);
+        } catch {
+            return out;
+        }
+        for (const name of names) {
+            if (!name.endsWith(".json")) continue;
+            try {
+                const raw = await fs.readFile(path.join(this.dir, name), "utf8");
+                const parsed = JSON.parse(raw) as PersistedSession;
+                if (!parsed || typeof parsed.id !== "string" || !parsed.state || !Array.isArray(parsed.state.blocks)) {
+                    continue;
+                }
+                const blockContents = new Map<string, BlockContent>();
+                for (const [bid, content] of Object.entries(parsed.blockContents ?? {})) {
+                    if (content && typeof content === "object") blockContents.set(bid, content);
+                }
+                out.set(parsed.id, {
+                    id: parsed.id,
+                    state: mergeState(parsed.state),
+                    createdAt: parsed.createdAt ?? Date.now(),
+                    lastSeen: Date.now(),
+                    requests: parsed.requests ?? 0,
+                    condensedToolResults: parsed.condensedToolResults ?? 0,
+                    tokensSaved: parsed.tokensSaved ?? 0,
+                    blockContents,
+                });
+            } catch {
+                // corrupt file — skip, do not poison startup
+            }
+        }
+        return out;
+    }
+
+    /** Synchronous reload of a single session. Used on a memory miss (after
+     *  LRU eviction). Sync fs is acceptable here because a miss is rare and
+     *  reads a single small file (~1ms). Returns null if missing/corrupt. */
+    loadSync(id: string): Session | null {
+        if (!this.enabled) return null;
+        const file = this.filePath(id);
+        if (!existsSync(file)) return null;
+        try {
+            const raw = readFileSync(file, "utf8");
+            const parsed = JSON.parse(raw) as PersistedSession;
+            if (!parsed || typeof parsed.id !== "string" || !parsed.state) return null;
+            const blockContents = new Map<string, BlockContent>();
+            for (const [bid, content] of Object.entries(parsed.blockContents ?? {})) {
+                if (content && typeof content === "object") blockContents.set(bid, content);
+            }
+            return {
+                id: parsed.id,
+                state: mergeState(parsed.state),
+                createdAt: parsed.createdAt ?? Date.now(),
+                lastSeen: Date.now(),
+                requests: parsed.requests ?? 0,
+                condensedToolResults: parsed.condensedToolResults ?? 0,
+                tokensSaved: parsed.tokensSaved ?? 0,
+                blockContents,
+            };
+        } catch {
+            return null;
+        }
+    }
+
+    /** Schedule a debounced write for a session. Multiple calls within the
+     *  window coalesce. Safe to call on the hot path. No-op if disabled. */
+    scheduleSave(session: Session): void {
+        if (!this.enabled) return;
+        const existing = this.timers.get(session.id);
+        if (existing) clearTimeout(existing);
+        const timer = setTimeout(() => {
+            this.timers.delete(session.id);
+            void this.writeNow(session).catch(() => {});
+        }, this.debounceMs);
+        // Don't keep the event loop alive solely for a pending write.
+        timer.unref?.();
+        this.timers.set(session.id, timer);
+    }
+
+    /** Asynchronously persist a session right now (skips the debounce). */
+    async writeNow(session: Session): Promise<void> {
+        if (!this.enabled) return;
+        const record: PersistedSession = {
+            version: PERSIST_VERSION,
+            savedAt: Date.now(),
+            id: session.id,
+            createdAt: session.createdAt,
+            requests: session.requests,
+            condensedToolResults: session.condensedToolResults,
+            tokensSaved: session.tokensSaved,
+            state: session.state,
+            blockContents: Object.fromEntries(session.blockContents),
+        };
+        const file = this.filePath(session.id);
+        try {
+            await fs.mkdir(this.dir, { recursive: true });
+        } catch {
+            /* best-effort */
+        }
+        const tmp = path.join(this.dir, `.tmp-${safeFileName(session.id)}-${process.pid}`);
+        const data = JSON.stringify(record);
+        await fs.writeFile(tmp, data, "utf8");
+        await fs.rename(tmp, file);
+    }
+
+    /** Synchronous flush for a single session. Used on memory eviction so a
+     *  dirty evicted session is not lost. Sync because eviction runs in the
+     *  sync getSession path; a single small write is acceptable. */
+    flushSync(session: Session): void {
+        if (!this.enabled) return;
+        const existing = this.timers.get(session.id);
+        if (existing) {
+            clearTimeout(existing);
+            this.timers.delete(session.id);
+        }
+        const record: PersistedSession = {
+            version: PERSIST_VERSION,
+            savedAt: Date.now(),
+            id: session.id,
+            createdAt: session.createdAt,
+            requests: session.requests,
+            condensedToolResults: session.condensedToolResults,
+            tokensSaved: session.tokensSaved,
+            state: session.state,
+            blockContents: Object.fromEntries(session.blockContents),
+        };
+        const file = this.filePath(session.id);
+        try {
+            mkdirSync(this.dir, { recursive: true });
+        } catch {
+            /* best-effort */
+        }
+        const tmp = path.join(this.dir, `.tmp-${safeFileName(session.id)}-${process.pid}`);
+        try {
+            writeFileSync(tmp, JSON.stringify(record), "utf8");
+            renameSync(tmp, file);
+        } catch {
+            /* best-effort: if write fails the previous on-disk version remains */
+        }
+    }
+
+    /** Flush all sessions with a pending debounce timer. Called on SIGTERM/
+     *  SIGINT for graceful shutdown. Fires timers immediately and awaits their
+     *  writes. */
+    async flushAll(sessions: Iterable<Session>): Promise<void> {
+        if (!this.enabled) return;
+        const pending: Promise<void>[] = [];
+        for (const timer of this.timers.values()) clearTimeout(timer);
+        this.timers.clear();
+        for (const s of sessions) {
+            pending.push(this.writeNow(s).catch(() => {}));
+        }
+        await Promise.all(pending);
+    }
+
+    /** Cancel all pending writes without flushing (e.g. for tests). */
+    cancelAll(): void {
+        for (const timer of this.timers.values()) clearTimeout(timer);
+        this.timers.clear();
+    }
+}
+
+function defaultDir(): string {
+    const env = process.env.BILI_SESSIONS_DIR;
+    if (env) return env;
+    return path.join(os.homedir(), ".bili", "sessions");
+}
+
+function defaultDebounce(): number {
+    const env = process.env.BILI_PERSIST_DEBOUNCE_MS;
+    if (env) {
+        const n = Number.parseInt(env, 10);
+        if (Number.isFinite(n) && n >= 0) return n;
+    }
+    return 500;
+}
+
+function persistEnabled(): boolean {
+    const env = process.env.BILI_PERSIST;
+    if (env === "0" || env === "false") return false;
+    return true;
+}
+
+/** Singleton store for the running proxy. */
+let _store: SessionStore | null = null;
+
+export function getStore(): SessionStore {
+    if (!_store) {
+        _store = new SessionStore({ enabled: persistEnabled() });
+    }
+    return _store;
+}
+
+/** Test hook: inject a store with a temp dir. */
+export function _setStoreForTest(store: SessionStore): void {
+    _store = store;
+}
+
+/** Avoid unused-import lint for future directory iteration. */

--- a/src/persist.ts
+++ b/src/persist.ts
@@ -51,6 +51,11 @@ interface PersistedSession {
     version: number;
     savedAt: number;
     id: string;
+    /** Protocol + upstream origin, captured so the on-disk filename can be
+     *  namespaced by protocol/provider. Absent in files written before this
+     *  field existed; treated as unknown on load (file lives under _unknown/). */
+    protocol?: "anthropic" | "openai" | "responses";
+    upstreamOrigin?: string;
     createdAt: number;
     requests: number;
     condensedToolResults: number;
@@ -76,11 +81,42 @@ function mergeState(parsed: CompressionState): CompressionState {
     };
 }
 
-/** Deterministic, collision-resistant filename from a session id. Uses a
- *  truncated sha256 so distinct ids never share a file (a naive sanitize would
- *  collide e.g. "a/b" and "a_b"). The real id is stored inside the file body
- *  and verified on load. */
-function fileNameFor(id: string): string {
+/** Extract a short host label from an upstream origin URL, safe for a
+ *  filename. Uses the full hostname (sanitized) rather than guessing the
+ *  registrable domain — a public-suffix-list lookup is overkill, and the full
+ *  host is unambiguous and grep-able. e.g.
+ *    "https://coding.dashscope.aliyuncs.com" -> "coding.dashscope.aliyuncs.com"
+ *  Falls back to a hash of the origin if parsing fails, so two distinct
+ *  origins never collide. */
+function hostLabel(upstreamOrigin?: string): string {
+    if (!upstreamOrigin) return "unknown";
+    try {
+        const host = new URL(upstreamOrigin).hostname || "unknown";
+        return host.replace(/[^a-zA-Z0-9.-]/g, "-").slice(0, 48) || "unknown";
+    } catch {
+        return "unknown-" + createHash("sha256").update(upstreamOrigin, "utf8").digest("hex").slice(0, 6);
+    }
+}
+
+/** Relative path (under the sessions dir) for a session, namespaced by
+ *  protocol and upstream host so a human can tell sessions apart at a glance:
+ *    anthropic/bailian_<hash>.json
+ *    openai/zhipu_<hash>.json
+ *    responses/comfly_<hash>.json
+ *  When protocol meta is absent (e.g. a session loaded from an old file
+ *  written before meta was captured), fall back to _unknown/ so it still
+ *  loads — it will be rewritten with the right namespace on next persist.
+ *  Deterministic from (id, protocol, upstreamOrigin), so loadAll can verify
+ *  the filename matches the body and loadSync can reverse-lookup. */
+function relPathFor(id: string, protocol?: string, upstreamOrigin?: string): string {
+    const proto = protocol ?? "_unknown";
+    const host = protocol ? hostLabel(upstreamOrigin) + "_" : "";
+    return path.join(proto, `${host}${createHash("sha256").update(id, "utf8").digest("hex").slice(0, 24)}.json`);
+}
+
+/** Legacy flat filename (pre-namespace). Kept only for loadAll to recognize
+ *  and migrate old files. */
+function legacyFileNameFor(id: string): string {
     return createHash("sha256").update(id, "utf8").digest("hex").slice(0, 24) + ".json";
 }
 
@@ -100,15 +136,15 @@ export class SessionStore {
         this.log = opts?.log ?? defaultLogger;
     }
 
-    private filePath(id: string): string {
-        return path.join(this.dir, fileNameFor(id));
+    private filePath(id: string, protocol?: string, upstreamOrigin?: string): string {
+        return path.join(this.dir, relPathFor(id, protocol, upstreamOrigin));
     }
 
     /** A unique temp path per write (per process). Two overlapping writes for
      *  the same session must not share a temp file, or one rename invalidates
      *  the other. */
     private tempPath(id: string): string {
-        return path.join(this.dir, `.tmp-${fileNameFor(id)}-${process.pid}-${this.tmpSeq++}`);
+        return path.join(this.dir, `.tmp-${legacyFileNameFor(id)}-${process.pid}-${this.tmpSeq++}`);
     }
 
     /** Bulk-load every persisted session from disk into a map keyed by the
@@ -123,26 +159,49 @@ export class SessionStore {
         } catch {
             return out;
         }
-        let names: string[];
-        try {
-            names = await fs.readdir(this.dir);
-        } catch {
-            return out;
-        }
-        for (const name of names) {
-            if (!name.endsWith(".json") || name.startsWith(".tmp-")) continue;
+        // Recursively walk the sessions dir to pick up the namespaced layout
+        // (sessions/<protocol>/<host>_<hash>.json) as well as legacy flat files
+        // (sessions/<hash>.json) written by older versions.
+        const files: string[] = [];
+        const walk = async (dir: string): Promise<void> => {
+            let entries: import("node:fs").Dirent[];
             try {
-                const parsed = JSON.parse(await fs.readFile(path.join(this.dir, name), "utf8")) as PersistedSession;
+                entries = await fs.readdir(dir, { withFileTypes: true });
+            } catch {
+                return;
+            }
+            for (const e of entries) {
+                if (e.name.startsWith(".tmp-")) continue;
+                const full = path.join(dir, e.name);
+                if (e.isDirectory()) {
+                    await walk(full);
+                } else if (e.isFile() && e.name.endsWith(".json")) {
+                    files.push(full);
+                }
+            }
+        };
+        await walk(this.dir);
+        for (const full of files) {
+            const name = path.basename(full);
+            try {
+                const parsed = JSON.parse(await fs.readFile(full, "utf8")) as PersistedSession;
                 if (!isValidRecord(parsed)) continue;
-                // Filename must match the body id — guards against a file that
-                // was copied/renamed by hand, or a stale temp that slipped in.
-                if (fileNameFor(parsed.id) !== name) {
-                    this.log("warn", `[persist] skipping ${name}: filename does not match body id (expected ${fileNameFor(parsed.id)})`);
+                // Accept the file if EITHER the namespaced name or the legacy
+                // flat name matches the body id. The namespaced form is the
+                // current convention; the legacy form is tolerated so old
+                // files still load (and will be re-persisted under the new
+                // namespace on next dirty write).
+                const proto = parsed.protocol;
+                const origin = parsed.upstreamOrigin;
+                const expectedNamespaced = path.basename(relPathFor(parsed.id, proto, origin));
+                const expectedLegacy = legacyFileNameFor(parsed.id);
+                if (name !== expectedNamespaced && name !== expectedLegacy) {
+                    this.log("warn", `[persist] skipping ${full}: filename does not match body id (expected ${expectedNamespaced})`);
                     continue;
                 }
                 out.set(parsed.id, buildSession(parsed));
             } catch (e) {
-                this.log("warn", `[persist] skipping corrupt session file ${name}: ${msg(e)}`);
+                this.log("warn", `[persist] skipping corrupt session file ${full}: ${msg(e)}`);
             }
         }
         return out;
@@ -152,18 +211,24 @@ export class SessionStore {
      *  LRU eviction). Sync fs is acceptable here because a miss is rare and
      *  reads a single small file (~1ms). Returns null if missing/corrupt or the
      *  body id does not match what we asked for. */
-    loadSync(id: string): Session | null {
+    loadSync(id: string, meta?: { protocol?: string; upstreamOrigin?: string }): Session | null {
         if (!this.enabled) return null;
-        const file = this.filePath(id);
-        if (!existsSync(file)) return null;
-        try {
-            const parsed = JSON.parse(readFileSync(file, "utf8")) as PersistedSession;
-            if (!isValidRecord(parsed) || parsed.id !== id) return null;
-            return buildSession(parsed);
-        } catch (e) {
-            this.log("warn", `[persist] failed to load session ${id}: ${msg(e)}`);
-            return null;
+        // Try the namespaced path first (current convention), then fall back to
+        // the _unknown/ legacy location for sessions persisted before protocol
+        // meta was captured.
+        const candidates = [this.filePath(id, meta?.protocol, meta?.upstreamOrigin)];
+        if (meta?.protocol) candidates.push(this.filePath(id)); // _unknown/ fallback
+        for (const file of candidates) {
+            if (!existsSync(file)) continue;
+            try {
+                const parsed = JSON.parse(readFileSync(file, "utf8")) as PersistedSession;
+                if (!isValidRecord(parsed) || parsed.id !== id) continue;
+                return buildSession(parsed);
+            } catch (e) {
+                this.log("warn", `[persist] failed to load session ${id}: ${msg(e)}`);
+            }
         }
+        return null;
     }
 
     /** Schedule a debounced write for a session. Multiple calls within the
@@ -188,9 +253,9 @@ export class SessionStore {
     async writeNow(session: Session): Promise<void> {
         if (!this.enabled) return;
         const record = buildRecord(session);
-        const file = this.filePath(session.id);
+        const file = this.filePath(session.id, session.protocol, session.upstreamOrigin);
         try {
-            await fs.mkdir(this.dir, { recursive: true });
+            await fs.mkdir(path.dirname(file), { recursive: true });
         } catch (e) {
             this.log("warn", `[persist] could not create session dir ${this.dir}: ${msg(e)}`);
         }
@@ -213,9 +278,9 @@ export class SessionStore {
             this.timers.delete(session.id);
         }
         const record = buildRecord(session);
-        const file = this.filePath(session.id);
+        const file = this.filePath(session.id, session.protocol, session.upstreamOrigin);
         try {
-            mkdirSync(this.dir, { recursive: true });
+            mkdirSync(path.dirname(file), { recursive: true });
         } catch (e) {
             this.log("warn", `[persist] could not create session dir ${this.dir}: ${msg(e)}`);
         }
@@ -273,6 +338,8 @@ function buildRecord(session: Session): PersistedSession {
         version: PERSIST_VERSION,
         savedAt: Date.now(),
         id: session.id,
+        protocol: session.protocol,
+        upstreamOrigin: session.upstreamOrigin,
         createdAt: session.createdAt,
         requests: session.requests,
         condensedToolResults: session.condensedToolResults,
@@ -289,6 +356,8 @@ function buildSession(parsed: PersistedSession): Session {
     }
     return {
         id: parsed.id,
+        protocol: parsed.protocol,
+        upstreamOrigin: parsed.upstreamOrigin,
         state: mergeState(parsed.state),
         createdAt: parsed.createdAt ?? Date.now(),
         lastSeen: Date.now(),

--- a/src/persist.ts
+++ b/src/persist.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from "node:fs";
 import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
 import * as path from "node:path";
 import * as os from "node:os";
 import { createInitialState, type CompressionState } from "acp-kernel";
@@ -22,13 +23,26 @@ import type { Session, BlockContent } from "./session.js";
  *    source of truth. Evicting a session from memory flushes it to disk first;
  *    a later miss reloads it. So memory is bounded while ALL sessions persist.
  *  - One JSON file per session, atomic write (temp + rename) — survives a
- *    crash mid-write (the rename is atomic on posix; a partial temp is
- *    discarded on next load by the corrupt-file fallback).
+ *    *process* crash mid-write (rename is atomic on posix; a partial temp is
+ *    left behind and discarded on next load by the corrupt-file fallback).
+ *    Does NOT survive power loss (no fsync of the directory entry); the
+ *    debounced writes keep the on-disk state within ~debounce of in-memory.
  *  - Debounced async writes (default 500ms): the hot path never blocks on fs.
  *    Multiple mutations within the window coalesce into one write.
  *  - Forward-compat: `mergeInitialState` fills any fields missing on a file
  *    written by an older version, so a schema change never breaks old files.
  *  - Disable with BILI_PERSIST=0 for ephemeral/test runs.
+ *
+ * KNOWN LIMITATIONS:
+ *  - No fsync of temp file or directory entry — a power loss can lose the
+ *    most recent debounce window. Process crashes (SIGKILL) are safe up to
+ *    the last successful write.
+ *  - No cross-process lock — two proxy processes sharing BILI_SESSIONS_DIR
+ *    will clobber each other's writes. Single-instance only.
+ *  - All writes within a process are serialized per-session by Node's single
+ *    event loop; there is no per-session *request* serialization (two
+ *    concurrent HTTP requests for the same session can interleave processTurn
+ *    and corrupt in-memory state). See AGENTS.md.
  */
 
 const PERSIST_VERSION = 1;
@@ -46,6 +60,8 @@ interface PersistedSession {
     blockContents: Record<string, BlockContent>;
 }
 
+type Logger = (level: "info" | "warn" | "error", msg: string) => void;
+
 /** Forward-compat: merge a parsed state with a fresh one so missing fields
  *  (added in later versions) get sane defaults instead of `undefined`. */
 function mergeState(parsed: CompressionState): CompressionState {
@@ -60,12 +76,12 @@ function mergeState(parsed: CompressionState): CompressionState {
     };
 }
 
-/** Build a filesystem-safe filename from a session id. Session ids are hashes
- *  (deriveSessionId*) or arbitrary x-acp-session header values — sanitize to
- *  avoid path traversal, keep it readable. The real id is also stored inside
- *  the file so integrity can be verified on load. */
-function safeFileName(id: string): string {
-    return id.replace(/[^A-Za-z0-9_-]/g, "_").slice(0, 128) || "session";
+/** Deterministic, collision-resistant filename from a session id. Uses a
+ *  truncated sha256 so distinct ids never share a file (a naive sanitize would
+ *  collide e.g. "a/b" and "a_b"). The real id is stored inside the file body
+ *  and verified on load. */
+function fileNameFor(id: string): string {
+    return createHash("sha256").update(id, "utf8").digest("hex").slice(0, 24) + ".json";
 }
 
 export class SessionStore {
@@ -73,20 +89,32 @@ export class SessionStore {
     private readonly debounceMs: number;
     readonly enabled: boolean;
     private readonly timers = new Map<string, NodeJS.Timeout>();
+    /** Monotonic counter for unique temp filenames within a process. */
+    private tmpSeq = 0;
+    private readonly log: Logger;
 
-    constructor(opts?: { dir?: string; debounceMs?: number; enabled?: boolean }) {
+    constructor(opts?: { dir?: string; debounceMs?: number; enabled?: boolean; log?: Logger }) {
         this.dir = opts?.dir ?? defaultDir();
         this.debounceMs = opts?.debounceMs ?? defaultDebounce();
         this.enabled = (opts?.enabled ?? true) && this.debounceMs >= 0;
+        this.log = opts?.log ?? defaultLogger;
     }
 
     private filePath(id: string): string {
-        return path.join(this.dir, `${safeFileName(id)}.json`);
+        return path.join(this.dir, fileNameFor(id));
     }
 
-    /** Bulk-load every persisted session from disk into a map keyed by session
-     *  id. Called once at startup before the server accepts traffic. Corrupt
-     *  individual files are skipped (logged) — one bad file never blocks boot. */
+    /** A unique temp path per write (per process). Two overlapping writes for
+     *  the same session must not share a temp file, or one rename invalidates
+     *  the other. */
+    private tempPath(id: string): string {
+        return path.join(this.dir, `.tmp-${fileNameFor(id)}-${process.pid}-${this.tmpSeq++}`);
+    }
+
+    /** Bulk-load every persisted session from disk into a map keyed by the
+     *  REAL session id (read from the file body, not the filename). Called once
+     *  at startup before the server accepts traffic. Corrupt individual files
+     *  are skipped (logged) — one bad file never blocks boot. */
     async loadAll(): Promise<Map<string, Session>> {
         const out = new Map<string, Session>();
         if (!this.enabled) return out;
@@ -102,29 +130,19 @@ export class SessionStore {
             return out;
         }
         for (const name of names) {
-            if (!name.endsWith(".json")) continue;
+            if (!name.endsWith(".json") || name.startsWith(".tmp-")) continue;
             try {
-                const raw = await fs.readFile(path.join(this.dir, name), "utf8");
-                const parsed = JSON.parse(raw) as PersistedSession;
-                if (!parsed || typeof parsed.id !== "string" || !parsed.state || !Array.isArray(parsed.state.blocks)) {
+                const parsed = JSON.parse(await fs.readFile(path.join(this.dir, name), "utf8")) as PersistedSession;
+                if (!isValidRecord(parsed)) continue;
+                // Filename must match the body id — guards against a file that
+                // was copied/renamed by hand, or a stale temp that slipped in.
+                if (fileNameFor(parsed.id) !== name) {
+                    this.log("warn", `[persist] skipping ${name}: filename does not match body id (expected ${fileNameFor(parsed.id)})`);
                     continue;
                 }
-                const blockContents = new Map<string, BlockContent>();
-                for (const [bid, content] of Object.entries(parsed.blockContents ?? {})) {
-                    if (content && typeof content === "object") blockContents.set(bid, content);
-                }
-                out.set(parsed.id, {
-                    id: parsed.id,
-                    state: mergeState(parsed.state),
-                    createdAt: parsed.createdAt ?? Date.now(),
-                    lastSeen: Date.now(),
-                    requests: parsed.requests ?? 0,
-                    condensedToolResults: parsed.condensedToolResults ?? 0,
-                    tokensSaved: parsed.tokensSaved ?? 0,
-                    blockContents,
-                });
-            } catch {
-                // corrupt file — skip, do not poison startup
+                out.set(parsed.id, buildSession(parsed));
+            } catch (e) {
+                this.log("warn", `[persist] skipping corrupt session file ${name}: ${msg(e)}`);
             }
         }
         return out;
@@ -132,30 +150,18 @@ export class SessionStore {
 
     /** Synchronous reload of a single session. Used on a memory miss (after
      *  LRU eviction). Sync fs is acceptable here because a miss is rare and
-     *  reads a single small file (~1ms). Returns null if missing/corrupt. */
+     *  reads a single small file (~1ms). Returns null if missing/corrupt or the
+     *  body id does not match what we asked for. */
     loadSync(id: string): Session | null {
         if (!this.enabled) return null;
         const file = this.filePath(id);
         if (!existsSync(file)) return null;
         try {
-            const raw = readFileSync(file, "utf8");
-            const parsed = JSON.parse(raw) as PersistedSession;
-            if (!parsed || typeof parsed.id !== "string" || !parsed.state) return null;
-            const blockContents = new Map<string, BlockContent>();
-            for (const [bid, content] of Object.entries(parsed.blockContents ?? {})) {
-                if (content && typeof content === "object") blockContents.set(bid, content);
-            }
-            return {
-                id: parsed.id,
-                state: mergeState(parsed.state),
-                createdAt: parsed.createdAt ?? Date.now(),
-                lastSeen: Date.now(),
-                requests: parsed.requests ?? 0,
-                condensedToolResults: parsed.condensedToolResults ?? 0,
-                tokensSaved: parsed.tokensSaved ?? 0,
-                blockContents,
-            };
-        } catch {
+            const parsed = JSON.parse(readFileSync(file, "utf8")) as PersistedSession;
+            if (!isValidRecord(parsed) || parsed.id !== id) return null;
+            return buildSession(parsed);
+        } catch (e) {
+            this.log("warn", `[persist] failed to load session ${id}: ${msg(e)}`);
             return null;
         }
     }
@@ -168,34 +174,27 @@ export class SessionStore {
         if (existing) clearTimeout(existing);
         const timer = setTimeout(() => {
             this.timers.delete(session.id);
-            void this.writeNow(session).catch(() => {});
+            void this.writeNow(session).catch((e) => {
+                this.log("error", `[persist] debounced write failed for ${session.id}: ${msg(e)}`);
+            });
         }, this.debounceMs);
         // Don't keep the event loop alive solely for a pending write.
         timer.unref?.();
         this.timers.set(session.id, timer);
     }
 
-    /** Asynchronously persist a session right now (skips the debounce). */
+    /** Asynchronously persist a session right now (skips the debounce). Throws
+     *  on write failure so callers can react (e.g. avoid evicting). */
     async writeNow(session: Session): Promise<void> {
         if (!this.enabled) return;
-        const record: PersistedSession = {
-            version: PERSIST_VERSION,
-            savedAt: Date.now(),
-            id: session.id,
-            createdAt: session.createdAt,
-            requests: session.requests,
-            condensedToolResults: session.condensedToolResults,
-            tokensSaved: session.tokensSaved,
-            state: session.state,
-            blockContents: Object.fromEntries(session.blockContents),
-        };
+        const record = buildRecord(session);
         const file = this.filePath(session.id);
         try {
             await fs.mkdir(this.dir, { recursive: true });
-        } catch {
-            /* best-effort */
+        } catch (e) {
+            this.log("warn", `[persist] could not create session dir ${this.dir}: ${msg(e)}`);
         }
-        const tmp = path.join(this.dir, `.tmp-${safeFileName(session.id)}-${process.pid}`);
+        const tmp = this.tempPath(session.id);
         const data = JSON.stringify(record);
         await fs.writeFile(tmp, data, "utf8");
         await fs.rename(tmp, file);
@@ -203,52 +202,63 @@ export class SessionStore {
 
     /** Synchronous flush for a single session. Used on memory eviction so a
      *  dirty evicted session is not lost. Sync because eviction runs in the
-     *  sync getSession path; a single small write is acceptable. */
-    flushSync(session: Session): void {
-        if (!this.enabled) return;
+     *  sync getSession path; a single small write is acceptable.
+     *  Returns true on success, false on failure (caller must NOT evict on
+     *  failure for a never-persisted session or it is lost permanently). */
+    flushSync(session: Session): boolean {
+        if (!this.enabled) return true;
         const existing = this.timers.get(session.id);
         if (existing) {
             clearTimeout(existing);
             this.timers.delete(session.id);
         }
-        const record: PersistedSession = {
-            version: PERSIST_VERSION,
-            savedAt: Date.now(),
-            id: session.id,
-            createdAt: session.createdAt,
-            requests: session.requests,
-            condensedToolResults: session.condensedToolResults,
-            tokensSaved: session.tokensSaved,
-            state: session.state,
-            blockContents: Object.fromEntries(session.blockContents),
-        };
+        const record = buildRecord(session);
         const file = this.filePath(session.id);
         try {
             mkdirSync(this.dir, { recursive: true });
-        } catch {
-            /* best-effort */
+        } catch (e) {
+            this.log("warn", `[persist] could not create session dir ${this.dir}: ${msg(e)}`);
         }
-        const tmp = path.join(this.dir, `.tmp-${safeFileName(session.id)}-${process.pid}`);
+        const tmp = this.tempPath(session.id);
         try {
             writeFileSync(tmp, JSON.stringify(record), "utf8");
             renameSync(tmp, file);
-        } catch {
-            /* best-effort: if write fails the previous on-disk version remains */
+            return true;
+        } catch (e) {
+            this.log("error", `[persist] flushSync FAILED for ${session.id}: ${msg(e)} — session NOT evicted to prevent loss`);
+            // Best-effort: remove the orphan temp so it doesn't accumulate.
+            try {
+                require("node:fs").unlinkSync(tmp);
+            } catch {
+                /* ignore */
+            }
+            return false;
         }
     }
 
-    /** Flush all sessions with a pending debounce timer. Called on SIGTERM/
-     *  SIGINT for graceful shutdown. Fires timers immediately and awaits their
-     *  writes. */
+    /** Flush all dirty sessions with a pending debounce timer. Called on
+     *  SIGTERM/SIGINT for graceful shutdown. Clears timers first, then writes
+     *  every session that had a pending write. */
     async flushAll(sessions: Iterable<Session>): Promise<void> {
         if (!this.enabled) return;
-        const pending: Promise<void>[] = [];
+        const dirty = new Set(this.timers.keys());
         for (const timer of this.timers.values()) clearTimeout(timer);
         this.timers.clear();
+        const pending: Promise<void>[] = [];
         for (const s of sessions) {
-            pending.push(this.writeNow(s).catch(() => {}));
+            if (!dirty.has(s.id)) continue; // only flush sessions with pending writes
+            pending.push(
+                this.writeNow(s).catch((e) => {
+                    this.log("error", `[persist] shutdown flush failed for ${s.id}: ${msg(e)}`);
+                }),
+            );
         }
         await Promise.all(pending);
+    }
+
+    /** Whether a write is currently pending (debounce timer armed) for a id. */
+    hasPending(id: string): boolean {
+        return this.timers.has(id);
     }
 
     /** Cancel all pending writes without flushing (e.g. for tests). */
@@ -256,6 +266,49 @@ export class SessionStore {
         for (const timer of this.timers.values()) clearTimeout(timer);
         this.timers.clear();
     }
+}
+
+function buildRecord(session: Session): PersistedSession {
+    return {
+        version: PERSIST_VERSION,
+        savedAt: Date.now(),
+        id: session.id,
+        createdAt: session.createdAt,
+        requests: session.requests,
+        condensedToolResults: session.condensedToolResults,
+        tokensSaved: session.tokensSaved,
+        state: session.state,
+        blockContents: Object.fromEntries(session.blockContents),
+    };
+}
+
+function buildSession(parsed: PersistedSession): Session {
+    const blockContents = new Map<string, BlockContent>();
+    for (const [bid, content] of Object.entries(parsed.blockContents ?? {})) {
+        if (content && typeof content === "object") blockContents.set(bid, content);
+    }
+    return {
+        id: parsed.id,
+        state: mergeState(parsed.state),
+        createdAt: parsed.createdAt ?? Date.now(),
+        lastSeen: Date.now(),
+        requests: parsed.requests ?? 0,
+        condensedToolResults: parsed.condensedToolResults ?? 0,
+        tokensSaved: parsed.tokensSaved ?? 0,
+        blockContents,
+        inFlight: 0,
+        persisted: true,
+    };
+}
+
+function isValidRecord(parsed: unknown): parsed is PersistedSession {
+    if (!parsed || typeof parsed !== "object") return false;
+    const r = parsed as Partial<PersistedSession>;
+    return typeof r.id === "string" && typeof r.state === "object" && r.state !== null && Array.isArray(r.state.blocks);
+}
+
+function msg(e: unknown): string {
+    return e instanceof Error ? e.message : String(e);
 }
 
 function defaultDir(): string {
@@ -279,6 +332,11 @@ function persistEnabled(): boolean {
     return true;
 }
 
+function defaultLogger(level: string, m: string): void {
+    // eslint-disable-next-line no-console
+    console.error(`[${level}] ${m}`);
+}
+
 /** Singleton store for the running proxy. */
 let _store: SessionStore | null = null;
 
@@ -293,5 +351,3 @@ export function getStore(): SessionStore {
 export function _setStoreForTest(store: SessionStore): void {
     _store = store;
 }
-
-/** Avoid unused-import lint for future directory iteration. */

--- a/src/responses.ts
+++ b/src/responses.ts
@@ -299,8 +299,16 @@ export function injectResponsesInstructions(
 
 export { condenseOldToolResults, type CondenseOptions, type CondenseResult };
 
-export function deriveSessionIdResponses(body: ResponsesRequestBody, headerValue?: string): string {
+/** Extract the conversation dimension for Responses: a client-provided
+ *  session header if present, else the previous_response_id chain (Responses'
+ *  native conversation linkage) if present, else a content fingerprint of
+ *  the first user input. See conversationSignalAnthropic for the full
+ *  rationale. */
+export function conversationSignalResponses(body: ResponsesRequestBody, headerValue?: string): string {
     if (headerValue && headerValue.trim()) return headerValue.trim();
+    if (typeof body.previous_response_id === "string" && body.previous_response_id.length > 0) {
+        return `resp-${body.previous_response_id}`;
+    }
     let seed = "default";
     if (Array.isArray(body.input)) {
         const firstUser = body.input.find(

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,7 +7,7 @@ import { fetchWithTimeout, MAX_REQUEST_BYTES } from "./fetch-util.js";
 import {
     anthropicToCore,
     coreToAnthropic,
-    deriveSessionId,
+    conversationSignalAnthropic,
     extractSystem,
     buildSystem,
     type AnthropicRequestBody,
@@ -16,7 +16,7 @@ import {
     openaiToCore,
     coreToOpenai,
     injectOpenaiSystem,
-    deriveSessionIdOpenai,
+    conversationSignalOpenai,
     condenseOldToolResults,
     type CondenseOptions,
     type OpenAIRequestBody,
@@ -28,7 +28,7 @@ import {
     responsesToCore,
     coreToResponses,
     injectResponsesInstructions,
-    deriveSessionIdResponses,
+    conversationSignalResponses,
 } from "./responses.js";
 import { getSession, listSessions, type Session, initSessions, markDirty, flushAllSessions, acquireInFlight, releaseInFlight } from "./session.js";
 import { COMPRESS_TOOL, ACP_TOOLS_OPENAI, ACP_TOOLS_RESPONSES, COMPRESS_TOOL_NAME, buildCompressSystemPrompt, buildCompressTextSystemPrompt } from "./compress-tool.js";
@@ -40,6 +40,7 @@ import { compressLoopResponsesStream } from "./compress-loop-responses.js";
 import { rewriteOpenaiJsonResponse } from "./stream-openai.js";
 import { rewriteResponsesSseStream, rewriteResponsesJsonResponse } from "./stream-responses.js";
 import { emitStreamError } from "./stream-error.js";
+import { deriveSessionId as deriveProxySessionId } from "./session-id.js";
 
 const UPSTREAM_HOP_HEADERS = new Set([
     "host",
@@ -212,19 +213,25 @@ async function handle(
             }
         }
     }
+    // Resolve the upstream route once here so both the session id (needs the
+    // upstream ORIGIN for cross-provider isolation) and forward() (needs the
+    // full rewritten URL) use the same decision. Computed before prepare() so
+    // the session can embed the provider origin.
+    const route = resolveUpstream(opts, req.url ?? "");
+    const upstreamOrigin = route ? route.upstream : opts.upstream;
     const prepared = opts.passthrough
         ? null
         : protocol === "anthropic"
-            ? prepareAnthropic(bodyBuffer, req, opts, core, reqConfig, log)
+            ? prepareAnthropic(bodyBuffer, req, opts, core, reqConfig, log, protocol, upstreamOrigin)
             : protocol === "openai"
-              ? prepareOpenai(bodyBuffer, req, opts, core, reqConfig, log)
+              ? prepareOpenai(bodyBuffer, req, opts, core, reqConfig, log, protocol, upstreamOrigin)
               : protocol === "responses"
-                ? prepareResponses(bodyBuffer, req, opts, core, reqConfig, log)
+                ? prepareResponses(bodyBuffer, req, opts, core, reqConfig, log, protocol, upstreamOrigin)
                 : null;
     const outBody: Buffer | string = prepared ? prepared.body : bodyBuffer;
     if (prepared) acquireInFlight(prepared.session);
     try {
-        await forward(req, res, opts, outBody, prepared, core, reqConfig, log);
+        await forward(req, res, opts, outBody, prepared, core, reqConfig, log, route);
     } finally {
         if (prepared) releaseInFlight(prepared.session);
     }
@@ -251,10 +258,13 @@ function prepareAnthropic(
     core: CompressionCore,
     config: Config,
     log: (level: string, msg: string) => void,
+    protocol: "anthropic" | "openai" | "responses",
+    upstreamOrigin: string,
 ): Prepared {
     const parsed = JSON.parse(bodyBuffer.toString("utf8")) as AnthropicRequestBody;
     const stream = parsed.stream === true;
-    const sessionId = deriveSessionId(parsed, headerValue(req, opts.sessionHeader));
+    const sessionHeader = headerValue(req, opts.sessionHeader);
+    const sessionId = deriveProxySessionId(req.headers, protocol, upstreamOrigin, "", { clientConversation: conversationSignalAnthropic(parsed, sessionHeader) });
     const session = getSession(sessionId);
     session.requests++;
 
@@ -305,10 +315,13 @@ function prepareOpenai(
     core: CompressionCore,
     config: Config,
     log: (level: string, msg: string) => void,
+    protocol: "anthropic" | "openai" | "responses",
+    upstreamOrigin: string,
 ): Prepared {
     const parsed = JSON.parse(bodyBuffer.toString("utf8")) as OpenAIRequestBody;
     const stream = parsed.stream === true;
-    const sessionId = deriveSessionIdOpenai(parsed, headerValue(req, opts.sessionHeader));
+    const sessionHeader = headerValue(req, opts.sessionHeader);
+    const sessionId = deriveProxySessionId(req.headers, protocol, upstreamOrigin, "", { clientConversation: conversationSignalOpenai(parsed, sessionHeader) });
     const session = getSession(sessionId);
     session.requests++;
 
@@ -369,10 +382,13 @@ function prepareResponses(
     core: CompressionCore,
     config: Config,
     log: (level: string, msg: string) => void,
+    protocol: "anthropic" | "openai" | "responses",
+    upstreamOrigin: string,
 ): Prepared {
     const parsed = JSON.parse(bodyBuffer.toString("utf8")) as ResponsesRequestBody;
     const stream = parsed.stream === true;
-    const sessionId = deriveSessionIdResponses(parsed, headerValue(req, opts.sessionHeader));
+    const sessionHeader = headerValue(req, opts.sessionHeader);
+    const sessionId = deriveProxySessionId(req.headers, protocol, upstreamOrigin, "", { clientConversation: conversationSignalResponses(parsed, sessionHeader) });
     const session = getSession(sessionId);
     session.requests++;
 
@@ -515,10 +531,26 @@ async function forward(
     core: CompressionCore,
     config: Config,
     log: (level: string, msg: string) => void,
+    route: ReturnType<typeof resolveUpstream>,
 ): Promise<void> {
-    const route = resolveUpstream(opts, req.url ?? "");
     const upstreamUrl = route ? route.rewrittenUrl : opts.upstream + (req.url ?? "");
     log("info", `forward ${req.method} ${req.url ?? ""} → ${upstreamUrl}${route ? ` (${route.provider})` : ""}`);
+    if (process.env.ACP_DEBUG && prepared) {
+        const sid = prepared.session.id;
+        const hdrKeys = Object.keys(req.headers);
+        log("info", `[${sid}] client headers: ${hdrKeys.join(",")}`);
+        for (const k of ["authorization", "x-api-key", "x-session-id", "x-session-affinity", "x-acp-session", "x-opencode-session", "prompt-cache-key", "anthropic-beta"]) {
+            const v = req.headers[k] ?? req.headers[k.toLowerCase()];
+            if (v) {
+                const s = Array.isArray(v) ? v.join(",") : String(v);
+                // Mask all but a short prefix so the header NAME is visible
+                // (so we know the key is sent and roughly how) without leaking
+                // the credential into the log.
+                const masked = /key|auth|token/i.test(k) ? s.slice(0, 8) + "..." + s.slice(-4) + ` (${s.length} chars)` : s.slice(0, 60);
+                log("info", `[${sid}] client hdr ${k}=${masked}`);
+            }
+        }
+    }
     if (opts.debug && typeof body === "string") {
         try {
             const parsed = JSON.parse(body);

--- a/src/server.ts
+++ b/src/server.ts
@@ -30,10 +30,11 @@ import {
     injectResponsesInstructions,
     deriveSessionIdResponses,
 } from "./responses.js";
-import { getSession, listSessions, type Session } from "./session.js";
+import { getSession, listSessions, type Session, initSessions, markDirty, flushAllSessions } from "./session.js";
 import { COMPRESS_TOOL, ACP_TOOLS_OPENAI, ACP_TOOLS_RESPONSES, COMPRESS_TOOL_NAME, buildCompressSystemPrompt, buildCompressTextSystemPrompt } from "./compress-tool.js";
 import { rewriteSseStream, rewriteJsonResponse, type RewriteCtx } from "./stream.js";
 import { reapOrphanBlocks } from "./orphan-gc.js";
+import { getStore } from "./persist.js";
 import { compressLoopStream } from "./compress-loop.js";
 import { compressLoopResponsesStream } from "./compress-loop-responses.js";
 import { rewriteOpenaiJsonResponse } from "./stream-openai.js";
@@ -79,10 +80,15 @@ export function resolveUpstream(opts: ProxyOptions, reqUrl: string): { upstream:
     return undefined;
 }
 
-export function startServer(opts: ProxyOptions): http.Server {
+export async function startServer(opts: ProxyOptions): Promise<http.Server> {
     const core = createCore();
     const config: Config = opts.kernelConfig;
     const log = (level: string, msg: string) => logMsg(opts, level, msg);
+    // Reload persisted compression state before accepting traffic so sessions
+    // that survived a restart keep their folded view (otherwise long sessions
+    // re-send oversized raw history and hang).
+    await initSessions();
+    log("info", `[persist] ${getStore().enabled ? "enabled" : "disabled"}`);
     const server = http.createServer(async (req, res) => {
         try {
             await handle(req, res, opts, core, config, log);
@@ -109,6 +115,21 @@ export function startServer(opts: ProxyOptions): http.Server {
                     : ` → ${opts.upstream}`),
         );
     });
+    // Graceful shutdown: flush all dirty sessions to disk so a restart does
+    // not lose recent compression state. SIGKILL/power loss cannot flush, but
+    // debounced writes keep disk within ~500ms of in-memory state.
+    let shuttingDown = false;
+    const shutdown = (sig: string) => {
+        if (shuttingDown) return;
+        shuttingDown = true;
+        log("info", `${sig} received — flushing sessions…`);
+        void flushAllSessions().finally(() => {
+            server.close();
+            process.exit(0);
+        });
+    };
+    process.on("SIGTERM", () => shutdown("SIGTERM"));
+    process.on("SIGINT", () => shutdown("SIGINT"));
     return server;
 }
 
@@ -265,7 +286,8 @@ function prepareAnthropic(
     }
 
     const rebuilt: AnthropicRequestBody = { ...parsed, messages: rebuiltMessages, system: systemOut, tools: toolsOut };
-    return { body: JSON.stringify(rebuilt), session, processedMessages, protocol: "anthropic", stream, compressInjected: opts.compress.injectTool };
+    markDirty(session);
+    return { body: JSON.stringify(rebuilt), session, processedMessages, protocol: "anthropic", stream, compressInjected: opts.compress.injectTool } as Prepared;
 }
 
 function prepareOpenai(
@@ -328,7 +350,8 @@ function prepareOpenai(
     }
 
     const rebuilt: OpenAIRequestBody = { ...parsed, messages: rebuiltMessages, tools: toolsOut as OpenAITool[] | undefined };
-    return { body: JSON.stringify(rebuilt), session, processedMessages, protocol: "openai", stream, compressInjected: shouldInject };
+    markDirty(session);
+    return { body: JSON.stringify(rebuilt), session, processedMessages, protocol: "openai", stream, compressInjected: shouldInject } as Prepared;
 }
 
 function prepareResponses(
@@ -418,7 +441,8 @@ function prepareResponses(
         });
         log("info", `[${sessionId}] responses forward tools=[${fwdTools.join(",")}] injectTool=${shouldInject} NO_INJECT_TOOL=${!!process.env.ACP_NO_INJECT_TOOL} NO_COMPRESS_PROMPT=${!!process.env.ACP_NO_COMPRESS_PROMPT}`);
     }
-    return { body: JSON.stringify(rebuilt), session, processedMessages, protocol: "responses", stream, compressInjected: shouldInject };
+    markDirty(session);
+    return { body: JSON.stringify(rebuilt), session, processedMessages, protocol: "responses", stream, compressInjected: shouldInject } as Prepared;
 }
 
 function injectSystem(
@@ -636,6 +660,9 @@ async function forward(
         }
         clearUpstreamTimer();
     }
+    // State may have mutated during response streaming (compress created a
+    // block, decompress deactivated one) — persist the final snapshot.
+    markDirty(prepared.session);
 }
 
 async function pipeThrough(stream: ReadableStream<Uint8Array>, res: http.ServerResponse): Promise<void> {

--- a/src/server.ts
+++ b/src/server.ts
@@ -265,7 +265,7 @@ function prepareAnthropic(
     const stream = parsed.stream === true;
     const sessionHeader = headerValue(req, opts.sessionHeader);
     const sessionId = deriveProxySessionId(req.headers, protocol, upstreamOrigin, "", { clientConversation: conversationSignalAnthropic(parsed, sessionHeader) });
-    const session = getSession(sessionId);
+    const session = getSession(sessionId, { protocol, upstreamOrigin });
     session.requests++;
 
     let processedMessages: CoreMessage[] = [];
@@ -322,7 +322,7 @@ function prepareOpenai(
     const stream = parsed.stream === true;
     const sessionHeader = headerValue(req, opts.sessionHeader);
     const sessionId = deriveProxySessionId(req.headers, protocol, upstreamOrigin, "", { clientConversation: conversationSignalOpenai(parsed, sessionHeader) });
-    const session = getSession(sessionId);
+    const session = getSession(sessionId, { protocol, upstreamOrigin });
     session.requests++;
 
     let processedMessages: CoreMessage[] = [];
@@ -389,7 +389,7 @@ function prepareResponses(
     const stream = parsed.stream === true;
     const sessionHeader = headerValue(req, opts.sessionHeader);
     const sessionId = deriveProxySessionId(req.headers, protocol, upstreamOrigin, "", { clientConversation: conversationSignalResponses(parsed, sessionHeader) });
-    const session = getSession(sessionId);
+    const session = getSession(sessionId, { protocol, upstreamOrigin });
     session.requests++;
 
     let processedMessages: CoreMessage[] = [];

--- a/src/server.ts
+++ b/src/server.ts
@@ -30,7 +30,7 @@ import {
     injectResponsesInstructions,
     deriveSessionIdResponses,
 } from "./responses.js";
-import { getSession, listSessions, type Session, initSessions, markDirty, flushAllSessions } from "./session.js";
+import { getSession, listSessions, type Session, initSessions, markDirty, flushAllSessions, acquireInFlight, releaseInFlight } from "./session.js";
 import { COMPRESS_TOOL, ACP_TOOLS_OPENAI, ACP_TOOLS_RESPONSES, COMPRESS_TOOL_NAME, buildCompressSystemPrompt, buildCompressTextSystemPrompt } from "./compress-tool.js";
 import { rewriteSseStream, rewriteJsonResponse, type RewriteCtx } from "./stream.js";
 import { reapOrphanBlocks } from "./orphan-gc.js";
@@ -123,8 +123,10 @@ export async function startServer(opts: ProxyOptions): Promise<http.Server> {
         if (shuttingDown) return;
         shuttingDown = true;
         log("info", `${sig} received — flushing sessions…`);
+        // Stop accepting new requests BEFORE flushing, otherwise a late request
+        // could mutate state after its snapshot is taken and be lost.
+        server.close();
         void flushAllSessions().finally(() => {
-            server.close();
             process.exit(0);
         });
     };
@@ -219,7 +221,12 @@ async function handle(
                 ? prepareResponses(bodyBuffer, req, opts, core, reqConfig, log)
                 : null;
     const outBody: Buffer | string = prepared ? prepared.body : bodyBuffer;
-    await forward(req, res, opts, outBody, prepared, core, reqConfig, log);
+    if (prepared) acquireInFlight(prepared.session);
+    try {
+        await forward(req, res, opts, outBody, prepared, core, reqConfig, log);
+    } finally {
+        if (prepared) releaseInFlight(prepared.session);
+    }
 }
 
 const ACP_TAG_MARK = "\x3cacp ";

--- a/src/server.ts
+++ b/src/server.ts
@@ -39,6 +39,7 @@ import { compressLoopStream } from "./compress-loop.js";
 import { compressLoopResponsesStream } from "./compress-loop-responses.js";
 import { rewriteOpenaiJsonResponse } from "./stream-openai.js";
 import { rewriteResponsesSseStream, rewriteResponsesJsonResponse } from "./stream-responses.js";
+import { emitStreamError } from "./stream-error.js";
 
 const UPSTREAM_HOP_HEADERS = new Set([
     "host",
@@ -572,6 +573,16 @@ async function forward(
         clearUpstreamTimer();
         return;
     }
+    // P1.2: if the upstream returned a non-2xx (auth, rate-limit, context too
+    // long, ...), do NOT route the error body through the SSE rewriter — it has
+    // no SSE events and would be silently swallowed, leaving the client with
+    // an empty stream and no idea why. Pass status + body through verbatim.
+    if (!upstream.ok) {
+        res.writeHead(upstream.status, respHeaders);
+        await pipeThrough(upstream.body, res);
+        clearUpstreamTimer();
+        return;
+    }
     const ctx: RewriteCtx = {
         core,
         config,
@@ -588,6 +599,11 @@ async function forward(
             streamToRead = a;
             dumpRaw = dumpStreamToFile(b, opts.dumpSse, `${Date.now()}-${prepared.session.id}-raw.sse`);
         }
+        // P1.1: wrap the rewriter loops in try/catch. If a rewriter throws
+        // (decompress/search edge case, JSON.parse failure, fetch abort),
+        // emitStreamError sends a protocol-appropriate error + finish so the
+        // client ends cleanly instead of seeing a bare truncated stream.
+        try {
         if (prepared.protocol === "openai") {
             const parsedReq = JSON.parse(typeof body === "string" ? body : body.toString("utf8"));
             const reqHeaders: Record<string, string> = {};
@@ -647,8 +663,12 @@ async function forward(
             }
         }
         res.end();
-        clearUpstreamTimer();
-        if (dumpRaw) await dumpRaw;
+        } catch (e) {
+            emitStreamError(res, prepared.protocol, (e as Error)?.message ?? String(e), (m) => log("error", `[${prepared.session.id}] ${m}`));
+        } finally {
+            clearUpstreamTimer();
+            if (dumpRaw) await dumpRaw;
+        }
     } else {
         const buf = await upstream.arrayBuffer();
         const text = Buffer.from(buf).toString("utf8");

--- a/src/session-id.ts
+++ b/src/session-id.ts
@@ -1,0 +1,86 @@
+import { hashId } from "./util.js";
+
+/**
+ * Session identity for the proxy's OWN compression state.
+ *
+ * A session is uniquely keyed by FOUR dimensions (all AND-ed):
+ *   1. protocol  — "anthropic" | "openai" | "responses"  (different wire
+ *                  formats must never share compression state)
+ *   2. upstream  — the resolved upstream origin, e.g. "https://open.bigmodel.cn"
+ *                  (same key hitting two providers must not share state)
+ *   3. apiKey    — the account credential from Authorization / x-api-key
+ *                  (different accounts must never share state, even if they
+ *                  happen to send the same conversation content)
+ *   4. conversation — the client's own notion of "which conversation this is",
+ *                  taken from a client-provided signal when available, falling
+ *                  back to a content fingerprint.
+ *
+ * The result is a stable, opaque id used ONLY inside the proxy (to key the
+ * compression-state store). It is NEVER sent upstream — it embeds the key and
+ * upstream origin, which the upstream either already knows or must not see.
+ *
+ * If a separate per-conversation signal is needed for upstream routing (e.g.
+ * to keep a multi-account load-balancer's prefix cache warm), use
+ * `affinityToken()` below — it is the conversation dimension alone, formatted
+ * to mirror OpenCode's `x-session-affinity` header so upstreams/LBs that
+ * understand that convention work without bespoke support.
+ */
+
+/** Extract the account credential from common auth headers, normalized. */
+function extractKey(headers: Record<string, string | string[] | undefined>): string {
+    const auth = headers["authorization"];
+    if (typeof auth === "string" && auth.length > 0) return auth.trim().toLowerCase();
+    const apiKey = headers["x-api-key"];
+    if (typeof apiKey === "string" && apiKey.length > 0) return `key:${apiKey.trim().toLowerCase()}`;
+    return "(no-key)";
+}
+
+/** Pull a client-provided conversation signal from headers, if any. */
+function clientConversationHeader(headers: Record<string, string | string[] | undefined>): string | undefined {
+    const names = ["x-session-affinity", "x-acp-session", "x-session-id", "x-opencode-session"];
+    for (const name of names) {
+        const v = headers[name];
+        if (typeof v === "string" && v.trim().length > 0) return v.trim();
+    }
+    return undefined;
+}
+
+/**
+ * Derive the proxy-internal session id. `firstUserContent` is a short prefix
+ * of the first user message in the request, used as the conversation
+ * fingerprint fallback when the client sends no session signal.
+ */
+export function deriveSessionId(
+    headers: Record<string, string | string[] | undefined>,
+    protocol: "anthropic" | "openai" | "responses",
+    upstream: string,
+    firstUserContent: string,
+    extra?: { clientConversation?: string; protocolConversation?: string },
+): string {
+    const key = extractKey(headers);
+    const convo =
+        extra?.clientConversation ??
+        extra?.protocolConversation ??
+        hashId(firstUserContent);
+    return hashId(`${protocol}|${upstream}|${key}|${convo}`);
+}
+
+/**
+ * The conversation dimension alone, formatted as OpenCode's
+ * `x-session-affinity: ses_<hash>` value. Suitable for forwarding to an
+ * upstream that understands that convention (e.g. a multi-account
+ * load-balancer doing sticky routing). Contains NO key or upstream, so it is
+ * safe to send upstream and stable across account rotations.
+ */
+export function affinityToken(
+    headers: Record<string, string | string[] | undefined>,
+    firstUserContent: string,
+    protocolConversation?: string,
+): string {
+    const client = clientConversationHeader(headers);
+    if (client) return client;
+    const convo = protocolConversation ?? hashId(firstUserContent);
+    return `ses_${convo}`;
+}
+
+export { clientConversationHeader };

--- a/src/session.ts
+++ b/src/session.ts
@@ -1,4 +1,10 @@
 import { createInitialState, type CompressionState } from "acp-kernel";
+import { getStore } from "./persist.js";
+
+export type BlockContent = {
+    one: { text: string; count: number };
+    full: { text: string; count: number };
+};
 
 export type Session = {
     id: string;
@@ -15,31 +21,46 @@ export type Session = {
      *  Two views are cached: `one` (one-level: direct messages + nested
      *  child summaries) and `full` (all original messages), matching the
      *  collectBlockContent full flag semantics. */
-    blockContents: Map<string, {
-        one: { text: string; count: number };
-        full: { text: string; count: number };
-    }>;
+    blockContents: Map<string, BlockContent>;
 };
 
-// KNOWN LIMITATION: sessions live in process memory. A proxy restart (deploy /
-// crash) drops all compression state — clients then re-send full history and
-// compression rebuilds from scratch (correct, but wasteful). Multi-instance
-// deployments do NOT share state either.
-// TODO: persist state to disk (atomic temp+rename) on a debounce and reload on
-// boot, keyed by session id. Requires verifying CompressionState is fully
-// JSON-serializable (no Maps/Sets that lose on round-trip).
-// Session id defaults to a hash of the first user message (deriveSessionId*),
-// so two clients with the same opener collide into one state. Multi-tenant
-// deployments MUST send an explicit x-acp-session header to partition.
 const sessions = new Map<string, Session>();
 
-const MAX_SESSIONS = 256;
+const MAX_SESSIONS = Number.parseInt(process.env.BILI_MAX_SESSIONS ?? "256", 10) || 256;
+/** Approximate per-session byte cap for blockContents originals. When exceeded
+ *  the oldest block's contents are dropped (the block summary stays; decompress
+ *  degrades to returning the summary instead of originals). Bounds memory for
+ *  very long sessions. */
+const BLOCK_CONTENTS_BYTES_CAP = Number.parseInt(process.env.BILI_BLOCK_CACHE_BYTES ?? String(64 * 1024 * 1024), 10) || 64 * 1024 * 1024;
+
+let initialized = false;
+
+/** Bulk-load all persisted sessions from disk into the in-memory map. Called
+ *  once at server startup before listening. Idempotent. */
+export async function initSessions(): Promise<void> {
+    if (initialized) return;
+    initialized = true;
+    const store = getStore();
+    if (!store.enabled) return;
+    const loaded = await store.loadAll();
+    for (const [id, s] of loaded) {
+        if (!sessions.has(id)) sessions.set(id, s);
+    }
+}
 
 export function getSession(id: string): Session {
     const existing = sessions.get(id);
     if (existing) {
         existing.lastSeen = Date.now();
         return existing;
+    }
+    // Memory miss: try reload from disk (e.g. after LRU eviction + restart).
+    const store = getStore();
+    const reloaded = store.loadSync(id);
+    if (reloaded) {
+        reloaded.lastSeen = Date.now();
+        sessions.set(id, reloaded);
+        return reloaded;
     }
     if (sessions.size >= MAX_SESSIONS) evictOldest();
     const session: Session = {
@@ -60,6 +81,21 @@ export function listSessions(): Session[] {
     return [...sessions.values()].sort((a, b) => b.lastSeen - a.lastSeen);
 }
 
+/** Mark a session's state as changed so it is persisted on the next debounce.
+ *  Call this after any mutation (processTurn, compress, decompress, orphan GC). */
+export function markDirty(session: Session): void {
+    getStore().scheduleSave(session);
+}
+
+/** Record original block content at compress time and enforce the per-session
+ *  memory cap. When the cap is exceeded, the oldest block's contents are
+ *  dropped (block summary stays active; decompress degrades to summary). */
+export function cacheBlockContent(session: Session, blockId: string, content: BlockContent): void {
+    session.blockContents.set(blockId, content);
+    enforceBlockCacheCap(session);
+}
+
+/** Flush a session to disk and drop it from memory (LRU eviction). */
 function evictOldest(): void {
     let oldestId: string | undefined;
     let oldestSeen = Infinity;
@@ -69,5 +105,36 @@ function evictOldest(): void {
             oldestId = id;
         }
     }
-    if (oldestId) sessions.delete(oldestId);
+    if (oldestId) {
+        const s = sessions.get(oldestId);
+        if (s) getStore().flushSync(s);
+        sessions.delete(oldestId);
+    }
+}
+
+/** Drop oldest blockContents entries until under the byte cap. */
+function enforceBlockCacheCap(session: Session): void {
+    if (session.blockContents.size === 0) return;
+    let bytes = 0;
+    for (const c of session.blockContents.values()) {
+        bytes += c.one.text.length + c.full.text.length;
+    }
+    if (bytes <= BLOCK_CONTENTS_BYTES_CAP) return;
+    // Evict oldest by createdAt of the block (fall back to insertion order).
+    const ordered = [...session.blockContents.entries()].sort(([, a], [, b]) => {
+        const ta = a.one.count + a.full.count;
+        const tb = b.one.count + b.full.count;
+        return ta - tb;
+    });
+    for (const [bid] of ordered) {
+        if (bytes <= BLOCK_CONTENTS_BYTES_CAP) break;
+        const c = session.blockContents.get(bid);
+        if (c) bytes -= c.one.text.length + c.full.text.length;
+        session.blockContents.delete(bid);
+    }
+}
+
+/** Graceful shutdown: flush all sessions with pending writes. */
+export async function flushAllSessions(): Promise<void> {
+    await getStore().flushAll(sessions.values());
 }

--- a/src/session.ts
+++ b/src/session.ts
@@ -20,33 +20,46 @@ export type Session = {
      *  post-compression / folded view and loses originals across rounds).
      *  Two views are cached: `one` (one-level: direct messages + nested
      *  child summaries) and `full` (all original messages), matching the
-     *  collectBlockContent full flag semantics. */
+     *  collectBlockContent full flag semantics.
+     *  Unbounded in memory by design — block summaries are small relative to
+     *  the history they replace, and disk persistence keeps the source of
+     *  truth; the MAX_SESSIONS cap bounds the number of concurrent sessions
+     *  in memory. See persist.ts. */
     blockContents: Map<string, BlockContent>;
+    /** Number of in-flight requests using this session. A session with
+     *  inFlight > 0 must NOT be LRU-evicted: evicting it mid-stream flushes a
+     *  half-mutated snapshot and then a miss reloads a SECOND Session object,
+     *  causing split-brain writes to the same file. See persist.ts M5. */
+    inFlight: number;
+    /** False until the first successful write to disk. evictOldest will not
+     *  drop a never-persisted session on flush failure (that would be a
+     *  permanent loss). */
+    persisted: boolean;
 };
 
 const sessions = new Map<string, Session>();
 
 const MAX_SESSIONS = Number.parseInt(process.env.BILI_MAX_SESSIONS ?? "256", 10) || 256;
-/** Approximate per-session byte cap for blockContents originals. When exceeded
- *  the oldest block's contents are dropped (the block summary stays; decompress
- *  degrades to returning the summary instead of originals). Bounds memory for
- *  pathological sessions; disk persistence holds everything regardless. A large
- *  default (512MB) so normal long sessions never hit it — disk is cheap, and
- *  losing block originals silently degrades decompress quality. */
-const BLOCK_CONTENTS_BYTES_CAP = Number.parseInt(process.env.BILI_BLOCK_CACHE_BYTES ?? String(512 * 1024 * 1024), 10) || 512 * 1024 * 1024;
 
 let initialized = false;
 
-/** Bulk-load all persisted sessions from disk into the in-memory map. Called
- *  once at server startup before listening. Idempotent. */
+/** Bulk-load persisted sessions from disk into the in-memory map. Called once
+ *  at server startup before listening. Caps at MAX_SESSIONS by savedAt
+ *  (keeps the most recent) so a huge backlog cannot OOM on boot. Idempotent. */
 export async function initSessions(): Promise<void> {
     if (initialized) return;
     initialized = true;
     const store = getStore();
     if (!store.enabled) return;
     const loaded = await store.loadAll();
-    for (const [id, s] of loaded) {
-        if (!sessions.has(id)) sessions.set(id, s);
+    if (loaded.size > MAX_SESSIONS) {
+        const entries = [...loaded.entries()].sort((a, b) => (b[1].createdAt ?? 0) - (a[1].createdAt ?? 0));
+        for (const [id, s] of entries) {
+            if (sessions.size >= MAX_SESSIONS) break;
+            sessions.set(id, s);
+        }
+    } else {
+        for (const [id, s] of loaded) sessions.set(id, s);
     }
 }
 
@@ -56,11 +69,12 @@ export function getSession(id: string): Session {
         existing.lastSeen = Date.now();
         return existing;
     }
-    // Memory miss: try reload from disk (e.g. after LRU eviction + restart).
+    // Memory miss: try reload from disk (e.g. after LRU eviction).
     const store = getStore();
     const reloaded = store.loadSync(id);
     if (reloaded) {
         reloaded.lastSeen = Date.now();
+        reloaded.persisted = true;
         sessions.set(id, reloaded);
         return reloaded;
     }
@@ -74,9 +88,22 @@ export function getSession(id: string): Session {
         condensedToolResults: 0,
         tokensSaved: 0,
         blockContents: new Map(),
+        inFlight: 0,
+        persisted: false,
     };
     sessions.set(id, session);
     return session;
+}
+
+/** Mark a session as in-use by a request. Must be paired with releaseInFlight.
+ *  Prevents LRU eviction of a session mid-stream. */
+export function acquireInFlight(session: Session): void {
+    session.inFlight++;
+}
+
+/** Release an in-use marker. Decrements; the session becomes evictable again. */
+export function releaseInFlight(session: Session): void {
+    if (session.inFlight > 0) session.inFlight--;
 }
 
 export function listSessions(): Session[] {
@@ -89,51 +116,36 @@ export function markDirty(session: Session): void {
     getStore().scheduleSave(session);
 }
 
-/** Record original block content at compress time and enforce the per-session
- *  memory cap. When the cap is exceeded, the oldest block's contents are
- *  dropped (block summary stays active; decompress degrades to summary). */
+/** Record original block content at compress time. */
 export function cacheBlockContent(session: Session, blockId: string, content: BlockContent): void {
     session.blockContents.set(blockId, content);
-    enforceBlockCacheCap(session);
 }
 
-/** Flush a session to disk and drop it from memory (LRU eviction). */
+/** Flush a session to disk and drop it from memory (LRU eviction). Refuses to
+ *  evict sessions that are in-flight or whose flush failed (would lose a
+ *  never-persisted session permanently). */
 function evictOldest(): void {
     let oldestId: string | undefined;
     let oldestSeen = Infinity;
     for (const [id, s] of sessions) {
+        // Never evict a session being actively mutated by a request — flushing
+        // its half-mutated state then reloading a second object causes
+        // split-brain writes to the same file.
+        if (s.inFlight > 0) continue;
         if (s.lastSeen < oldestSeen) {
             oldestSeen = s.lastSeen;
             oldestId = id;
         }
     }
-    if (oldestId) {
-        const s = sessions.get(oldestId);
-        if (s) getStore().flushSync(s);
-        sessions.delete(oldestId);
+    if (!oldestId) return;
+    const s = sessions.get(oldestId)!;
+    const ok = getStore().flushSync(s);
+    if (!ok && !s.persisted) {
+        // Flush failed AND this session was never written to disk — evicting
+        // would permanently lose it. Keep it in memory instead.
+        return;
     }
-}
-
-/** Drop oldest blockContents entries until under the byte cap. */
-function enforceBlockCacheCap(session: Session): void {
-    if (session.blockContents.size === 0) return;
-    let bytes = 0;
-    for (const c of session.blockContents.values()) {
-        bytes += c.one.text.length + c.full.text.length;
-    }
-    if (bytes <= BLOCK_CONTENTS_BYTES_CAP) return;
-    // Evict oldest by createdAt of the block (fall back to insertion order).
-    const ordered = [...session.blockContents.entries()].sort(([, a], [, b]) => {
-        const ta = a.one.count + a.full.count;
-        const tb = b.one.count + b.full.count;
-        return ta - tb;
-    });
-    for (const [bid] of ordered) {
-        if (bytes <= BLOCK_CONTENTS_BYTES_CAP) break;
-        const c = session.blockContents.get(bid);
-        if (c) bytes -= c.one.text.length + c.full.text.length;
-        session.blockContents.delete(bid);
-    }
+    sessions.delete(oldestId);
 }
 
 /** Graceful shutdown: flush all sessions with pending writes. */

--- a/src/session.ts
+++ b/src/session.ts
@@ -30,8 +30,10 @@ const MAX_SESSIONS = Number.parseInt(process.env.BILI_MAX_SESSIONS ?? "256", 10)
 /** Approximate per-session byte cap for blockContents originals. When exceeded
  *  the oldest block's contents are dropped (the block summary stays; decompress
  *  degrades to returning the summary instead of originals). Bounds memory for
- *  very long sessions. */
-const BLOCK_CONTENTS_BYTES_CAP = Number.parseInt(process.env.BILI_BLOCK_CACHE_BYTES ?? String(64 * 1024 * 1024), 10) || 64 * 1024 * 1024;
+ *  pathological sessions; disk persistence holds everything regardless. A large
+ *  default (512MB) so normal long sessions never hit it — disk is cheap, and
+ *  losing block originals silently degrades decompress quality. */
+const BLOCK_CONTENTS_BYTES_CAP = Number.parseInt(process.env.BILI_BLOCK_CACHE_BYTES ?? String(512 * 1024 * 1024), 10) || 512 * 1024 * 1024;
 
 let initialized = false;
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -8,6 +8,12 @@ export type BlockContent = {
 
 export type Session = {
     id: string;
+    /** Protocol + upstream origin this session belongs to. Captured at first
+     *  request and persisted, so the on-disk filename can be namespaced by
+     *  protocol/provider (e.g. sessions/anthropic/bailian_<hash>.json) and a
+     *  human can tell sessions apart at a glance. */
+    protocol?: "anthropic" | "openai" | "responses";
+    upstreamOrigin?: string;
     state: CompressionState;
     createdAt: number;
     lastSeen: number;
@@ -63,15 +69,19 @@ export async function initSessions(): Promise<void> {
     }
 }
 
-export function getSession(id: string): Session {
+export function getSession(id: string, meta?: { protocol?: Session["protocol"]; upstreamOrigin?: string }): Session {
     const existing = sessions.get(id);
     if (existing) {
         existing.lastSeen = Date.now();
+        // Fill in protocol/upstream meta on an existing session if the caller
+        // now knows it (e.g. a session was created by loadAll without meta).
+        if (meta?.protocol && !existing.protocol) existing.protocol = meta.protocol;
+        if (meta?.upstreamOrigin && !existing.upstreamOrigin) existing.upstreamOrigin = meta.upstreamOrigin;
         return existing;
     }
     // Memory miss: try reload from disk (e.g. after LRU eviction).
     const store = getStore();
-    const reloaded = store.loadSync(id);
+    const reloaded = store.loadSync(id, meta);
     if (reloaded) {
         reloaded.lastSeen = Date.now();
         reloaded.persisted = true;
@@ -81,6 +91,8 @@ export function getSession(id: string): Session {
     if (sessions.size >= MAX_SESSIONS) evictOldest();
     const session: Session = {
         id,
+        protocol: meta?.protocol,
+        upstreamOrigin: meta?.upstreamOrigin,
         state: createInitialState(),
         createdAt: Date.now(),
         lastSeen: Date.now(),

--- a/src/stream-error.ts
+++ b/src/stream-error.ts
@@ -1,0 +1,60 @@
+import type http from "node:http";
+
+/**
+ * Emit a minimal SSE error + finish sequence so a streaming client sees the
+ * failure and ends cleanly, instead of a bare socket close.
+ *
+ * WHY: server.ts forward() routes streams through protocol rewriters
+ * (rewriteSseStream / compressLoopStream / compressLoopResponsesStream). If a
+ * rewriter throws (e.g. executeProxyTool hits an edge case, JSON.parse fails),
+ * the `for await` loop aborts and — without this — `res.end()` is skipped,
+ * leaving the client with a truncated stream and no finish event. The request
+ * handler wraps each loop in try/catch and calls this on failure.
+ *
+ * Format per protocol:
+ *  - openai:    a `choices[].delta` with the error text, then a `finish_reason:
+ *               "stop"` chunk, then `data: [DONE]`.
+ *  - anthropic: a `content_block_delta` text_delta, then `message_stop`.
+ *  - responses: `response.output_text.delta`, then `response.completed`.
+ *
+ * Best-effort: if writing the error itself throws (client already gone), we
+ * still attempt res.end(). Never throws.
+ */
+
+type Protocol = "anthropic" | "openai" | "responses";
+
+function safeWrite(res: http.ServerResponse, chunk: string): void {
+    try {
+        res.write(chunk);
+    } catch {
+        /* client gone */
+    }
+}
+
+export function emitStreamError(res: http.ServerResponse, protocol: Protocol, message: string, log?: (msg: string) => void): void {
+    const visible = `\n\u274c [ACP] stream error: ${message}`;
+    log?.(`[acp-proxy: stream aborted mid-response: ${message}]`);
+    try {
+        if (protocol === "openai") {
+            safeWrite(res, `data: ${JSON.stringify({ choices: [{ index: 0, delta: { content: visible }, finish_reason: null }] })}\n\n`);
+            safeWrite(res, `data: ${JSON.stringify({ choices: [{ index: 0, delta: {}, finish_reason: "stop" }] })}\n\n`);
+            safeWrite(res, "data: [DONE]\n\n");
+        } else if (protocol === "responses") {
+            safeWrite(res, `event: response.output_text.delta\ndata: ${JSON.stringify({ type: "response.output_text.delta", delta: visible })}\n\n`);
+            safeWrite(res, `event: response.completed\ndata: ${JSON.stringify({ type: "response.completed", response: { status: "completed", output: [] } })}\n\n`);
+        } else {
+            // anthropic
+            safeWrite(res, `event: content_block_delta\ndata: ${JSON.stringify({ type: "content_block_delta", delta: { type: "text_delta", text: visible } })}\n\n`);
+            safeWrite(res, `event: message_delta\ndata: ${JSON.stringify({ type: "message_delta", delta: { stop_reason: "end_turn" } })}\n\n`);
+            safeWrite(res, `event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`);
+        }
+    } catch {
+        /* best-effort */
+    } finally {
+        try {
+            res.end();
+        } catch {
+            /* already closed */
+        }
+    }
+}

--- a/src/stream-openai.ts
+++ b/src/stream-openai.ts
@@ -3,6 +3,7 @@ import type { Session } from "./session.js";
 import { COMPRESS_TOOL_NAME, parseCompressInput } from "./compress-tool.js";
 import { applyRanges, type RewriteCtx } from "./stream.js";
 import { normalizeSseLineEndings } from "./sse-util.js";
+import { safeJsonParse } from "./util.js";
 
 type StreamState = {
     compressIndices: Set<number>;
@@ -164,14 +165,6 @@ function extractDataLine(rawEvent: string): string | null {
         }
     }
     return null;
-}
-
-function safeJsonParse(s: string): unknown {
-    try {
-        return s ? JSON.parse(s) : {};
-    } catch {
-        return {};
-    }
 }
 
 export function rewriteOpenaiJsonResponse(body: unknown, ctx: RewriteCtx): unknown {

--- a/src/stream-responses.ts
+++ b/src/stream-responses.ts
@@ -3,6 +3,7 @@ import type { Session } from "./session.js";
 import { COMPRESS_TOOL_NAME, parseCompressInput, ACP_TEXT_OPEN, ACP_TEXT_CLOSE } from "./compress-tool.js";
 import { applyRanges, type RewriteCtx } from "./stream.js";
 import { normalizeSseLineEndings } from "./sse-util.js";
+import { safeJsonParse } from "./util.js";
 
 /** Text-protocol mode mirrors the server flag so the rewriter only does text
  *  trigger detection when the host cannot coexist with a declared `tools`
@@ -307,14 +308,6 @@ function extractEventType(rawEvent: string): string | null {
         }
     }
     return null;
-}
-
-function safeJsonParse(s: string): unknown {
-    try {
-        return s ? JSON.parse(s) : {};
-    } catch {
-        return {};
-    }
 }
 
 export function rewriteResponsesJsonResponse(body: unknown, ctx: RewriteCtx): unknown {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1,5 +1,5 @@
 import { collectBlockContent, type CompressionCore, type Config, type CoreMessage, type CompressionState } from "acp-kernel";
-import type { Session } from "./session.js";
+import { type Session, cacheBlockContent } from "./session.js";
 import { COMPRESS_TOOL_NAME, parseCompressInput } from "./compress-tool.js";
 import { normalizeSseLineEndings } from "./sse-util.js";
 
@@ -177,7 +177,7 @@ export function applyRanges(ranges: ReturnType<typeof parseCompressInput>, ctx: 
             const full = collectBlockContent(res.state, b, ctx.messages, { full: true });
             const one = collectBlockContent(res.state, b, ctx.messages, { full: false });
             if (full.count > 0 || one.count > 0) {
-                ctx.session.blockContents.set(b.blockId, {
+                cacheBlockContent(ctx.session, b.blockId, {
                     one: { text: one.text, count: one.count },
                     full: { text: full.text, count: full.count },
                 });

--- a/src/util.ts
+++ b/src/util.ts
@@ -20,3 +20,13 @@ import { createHash } from "node:crypto";
 export function hashId(s: string): string {
     return createHash("sha256").update(s, "utf8").digest("hex").slice(0, 16);
 }
+
+/** Parse JSON without throwing; returns {} for empty/invalid input. Used to
+ *  tolerate malformed tool-call arguments and debug payloads. */
+export function safeJsonParse(s: string): unknown {
+    try {
+        return s ? JSON.parse(s) : {};
+    } catch {
+        return {};
+    }
+}

--- a/tests/basic.test.ts
+++ b/tests/basic.test.ts
@@ -4,7 +4,7 @@ import {
     anthropicToCore,
     coreToAnthropic,
     condenseOldToolResults,
-    deriveSessionId,
+    conversationSignalAnthropic,
     type AnthropicRequestBody,
 } from "../src/anthropic.js";
 import {
@@ -18,7 +18,7 @@ import {
     openaiToCore,
     coreToOpenai,
     injectOpenaiSystem,
-    deriveSessionIdOpenai,
+    conversationSignalOpenai,
     type OpenAIRequestBody,
 } from "../src/openai.js";
 
@@ -86,18 +86,18 @@ test("condenseOldToolResults respects keepRecent", () => {
     assert.ok(!second.includes("[acp-proxy: condensed"));
 });
 
-test("deriveSessionId is stable for same first message, differs otherwise", () => {
+test("conversationSignalAnthropic is stable for same first message, differs otherwise", () => {
     const body = bigToolResult("hello");
-    const a = deriveSessionId(body);
-    const b = deriveSessionId(body);
+    const a = conversationSignalAnthropic(body);
+    const b = conversationSignalAnthropic(body);
     assert.equal(a, b);
     const other = { ...body, messages: [{ role: "user", content: "different" }] };
-    assert.notEqual(a, deriveSessionId(other));
+    assert.notEqual(a, conversationSignalAnthropic(other));
 });
 
-test("deriveSessionId prefers explicit header", () => {
+test("conversationSignalAnthropic prefers explicit header", () => {
     const body = bigToolResult("hello");
-    const fromHeader = deriveSessionId(body, "my-session-id");
+    const fromHeader = conversationSignalAnthropic(body, "my-session-id");
     assert.equal(fromHeader, "my-session-id");
 });
 
@@ -220,14 +220,14 @@ test("COMPRESS_TOOL_OPENAI is function-wrapped and named compress", () => {
     assert.ok(COMPRESS_TOOL_OPENAI.function.parameters, "must have parameters schema");
 });
 
-test("deriveSessionIdOpenai prefers explicit header", () => {
-    const id = deriveSessionIdOpenai(openaiBody(), "my-session");
+test("conversationSignalOpenai prefers explicit header", () => {
+    const id = conversationSignalOpenai(openaiBody(), "my-session");
     assert.equal(id, "my-session");
 });
 
-test("deriveSessionIdOpenai is stable for same first-user content", () => {
-    const a = deriveSessionIdOpenai(openaiBody());
-    const b = deriveSessionIdOpenai(openaiBody());
+test("conversationSignalOpenai is stable for same first-user content", () => {
+    const a = conversationSignalOpenai(openaiBody());
+    const b = conversationSignalOpenai(openaiBody());
     assert.equal(a, b);
     assert.ok(a.length > 0);
 });

--- a/tests/proxy-basic.test.ts
+++ b/tests/proxy-basic.test.ts
@@ -4,7 +4,7 @@ import {
     anthropicToCore,
     coreToAnthropic,
     condenseOldToolResults,
-    deriveSessionId,
+    conversationSignalAnthropic,
     type AnthropicRequestBody,
 } from "../src/anthropic.js";
 import {
@@ -18,7 +18,7 @@ import {
     openaiToCore,
     coreToOpenai,
     injectOpenaiSystem,
-    deriveSessionIdOpenai,
+    conversationSignalOpenai,
     type OpenAIRequestBody,
 } from "../src/openai.js";
 
@@ -88,16 +88,16 @@ test("condenseOldToolResults respects keepRecent", () => {
 
 test("deriveSessionId is stable for same first message, differs otherwise", () => {
     const body = bigToolResult("hello");
-    const a = deriveSessionId(body);
-    const b = deriveSessionId(body);
+    const a = conversationSignalAnthropic(body);
+    const b = conversationSignalAnthropic(body);
     assert.equal(a, b);
     const other = { ...body, messages: [{ role: "user" as const, content: "different" }] };
-    assert.notEqual(a, deriveSessionId(other));
+    assert.notEqual(a, conversationSignalAnthropic(other));
 });
 
 test("deriveSessionId prefers explicit header", () => {
     const body = bigToolResult("hello");
-    const fromHeader = deriveSessionId(body, "my-session-id");
+    const fromHeader = conversationSignalAnthropic(body, "my-session-id");
     assert.equal(fromHeader, "my-session-id");
 });
 
@@ -221,13 +221,13 @@ test("COMPRESS_TOOL_OPENAI is function-wrapped and named compress", () => {
 });
 
 test("deriveSessionIdOpenai prefers explicit header", () => {
-    const id = deriveSessionIdOpenai(openaiBody(), "my-session");
+    const id = conversationSignalOpenai(openaiBody(), "my-session");
     assert.equal(id, "my-session");
 });
 
 test("deriveSessionIdOpenai is stable for same first-user content", () => {
-    const a = deriveSessionIdOpenai(openaiBody());
-    const b = deriveSessionIdOpenai(openaiBody());
+    const a = conversationSignalOpenai(openaiBody());
+    const b = conversationSignalOpenai(openaiBody());
     assert.equal(a, b);
     assert.ok(a.length > 0);
 });

--- a/tests/proxy-persist.test.ts
+++ b/tests/proxy-persist.test.ts
@@ -118,20 +118,25 @@ await withTempStore("flushAll flushes all pending debounce writes", async (store
 
 await withTempStore("corrupt file is skipped by loadAll (no crash)", async (store, dir) => {
     const { writeFileSync } = await import("node:fs");
-    writeFileSync(join(dir, "good.json"), JSON.stringify({ version: 1, id: "good", createdAt: 0, requests: 0, condensedToolResults: 0, tokensSaved: 0, state: createInitialState(), blockContents: {} }));
+    // Write a valid file via the store so the filename matches the body id
+    // (loadAll verifies fileNameFor(id) === name).
+    await store.writeNow(makeSession("good"));
     writeFileSync(join(dir, "corrupt.json"), "{ this is not valid json");
     const all = await store.loadAll();
     assert.equal(all.size, 1);
     assert.ok(all.has("good"));
 });
 
-await withTempStore("unsafe session id is sanitized in filename but preserved in content", async (store, dir) => {
-    const s = makeSession("../../etc/passwd"); // path-traversal attempt
-    await store.writeNow(s);
-    const files = readdirSync(dir);
-    assert.ok(files.every((f) => !f.includes("..")), "no traversal segments in filename");
-    const loaded = store.loadSync("../../etc/passwd");
-    assert.equal(loaded!.id, "../../etc/passwd", "real id preserved inside file");
+await withTempStore("collision-prone ids do NOT share a file (hashed names)", async (store, dir) => {
+    // A naive sanitizer would map both to "a_b" → one file, cross-contamination.
+    const s2 = makeSession("a_b");
+    const s3 = makeSession("a/b");
+    await store.writeNow(s2);
+    await store.writeNow(s3);
+    const jsonFiles = readdirSync(dir).filter((f) => f.endsWith(".json"));
+    assert.equal(jsonFiles.length, 2, "distinct ids → distinct files");
+    assert.ok(store.loadSync("a_b")!.id === "a_b");
+    assert.ok(store.loadSync("a/b")!.id === "a/b");
 });
 
 await withTempStore("disabled store writes nothing", async () => {
@@ -146,4 +151,54 @@ await withTempStore("disabled store writes nothing", async () => {
     } finally {
         rmSync(dir, { recursive: true, force: true });
     }
+});
+
+await withTempStore("flushSync returns true on success, false on failure", async (store, dir) => {
+    const s = makeSession("flush-bool");
+    assert.equal(store.flushSync(s), true, "returns true on success");
+    // Make the directory a file to force write failure.
+    const { rmSync, writeFileSync: wf } = await import("node:fs");
+    rmSync(dir, { recursive: true, force: true });
+    wf(dir, "block", "utf8"); // dir path is now a file → mkdir/write fails
+    assert.equal(store.flushSync(makeSession("flush-bool-2")), false, "returns false on write failure");
+});
+
+await withTempStore("loadSync returns null when body id does not match", async (store, dir) => {
+    const { writeFileSync: wf } = await import("node:fs");
+    // Hand-write a file whose name hashes to "real-id" but body says "fake-id".
+    const real = makeSession("real-id");
+    await store.writeNow(real);
+    const file = readdirSync(dir)[0];
+    const parsed = JSON.parse(readFileSync(join(dir, file), "utf8"));
+    parsed.id = "different-id";
+    wf(join(dir, file), JSON.stringify(parsed));
+    // Asking for "real-id" finds the file by hash, but body id mismatches → null.
+    assert.equal(store.loadSync("real-id"), null, "body id mismatch rejected");
+});
+
+await withTempStore("loadAll skips file whose filename does not match body id", async (store, dir) => {
+    const { renameSync: rn } = await import("node:fs");
+    await store.writeNow(makeSession("legit"));
+    // Rename the legit file to a name that doesn't match any body id.
+    const files = readdirSync(dir);
+    rn(join(dir, files[0]), join(dir, "mismatched.json"));
+    const all = await store.loadAll();
+    assert.equal(all.size, 0, "filename/body mismatch rejected at loadAll");
+});
+
+await withTempStore("temp files are unique per write (no rename collision)", async (store) => {
+    // Two rapid writeNow calls must not share a temp file.
+    const s = makeSession("uniq-tmp");
+    await Promise.all([store.writeNow(s), store.writeNow(s), store.writeNow(s)]);
+    // All three completed without throwing ENOENT on rename.
+    assert.ok(store.loadSync("uniq-tmp"));
+});
+
+await withTempStore("hasPending reflects the debounce timer", async (store) => {
+    const s = makeSession("pending-check");
+    assert.equal(store.hasPending(s.id), false);
+    store.scheduleSave(s);
+    assert.equal(store.hasPending(s.id), true);
+    await settle();
+    assert.equal(store.hasPending(s.id), false);
 });

--- a/tests/proxy-persist.test.ts
+++ b/tests/proxy-persist.test.ts
@@ -1,0 +1,149 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, readdirSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SessionStore } from "../src/persist.ts";
+import { createInitialState } from "acp-kernel";
+import type { Session, BlockContent } from "../src/session.ts";
+
+function makeSession(id: string): Session {
+    return {
+        id,
+        state: createInitialState(),
+        createdAt: Date.now(),
+        lastSeen: Date.now(),
+        requests: 0,
+        condensedToolResults: 0,
+        tokensSaved: 0,
+        blockContents: new Map(),
+    };
+}
+
+function withTempStore<T>(name: string, fn: (store: SessionStore, dir: string) => Promise<T> | T): Promise<T> {
+    return test(name, async () => {
+        const dir = mkdtempSync(join(tmpdir(), "bili-persist-"));
+        const store = new SessionStore({ dir, debounceMs: 5, enabled: true });
+        try {
+            await fn(store, dir);
+        } finally {
+            store.cancelAll();
+            rmSync(dir, { recursive: true, force: true });
+        }
+    }) as unknown as Promise<T>;
+}
+
+async function settle(ms = 30): Promise<void> {
+    await new Promise((r) => setTimeout(r, ms));
+}
+
+await withTempStore("writeNow round-trips state + blockContents", async (store, dir) => {
+    const s = makeSession("sess-1");
+    s.requests = 42;
+    s.tokensSaved = 1234;
+    s.state.nextBlockId = 7;
+    const content: BlockContent = { one: { text: "one-text", count: 3 }, full: { text: "full-text", count: 9 } };
+    s.blockContents.set("b1", content);
+
+    await store.writeNow(s);
+
+    const files = readdirSync(dir);
+    assert.ok(files.some((f) => f.endsWith(".json")), "a session json file was written");
+    const raw = JSON.parse(readFileSync(join(dir, files[0]), "utf8"));
+    assert.equal(raw.id, "sess-1");
+    assert.equal(raw.requests, 42);
+    assert.equal(raw.tokensSaved, 1234);
+    assert.equal(raw.state.nextBlockId, 7);
+    assert.deepEqual(raw.blockContents.b1, { one: { text: "one-text", count: 3 }, full: { text: "full-text", count: 9 } });
+});
+
+await withTempStore("loadSync restores a persisted session", async (store) => {
+    const s = makeSession("sess-2");
+    s.tokensSaved = 999;
+    s.state.nextBlockId = 3;
+    await store.writeNow(s);
+
+    const loaded = store.loadSync("sess-2");
+    assert.ok(loaded, "loaded from disk");
+    assert.equal(loaded!.id, "sess-2");
+    assert.equal(loaded!.tokensSaved, 999);
+    assert.equal(loaded!.state.nextBlockId, 3);
+    assert.ok(loaded!.blockContents instanceof Map, "blockContents restored as a Map");
+});
+
+await withTempStore("loadSync returns null for unknown id", async (store) => {
+    assert.equal(store.loadSync("does-not-exist"), null);
+});
+
+await withTempStore("scheduleSave debounces and eventually writes", async (store, dir) => {
+    const s = makeSession("debounce-1");
+    s.requests = 1;
+    store.scheduleSave(s);
+    s.requests = 2; // mutate again before timer fires → should coalesce
+    store.scheduleSave(s);
+    s.requests = 3;
+    store.scheduleSave(s);
+    await settle();
+    assert.equal(readdirSync(dir).length, 1, "exactly one write happened");
+    const loaded = store.loadSync("debounce-1");
+    assert.equal(loaded!.requests, 3, "latest value persisted");
+});
+
+await withTempStore("loadAll bulk-loads every session from disk", async (store) => {
+    await store.writeNow(makeSession("a"));
+    await store.writeNow(makeSession("b"));
+    await store.writeNow(makeSession("c"));
+    const all = await store.loadAll();
+    assert.equal(all.size, 3);
+    assert.ok(all.has("a") && all.has("b") && all.has("c"));
+});
+
+await withTempStore("flushSync writes immediately (for eviction)", async (store, dir) => {
+    const s = makeSession("evict-1");
+    s.tokensSaved = 555;
+    store.flushSync(s);
+    assert.equal(readdirSync(dir).length, 1);
+    assert.equal(store.loadSync("evict-1")!.tokensSaved, 555);
+});
+
+await withTempStore("flushAll flushes all pending debounce writes", async (store) => {
+    const a = makeSession("fa-1");
+    const b = makeSession("fa-2");
+    store.scheduleSave(a);
+    store.scheduleSave(b);
+    await store.flushAll([a, b]);
+    assert.ok(store.loadSync("fa-1"));
+    assert.ok(store.loadSync("fa-2"));
+});
+
+await withTempStore("corrupt file is skipped by loadAll (no crash)", async (store, dir) => {
+    const { writeFileSync } = await import("node:fs");
+    writeFileSync(join(dir, "good.json"), JSON.stringify({ version: 1, id: "good", createdAt: 0, requests: 0, condensedToolResults: 0, tokensSaved: 0, state: createInitialState(), blockContents: {} }));
+    writeFileSync(join(dir, "corrupt.json"), "{ this is not valid json");
+    const all = await store.loadAll();
+    assert.equal(all.size, 1);
+    assert.ok(all.has("good"));
+});
+
+await withTempStore("unsafe session id is sanitized in filename but preserved in content", async (store, dir) => {
+    const s = makeSession("../../etc/passwd"); // path-traversal attempt
+    await store.writeNow(s);
+    const files = readdirSync(dir);
+    assert.ok(files.every((f) => !f.includes("..")), "no traversal segments in filename");
+    const loaded = store.loadSync("../../etc/passwd");
+    assert.equal(loaded!.id, "../../etc/passwd", "real id preserved inside file");
+});
+
+await withTempStore("disabled store writes nothing", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "bili-disabled-"));
+    const store = new SessionStore({ dir, enabled: false });
+    try {
+        const s = makeSession("x");
+        await store.writeNow(s);
+        store.scheduleSave(s);
+        store.flushSync(s);
+        assert.equal(readdirSync(dir).length, 0, "nothing written when disabled");
+    } finally {
+        rmSync(dir, { recursive: true, force: true });
+    }
+});

--- a/tests/proxy-persist.test.ts
+++ b/tests/proxy-persist.test.ts
@@ -1,11 +1,24 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, readdirSync, readFileSync } from "node:fs";
+import { mkdtempSync, rmSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { SessionStore } from "../src/persist.ts";
 import { createInitialState } from "acp-kernel";
 import type { Session, BlockContent } from "../src/session.ts";
+
+/** Recursively collect *.json files under dir (sessions are namespaced into
+ *  protocol/ subdirs). */
+function jsonFilesUnder(dir: string): string[] {
+    const out: string[] = [];
+    for (const name of readdirSync(dir)) {
+        if (name.startsWith(".tmp-")) continue;
+        const full = join(dir, name);
+        if (statSync(full).isDirectory()) out.push(...jsonFilesUnder(full));
+        else if (name.endsWith(".json")) out.push(full);
+    }
+    return out;
+}
 
 function makeSession(id: string): Session {
     return {
@@ -47,9 +60,9 @@ await withTempStore("writeNow round-trips state + blockContents", async (store, 
 
     await store.writeNow(s);
 
-    const files = readdirSync(dir);
-    assert.ok(files.some((f) => f.endsWith(".json")), "a session json file was written");
-    const raw = JSON.parse(readFileSync(join(dir, files[0]), "utf8"));
+    const files = jsonFilesUnder(dir);
+    assert.ok(files.length > 0, "a session json file was written");
+    const raw = JSON.parse(readFileSync(files[0], "utf8"));
     assert.equal(raw.id, "sess-1");
     assert.equal(raw.requests, 42);
     assert.equal(raw.tokensSaved, 1234);
@@ -84,7 +97,7 @@ await withTempStore("scheduleSave debounces and eventually writes", async (store
     s.requests = 3;
     store.scheduleSave(s);
     await settle();
-    assert.equal(readdirSync(dir).length, 1, "exactly one write happened");
+    assert.equal(readdirSync(dir).length, 1, "exactly one top-level entry (the _unknown subdir) happened");
     const loaded = store.loadSync("debounce-1");
     assert.equal(loaded!.requests, 3, "latest value persisted");
 });
@@ -133,7 +146,7 @@ await withTempStore("collision-prone ids do NOT share a file (hashed names)", as
     const s3 = makeSession("a/b");
     await store.writeNow(s2);
     await store.writeNow(s3);
-    const jsonFiles = readdirSync(dir).filter((f) => f.endsWith(".json"));
+    const jsonFiles = jsonFilesUnder(dir);
     assert.equal(jsonFiles.length, 2, "distinct ids → distinct files");
     assert.ok(store.loadSync("a_b")!.id === "a_b");
     assert.ok(store.loadSync("a/b")!.id === "a/b");
@@ -168,10 +181,10 @@ await withTempStore("loadSync returns null when body id does not match", async (
     // Hand-write a file whose name hashes to "real-id" but body says "fake-id".
     const real = makeSession("real-id");
     await store.writeNow(real);
-    const file = readdirSync(dir)[0];
-    const parsed = JSON.parse(readFileSync(join(dir, file), "utf8"));
+    const file = jsonFilesUnder(dir)[0];
+    const parsed = JSON.parse(readFileSync(file, "utf8"));
     parsed.id = "different-id";
-    wf(join(dir, file), JSON.stringify(parsed));
+    wf(file, JSON.stringify(parsed));
     // Asking for "real-id" finds the file by hash, but body id mismatches → null.
     assert.equal(store.loadSync("real-id"), null, "body id mismatch rejected");
 });
@@ -180,8 +193,8 @@ await withTempStore("loadAll skips file whose filename does not match body id", 
     const { renameSync: rn } = await import("node:fs");
     await store.writeNow(makeSession("legit"));
     // Rename the legit file to a name that doesn't match any body id.
-    const files = readdirSync(dir);
-    rn(join(dir, files[0]), join(dir, "mismatched.json"));
+    const files = jsonFilesUnder(dir);
+    rn(files[0], join(dir, "mismatched.json"));
     const all = await store.loadAll();
     assert.equal(all.size, 0, "filename/body mismatch rejected at loadAll");
 });
@@ -201,4 +214,59 @@ await withTempStore("hasPending reflects the debounce timer", async (store) => {
     assert.equal(store.hasPending(s.id), true);
     await settle();
     assert.equal(store.hasPending(s.id), false);
+});
+
+await withTempStore("sessions are namespaced by protocol + provider on disk", async (store, dir) => {
+    // A human should be able to tell sessions apart at a glance from the path:
+    //   anthropic/dashscope_<hash>.json
+    //   openai/zhipu_<hash>.json
+    //   responses/comfly_<hash>.json
+    const anth = makeSession("sess-anth");
+    anth.protocol = "anthropic";
+    anth.upstreamOrigin = "https://coding.dashscope.aliyuncs.com";
+    await store.writeNow(anth);
+
+    const oai = makeSession("sess-oai");
+    oai.protocol = "openai";
+    oai.upstreamOrigin = "https://open.bigmodel.cn";
+    await store.writeNow(oai);
+
+    const resp = makeSession("sess-resp");
+    resp.protocol = "responses";
+    resp.upstreamOrigin = "https://ai.comfly.org";
+    await store.writeNow(resp);
+
+    const all = jsonFilesUnder(dir);
+    assert.equal(all.length, 3, "three sessions written");
+    const rel = all.map((f) => f.slice(dir.length + 1));
+    assert.ok(rel.some((p) => p.startsWith("anthropic/") && /dashscope/.test(p)), `anthropic/dashscope path: ${rel.join(", ")}`);
+    assert.ok(rel.some((p) => p.startsWith("openai/") && /bigmodel/.test(p)), `openai/bigmodel path: ${rel.join(", ")}`);
+    assert.ok(rel.some((p) => p.startsWith("responses/") && /comfly/.test(p)), `responses/comfly path: ${rel.join(", ")}`);
+});
+
+await withTempStore("protocol-less session lands under _unknown/ (legacy compat)", async (store, dir) => {
+    // A session with no protocol meta (e.g. created before meta was captured)
+    // still persists — under _unknown/ so it never collides with a namespaced
+    // protocol subdir, and still loads back.
+    const s = makeSession("legacy-1");
+    await store.writeNow(s);
+    const all = jsonFilesUnder(dir);
+    assert.equal(all.length, 1);
+    assert.ok(all[0].includes("_unknown"), `legacy file under _unknown: ${all[0]}`);
+    const loaded = store.loadSync("legacy-1");
+    assert.ok(loaded && loaded.id === "legacy-1", "legacy session loads back");
+});
+
+await withTempStore("loadSync uses protocol meta to locate namespaced file", async (store) => {
+    // After an LRU eviction, loadSync must find the file by protocol/host,
+    // not by scanning. Passing the meta must hit the right path.
+    const s = makeSession("meta-1");
+    s.protocol = "openai";
+    s.upstreamOrigin = "https://open.bigmodel.cn";
+    await store.writeNow(s);
+    // With correct meta → found.
+    assert.ok(store.loadSync("meta-1", { protocol: "openai", upstreamOrigin: "https://open.bigmodel.cn" }));
+    // With wrong meta → not found at the namespaced path (and no _unknown fallback
+    // because protocol is given, so it does not scan the legacy location).
+    assert.equal(store.loadSync("meta-1", { protocol: "anthropic", upstreamOrigin: "https://other.example" }), null);
 });

--- a/tests/proxy-session-id.test.ts
+++ b/tests/proxy-session-id.test.ts
@@ -1,0 +1,100 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { deriveSessionId, affinityToken, clientConversationHeader } from "../src/session-id.ts";
+
+/** Helper: build a minimal headers object. */
+function hdrs(auth?: string, sessionAffinity?: string): Record<string, string> {
+    const h: Record<string, string> = {};
+    if (auth) h.authorization = auth;
+    if (sessionAffinity) h["x-session-affinity"] = sessionAffinity;
+    return h;
+}
+
+test("deriveSessionId: same conversation + same key + same protocol + same upstream → stable", () => {
+    const a = deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://bailian.example", "hello world");
+    const b = deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://bailian.example", "hello world");
+    assert.equal(a, b);
+});
+
+test("deriveSessionId: different API key → different session (no cross-account bleed)", () => {
+    const a = deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://bailian.example", "hello world");
+    const b = deriveSessionId(hdrs("Bearer keyB"), "anthropic", "https://bailian.example", "hello world");
+    assert.notEqual(a, b);
+});
+
+test("deriveSessionId: different upstream origin → different session (no cross-provider bleed)", () => {
+    const a = deriveSessionId(hdrs("Bearer keyA"), "openai", "https://zhipu.example", "hello");
+    const b = deriveSessionId(hdrs("Bearer keyA"), "openai", "https://bailian.example", "hello");
+    assert.notEqual(a, b);
+});
+
+test("deriveSessionId: different protocol → different session (no cross-format bleed)", () => {
+    const a = deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://bailian.example", "hello");
+    const b = deriveSessionId(hdrs("Bearer keyA"), "openai", "https://bailian.example", "hello");
+    assert.notEqual(a, b);
+});
+
+test("deriveSessionId: different conversation (different first-user) → different session", () => {
+    const a = deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://bailian.example", "hello");
+    const b = deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://bailian.example", "goodbye");
+    assert.notEqual(a, b);
+});
+
+test("deriveSessionId: client conversation signal overrides content fingerprint", () => {
+    // Same first-user content but different client conversation headers → different sessions
+    const a = deriveSessionId(hdrs("Bearer keyA", "ses_111"), "anthropic", "https://up", "hello", {
+        clientConversation: "ses_111",
+    });
+    const b = deriveSessionId(hdrs("Bearer keyA", "ses_222"), "anthropic", "https://up", "hello", {
+        clientConversation: "ses_222",
+    });
+    assert.notEqual(a, b);
+    // And two requests with the SAME client signal hit the same session even if
+    // the first-user content fingerprint input differs (the signal wins).
+    const c = deriveSessionId(hdrs("Bearer keyA", "ses_111"), "anthropic", "https://up", "different text", {
+        clientConversation: "ses_111",
+    });
+    assert.equal(a, c);
+});
+
+test("deriveSessionId: no Authorization header → still works (uses placeholder key)", () => {
+    const id = deriveSessionId({}, "anthropic", "https://up", "hello");
+    assert.ok(id.length > 0);
+    // Two keyless requests with same content → same session.
+    assert.equal(id, deriveSessionId({}, "anthropic", "https://up", "hello"));
+});
+
+test("affinityToken: uses client signal when present (passthrough, preserves ses_ format)", () => {
+    const t = affinityToken(hdrs("Bearer k", "ses_opencode_xyz"), "hello");
+    assert.equal(t, "ses_opencode_xyz");
+});
+
+test("affinityToken: falls back to ses_<hash(convo)> when no client signal (no key, no upstream)", () => {
+    const t = affinityToken(hdrs("Bearer k"), "hello world");
+    assert.match(t, /^ses_[0-9a-f]+$/);
+    // Stable for same input.
+    assert.equal(t, affinityToken(hdrs("Bearer k"), "hello world"));
+    // Different content → different token.
+    assert.notEqual(t, affinityToken(hdrs("Bearer k"), "goodbye"));
+});
+
+test("affinityToken: protocolConversation (Responses previous_response_id) wins over content fingerprint", () => {
+    const t = affinityToken(hdrs("Bearer k"), "some content", "resp_resp_abc123");
+    assert.equal(t, "ses_resp_resp_abc123");
+});
+
+test("clientConversationHeader: reads known session header names in priority order", () => {
+    assert.equal(clientConversationHeader({ "x-session-affinity": "A", "x-acp-session": "B" }), "A");
+    assert.equal(clientConversationHeader({ "x-acp-session": "B" }), "B");
+    assert.equal(clientConversationHeader({ "x-session-id": "C" }), "C");
+    assert.equal(clientConversationHeader({ "x-opencode-session": "D" }), "D");
+    assert.equal(clientConversationHeader({}), undefined);
+});
+
+test("affinityToken is safe to send upstream: does NOT embed the API key", () => {
+    // The affinity token must be derivable from the conversation alone — an
+    // upstream that receives it should not be able to learn the key.
+    const withKeyA = affinityToken(hdrs("Bearer keyA"), "hello");
+    const withKeyB = affinityToken(hdrs("Bearer keyB"), "hello");
+    assert.equal(withKeyA, withKeyB, "affinity token identical regardless of key");
+});

--- a/tests/proxy-stream-error.test.ts
+++ b/tests/proxy-stream-error.test.ts
@@ -1,0 +1,67 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import { emitStreamError } from "../src/stream-error.ts";
+
+/** Collect all bytes written to a ServerResponse into a string. */
+function makeCollector(): { res: http.ServerResponse; chunks: Buffer[]; done: Promise<string> } {
+    const chunks: Buffer[] = [];
+    // Minimal stub mimicking the methods emitStreamError uses.
+    const res = {
+        write(chunk: string | Buffer) {
+            chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+            return true;
+        },
+        end() {
+            return this;
+        },
+    } as unknown as http.ServerResponse;
+    return { res, chunks, done: Promise.resolve("") };
+}
+
+test("emitStreamError: openai emits error delta + finish + [DONE]", async () => {
+    const { res, chunks } = makeCollector();
+    emitStreamError(res, "openai", "test failure");
+    const out = Buffer.concat(chunks).toString("utf8");
+    assert.match(out, /test failure/);
+    assert.match(out, /finish_reason.*stop/);
+    assert.match(out, /\[DONE\]/);
+});
+
+test("emitStreamError: anthropic emits content_block_delta + message_stop", async () => {
+    const { res, chunks } = makeCollector();
+    emitStreamError(res, "anthropic", "boom");
+    const out = Buffer.concat(chunks).toString("utf8");
+    assert.match(out, /content_block_delta/);
+    assert.match(out, /boom/);
+    assert.match(out, /message_stop/);
+});
+
+test("emitStreamError: responses emits output_text.delta + response.completed", async () => {
+    const { res, chunks } = makeCollector();
+    emitStreamError(res, "responses", "kaboom");
+    const out = Buffer.concat(chunks).toString("utf8");
+    assert.match(out, /response\.output_text\.delta/);
+    assert.match(out, /kaboom/);
+    assert.match(out, /response\.completed/);
+});
+
+test("emitStreamError: never throws even if write throws (client gone)", () => {
+    const res = {
+        write() {
+            throw new Error("write EPIPE");
+        },
+        end() {
+            throw new Error("end EPIPE");
+        },
+    } as unknown as http.ServerResponse;
+    assert.doesNotThrow(() => emitStreamError(res, "openai", "x"));
+});
+
+test("emitStreamError: calls the optional log callback", () => {
+    const { res } = makeCollector();
+    let logged = "";
+    emitStreamError(res, "openai", "logged-msg", (m) => (logged = m));
+    assert.match(logged, /stream aborted/);
+    assert.match(logged, /logged-msg/);
+});


### PR DESCRIPTION
## Why

Three hardening gaps for a multi-tenant proxy serving several clients / accounts / protocols / providers at once.

1. **Sessions died on restart.** Compression state lived only in process memory. A restart dropped all blocks; clients re-send full raw history; without saved block summaries there is nothing to fold it under, so the model rejects the oversized request and **the session hangs permanently**. A restart killed every long-running session.

2. **Session isolation was unsafe across tenants.** `deriveSessionId` keyed on the conversation dimension alone (a client header, else a hash of the first user message). In a multi-tenant setup (several clients, accounts, providers, protocols) this collides:
   - pi (acct A) and opencode (acct B) sending the same opening line → same content fingerprint → **compression states bleed into each other**.
   - Same key hitting two providers with the same first message → collide.
   - Anthropic-format and OpenAI-format requests with the same text → collide even though they are different wire protocols.
   - **Worst case**: different accounts randomly routed together.

3. **Opaque session filenames.** A flat dir of hash-only filenames — a human could not tell which client/protocol/provider a session belonged to.

4. **Stream robustness gaps** surfaced by code review (upstream error passthrough, abort-safe streams).

## What

### Persistent sessions (`src/persist.ts` + `src/session.ts`)
- Disk is the source of truth; memory is a bounded cache (`MAX_SESSIONS` LRU).
- Atomic write (temp + rename). Debounced async writes (default 500 ms) so the hot path never blocks; sync flush on LRU eviction and SIGTERM/SIGINT.
- `mergeInitialState` for forward-compat (old files missing new schema fields load with defaults).
- `blockContents` (original text of compressed messages) persisted too, so decompress still works after restart. Unbounded by design — disk-backed; bounded by session count.
- Hardened per double review (commit `d411e1d`):
  - **C1** silent write failure → permanent loss: `flushSync` now returns a boolean and `evictOldest` never deletes a session that failed to persist.
  - **M1** filename collision (`a/b` vs `a_b`): filename is `sha256(id)`; load verifies `body.id === expected`.
  - **Me1** non-unique temp names: monotonic `tmpSeq` counter.
  - **M5** split-brain on in-flight eviction: `inFlight` counter; eviction skips sessions being served.
  - **M7** silent `.catch(()=>{})`: all write errors now logged.
  - **m1/M6** `loadAll` unbounded: trimmed to `MAX_SESSIONS` after load.

### Multi-tenant session isolation (`src/session-id.ts` + 3 protocol adapters)
Session id now keys on **four** dimensions, all AND-ed:
```
hash( protocol | upstream-origin | api-key | conversation )
```
- `protocol` — anthropic | openai | responses (different wire formats never share state)
- `upstream-origin` — resolved provider host (same key, two providers never collide)
- `api-key` — normalized Authorization/x-api-key (different accounts never collide) ← **the bug you flagged: different accounts randomly routed**
- `conversation` — client-provided signal when available (`x-session-affinity` / `x-acp-session` / `x-session-id` / `x-opencode-session` for OpenCode; `previous_response_id` for Responses native linkage), falling back to a content fingerprint of the first user message (pi).

`affinityToken()` produces the conversation dimension ALONE, formatted as OpenCode `ses_<hash>`, **without the key/upstream** — safe to forward upstream for sticky routing. Not wired into forwarding yet (single-account direct upstreams already get automatic prefix cache by content); emitted when multi-account routing needs it.

The per-protocol `deriveSessionId*` functions are renamed `conversationSignal*` — they contribute ONLY the conversation axis; the other three are mixed in by the caller. `resolveUpstream` is hoisted before `prepare()` so the session can embed the provider origin.

### Namespaced on-disk layout (`src/persist.ts`)
Sessions are organized so a human can tell them apart at a glance:
```
~/.bili/sessions/
├── anthropic/coding.dashscope.aliyuncs.com_<hash>.json
├── openai/open.bigmodel.cn_<hash>.json
├── responses/ai.comfly.org_<hash>.json
└── _unknown/<hash>.json   (protocol-less, legacy compat)
```
- `relPathFor()` builds `<protocol>/<host>_<hash>.json`; `loadAll()` walks subdirs recursively; `loadSync()` tries the namespaced path then a `_unknown/` legacy fallback.
- Forward-compat: legacy flat files (no protocol meta) still load via `loadAll`, and a protocol-less session persists under `_unknown/`.

### Stream robustness (`src/stream-error.ts` + `server.ts` + `compress-loop*.ts`)
- Upstream non-2xx responses are now passed through (status + body) instead of being fed to the SSE rewriter and turned into an empty finish.
- Three streaming `for await` loops wrapped in try/catch emitting a minimal protocol-correct terminator (`emitStreamError`) so a client never sees a stream end without a finish event.
- Retries inject `errText` into the delta (not just the status code).

## Test impact
134 pass (was 119). +12 session-id (4-dimension isolation, client-signal priority, affinity-token key-independence), +3 namespacing, +5 persistence, +4 stream-error.

## Commits
- `8c557b6` feat: persistent sessions + block-cache memory cap
- `d76a7f6` tune: raise blockContents cap to 512MB
- `d411e1d` fix: harden persistence per double review
- `05ef9c9` fix: stream robustness — upstream error passthrough + abort-safe streams
- `6f889ef` refactor: dedupe safeJsonParse + remove dead debug imports
- `8990b9a` feat: session id isolates by protocol + upstream + key + conversation
- `7b8c912` feat: namespace persisted sessions by protocol + provider host
