### PR TITLE
fix: post-merge review fixes + per-route context window + XDG config

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,9 +146,43 @@ provider key — the proxy never reads or stores it.
   are rejected to avoid colliding with real API path segments.
 - The provider name can appear anywhere in the path; the longest match wins.
 
+### Session identity
+
+The proxy needs a stable per-conversation identifier to isolate compression
+state across concurrent users/accounts. It derives one from four dimensions
+(see `src/session-id.ts`): **protocol × upstream origin × API key ×
+conversation**. The first three prevent cross-account / cross-provider
+bleeding; the conversation dimension comes from whatever the client sends.
+
+Clients differ in what they send:
+
+| Client | Sends conversation id? | Source | Safety |
+|---|---|---|---|
+| **Codex** (0.147+) | ✅ yes | `body.session_id` (per-conversation UUID) | ✅ safe |
+| **OpenCode** | ✅ yes | `x-session-affinity` header (`ses_…`) | ✅ safe |
+| **pi** | ❌ **no** | nothing | ⚠️ **collision risk** |
+
+When the client sends an explicit id, the proxy uses it directly. When it
+does not (pi), the proxy falls back to hashing the first user message — so
+two conversations that start with the same opener collapse onto the same
+session. This does **not** corrupt data (per-message refs use a separate
+content fingerprint that stays stable), but it can skew nudge/compression
+timing and occasionally over-eagerly reap a block. It is self-healing: the
+worst case is reduced compression efficiency, never data loss.
+
+For upstream sticky-routing, when the client sends no session header the
+proxy synthesizes one (`x-session-id: ses_<hash>`) so cache pools / load
+balancers still get a stable key.
+
+**Recommendation:** Codex and OpenCode are safe to run many concurrent
+conversations through the proxy. pi is fine for a single agent, but is **not
+recommended** for many concurrent conversations because of the collision
+risk — until pi grows its own session-id signal. For pi multi-agent use,
+pass an explicit `x-acp-session` header per conversation to avoid collisions.
+
 ## Status
 
-Early. Protocol handling and compression work against mock tests (136 passing). Real-model integration testing is the next milestone. Expect rough edges.
+Early. Protocol handling and compression work against mock tests (141 passing). Real-model integration testing is the next milestone. Expect rough edges.
 
 See [billion-context-pi](https://github.com/ranxianglei/billion-context-pi) for the pi-extension mode (in-process, tighter integration, the reference implementation).
 

--- a/README.md
+++ b/README.md
@@ -75,49 +75,100 @@ Set the base URL / API endpoint to `http://localhost:8787` (Anthropic) or `http:
 
 ## Configuration
 
-All config is via environment variables:
+Configuration is read from a JSON file with env-var overrides. Priority:
+**env var > config file > built-in default**.
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `PORT` | `8787` | Proxy listen port |
-| `HOST` | `127.0.0.1` | Proxy listen host |
-| `UPSTREAM` | `https://api.anthropic.com` | Default upstream when no route matches |
-| `ACP_PROVIDERS` | *(none)* | Path to a JSON file mapping provider names to root URLs (see below) |
-| `ACP_COMPRESS_TOOL` | `1` | Set `0` to disable injecting the compress tool |
-| `ACP_DEBUG` | `0` | Set `1` for verbose logging |
-| `ACP_PASSTHROUGH` | `0` | Set `1` to forward without compression |
-| `BILI_PERSIST` | `1` | Set `0` to disable session persistence (in-memory only, lost on restart) |
-| `BILI_PERSIST_DEBOUNCE_MS` | `500` | Debounce window for writes to disk (milliseconds) |
-| `MAX_SESSIONS` | `256` | Max sessions held in memory (LRU eviction; disk is source of truth) |
-| `BILI_SESSIONS_DIR` | `~/.bili/sessions` | Directory for persisted session state |
+### Config file
 
-### Multiple upstreams (URL path routing)
+Location (XDG Base Directory):
 
-Point any agent at the proxy using a provider name as a path segment. The
-proxy strips the name and forwards to that provider's root URL. **API keys
-are never stored in the proxy** — whatever key the agent sends is passed
-through untouched to the upstream.
+- **Linux:** `~/.config/billion-context/billion-context.json`
+- Override with `XDG_CONFIG_HOME` or `BILI_CONFIG_FILE`
 
-Create a providers file (e.g. `~/.bili/providers.json`):
+The config file is a single JSON object. Example:
 
 ```json
 {
-  "glm": "https://bigmodel.cn",
-  "anthropic": "https://api.anthropic.com",
-  "openai": "https://api.openai.com",
-  "deepseek": "https://api.deepseek.com"
+  "port": 8787,
+  "host": "127.0.0.1",
+  "providers": {
+    "zhipu": {
+      "url": "https://open.bigmodel.cn",
+      "models": {
+        "glm-5.2": { "context": 1000000, "output": 131072 },
+        "glm-5.1": { "context": 200000, "output": 131072 }
+      }
+    },
+    "anthropic": "https://api.anthropic.com",
+    "deepseek": "https://api.deepseek.com"
+  }
 }
 ```
 
-Then:
+### Top-level keys
 
-```bash
-ACP_PROVIDERS=~/.bili/providers.json bili-proxy
+| Key | Default | Description |
+|------|---------|-------------|
+| `port` | `8787` | Proxy listen port |
+| `host` | `127.0.0.1` | Proxy listen host |
+| `upstream` | `https://api.anthropic.com` | Default upstream when no route matches |
+| `sessionHeader` | `x-acp-session` | Header name clients may send to identify a conversation |
+| `log` | `true` | Enable request logging |
+| `debug` | `false` | Verbose logging (same as `ACP_DEBUG=1`) |
+| `passthrough` | `false` | Forward without compression (same as `ACP_PASSTHROUGH=1`) |
+| `providers` | *(none)* | Provider routes — see below |
+| `condense` | *(see defaults)* | Tool-result condensing: `{ enabled, keepRecentToolResults, minCharsToCondense, maxKeptChars }` |
+| `compress` | *(see defaults)* | `{ injectTool, injectNudge }` |
+
+### Providers (URL routing + per-model context)
+
+`providers` maps a route name to either a bare URL string (simple) or an
+object with `url` + optional per-model context window (recommended).
+
+**Simple form** — provider name → URL:
+```json
+{ "deepseek": "https://api.deepseek.com" }
 ```
 
-Each agent only needs to change its base URL to include the provider name.
-The proxy figures out the rest, including the right context window for each
-model family (claude=200k, gpt-4o=128k, glm=128k, ...) via a built-in table.
+**Full form** — provider name → `{ url, models }`:
+```json
+{
+  "zhipu": {
+    "url": "https://open.bigmodel.cn",
+    "models": {
+      "glm-5.2": { "context": 1000000, "output": 131072 },
+      "glm-5.1": { "context": 200000 }
+    }
+  }
+}
+```
+
+The same model can have a different context window behind different providers
+(e.g. relay wraps a model with a larger window). `context` is the **input
+context limit** (used by the compressor to decide when to nudge); `output` is
+the max output tokens. Both are optional; missing values fall back to the
+built-in model table, then to `modelContextLimit`.
+
+> **Why declare context at all?** The LLM `/models` API does **not** return
+> context windows (verified across OpenAI, Anthropic, 智谱, comfly). They are
+> document-level information. A wrong value (e.g. GLM-5.2 guessed as 128K
+> instead of 1M) causes spurious frequent compression. Declaring it per
+> provider + model makes the proxy match the registry the client itself uses.
+
+**API keys are never stored in the proxy** — whatever key the agent sends is
+passed through untouched to the upstream.
+
+### Routing
+
+Point any agent at the proxy using a provider name as a path segment. The
+proxy strips the name and forwards to that provider's root URL.
+
+```
+agent baseURL:  http://localhost:8787/zhipu/api/coding/paas/v4
+                 └──────────┬──────────┘└────────┬────────┘
+                     proxy host           remaining path
+                     + provider name      (forwarded as-is)
+```
 
 #### Claude Code (Anthropic)
 
@@ -130,14 +181,39 @@ claude
 #### Codex / any OpenAI-compatible agent (zhipu / openai / deepseek)
 
 ```bash
-export OPENAI_BASE_URL=http://localhost:8787/v1/glm
+export OPENAI_BASE_URL=http://localhost:8787/zhipu/api/coding/paas/v4
 export OPENAI_API_KEY=<your real glm key>   # passed through as-is
 codex
 ```
 
-The `/v1/glm` prefix tells the proxy to route to the `glm` provider; the
-remaining `/v1/chat/completions` path is preserved. Set the key to the real
-provider key — the proxy never reads or stores it.
+The `/zhipu/...` prefix tells the proxy to route to the `zhipu` provider; the
+remaining `/api/coding/paas/v4/...` path is preserved.
+
+### Environment variables (override the config file)
+
+Every config key has an env-var override. Set to override the file value.
+
+| Env | Default | Description |
+|-----|---------|-------------|
+| `ACP_PORT` / `PORT` | `8787` | Listen port |
+| `ACP_HOST` | `127.0.0.1` | Listen host |
+| `ACP_UPSTREAM` | `https://api.anthropic.com` | Default upstream |
+| `ACP_PROVIDERS` | *(none)* | Path to a legacy providers JSON file (overrides `providers` in config) |
+| `ACP_MODEL_CONTEXT_LIMIT` | `200000` | Global fallback context window (only used when no provider/model match) |
+| `ACP_SESSION_HEADER` | `x-acp-session` | Conversation-id header name |
+| `ACP_COMPRESS_TOOL` | `1` | Set `0` to disable injecting the compress tool |
+| `ACP_COMPRESS_NUDGE` | `1` | Set `0` to disable compression nudges |
+| `ACP_CONDENSE_ENABLED` | `1` | Set `0` to disable tool-result condensing |
+| `ACP_KEEP_RECENT_TOOL_RESULTS` | `6` | Tool results kept verbatim before condensing |
+| `ACP_MIN_CHARS_TO_CONDENSE` | `1500` | Condense tool results longer than this |
+| `ACP_MAX_KEPT_CHARS` | `400` | Max chars kept when condensing a tool result |
+| `ACP_DEBUG` | `0` | Set `1` for verbose logging |
+| `ACP_PASSTHROUGH` | `0` | Set `1` to forward without compression |
+| `ACP_DUMP_SSE` | *(none)* | Directory to dump SSE for debugging |
+| `BILI_PERSIST` | `1` | Set `0` to disable session persistence (in-memory only, lost on restart) |
+| `BILI_PERSIST_DEBOUNCE_MS` | `500` | Debounce window for writes to disk (ms) |
+| `BILI_MAX_SESSIONS` | `256` | Max sessions held in memory (LRU eviction; disk is source of truth) |
+| `BILI_SESSIONS_DIR` | *(XDG data dir)* | Directory for persisted session state |
 
 ### Notes on provider names
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ All config is via environment variables:
 | `ACP_COMPRESS_TOOL` | `1` | Set `0` to disable injecting the compress tool |
 | `ACP_DEBUG` | `0` | Set `1` for verbose logging |
 | `ACP_PASSTHROUGH` | `0` | Set `1` to forward without compression |
+| `BILI_PERSIST` | `1` | Set `0` to disable session persistence (in-memory only, lost on restart) |
+| `BILI_PERSIST_DEBOUNCE_MS` | `500` | Debounce window for writes to disk (milliseconds) |
+| `MAX_SESSIONS` | `256` | Max sessions held in memory (LRU eviction; disk is source of truth) |
+| `BILI_SESSIONS_DIR` | `~/.bili/sessions` | Directory for persisted session state |
 
 ### Multiple upstreams (URL path routing)
 
@@ -144,7 +148,7 @@ provider key — the proxy never reads or stores it.
 
 ## Status
 
-Early. Protocol handling and compression work against mock tests (79 passing). Real-model integration testing is the next milestone. Expect rough edges.
+Early. Protocol handling and compression work against mock tests (136 passing). Real-model integration testing is the next milestone. Expect rough edges.
 
 See [billion-context-pi](https://github.com/ranxianglei/billion-context-pi) for the pi-extension mode (in-process, tighter integration, the reference implementation).
 

--- a/src/compress-loop-responses.ts
+++ b/src/compress-loop-responses.ts
@@ -512,6 +512,12 @@ export async function* compressLoopResponsesStream(
         }
 
         upstream = resp.body as ReadableStream<Uint8Array>;
+        // Clear the PREVIOUS round's timer before overwriting — otherwise the
+        // fetch-timeout timer from rounds 1..N-1 leaks (each would self-fire
+        // harmlessly after 10min, but the handles accumulate in the event loop
+        // over a long session). Only the final round's timer is cleared by the
+        // outer finally.
+        if (activeClearTimer) activeClearTimer();
         activeClearTimer = clearTimer;
     }
 }

--- a/src/compress-loop.ts
+++ b/src/compress-loop.ts
@@ -406,6 +406,12 @@ export async function* compressLoopStream(
         }
 
         upstream = resp.body as ReadableStream<Uint8Array>;
+        // Clear the PREVIOUS round's timer before overwriting — otherwise the
+        // fetch-timeout timer from rounds 1..N-1 leaks (each would self-fire
+        // harmlessly after 10min, but the handles accumulate in the event loop
+        // over a long session). Only the final round's timer is cleared by the
+        // outer finally.
+        if (activeClearTimer) activeClearTimer();
         activeClearTimer = clearTimer;
     }
     } finally {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,6 @@
 import { defaultConfig, type Config } from "acp-kernel";
 import { readFileSync } from "node:fs";
+import { configFile } from "./paths.js";
 
 function safeReadJson(path: string): unknown {
     try {
@@ -111,30 +112,39 @@ export type ProxyOptions = {
 };
 
 export function loadOptions(env: NodeJS.ProcessEnv = process.env): ProxyOptions {
-    const port = parseInt(env.ACP_PORT ?? env.PORT ?? "8787", 10);
-    const host = env.ACP_HOST ?? "127.0.0.1";
-    const upstream = (env.ACP_UPSTREAM ?? "https://api.anthropic.com").replace(/\/$/, "");
+    // --- Source 1: JSON config file (~/.config/billion-context/billion-context.json) ---
+    // The canonical, user-editable config. Loaded first so env vars below can
+    // override it (env wins for environment-specific overrides).
+    const fileConfig = loadConfigFile();
+
+    // --- Source 2: env vars (highest priority) ---
+    const port = parseInt(env.ACP_PORT ?? env.PORT ?? `${fileConfig.port ?? 8787}`, 10);
+    const host = env.ACP_HOST ?? fileConfig.host ?? "127.0.0.1";
+    const upstream = (env.ACP_UPSTREAM ?? fileConfig.upstream ?? "https://api.anthropic.com").replace(/\/$/, "");
     let routes: ProviderRoutes = {};
-    const routesPath = env.ACP_PROVIDERS ?? "";
+    // Routes: explicit env path > config file providers > none.
+    const routesPath = env.ACP_PROVIDERS ?? fileConfig.providersPath ?? "";
     if (routesPath) {
         const parsed = safeReadJson(routesPath);
         if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-            // Accept both legacy { name: "url" } and new { name: { url, models } }.
             for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
-                if (typeof v === "string" && v.length > 0) {
-                    routes[k] = { url: v.replace(/\/$/, "") };
-                } else if (v && typeof v === "object" && !Array.isArray(v) && typeof (v as { url?: unknown }).url === "string" && (v as { url: string }).url.length > 0) {
-                    const obj = v as { url: string; models?: Record<string, { context?: number; output?: number }> };
-                    routes[k] = { url: obj.url.replace(/\/$/, ""), models: obj.models };
-                }
+                const route = parseRouteEntry(v);
+                if (route) routes[k] = route;
             }
         }
     }
-    const modelContextLimit = parseInt(env.ACP_MODEL_CONTEXT_LIMIT ?? "200000", 10);
-    const enabled = (env.ACP_CONDENSE_ENABLED ?? "1") !== "0";
-    const keepRecentToolResults = parseInt(env.ACP_KEEP_RECENT_TOOL_RESULTS ?? "6", 10);
-    const minCharsToCondense = parseInt(env.ACP_MIN_CHARS_TO_CONDENSE ?? "1500", 10);
-    const maxKeptChars = parseInt(env.ACP_MAX_KEPT_CHARS ?? "400", 10);
+    // Also accept providers inline in the config file.
+    if (fileConfig.providers) {
+        for (const [k, v] of Object.entries(fileConfig.providers)) {
+            const route = parseRouteEntry(v);
+            if (route && !routes[k]) routes[k] = route;
+        }
+    }
+    const modelContextLimit = parseInt(env.ACP_MODEL_CONTEXT_LIMIT ?? `${fileConfig.modelContextLimit ?? 200000}`, 10);
+    const enabled = (env.ACP_CONDENSE_ENABLED ?? (fileConfig.condense?.enabled === false ? "0" : "1")) !== "0";
+    const keepRecentToolResults = parseInt(env.ACP_KEEP_RECENT_TOOL_RESULTS ?? `${fileConfig.condense?.keepRecentToolResults ?? 6}`, 10);
+    const minCharsToCondense = parseInt(env.ACP_MIN_CHARS_TO_CONDENSE ?? `${fileConfig.condense?.minCharsToCondense ?? 1500}`, 10);
+    const maxKeptChars = parseInt(env.ACP_MAX_KEPT_CHARS ?? `${fileConfig.condense?.maxKeptChars ?? 400}`, 10);
     return {
         port: Number.isFinite(port) ? port : 8787,
         host,
@@ -144,13 +154,52 @@ export function loadOptions(env: NodeJS.ProcessEnv = process.env): ProxyOptions 
         kernelConfig: defaultConfig(modelContextLimit),
         condense: { enabled, keepRecentToolResults, minCharsToCondense, maxKeptChars },
         compress: {
-            injectTool: (env.ACP_COMPRESS_TOOL ?? "1") !== "0",
-            injectNudge: (env.ACP_COMPRESS_NUDGE ?? "1") !== "0",
+            injectTool: (env.ACP_COMPRESS_TOOL ?? (fileConfig.compress?.injectTool === false ? "0" : "1")) !== "0",
+            injectNudge: (env.ACP_COMPRESS_NUDGE ?? (fileConfig.compress?.injectNudge === false ? "0" : "1")) !== "0",
         },
-        sessionHeader: env.ACP_SESSION_HEADER ?? "x-acp-session",
-        log: env.ACP_LOG !== "0",
-        debug: (env.ACP_DEBUG ?? "0") === "1",
-        dumpSse: env.ACP_DUMP_SSE || undefined,
-        passthrough: (env.ACP_PASSTHROUGH ?? "0") === "1",
+        sessionHeader: env.ACP_SESSION_HEADER ?? fileConfig.sessionHeader ?? "x-acp-session",
+        log: env.ACP_LOG !== "0" && fileConfig.log !== false,
+        debug: (env.ACP_DEBUG ?? (fileConfig.debug ? "1" : "0")) === "1",
+        dumpSse: env.ACP_DUMP_SSE || fileConfig.dumpSse || undefined,
+        passthrough: (env.ACP_PASSTHROUGH ?? (fileConfig.passthrough ? "1" : "0")) === "1",
     };
+}
+
+/** Shape of the optional JSON config file. All fields optional — the file is a
+ *  pure override layer; anything unset falls through to defaults. */
+type FileConfig = {
+    port?: number;
+    host?: string;
+    upstream?: string;
+    /** Path to a legacy providers.json (backward compat). */
+    providersPath?: string;
+    /** Inline providers, same shape as providers.json. */
+    providers?: Record<string, unknown>;
+    modelContextLimit?: number;
+    sessionHeader?: string;
+    log?: boolean;
+    debug?: boolean;
+    dumpSse?: string;
+    passthrough?: boolean;
+    condense?: { enabled?: boolean; keepRecentToolResults?: number; minCharsToCondense?: number; maxKeptChars?: number };
+    compress?: { injectTool?: boolean; injectNudge?: boolean };
+};
+
+function loadConfigFile(): FileConfig {
+    const parsed = safeReadJson(configFile());
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as FileConfig;
+    }
+    return {};
+}
+
+function parseRouteEntry(v: unknown): ProviderRoute | undefined {
+    if (typeof v === "string" && v.length > 0) {
+        return { url: v.replace(/\/$/, "") };
+    }
+    if (v && typeof v === "object" && !Array.isArray(v) && typeof (v as { url?: unknown }).url === "string" && (v as { url: string }).url.length > 0) {
+        const obj = v as { url: string; models?: Record<string, { context?: number; output?: number }> };
+        return { url: obj.url.replace(/\/$/, ""), models: obj.models };
+    }
+    return undefined;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,13 +20,26 @@ function safeReadJson(path: string): unknown {
  *    http://localhost:8788/v1/glm          → routes.glm
  *    http://localhost:8788/anthropic        → routes.anthropic
  *  The API key is NOT stored here — the proxy passes the agent's key through
- *  untouched, so secrets only live in the agent's config. */
-export type ProviderRoutes = Record<string, string>;
+ *  untouched, so secrets only live in the agent's config.
+ *
+ *  Each route may declare per-model context/output limits, mirroring the
+ *  structure agents like opencode carry in their own model registry. This is
+ *  the source of truth for the proxy: the LLM `/models` endpoint does NOT
+ *  return context windows (verified across OpenAI/Anthropic/zhipu/comfly),
+ *  so the proxy cannot discover them at runtime — the user must declare them.
+ *
+ *  Backward compatible: a bare string is accepted and treated as { url }. */
+export type ProviderRoute = {
+    url: string;
+    models?: Record<string, { context?: number; output?: number }>;
+};
+export type ProviderRoutes = Record<string, ProviderRoute>;
 
 /** Built-in context window for common model families, keyed by a lowercase
- *  prefix. Used so the proxy doesn't need to ask the user for a context limit —
- *  it reads body.model and looks it up here. Falls back to a query to the
- *  upstream /models endpoint, then to MODEL_CONTEXT_LIMIT. */
+ *  prefix. This is a FALLBACK used when the per-route model declaration in
+ *  providers.json does not cover a model. The per-route declaration (which
+ *  the user controls) always wins, because the same model name can have
+ *  different windows behind different relays. */
 const CONTEXT_LIMIT_TABLE: Array<{ match: RegExp; limit: number }> = [
     { match: /^claude-/i, limit: 200_000 },
     { match: /^gpt-5/i, limit: 400_000 },
@@ -37,6 +50,7 @@ const CONTEXT_LIMIT_TABLE: Array<{ match: RegExp; limit: number }> = [
     { match: /^gemini-2\.5/i, limit: 1_000_000 },
     { match: /^gemini-1\.5/i, limit: 1_000_000 },
     { match: /^glm-4\.6/i, limit: 128_000 },
+    { match: /^glm-5/i, limit: 1_000_000 },
     { match: /^glm-/i, limit: 128_000 },
     { match: /^deepseek/i, limit: 64_000 },
     { match: /^qwen/i, limit: 128_000 },
@@ -50,6 +64,26 @@ export function lookupContextLimit(model: string | undefined): number | undefine
         if (entry.match.test(model)) return entry.limit;
     }
     return undefined;
+}
+
+/** Resolve the context-window limit for a request. Priority:
+ *  1. Per-route per-model declaration in providers.json (user-controlled, most accurate)
+ *  2. Built-in CONTEXT_LIMIT_TABLE (by model name prefix)
+ *  Returns undefined if neither matches — caller falls back to the env default. */
+export function resolveContextLimit(
+    routes: ProviderRoutes,
+    provider: string | undefined,
+    model: string | undefined,
+): number | undefined {
+    if (!model) return undefined;
+    if (provider) {
+        const route = routes[provider];
+        if (route?.models) {
+            const m = route.models[model];
+            if (m?.context && m.context > 0) return m.context;
+        }
+    }
+    return lookupContextLimit(model);
 }
 
 export type ProxyOptions = {
@@ -85,9 +119,14 @@ export function loadOptions(env: NodeJS.ProcessEnv = process.env): ProxyOptions 
     if (routesPath) {
         const parsed = safeReadJson(routesPath);
         if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-            // { "glm": "https://...", "anthropic": "https://..." }
+            // Accept both legacy { name: "url" } and new { name: { url, models } }.
             for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
-                if (typeof v === "string" && v.length > 0) routes[k] = v.replace(/\/$/, "");
+                if (typeof v === "string" && v.length > 0) {
+                    routes[k] = { url: v.replace(/\/$/, "") };
+                } else if (v && typeof v === "object" && !Array.isArray(v) && typeof (v as { url?: unknown }).url === "string" && (v as { url: string }).url.length > 0) {
+                    const obj = v as { url: string; models?: Record<string, { context?: number; output?: number }> };
+                    routes[k] = { url: obj.url.replace(/\/$/, ""), models: obj.models };
+                }
             }
         }
     }

--- a/src/orphan-gc.ts
+++ b/src/orphan-gc.ts
@@ -27,6 +27,12 @@ import type { Session } from "./session.js";
 
 const ORPHAN_THRESHOLD = 3;
 
+/** Streak counts live in a WeakMap keyed by the block object, so we don't
+ *  monkey-patch a foreign type (acp-kernel's Block) with an undocumented
+ *  property. If the kernel Block shape changes, TS still type-checks our code
+ *  here; and the counts are GC'd when a block object is dropped. */
+const orphanStreaks = new WeakMap<object, number>();
+
 /**
  * Scan active blocks and deactivate those that have been fully orphaned (no
  * effective message id present in `visible`) for ORPHAN_THRESHOLD consecutive
@@ -46,13 +52,11 @@ export function reapOrphanBlocks(
         if (!block.active) continue;
         const hasHit = block.effectiveMessageIds.some((id) => presentIds.has(id));
         if (hasHit) {
-            if ((block as unknown as { orphanStreak?: number }).orphanStreak) {
-                (block as unknown as { orphanStreak?: number }).orphanStreak = 0;
-            }
+            orphanStreaks.delete(block);
             continue;
         }
-        const streak = ((block as unknown as { orphanStreak?: number }).orphanStreak ?? 0) + 1;
-        (block as unknown as { orphanStreak?: number }).orphanStreak = streak;
+        const streak = (orphanStreaks.get(block) ?? 0) + 1;
+        orphanStreaks.set(block, streak);
         if (streak >= ORPHAN_THRESHOLD) {
             reaped.push(block.blockId);
         }

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,0 +1,46 @@
+import { homedir } from "node:os";
+import path from "node:path";
+
+/** XDG base-directory paths for billion-context.
+ *
+ *  Follows the XDG Base Directory Specification so the proxy lands in the
+ *  conventional Linux/macOS locations instead of a bespoke ~/.bili/:
+ *
+ *    config (user-edited, dotfile-managed):
+ *      $XDG_CONFIG_HOME/billion-context/billion-context.json
+ *      default: ~/.config/billion-context/billion-context.json
+ *
+ *    data (persisted session state, grows over time):
+ *      $XDG_DATA_HOME/billion-context/sessions/
+ *      default: ~/.local/share/billion-context/sessions/
+ *
+ *  Env overrides (highest priority) are kept so test runners and container
+ *  setups can relocate everything without touching the config file. */
+
+function xdg(envVar: string, fallback: string): string {
+    const v = process.env[envVar];
+    if (v && v.length > 0) return path.resolve(v);
+    return path.join(homedir(), fallback);
+}
+
+/** Root config dir: user-editable configuration lives here. */
+export function configDir(): string {
+    return path.join(xdg("XDG_CONFIG_HOME", ".config"), "billion-context");
+}
+
+/** Main config file path. */
+export function configFile(): string {
+    return path.join(configDir(), "billion-context.json");
+}
+
+/** Root data dir: persistent session state lives here. */
+export function dataDir(): string {
+    return path.join(xdg("XDG_DATA_HOME", ".local/share"), "billion-context");
+}
+
+/** Sessions dir: one JSON file per session. */
+export function sessionsDir(): string {
+    const env = process.env.BILI_SESSIONS_DIR;
+    if (env && env.length > 0) return path.resolve(env);
+    return path.join(dataDir(), "sessions");
+}

--- a/src/persist.ts
+++ b/src/persist.ts
@@ -1,5 +1,5 @@
 import { promises as fs } from "node:fs";
-import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { createHash } from "node:crypto";
 import * as path from "node:path";
 import * as os from "node:os";
@@ -293,7 +293,7 @@ export class SessionStore {
             this.log("error", `[persist] flushSync FAILED for ${session.id}: ${msg(e)} — session NOT evicted to prevent loss`);
             // Best-effort: remove the orphan temp so it doesn't accumulate.
             try {
-                require("node:fs").unlinkSync(tmp);
+                unlinkSync(tmp);
             } catch {
                 /* ignore */
             }

--- a/src/persist.ts
+++ b/src/persist.ts
@@ -42,7 +42,8 @@ import type { Session, BlockContent } from "./session.js";
  *  - All writes within a process are serialized per-session by Node's single
  *    event loop; there is no per-session *request* serialization (two
  *    concurrent HTTP requests for the same session can interleave processTurn
- *    and corrupt in-memory state). See AGENTS.md.
+ *    and corrupt in-memory state). This is a known limitation; a per-session
+ *    lock should be added before promoting multi-agent concurrency as safe.
  */
 
 const PERSIST_VERSION = 1;

--- a/src/persist.ts
+++ b/src/persist.ts
@@ -2,7 +2,7 @@ import { promises as fs } from "node:fs";
 import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { createHash } from "node:crypto";
 import * as path from "node:path";
-import * as os from "node:os";
+import { sessionsDir } from "./paths.js";
 import { createInitialState, type CompressionState } from "acp-kernel";
 import type { Session, BlockContent } from "./session.js";
 
@@ -382,9 +382,7 @@ function msg(e: unknown): string {
 }
 
 function defaultDir(): string {
-    const env = process.env.BILI_SESSIONS_DIR;
-    if (env) return env;
-    return path.join(os.homedir(), ".bili", "sessions");
+    return sessionsDir();
 }
 
 function defaultDebounce(): number {

--- a/src/responses.ts
+++ b/src/responses.ts
@@ -53,6 +53,10 @@ export type ResponsesRequestBody = {
     instructions?: string;
     tools?: unknown[];
     stream?: boolean;
+    /** Codex 0.147+ sends a per-conversation UUID here. This is the most
+     *  explicit conversation identifier any client sends — prefer it over
+     *  previous_response_id and content hashing. */
+    session_id?: string;
     previous_response_id?: string;
     [key: string]: unknown;
 };
@@ -306,6 +310,13 @@ export { condenseOldToolResults, type CondenseOptions, type CondenseResult };
  *  rationale. */
 export function conversationSignalResponses(body: ResponsesRequestBody, headerValue?: string): string {
     if (headerValue && headerValue.trim()) return headerValue.trim();
+    // Codex 0.147+ sends body.session_id (a per-conversation UUID). Prefer it
+    // over previous_response_id (may be absent on the first turn) and over
+    // content hashing (collides on identical openers). See README "Session
+    // identity" for the per-client story.
+    if (typeof body.session_id === "string" && body.session_id.length > 0) {
+        return `codex-${body.session_id}`;
+    }
     if (typeof body.previous_response_id === "string" && body.previous_response_id.length > 0) {
         return `resp-${body.previous_response_id}`;
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -254,6 +254,20 @@ function diagTagSummary(messages: CoreMessage[], sessionId: string, strategy: st
     return `[${sessionId}] processTurn: ${messages.length} msgs, renderTags=${strategy}, ${textTagged} text tagged, ${toolTagged} tool tagged (should be 0 with text-only)`;
 }
 
+function diagNudge(turn: { nudge?: { shouldInject: boolean; reason: string; contextUsage: number; tier: number | null; breakdown?: Record<string, number> } | null }, sessionId: string, tokenCount: number, limit: number): string {
+    const n = turn.nudge;
+    if (!n) return `[${sessionId}] nudge: unavailable`;
+    const b = n.breakdown ?? {};
+    const pct = limit > 0 ? `${Math.round((tokenCount / limit) * 100)}%` : "?";
+    const growth = b["growth"] ?? 0;
+    const floor = b["growthFloor"] ?? 0;
+    const interval = b["nudgeGrowthTokens"] ?? 0;
+    const pendingT1 = b["pendingT1"] ?? 0;
+    const ref = b["growthReference"] ?? 0;
+    const inject = n.shouldInject ? `INJECT T${n.tier ?? "?"}` : "idle";
+    return `[${sessionId}] nudge ${inject}: usage=${pct} (${tokenCount}/${limit}), growth=${growth}/${floor} (ref=${ref}, interval=${interval}), pendingT1=${pendingT1}/${interval}, reason="${n.reason.slice(0, 120)}"`;
+}
+
 function prepareAnthropic(
     bodyBuffer: Buffer,
     req: http.IncomingMessage,
@@ -282,6 +296,7 @@ function prepareAnthropic(
         const turn = core.processTurn({ messages: msgs, state: session.state, config, tokenCount, renderTags: "text-only" });
         session.state = turn.state;
         log("info", diagTagSummary(turn.messages, sessionId, "text-only"));
+        log("info", diagNudge(turn, sessionId, tokenCount, config.modelContextLimit));
         processedMessages = applyCondense(turn.messages, opts, session);
         reapOrphanBlocks(session, msgs, deactivateBlock);
         rebuiltMessages = coreToAnthropic(processedMessages);
@@ -342,6 +357,7 @@ function prepareOpenai(
         const turn = core.processTurn({ messages: msgs, state: session.state, config, tokenCount, renderTags: "text-only" });
         session.state = turn.state;
         log("info", diagTagSummary(turn.messages, sessionId, "text-only"));
+        log("info", diagNudge(turn, sessionId, tokenCount, config.modelContextLimit));
         processedMessages = applyCondense(turn.messages, opts, session);
         reapOrphanBlocks(session, msgs, deactivateBlock);
         rebuiltMessages = coreToOpenai(processedMessages);
@@ -410,6 +426,7 @@ function prepareResponses(
         const turn = core.processTurn({ messages: msgs, state: session.state, config, tokenCount, renderTags: process.env.ACP_RENDER_NONE ? "none" : "text-only" });
         session.state = turn.state;
         log("info", diagTagSummary(turn.messages, sessionId, "text-only"));
+        log("info", diagNudge(turn, sessionId, tokenCount, config.modelContextLimit));
         processedMessages = applyCondense(turn.messages, opts, session);
         reapOrphanBlocks(session, msgs, deactivateBlock);
         // Rebuild input preserving the responses_lite contract:

--- a/src/server.ts
+++ b/src/server.ts
@@ -185,7 +185,21 @@ async function handle(
         res.end(JSON.stringify({ ok: true, upstream: opts.upstream }));
         return;
     }
-    const bodyBuffer = await readBody(req);
+    let bodyBuffer: Buffer;
+    try {
+        bodyBuffer = await readBody(req);
+    } catch (err) {
+        if (err instanceof BodyTooLargeError) {
+            log("warn", `413: request body exceeds ${err.limit} bytes`);
+            res.writeHead(413, { "content-type": "application/json" });
+            res.end(JSON.stringify({ error: { type: "request_too_large", message: err.message } }));
+            return;
+        }
+        log("warn", `read body failed: ${String(err)}`);
+        res.writeHead(400, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: { type: "invalid_request", message: String(err) } }));
+        return;
+    }
     const url = req.url ?? "";
     // Strip query string before matching path suffixes: a request like
     // `/v1/responses?foo=1` must still be detected as the responses protocol.
@@ -837,7 +851,17 @@ function headerValue(req: http.IncomingMessage, name: string): string | undefine
     return undefined;
 }
 
-function readBody(req: http.IncomingMessage): Promise<Buffer> {
+/** A thrown BodyTooLargeError lets handle() respond 413 cleanly before
+ *  destroying the request. Avoids a bare req.destroy() that would reject
+ *  readBody but leave the client connection with no HTTP response. */
+export class BodyTooLargeError extends Error {
+    constructor(public readonly limit: number) {
+        super(`request body exceeds ${limit} bytes`);
+        this.name = "BodyTooLargeError";
+    }
+}
+
+export function readBody(req: http.IncomingMessage): Promise<Buffer> {
     return new Promise((resolve, reject) => {
         const chunks: Buffer[] = [];
         let size = 0;
@@ -847,8 +871,10 @@ function readBody(req: http.IncomingMessage): Promise<Buffer> {
             size += c.length;
             if (size > MAX_REQUEST_BYTES) {
                 aborted = true;
-                reject(new Error(`request body exceeds ${MAX_REQUEST_BYTES} bytes`));
-                req.destroy();
+                // Reject FIRST so handle() can write a 413 and return.
+                // Then drain remaining data so the socket can close
+                // cleanly instead of lingering mid-request.
+                reject(new BodyTooLargeError(MAX_REQUEST_BYTES));
                 return;
             }
             chunks.push(c);

--- a/src/server.ts
+++ b/src/server.ts
@@ -30,7 +30,7 @@ import {
     injectResponsesInstructions,
     conversationSignalResponses,
 } from "./responses.js";
-import { getSession, listSessions, type Session, initSessions, markDirty, flushAllSessions, acquireInFlight, releaseInFlight } from "./session.js";
+import { getSession, listSessions, type Session, initSessions, markDirty, flushAllSessions, acquireInFlight, releaseInFlight, withSessionLock } from "./session.js";
 import { COMPRESS_TOOL, ACP_TOOLS_OPENAI, ACP_TOOLS_RESPONSES, COMPRESS_TOOL_NAME, buildCompressSystemPrompt, buildCompressTextSystemPrompt } from "./compress-tool.js";
 import { rewriteSseStream, rewriteJsonResponse, type RewriteCtx } from "./stream.js";
 import { reapOrphanBlocks } from "./orphan-gc.js";
@@ -210,34 +210,61 @@ async function handle(
     // declaration in providers.json first (same model can have different
     // windows behind different relays), then the built-in table. Falls back to
     // the global env default if neither matches.
-    let reqConfig = config;
+    // Parse body once and reuse everywhere (fixes duplicate JSON.parse).
+    let parsed: unknown = null;
     if (protocol && bodyBuffer.length > 0) {
-        const m = bodyBuffer.toString("utf8").match(/"model"\s*:\s*"([^"]+)"/);
-        if (m) {
-            const limit = resolveContextLimit(opts.routes, route?.provider, m[1]);
+        try {
+            parsed = JSON.parse(bodyBuffer.toString("utf8"));
+        } catch {
+            parsed = null;
+        }
+    }
+    // Per-request context limit: look up body.model against the per-route
+    // model declaration first, then the built-in table.
+    let reqConfig = config;
+    if (parsed && typeof parsed === "object") {
+        const model = (parsed as { model?: string }).model;
+        if (model) {
+            const limit = resolveContextLimit(opts.routes, route?.provider, model);
             if (limit && limit !== config.modelContextLimit) {
                 reqConfig = { ...config, modelContextLimit: limit };
             }
         }
     }
-    const prepared = opts.passthrough
-        ? null
-        : protocol === "anthropic"
-            ? prepareAnthropic(bodyBuffer, req, opts, core, reqConfig, log, protocol, upstreamOrigin)
-            : protocol === "openai"
-              ? prepareOpenai(bodyBuffer, req, opts, core, reqConfig, log, protocol, upstreamOrigin)
-              : protocol === "responses"
-                ? prepareResponses(bodyBuffer, req, opts, core, reqConfig, log, protocol, upstreamOrigin)
-                : null;
-    if (protocol === null && !opts.passthrough) {
-        log("warn", `unrecognized path ${url} — not a known protocol (/chat/completions, /v1/messages, /responses); forwarding unchanged`);
+    let prepared: Prepared | null = null;
+    if (!opts.passthrough && protocol && parsed && typeof parsed === "object") {
+        const sessionHeader = headerValue(req, opts.sessionHeader);
+        const conversation =
+            protocol === "anthropic"
+                ? conversationSignalAnthropic(parsed as AnthropicRequestBody, sessionHeader)
+                : protocol === "openai"
+                  ? conversationSignalOpenai(parsed as OpenAIRequestBody, sessionHeader)
+                  : conversationSignalResponses(parsed as ResponsesRequestBody, sessionHeader);
+        const sessionId = deriveProxySessionId(req.headers, protocol, upstreamOrigin, conversation);
+        const session = getSession(sessionId, { protocol, upstreamOrigin });
+        // Serialize per-session: prepare (processTurn mutates state) + forward
+        // (stream rewriter mutates state via compress/decompress) must not
+        // interleave across concurrent requests on the same session.
+        await withSessionLock(session, async () => {
+            prepared =
+                protocol === "anthropic"
+                    ? prepareAnthropic(parsed as AnthropicRequestBody, req, opts, core, reqConfig, log, session)
+                    : protocol === "openai"
+                      ? prepareOpenai(parsed as OpenAIRequestBody, req, opts, core, reqConfig, log, session)
+                      : prepareResponses(parsed as ResponsesRequestBody, req, opts, core, reqConfig, log, session);
+            acquireInFlight(session);
+            try {
+                await forward(req, res, opts, prepared!.body, prepared!, core, reqConfig, log, route);
+            } finally {
+                releaseInFlight(session);
+            }
+        });
     }
-    const outBody: Buffer | string = prepared ? prepared.body : bodyBuffer;
-    if (prepared) acquireInFlight(prepared.session);
-    try {
-        await forward(req, res, opts, outBody, prepared, core, reqConfig, log, route);
-    } finally {
-        if (prepared) releaseInFlight(prepared.session);
+    if (!prepared) {
+        if (protocol === null && !opts.passthrough) {
+            log("warn", `unrecognized path ${url} — not a known protocol (/chat/completions, /v1/messages, /responses); forwarding unchanged`);
+        }
+        await forward(req, res, opts, bodyBuffer, null, core, reqConfig, log, route);
     }
 }
 
@@ -270,20 +297,16 @@ function diagNudge(turn: { nudge?: { shouldInject: boolean; reason: string; cont
 }
 
 function prepareAnthropic(
-    bodyBuffer: Buffer,
+    parsed: AnthropicRequestBody,
     req: http.IncomingMessage,
     opts: ProxyOptions,
     core: CompressionCore,
     config: Config,
     log: (level: string, msg: string) => void,
-    protocol: "anthropic" | "openai" | "responses",
-    upstreamOrigin: string,
+    session: Session,
 ): Prepared {
-    const parsed = JSON.parse(bodyBuffer.toString("utf8")) as AnthropicRequestBody;
+    const sessionId = session.id;
     const stream = parsed.stream === true;
-    const sessionHeader = headerValue(req, opts.sessionHeader);
-    const sessionId = deriveProxySessionId(req.headers, protocol, upstreamOrigin, conversationSignalAnthropic(parsed, sessionHeader));
-    const session = getSession(sessionId, { protocol, upstreamOrigin });
     session.requests++;
 
     let processedMessages: CoreMessage[] = [];
@@ -328,20 +351,16 @@ function prepareAnthropic(
 }
 
 function prepareOpenai(
-    bodyBuffer: Buffer,
+    parsed: OpenAIRequestBody,
     req: http.IncomingMessage,
     opts: ProxyOptions,
     core: CompressionCore,
     config: Config,
     log: (level: string, msg: string) => void,
-    protocol: "anthropic" | "openai" | "responses",
-    upstreamOrigin: string,
+    session: Session,
 ): Prepared {
-    const parsed = JSON.parse(bodyBuffer.toString("utf8")) as OpenAIRequestBody;
+    const sessionId = session.id;
     const stream = parsed.stream === true;
-    const sessionHeader = headerValue(req, opts.sessionHeader);
-    const sessionId = deriveProxySessionId(req.headers, protocol, upstreamOrigin, conversationSignalOpenai(parsed, sessionHeader));
-    const session = getSession(sessionId, { protocol, upstreamOrigin });
     session.requests++;
 
     let processedMessages: CoreMessage[] = [];
@@ -396,20 +415,16 @@ function prepareOpenai(
 }
 
 function prepareResponses(
-    bodyBuffer: Buffer,
+    parsed: ResponsesRequestBody,
     req: http.IncomingMessage,
     opts: ProxyOptions,
     core: CompressionCore,
     config: Config,
     log: (level: string, msg: string) => void,
-    protocol: "anthropic" | "openai" | "responses",
-    upstreamOrigin: string,
+    session: Session,
 ): Prepared {
-    const parsed = JSON.parse(bodyBuffer.toString("utf8")) as ResponsesRequestBody;
+    const sessionId = session.id;
     const stream = parsed.stream === true;
-    const sessionHeader = headerValue(req, opts.sessionHeader);
-    const sessionId = deriveProxySessionId(req.headers, protocol, upstreamOrigin, conversationSignalResponses(parsed, sessionHeader));
-    const session = getSession(sessionId, { protocol, upstreamOrigin });
     session.requests++;
 
     let processedMessages: CoreMessage[] = [];

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,7 +2,7 @@ import http from "node:http";
 import fs from "node:fs";
 import { createCore, type CompressionCore, type Config, type CoreMessage, type NudgeDecision, estimateTokensFast, renderNudgeText, deactivateBlock } from "acp-kernel";
 import type { ProxyOptions } from "./config.js";
-import { lookupContextLimit } from "./config.js";
+import { resolveContextLimit } from "./config.js";
 import { fetchWithTimeout, MAX_REQUEST_BYTES } from "./fetch-util.js";
 import {
     anthropicToCore,
@@ -73,7 +73,7 @@ export function resolveUpstream(opts: ProxyOptions, reqUrl: string): { upstream:
         if (RESERVED.has(name.toLowerCase())) continue;
         const idx = segments.indexOf(name);
         if (idx < 0) continue;
-        const base = opts.routes[name].replace(/\/$/, "");
+        const base = opts.routes[name].url.replace(/\/$/, "");
         // Drop the single provider-name segment, keep the rest.
         const rest = [...segments.slice(0, idx), ...segments.slice(idx + 1)].join("/");
         const rewrittenUrl = base + rest;
@@ -200,25 +200,26 @@ async function handle(
                     ? "responses"
                     : null
             : null;
-    // Per-request context limit: look up body.model in the built-in table.
-    // Lets the proxy run with the right window per model without asking the
-    // user to configure one. Falls back to the global default.
-    let reqConfig = config;
-    if (protocol && bodyBuffer.length > 0) {
-        const m = bodyBuffer.toString("utf8").match(/"model"\s*:\s*"([^"]+)"/);
-        if (m) {
-            const limit = lookupContextLimit(m[1]);
-            if (limit && limit !== config.modelContextLimit) {
-                reqConfig = { ...config, modelContextLimit: limit };
-            }
-        }
-    }
     // Resolve the upstream route once here so both the session id (needs the
     // upstream ORIGIN for cross-provider isolation) and forward() (needs the
     // full rewritten URL) use the same decision. Computed before prepare() so
     // the session can embed the provider origin.
     const route = resolveUpstream(opts, req.url ?? "");
     const upstreamOrigin = route ? route.upstream : opts.upstream;
+    // Per-request context limit: look up body.model against the per-route model
+    // declaration in providers.json first (same model can have different
+    // windows behind different relays), then the built-in table. Falls back to
+    // the global env default if neither matches.
+    let reqConfig = config;
+    if (protocol && bodyBuffer.length > 0) {
+        const m = bodyBuffer.toString("utf8").match(/"model"\s*:\s*"([^"]+)"/);
+        if (m) {
+            const limit = resolveContextLimit(opts.routes, route?.provider, m[1]);
+            if (limit && limit !== config.modelContextLimit) {
+                reqConfig = { ...config, modelContextLimit: limit };
+            }
+        }
+    }
     const prepared = opts.passthrough
         ? null
         : protocol === "anthropic"

--- a/src/server.ts
+++ b/src/server.ts
@@ -40,7 +40,7 @@ import { compressLoopResponsesStream } from "./compress-loop-responses.js";
 import { rewriteOpenaiJsonResponse } from "./stream-openai.js";
 import { rewriteResponsesSseStream, rewriteResponsesJsonResponse } from "./stream-responses.js";
 import { emitStreamError } from "./stream-error.js";
-import { deriveSessionId as deriveProxySessionId } from "./session-id.js";
+import { deriveSessionId as deriveProxySessionId, affinityToken, clientConversationHeader } from "./session-id.js";
 
 const UPSTREAM_HOP_HEADERS = new Set([
     "host",
@@ -242,6 +242,12 @@ async function handle(
                   : conversationSignalResponses(parsed as ResponsesRequestBody, sessionHeader);
         const sessionId = deriveProxySessionId(req.headers, protocol, upstreamOrigin, conversation);
         const session = getSession(sessionId, { protocol, upstreamOrigin });
+        // Affinity token to forward upstream: prefer the client's own session
+        // header (opencode x-session-affinity, codex body.session_id); if the
+        // client sent none (pi), synthesize ses_<conversation> so upstream
+        // sticky-routing / cache pools still get a stable key. See README
+        // "Session identity".
+        const affinity = affinityToken(req.headers, conversation);
         // Serialize per-session: prepare (processTurn mutates state) + forward
         // (stream rewriter mutates state via compress/decompress) must not
         // interleave across concurrent requests on the same session.
@@ -254,7 +260,7 @@ async function handle(
                       : prepareResponses(parsed as ResponsesRequestBody, req, opts, core, reqConfig, log, session);
             acquireInFlight(session);
             try {
-                await forward(req, res, opts, prepared!.body, prepared!, core, reqConfig, log, route);
+                await forward(req, res, opts, prepared!.body, prepared!, core, reqConfig, log, route, affinity);
             } finally {
                 releaseInFlight(session);
             }
@@ -264,7 +270,7 @@ async function handle(
         if (protocol === null && !opts.passthrough) {
             log("warn", `unrecognized path ${url} — not a known protocol (/chat/completions, /v1/messages, /responses); forwarding unchanged`);
         }
-        await forward(req, res, opts, bodyBuffer, null, core, reqConfig, log, route);
+        await forward(req, res, opts, bodyBuffer, null, core, reqConfig, log, route, undefined);
     }
 }
 
@@ -568,6 +574,7 @@ async function forward(
     config: Config,
     log: (level: string, msg: string) => void,
     route: ReturnType<typeof resolveUpstream>,
+    affinity?: string,
 ): Promise<void> {
     const upstreamUrl = route ? route.rewrittenUrl : opts.upstream + (req.url ?? "");
     log("info", `forward ${req.method} ${req.url ?? ""} → ${upstreamUrl}${route ? ` (${route.provider})` : ""}`);
@@ -609,6 +616,15 @@ async function forward(
         headers[k] = Array.isArray(v) ? v.join(", ") : v;
     }
     headers["host"] = new URL(route ? route.upstream : opts.upstream).host;
+    // Inject a synthesized session-affinity header for clients that send none
+    // (pi). opencode already sends x-session-affinity (passed through above);
+    // codex carries identity in body.session_id (passes through in the body).
+    // pi sends nothing, so upstream sticky-routing/cache pools would fall back
+    // to content fingerprinting — give them a stable key instead. Only inject
+    // when the client sent NO session header at all (don't shadow opencode's).
+    if (affinity && !clientConversationHeader(req.headers)) {
+        headers["x-session-id"] = affinity;
+    }
     const init: RequestInit = {
         method: req.method ?? "GET",
         headers,

--- a/src/server.ts
+++ b/src/server.ts
@@ -228,6 +228,9 @@ async function handle(
               : protocol === "responses"
                 ? prepareResponses(bodyBuffer, req, opts, core, reqConfig, log, protocol, upstreamOrigin)
                 : null;
+    if (protocol === null && !opts.passthrough) {
+        log("warn", `unrecognized path ${url} — not a known protocol (/chat/completions, /v1/messages, /responses); forwarding unchanged`);
+    }
     const outBody: Buffer | string = prepared ? prepared.body : bodyBuffer;
     if (prepared) acquireInFlight(prepared.session);
     try {
@@ -264,7 +267,7 @@ function prepareAnthropic(
     const parsed = JSON.parse(bodyBuffer.toString("utf8")) as AnthropicRequestBody;
     const stream = parsed.stream === true;
     const sessionHeader = headerValue(req, opts.sessionHeader);
-    const sessionId = deriveProxySessionId(req.headers, protocol, upstreamOrigin, "", { clientConversation: conversationSignalAnthropic(parsed, sessionHeader) });
+    const sessionId = deriveProxySessionId(req.headers, protocol, upstreamOrigin, conversationSignalAnthropic(parsed, sessionHeader));
     const session = getSession(sessionId, { protocol, upstreamOrigin });
     session.requests++;
 
@@ -321,7 +324,7 @@ function prepareOpenai(
     const parsed = JSON.parse(bodyBuffer.toString("utf8")) as OpenAIRequestBody;
     const stream = parsed.stream === true;
     const sessionHeader = headerValue(req, opts.sessionHeader);
-    const sessionId = deriveProxySessionId(req.headers, protocol, upstreamOrigin, "", { clientConversation: conversationSignalOpenai(parsed, sessionHeader) });
+    const sessionId = deriveProxySessionId(req.headers, protocol, upstreamOrigin, conversationSignalOpenai(parsed, sessionHeader));
     const session = getSession(sessionId, { protocol, upstreamOrigin });
     session.requests++;
 
@@ -388,7 +391,7 @@ function prepareResponses(
     const parsed = JSON.parse(bodyBuffer.toString("utf8")) as ResponsesRequestBody;
     const stream = parsed.stream === true;
     const sessionHeader = headerValue(req, opts.sessionHeader);
-    const sessionId = deriveProxySessionId(req.headers, protocol, upstreamOrigin, "", { clientConversation: conversationSignalResponses(parsed, sessionHeader) });
+    const sessionId = deriveProxySessionId(req.headers, protocol, upstreamOrigin, conversationSignalResponses(parsed, sessionHeader));
     const session = getSession(sessionId, { protocol, upstreamOrigin });
     session.requests++;
 
@@ -584,6 +587,19 @@ async function forward(
         if (UPSTREAM_HOP_HEADERS.has(k.toLowerCase())) return;
         respHeaders[k] = v;
     });
+    // P1.2: if the upstream returned a non-2xx (auth, rate-limit, context too
+    // long, ...), do NOT route the error body through the SSE rewriter — it has
+    // no SSE events and would be silently swallowed, leaving the client with
+    // an empty stream and no idea why. Pass status + body through verbatim.
+    // (writeHead is done HERE, only in the error branch, so we never double-
+    // write headers when a later branch would also call writeHead.)
+    if (!upstream.ok) {
+        res.writeHead(upstream.status, respHeaders);
+        if (upstream.body) await pipeThrough(upstream.body, res);
+        clearUpstreamTimer();
+        return;
+    }
+    // 2xx path: now safe to commit the status + headers, then stream the body.
     res.writeHead(upstream.status, respHeaders);
     if (!upstream.body) {
         res.end();
@@ -601,16 +617,6 @@ async function forward(
         prepared.compressInjected &&
         prepared.processedMessages.length > 0;
     if (!useRewriter || prepared === null) {
-        await pipeThrough(upstream.body, res);
-        clearUpstreamTimer();
-        return;
-    }
-    // P1.2: if the upstream returned a non-2xx (auth, rate-limit, context too
-    // long, ...), do NOT route the error body through the SSE rewriter — it has
-    // no SSE events and would be silently swallowed, leaving the client with
-    // an empty stream and no idea why. Pass status + body through verbatim.
-    if (!upstream.ok) {
-        res.writeHead(upstream.status, respHeaders);
         await pipeThrough(upstream.body, res);
         clearUpstreamTimer();
         return;

--- a/src/session-id.ts
+++ b/src/session-id.ts
@@ -46,23 +46,23 @@ function clientConversationHeader(headers: Record<string, string | string[] | un
 }
 
 /**
- * Derive the proxy-internal session id. `firstUserContent` is a short prefix
- * of the first user message in the request, used as the conversation
- * fingerprint fallback when the client sends no session signal.
+ * Derive the proxy-internal session id. The conversation dimension MUST be
+ * supplied by the caller via `extra.conversation` (typically the output of
+ * the per-protocol conversationSignal* helper, which already falls back to a
+ * hash of the first user message). There is intentionally NO content-
+ * fingerprint fallback inside this function — a silent "" default would
+ * collapse every anonymous session onto one id. If `conversation` is missing
+ * the caller has a bug and we throw rather than silently mis-isolating.
  */
 export function deriveSessionId(
     headers: Record<string, string | string[] | undefined>,
     protocol: "anthropic" | "openai" | "responses",
     upstream: string,
-    firstUserContent: string,
-    extra?: { clientConversation?: string; protocolConversation?: string },
+    conversation: string,
 ): string {
+    if (!conversation) throw new Error("deriveSessionId: conversation dimension is required (pass the conversationSignal* output)");
     const key = extractKey(headers);
-    const convo =
-        extra?.clientConversation ??
-        extra?.protocolConversation ??
-        hashId(firstUserContent);
-    return hashId(`${protocol}|${upstream}|${key}|${convo}`);
+    return hashId(`${protocol}|${upstream}|${key}|${conversation}`);
 }
 
 /**
@@ -74,13 +74,11 @@ export function deriveSessionId(
  */
 export function affinityToken(
     headers: Record<string, string | string[] | undefined>,
-    firstUserContent: string,
-    protocolConversation?: string,
+    conversation: string,
 ): string {
     const client = clientConversationHeader(headers);
     if (client) return client;
-    const convo = protocolConversation ?? hashId(firstUserContent);
-    return `ses_${convo}`;
+    return `ses_${conversation}`;
 }
 
 export { clientConversationHeader };

--- a/src/session-id.ts
+++ b/src/session-id.ts
@@ -36,7 +36,7 @@ function extractKey(headers: Record<string, string | string[] | undefined>): str
 }
 
 /** Pull a client-provided conversation signal from headers, if any. */
-function clientConversationHeader(headers: Record<string, string | string[] | undefined>): string | undefined {
+export function clientConversationHeader(headers: Record<string, string | string[] | undefined>): string | undefined {
     const names = ["x-session-affinity", "x-acp-session", "x-session-id", "x-opencode-session"];
     for (const name of names) {
         const v = headers[name];
@@ -80,5 +80,3 @@ export function affinityToken(
     if (client) return client;
     return `ses_${conversation}`;
 }
-
-export { clientConversationHeader };

--- a/src/session.ts
+++ b/src/session.ts
@@ -41,6 +41,11 @@ export type Session = {
      *  drop a never-persisted session on flush failure (that would be a
      *  permanent loss). */
     persisted: boolean;
+    /** Promise chain for per-session serialization. Two concurrent requests
+     *  sharing a session id would interleave processTurn / stream-rewriter
+     *  mutations on session.state, corrupting it. withSessionLock chains each
+     *  critical section onto the previous one so they run strictly in order. */
+    lockChain?: Promise<unknown>;
 };
 
 const sessions = new Map<string, Session>();
@@ -116,6 +121,26 @@ export function acquireInFlight(session: Session): void {
 /** Release an in-use marker. Decrements; the session becomes evictable again. */
 export function releaseInFlight(session: Session): void {
     if (session.inFlight > 0) session.inFlight--;
+}
+
+/** Serialize a critical section per session. Each call chains onto the
+ *  previous lockChain, so concurrent requests for the same session execute
+ *  strictly one-at-a-time. This prevents two processTurn / stream-rewriter
+ *  invocations from interleaving mutations on session.state.
+ *
+ *  For single-agent workflows (the common case) there is no contention and
+ *  the chain resolves immediately. The cost is one Promise allocation. */
+export async function withSessionLock<T>(session: Session, fn: () => Promise<T>): Promise<T> {
+    const prev = session.lockChain ?? Promise.resolve();
+    let release!: () => void;
+    const done = new Promise<void>((resolve) => { release = resolve; });
+    session.lockChain = prev.then(() => done);
+    await prev;
+    try {
+        return await fn();
+    } finally {
+        release();
+    }
 }
 
 export function listSessions(): Session[] {

--- a/src/stream-responses.ts
+++ b/src/stream-responses.ts
@@ -218,9 +218,12 @@ function routeResponsesEvent(rawEvent: string, state: StreamState): string | nul
     if (t === "response.completed" || t === "response.incomplete") {
         state.responseObj = (obj.response as Record<string, unknown>) ?? null;
         state.done = true;
-        // In text protocol we always re-emit completed at the tail (after
-        // flushing buffered text + executing triggers).
-        if (TEXT_PROTOCOL) return null;
+        // In text protocol: if NO trigger was detected, pass the original
+        // completion through verbatim (we buffered text but nothing to do).
+        // Only suppress+rebuild when we actually caught a trigger.
+        if (TEXT_PROTOCOL && state.triggerPayloads.length === 0) {
+            return rawEvent + "\n\n";
+        }
         if (!state.converted) return rawEvent + "\n\n";
         return null;
     }
@@ -230,27 +233,31 @@ function routeResponsesEvent(rawEvent: string, state: StreamState): string | nul
 
 function buildResponsesTail(state: StreamState, ctx: RewriteCtx): string {
     let out = "";
-    // Text protocol: drain buffered text (splitting out any trigger), execute
-    // triggers, then re-emit completion. Runs even without a trigger so the
-    // buffered text is flushed and a clean completed is emitted.
+    // Text protocol: only rebuild when a trigger was actually caught.
+    // If none was caught, routeResponsesEvent already passed everything
+    // through verbatim (including the original completed), so this tail is
+    // never reached for the no-trigger case — return empty for safety.
     if (TEXT_PROTOCOL) {
+        if (state.triggerPayloads.length === 0) {
+            // No trigger: nothing to rewrite. The original completion was
+            // already passed through; nothing else to emit.
+            return "";
+        }
         const safeText = drainText(state);
         if (safeText) {
             out += sse("response.output_text.delta", { item_id: "msg_acp", output_index: 0, delta: safeText });
         }
-        if (state.triggerPayloads.length > 0) {
-            for (const payload of state.triggerPayloads) {
-                let parsed: unknown = {};
-                try {
-                    parsed = JSON.parse(payload);
-                } catch {
-                    ctx.log(`text-trigger: malformed JSON payload, skipping`);
-                    continue;
-                }
-                const note = applyRanges(parseCompressInput(parsed), ctx);
-                ctx.log(`text-trigger: executed compress → ${note.split("\n")[0].slice(0, 80)}`);
-                out += sse("response.output_text.delta", { item_id: "msg_acp_note", output_index: 0, delta: "\n" + note + "\n" });
+        for (const payload of state.triggerPayloads) {
+            let parsed: unknown = {};
+            try {
+                parsed = JSON.parse(payload);
+            } catch {
+                ctx.log(`text-trigger: malformed JSON payload, skipping`);
+                continue;
             }
+            const note = applyRanges(parseCompressInput(parsed), ctx);
+            ctx.log(`text-trigger: executed compress → ${note.split("\n")[0].slice(0, 80)}`);
+            out += sse("response.output_text.delta", { item_id: "msg_acp_note", output_index: 0, delta: "\n" + note + "\n" });
         }
         const base = (state.responseObj ?? { id: "resp_acp" }) as Record<string, unknown>;
         const respId = typeof base.id === "string" ? base.id : "resp_acp";

--- a/tests/basic.test.ts
+++ b/tests/basic.test.ts
@@ -91,7 +91,7 @@ test("conversationSignalAnthropic is stable for same first message, differs othe
     const a = conversationSignalAnthropic(body);
     const b = conversationSignalAnthropic(body);
     assert.equal(a, b);
-    const other = { ...body, messages: [{ role: "user", content: "different" }] };
+    const other = { ...body, messages: [{ role: "user" as const, content: "different" }] };
     assert.notEqual(a, conversationSignalAnthropic(other));
 });
 
@@ -312,9 +312,9 @@ test("processTurn adds ACP tags but tool-call args can be restored", async () =>
     const state = createInitialState();
     const args = '{"command":"echo hello"}';
     const msgs = [
-        { id: "raw-0", role: "user", contentType: "text" as const, text: "run echo" },
-        { id: "raw-1", role: "assistant", contentType: "tool-call" as const, text: args, toolName: "bash", toolCallId: "tc1" },
-        { id: "raw-2", role: "tool", contentType: "tool-result" as const, text: "hello", toolName: "bash", toolCallId: "tc1" },
+        { id: "raw-0", role: "user" as const, contentType: "text" as const, text: "run echo" },
+        { id: "raw-1", role: "assistant" as const, contentType: "tool-call" as const, text: args, toolName: "bash", toolCallId: "tc1" },
+        { id: "raw-2", role: "tool" as const, contentType: "tool-result" as const, text: "hello", toolName: "bash", toolCallId: "tc1" },
     ];
     const turn = core.processTurn({ messages: msgs, state, config, tokenCount: 100 });
     const tc = turn.messages.find(m => m.contentType === "tool-call")!;

--- a/tests/proxy-basic.test.ts
+++ b/tests/proxy-basic.test.ts
@@ -312,9 +312,9 @@ test("processTurn adds ACP tags but tool-call args can be restored", async () =>
     const state = createInitialState();
     const args = '{"command":"echo hello"}';
     const msgs = [
-        { id: "raw-0", role: "user", contentType: "text" as const, text: "run echo" },
-        { id: "raw-1", role: "assistant", contentType: "tool-call" as const, text: args, toolName: "bash", toolCallId: "tc1" },
-        { id: "raw-2", role: "tool", contentType: "tool-result" as const, text: "hello", toolName: "bash", toolCallId: "tc1" },
+        { id: "raw-0", role: "user" as const, contentType: "text" as const, text: "run echo" },
+        { id: "raw-1", role: "assistant" as const, contentType: "tool-call" as const, text: args, toolName: "bash", toolCallId: "tc1" },
+        { id: "raw-2", role: "tool" as const, contentType: "tool-result" as const, text: "hello", toolName: "bash", toolCallId: "tc1" },
     ];
     const turn = core.processTurn({ messages: msgs, state, config, tokenCount: 100 });
     const tc = turn.messages.find(m => m.contentType === "tool-call")!;

--- a/tests/proxy-orphan-gc.test.ts
+++ b/tests/proxy-orphan-gc.test.ts
@@ -9,8 +9,13 @@ function makeSession(): Session {
         id: `test-${Math.random().toString(36).slice(2)}`,
         state: createInitialState(),
         createdAt: Date.now(),
+        lastSeen: Date.now(),
         requests: 0,
+        condensedToolResults: 0,
+        tokensSaved: 0,
         blockContents: new Map(),
+        inFlight: 0,
+        persisted: false,
     };
 }
 

--- a/tests/proxy-persist.test.ts
+++ b/tests/proxy-persist.test.ts
@@ -30,6 +30,8 @@ function makeSession(id: string): Session {
         condensedToolResults: 0,
         tokensSaved: 0,
         blockContents: new Map(),
+        inFlight: 0,
+        persisted: false,
     };
 }
 

--- a/tests/proxy-readbody.test.ts
+++ b/tests/proxy-readbody.test.ts
@@ -1,0 +1,45 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { Readable } from "node:stream";
+import { EventEmitter } from "node:events";
+import { BodyTooLargeError, readBody } from "../src/server.ts";
+import { MAX_REQUEST_BYTES } from "../src/fetch-util.ts";
+
+test("readBody: returns buffer for a normal request", async () => {
+    const buf = Buffer.from("hello");
+    const req = Readable.from([buf]) as never;
+    const out = await readBody(req);
+    assert.equal(out.toString("utf8"), "hello");
+});
+
+test("readBody: rejects with BodyTooLargeError when body exceeds MAX_REQUEST_BYTES (no req.destroy)", async () => {
+    // Two chunks that together exceed MAX_REQUEST_BYTES. We emit the first
+    // (over-limit) chunk and expect a rejection of the right kind BEFORE any
+    // destroy would have run. The fix removed req.destroy() so the client
+    // connection stays open for handle() to write a 413.
+    const req = new EventEmitter();
+    let destroyed = false;
+    Object.defineProperty(req, "destroy", { value: () => { destroyed = true; }, configurable: true });
+    const p = readBody(req as never);
+    // Emit a chunk large enough to trip the limit.
+    (req as EventEmitter).emit("data", Buffer.alloc(MAX_REQUEST_BYTES + 1));
+    await assert.rejects(p, (e: unknown) => {
+        assert.ok(e instanceof BodyTooLargeError, `expected BodyTooLargeError, got ${(e as Error)?.constructor?.name}`);
+        return true;
+    });
+    assert.equal(destroyed, false, "req.destroy() must NOT be called (it cuts off the 413 response)");
+});
+
+test("readBody: BodyTooLargeError carries the limit", async () => {
+    const req = new EventEmitter();
+    Object.defineProperty(req, "destroy", { value: () => {}, configurable: true });
+    const p = readBody(req as never);
+    (req as EventEmitter).emit("data", Buffer.alloc(MAX_REQUEST_BYTES + 100));
+    try {
+        await p;
+        assert.fail("should have rejected");
+    } catch (e) {
+        assert.ok(e instanceof BodyTooLargeError);
+        if (e instanceof BodyTooLargeError) assert.equal(e.limit, MAX_REQUEST_BYTES);
+    }
+});

--- a/tests/proxy-responses-no-trigger.test.ts
+++ b/tests/proxy-responses-no-trigger.test.ts
@@ -1,0 +1,78 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { compressLoopResponsesStream } from "../src/compress-loop-responses.ts";
+import type { Config, CoreMessage } from "acp-kernel";
+import { createCore, createInitialState } from "acp-kernel";
+import type { Session } from "../src/session.ts";
+
+function makeCtx(log: (m: string) => void): { core: ReturnType<typeof createCore>; config: Config; messages: CoreMessage[]; session: Session; log: (m: string) => void } {
+    return {
+        core: createCore(),
+        config: { modelContextLimit: 200000 } as Config,
+        messages: [] as CoreMessage[],
+        session: {
+            id: "test",
+            state: createInitialState(),
+            createdAt: Date.now(),
+            lastSeen: Date.now(),
+            requests: 0,
+            condensedToolResults: 0,
+            tokensSaved: 0,
+            blockContents: new Map(),
+            inFlight: 0,
+            persisted: false,
+        },
+        log,
+    };
+}
+
+async function drain(
+    stream: ReadableStream<Uint8Array>,
+    ctx: ReturnType<typeof makeCtx>,
+    requestBody: Record<string, unknown>,
+    requestOptions: { url: string; headers: Record<string, string> },
+): Promise<string> {
+    const chunks: Buffer[] = [];
+    for await (const chunk of compressLoopResponsesStream(stream, ctx, requestBody, requestOptions)) {
+        chunks.push(chunk);
+    }
+    return Buffer.concat(chunks).toString("utf8");
+}
+
+function sse(type: string, data: unknown): string {
+    return `event: ${type}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+// NOTE: this test validates the NO-TRIGGER passthrough path of the text
+// protocol. TEXT_PROTOCOL (ACP_COMPRESS_PROTOCOL=text) used to suppress ALL
+// output_text.delta/done and forge a response.completed with output:[] even
+// when no <acp_compress> trigger was present — corrupting normal Responses
+// output. The fix: when no trigger was caught, pass every event through
+// verbatim (including the original completed).
+//
+// We simulate by NOT including any trigger in the response and asserting the
+// completion is the ORIGINAL one (not a forged output:[] one). The function
+// protocol (default) also passes through, so this test passes either way; it
+// guards against a regression that re-introduces blanket suppression.
+test("responses stream: normal output (no compress trigger) completes without forging output:[]", async () => {
+    const events = [
+        sse("response.created", { response: { id: "resp_9", status: "in_progress" } }),
+        sse("response.output_item.added", { item: { type: "message", id: "msg_9", role: "assistant", content: [] }, output_index: 0 }),
+        sse("response.output_text.delta", { item_id: "msg_9", output_index: 0, delta: "Real answer" }),
+        sse("response.output_text.done", { item_id: "msg_9", output_index: 0, text: "Real answer" }),
+        sse("response.output_item.done", { item: { type: "message", id: "msg_9", content: [{ type: "output_text", text: "Real answer" }] }, output_index: 0 }),
+        sse("response.completed", { response: { id: "resp_9", status: "completed", output: [{ type: "message", id: "msg_9", role: "assistant", content: [{ type: "output_text", text: "Real answer" }] }] } }),
+    ].join("");
+    const out = await drain(
+        new Response(events).body!,
+        makeCtx(() => {}),
+        { model: "gpt-4o", input: [{ type: "message", role: "user", content: "hi" }], stream: true },
+        { url: "http://unused", headers: {} },
+    );
+    // The real text must survive.
+    assert.match(out, /Real answer/);
+    // The original completed must survive (with its real output content).
+    assert.match(out, /response\.completed/);
+    // No forged empty-output completion should appear.
+    assert.doesNotMatch(out, /"output":\[\]/, "must NOT forge a completed with output:[] when there was real content");
+});

--- a/tests/proxy-responses-review.test.ts
+++ b/tests/proxy-responses-review.test.ts
@@ -11,7 +11,7 @@ function makeCtx(log: (m: string) => void): { core: ReturnType<typeof createCore
         core: createCore(),
         config: { modelContextLimit: 200000 } as Config,
         messages: [] as CoreMessage[],
-        session: { id: "test", state: createInitialState(), createdAt: Date.now(), lastSeen: Date.now(), requests: 0, condensedToolResults: 0, tokensSaved: 0 },
+        session: { id: "test", state: createInitialState(), createdAt: Date.now(), lastSeen: Date.now(), requests: 0, condensedToolResults: 0, tokensSaved: 0, blockContents: new Map(), inFlight: 0, persisted: false },
         log,
     };
 }

--- a/tests/proxy-responses-stream.test.ts
+++ b/tests/proxy-responses-stream.test.ts
@@ -18,6 +18,9 @@ function makeCtx(log: (m: string) => void): { core: ReturnType<typeof createCore
             requests: 0,
             condensedToolResults: 0,
             tokensSaved: 0,
+            blockContents: new Map(),
+            inFlight: 0,
+            persisted: false,
         },
         log,
     };

--- a/tests/proxy-session-id.test.ts
+++ b/tests/proxy-session-id.test.ts
@@ -16,6 +16,12 @@ test("deriveSessionId: same conversation + same key + same protocol + same upstr
     assert.equal(a, b);
 });
 
+test("deriveSessionId: stable for same (key, protocol, upstream, conversation)", () => {
+    const a = deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://bailian.example", "hello world");
+    const b = deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://bailian.example", "hello world");
+    assert.equal(a, b);
+});
+
 test("deriveSessionId: different API key → different session (no cross-account bleed)", () => {
     const a = deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://bailian.example", "hello world");
     const b = deriveSessionId(hdrs("Bearer keyB"), "anthropic", "https://bailian.example", "hello world");
@@ -34,52 +40,51 @@ test("deriveSessionId: different protocol → different session (no cross-format
     assert.notEqual(a, b);
 });
 
-test("deriveSessionId: different conversation (different first-user) → different session", () => {
+test("deriveSessionId: different conversation → different session", () => {
     const a = deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://bailian.example", "hello");
     const b = deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://bailian.example", "goodbye");
     assert.notEqual(a, b);
 });
 
-test("deriveSessionId: client conversation signal overrides content fingerprint", () => {
-    // Same first-user content but different client conversation headers → different sessions
-    const a = deriveSessionId(hdrs("Bearer keyA", "ses_111"), "anthropic", "https://up", "hello", {
-        clientConversation: "ses_111",
-    });
-    const b = deriveSessionId(hdrs("Bearer keyA", "ses_222"), "anthropic", "https://up", "hello", {
-        clientConversation: "ses_222",
-    });
+test("deriveSessionId: conversation signal is the only conversation dimension", () => {
+    // The conversation dimension is whatever the caller passes — typically the
+    // output of conversationSignal*, which already prefers a client header
+    // and falls back to a content hash. Here we just confirm the passed value
+    // is what matters (same key/proto/upstream, different convo → different).
+    const a = deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://up", "ses_111");
+    const b = deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://up", "ses_222");
     assert.notEqual(a, b);
-    // And two requests with the SAME client signal hit the same session even if
-    // the first-user content fingerprint input differs (the signal wins).
-    const c = deriveSessionId(hdrs("Bearer keyA", "ses_111"), "anthropic", "https://up", "different text", {
-        clientConversation: "ses_111",
-    });
-    assert.equal(a, c);
+    // Same convo signal → same session, regardless of anything else.
+    assert.equal(a, deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://up", "ses_111"));
 });
 
 test("deriveSessionId: no Authorization header → still works (uses placeholder key)", () => {
-    const id = deriveSessionId({}, "anthropic", "https://up", "hello");
+    const id = deriveSessionId({}, "anthropic", "https://up", "convo-1");
     assert.ok(id.length > 0);
     // Two keyless requests with same content → same session.
-    assert.equal(id, deriveSessionId({}, "anthropic", "https://up", "hello"));
+    assert.equal(id, deriveSessionId({}, "anthropic", "https://up", "convo-1"));
+});
+
+test("deriveSessionId: empty conversation dimension THROWS (no silent collapse)", () => {
+    // A caller that forgets to pass the conversation signal must fail loudly,
+    // not silently collapse every anonymous session onto one id.
+    assert.throws(() => deriveSessionId({}, "anthropic", "https://up", ""), /conversation dimension is required/);
 });
 
 test("affinityToken: uses client signal when present (passthrough, preserves ses_ format)", () => {
-    const t = affinityToken(hdrs("Bearer k", "ses_opencode_xyz"), "hello");
+    const t = affinityToken(hdrs("Bearer k", "ses_opencode_xyz"), "convo-1");
     assert.equal(t, "ses_opencode_xyz");
 });
 
-test("affinityToken: falls back to ses_<hash(convo)> when no client signal (no key, no upstream)", () => {
-    const t = affinityToken(hdrs("Bearer k"), "hello world");
-    assert.match(t, /^ses_[0-9a-f]+$/);
-    // Stable for same input.
-    assert.equal(t, affinityToken(hdrs("Bearer k"), "hello world"));
-    // Different content → different token.
-    assert.notEqual(t, affinityToken(hdrs("Bearer k"), "goodbye"));
+test("affinityToken: falls back to ses_<convo> when no client signal", () => {
+    const t = affinityToken(hdrs("Bearer k"), "convo-hash-xyz");
+    assert.equal(t, "ses_convo-hash-xyz");
+    // Different conversation → different token.
+    assert.notEqual(t, affinityToken(hdrs("Bearer k"), "other-convo"));
 });
 
-test("affinityToken: protocolConversation (Responses previous_response_id) wins over content fingerprint", () => {
-    const t = affinityToken(hdrs("Bearer k"), "some content", "resp_resp_abc123");
+test("affinityToken: protocolConversation (Responses previous_response_id) is just the conversation arg", () => {
+    const t = affinityToken(hdrs("Bearer k"), "resp_resp_abc123");
     assert.equal(t, "ses_resp_resp_abc123");
 });
 

--- a/tests/proxy-session-id.test.ts
+++ b/tests/proxy-session-id.test.ts
@@ -1,6 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { deriveSessionId, affinityToken, clientConversationHeader } from "../src/session-id.ts";
+import { conversationSignalResponses } from "../src/responses.ts";
 
 /** Helper: build a minimal headers object. */
 function hdrs(auth?: string, sessionAffinity?: string): Record<string, string> {
@@ -102,4 +103,44 @@ test("affinityToken is safe to send upstream: does NOT embed the API key", () =>
     const withKeyA = affinityToken(hdrs("Bearer keyA"), "hello");
     const withKeyB = affinityToken(hdrs("Bearer keyB"), "hello");
     assert.equal(withKeyA, withKeyB, "affinity token identical regardless of key");
+});
+
+test("conversationSignalResponses: prefers codex body.session_id (UUID) over previous_response_id and content hash", () => {
+    // Codex 0.147+ sends body.session_id (a per-conversation UUID). It is the
+    // most explicit identifier and must win over the fallbacks.
+    const body = {
+        input: "hello",
+        session_id: "019fdc81-a420-7a00-bbd1-0a64e3eb772c",
+        previous_response_id: "resp_abc",
+    } as unknown as Parameters<typeof conversationSignalResponses>[0];
+    const sig = conversationSignalResponses(body, undefined);
+    assert.equal(sig, "codex-019fdc81-a420-7a00-bbd1-0a64e3eb772c");
+});
+
+test("conversationSignalResponses: header (opencode x-session-affinity) still wins over body.session_id", () => {
+    // A client-provided session header is the strongest signal (it is what
+    // the client itself uses to identify the conversation).
+    const body = {
+        input: "hello",
+        session_id: "019fdc81-a420-7a00-bbd1-0a64e3eb772c",
+    } as unknown as Parameters<typeof conversationSignalResponses>[0];
+    const sig = conversationSignalResponses(body, "ses_opencode-123");
+    assert.equal(sig, "ses_opencode-123");
+});
+
+test("conversationSignalResponses: falls back to previous_response_id when no session_id and no header", () => {
+    const body = {
+        input: "hello",
+        previous_response_id: "resp_xyz",
+    } as unknown as Parameters<typeof conversationSignalResponses>[0];
+    assert.equal(conversationSignalResponses(body, undefined), "resp-resp_xyz");
+});
+
+test("conversationSignalResponses: falls back to content hash when nothing else (pi path)", () => {
+    const body = { input: "hello world" } as unknown as Parameters<typeof conversationSignalResponses>[0];
+    // No header, no session_id, no previous_response_id → deterministic hash.
+    const a = conversationSignalResponses(body, undefined);
+    const b = conversationSignalResponses({ input: "hello world" } as never, undefined);
+    assert.equal(a, b);
+    assert.ok(/^[0-9a-f]{16}$/.test(a), `expected content-hash id, got ${a}`);
 });

--- a/tests/routing.test.ts
+++ b/tests/routing.test.ts
@@ -11,7 +11,7 @@ const writeRoutes = (name: string, obj: unknown) => {
     writeFileSync(p, JSON.stringify(obj));
     return p;
 };
-const OPTS = (routes: Record<string, string>): ProxyOptions => ({ ...loadOptions({}), routes });
+const OPTS = (routes: Record<string, string>): ProxyOptions => ({ ...loadOptions({}), routes: Object.fromEntries(Object.entries(routes).map(([k, v]) => [k, { url: v }])) });
 
 test("routes are parsed as an object map { provider: url }", () => {
     const opts = loadOptions({ ACP_PROVIDERS: writeRoutes("obj", {}) });
@@ -23,15 +23,24 @@ test("routes are parsed as an object map { provider: url }", () => {
 test("routes object strips trailing slashes from baseURLs", () => {
     const p = writeRoutes("slash", { glm: "https://bigmodel.cn/", anthropic: "https://api.anthropic.com/" });
     const opts = loadOptions({ ACP_PROVIDERS: p });
-    assert.equal(opts.routes.glm, "https://bigmodel.cn");
-    assert.equal(opts.routes.anthropic, "https://api.anthropic.com");
+    assert.equal(opts.routes.glm?.url, "https://bigmodel.cn");
+    assert.equal(opts.routes.anthropic?.url, "https://api.anthropic.com");
     unlinkSync(p);
 });
 
-test("routes ignore non-string entries (defensive)", () => {
-    const p = writeRoutes("defensive", { glm: "https://ok", bad: 123, also: null });
+test("routes accept object form { url, models }", () => {
+    const p = writeRoutes("obj-form", { glm: { url: "https://bigmodel.cn", models: { "glm-5.2": { context: 1000000 } } } });
     const opts = loadOptions({ ACP_PROVIDERS: p });
-    assert.equal(opts.routes.glm, "https://ok");
+    assert.equal(opts.routes.glm?.url, "https://bigmodel.cn");
+    assert.equal(opts.routes.glm?.models?.["glm-5.2"]?.context, 1000000);
+    unlinkSync(p);
+});
+
+test("routes ignore invalid entries (defensive)", () => {
+    const p = writeRoutes("defensive", { glm: "https://ok", bad: 123, also: null, obj: { url: "https://obj" } });
+    const opts = loadOptions({ ACP_PROVIDERS: p });
+    assert.equal(opts.routes.glm?.url, "https://ok");
+    assert.equal(opts.routes.obj?.url, "https://obj");
     assert.ok(!("bad" in opts.routes));
     assert.ok(!("also" in opts.routes));
     unlinkSync(p);
@@ -59,7 +68,7 @@ test("lookupContextLimit returns undefined for unknown models", () => {
 test("path-based routing does not require apiKey in route config", () => {
     const p = writeRoutes("nokey", { glm: "https://bigmodel.cn" });
     const opts = loadOptions({ ACP_PROVIDERS: p });
-    assert.equal(opts.routes.glm, "https://bigmodel.cn");
+    assert.equal(opts.routes.glm?.url, "https://bigmodel.cn");
     assert.ok(!("apiKey" in opts));
     assert.ok(!("apiKey" in opts.routes));
     unlinkSync(p);


### PR DESCRIPTION
Follow-up to PR#5 (which merged before these fixes landed). 7 commits, cherry-picked clean from master.

## Bug fixes (from three rounds of proxy-driven code review)
- **double writeHead** on upstream error (ERR_HTTP_HEADERS_SENT) — writeHead deferred until after error branch *(review #1)*
- **ESM `require()`** in persist.ts (undefined in ESM → orphaned temp files) → top-level `import` *(review #1)*
- **session-id collapse risk** — firstUserContent="" could fold unrelated sessions *(review #1)*
- **compress-loop timer leak** — activeClearTimer overwritten each round without clearing previous *(review #2)*
- **orphanStreak `as unknown`** monkey-patch → WeakMap (type-safe) *(review #2)*
- **stale test refs / 7 test typecheck errors** — full `tsc --noEmit` now clean *(review #2)*
- **per-session lock** — concurrent requests sharing a session id could interleave processTurn/stream-rewriter mutations on session.state. Added `withSessionLock()` promise chain to serialize the prepare→forward critical section *(review #3)*
- **duplicate JSON.parse** — request body was parsed 4× (prepare + debug + error paths); now parsed once in handle() *(review #3)*
- **codex `body.session_id` ignored** — Codex 0.147+ sends a per-conversation UUID in body.session_id; proxy only read previous_response_id. Now preferred after the client header *(highest-priority body signal)*
- **pi sends no session identity** — when the client sends no session header, forward() injects a synthesized `x-session-id: ses_<hash>` so upstream sticky-routing gets a stable key (does not shadow opencode's `x-session-affinity` or codex's body id)

## Features
- **per-route per-model context window** — providers.json now carries model context/output limits (mirrors opencode/pi registries). LLM `/models` API does NOT return context windows (verified across OpenAI/Anthropic/智谱/comfly); this is the source of truth. Resolves spurious-frequent-compression bug (GLM-5.2 was guessed as 128K, actually 1M).
- **nudge decision logging** — logs growth/usage/pendingT1/shouldInject per processTurn for compression-frequency analysis.
- **XDG-standard config + data layout** — `~/.bili/` → `~/.config/billion-context/billion-context.json` (config) + `~/.local/share/billion-context/sessions/` (data). Single JSON config consolidates ~15 ACP_`* env vars. Env vars still work (override the file).

## Session identity (documented in README)
| Client | Sends id? | Source | Safety |
|---|---|---|---|
| Codex | ✅ | `body.session_id` (UUID) | ✅ safe |
| OpenCode | ✅ | `x-session-affinity` header | ✅ safe |
| pi | ❌ | nothing | ⚠️ collision risk, not recommended for many concurrent conversations |

## Verification
- `tsc --noEmit`: 0 errors (incl. tests)
- 141 tests pass
- `npm run build`: ✅