### PR TITLE
feat: bili CLI + debug in config + README rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,42 +36,68 @@ The proxy injects four context-management tools (`compress`, `decompress`, `sear
 npm install -g billion-context
 ```
 
+This installs the `bili` command (`bili-proxy` is kept as an alias).
+
 ## Usage
 
-### Single provider
-
-Start the proxy pointing at one upstream (simplest):
+### Start the proxy
 
 ```bash
-UPSTREAM=https://api.anthropic.com bili-proxy
+bili
 ```
 
-Then point your agent at the proxy.
+That's it. The proxy reads its config from `~/.config/billion-context/billion-context.json` (XDG) and listens on `127.0.0.1:8787`. If no config file exists yet, it uses sensible defaults and logs where it expects the file.
 
-### Multiple providers (recommended)
-
-See [Configuration](#configuration) below for how to route to multiple
-providers by URL path — most users will want this.
-
-### Claude Code
+### Quick overrides (flags)
 
 ```bash
-export ANTHROPIC_BASE_URL=http://localhost:8787
-export ANTHROPIC_API_KEY=sk-ant-...
+bili --port 9000              # change listen port
+bili --host 0.0.0.0           # listen on all interfaces
+bili --debug                 # verbose logging (also: set "debug": true in config)
+bili --passthrough           # forward without compression (smoke-test mode)
+bili --config ~/my-bili.json # use a different config file
+```
+
+Flags override the config file and env vars. `bili --help` lists them all.
+
+### Point your agent at the proxy
+
+The proxy routes by a **provider name in the URL path**. Set your agent's base URL to `http://localhost:8787/<provider>/...` and the proxy forwards to that provider (see [Configuration](#configuration) for how providers are declared).
+
+#### Claude Code (Anthropic)
+
+```bash
+export ANTHROPIC_BASE_URL=http://localhost:8787/anthropic
+export ANTHROPIC_API_KEY=sk-ant-...   # real key — passed through as-is
 claude
 ```
 
-### Codex / any OpenAI-compatible agent
+#### Codex / any OpenAI-compatible agent (zhipu / openai / deepseek)
 
 ```bash
-export OPENAI_BASE_URL=http://localhost:8787/v1
-export OPENAI_API_KEY=sk-...
+export OPENAI_BASE_URL=http://localhost:8787/zhipu/api/coding/paas/v4
+export OPENAI_API_KEY=<your real glm key>   # passed through as-is
 codex
 ```
 
-### Cursor / Aider / others
+The `/zhipu/...` prefix tells the proxy to route to the `zhipu` provider; the
+remaining path is preserved.
 
-Set the base URL / API endpoint to `http://localhost:8787` (Anthropic) or `http://localhost:8787/v1` (OpenAI) in the agent's settings.
+#### Cursor / Aider / others
+
+Set the base URL to `http://localhost:8787/<provider>` in the agent's settings.
+
+### Debugging
+
+Three ways to enable verbose logging (priority: flag > env > config):
+
+1. **CLI flag** (quickest): `bili --debug`
+2. **Env var**: `ACP_DEBUG=1 bili`
+3. **Config file**: `"debug": true` in `billion-context.json`
+
+Verbose mode logs every `processTurn` (tag counts, token usage), the nudge
+decision (growth/usage/pendingT1/shouldInject), client headers, and SSE
+rewrites.
 
 ## Configuration
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "main": "dist/index.js",
   "bin": {
+    "bili": "./dist/index.js",
     "bili-proxy": "./dist/index.js"
   },
   "scripts": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+/**
+ * `bili` — billion-context proxy CLI.
+ *
+ * Usage:
+ *   bili                          start the proxy (default command)
+ *   bili start                    start the proxy (explicit)
+ *   bili start --port 9000        override listen port
+ *   bili start --host 0.0.0.0     override listen host
+ *   bili start --debug            verbose logging
+ *   bili start --config FILE      path to config file (default: XDG)
+ *   bili start --passthrough      forward without compression
+ *   bili --version
+ *   bili --help
+ *
+ * Flags override values from the config file / env. See README §Configuration
+ * for the full config-file schema (which also supports `debug`, `port`, etc.
+ * — flags are just convenient overrides).
+ */
+import { loadOptions } from "./config.js";
+import { startServer } from "./server.js";
+import { configFile as defaultConfigFile } from "./paths.js";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const VERSION = (() => {
+    try {
+        // Works in both dev (tsx: src/cli.ts → ../package.json) and bundled
+        // (tsup: dist/index.js → ../package.json).
+        const here = fileURLToPath(import.meta.url);
+        const pkg = path.join(path.dirname(here), "..", "package.json");
+        return (JSON.parse(readFileSync(pkg, "utf8")).version as string) ?? "dev";
+    } catch {
+        return "dev";
+    }
+})();
+
+const HELP = `bili ${VERSION} — billion-context proxy
+
+Usage:
+  bili [start] [options]        start the proxy (default: reads ${defaultConfigFile()})
+  bili --version                print version
+  bili --help                   show this help
+
+Options (override config file / env):
+  --port <N>                    listen port (default 8787)
+  --host <ADDR>                 listen host (default 127.0.0.1)
+  --config <FILE>               path to config JSON (default: XDG location)
+  --debug                       verbose logging
+  --passthrough                 forward without compression
+  --no-passthrough              force compression on (overrides config)
+
+Config: ${defaultConfigFile()}
+  Set port/host/debug/providers/condense/compress there. See README §Configuration.
+  Env vars (ACP_*, BILI_*) also work and override the file; CLI flags win.
+
+Docs: https://github.com/ranxianglei/billion-context
+`;
+
+type Parsed = {
+    command: "start" | "help" | "version";
+    overrides: Record<string, string | undefined>;
+};
+
+function parseArgs(argv: string[]): Parsed {
+    const overrides: Record<string, string | undefined> = {};
+    let command: Parsed["command"] = "start";
+    const positional: string[] = [];
+
+    for (let i = 0; i < argv.length; i++) {
+        const a = argv[i]!;
+        switch (a) {
+            case "--help":
+            case "-h":
+                command = "help";
+                break;
+            case "--version":
+            case "-V":
+                command = "version";
+                break;
+            case "--debug":
+                overrides.ACP_DEBUG = "1";
+                break;
+            case "--passthrough":
+                overrides.ACP_PASSTHROUGH = "1";
+                break;
+            case "--no-passthrough":
+                overrides.ACP_PASSTHROUGH = "0";
+                break;
+            case "--port":
+            case "--host":
+            case "--config": {
+                const val = argv[++i];
+                if (val === undefined) {
+                    console.error(`bili: ${a} requires a value`);
+                    process.exit(2);
+                }
+                if (a === "--port") overrides.ACP_PORT = val;
+                else if (a === "--host") overrides.ACP_HOST = val;
+                else overrides.BILI_CONFIG_FILE = val;
+                break;
+            }
+            default:
+                if (a.startsWith("--")) {
+                    // Allow --port=9000 form.
+                    const eq = a.indexOf("=");
+                    if (eq > 0) {
+                        argv.splice(i, 1, a.slice(0, eq), a.slice(eq + 1));
+                        i--;
+                        break;
+                    }
+                    console.error(`bili: unknown option ${a}`);
+                    process.exit(2);
+                }
+                positional.push(a);
+        }
+    }
+
+    // First positional (if any) is the command. Only "start" is recognized;
+    // an unknown command is an error.
+    if (positional.length > 0) {
+        const cmd = positional[0]!;
+        if (cmd === "start") {
+            command = command === "help" || command === "version" ? command : "start";
+        } else {
+            console.error(`bili: unknown command "${cmd}" (try "bili --help")`);
+            process.exit(2);
+        }
+    }
+
+    return { command, overrides };
+}
+
+export async function main(): Promise<void> {
+    const { command, overrides } = parseArgs(process.argv.slice(2));
+    if (command === "help") {
+        process.stdout.write(HELP);
+        return;
+    }
+    if (command === "version") {
+        process.stdout.write(VERSION + "\n");
+        return;
+    }
+
+    // CLI flags override env (which overrides the config file inside
+    // loadOptions). Merge into process.env so loadOptions picks them up.
+    for (const [k, v] of Object.entries(overrides)) {
+        if (v !== undefined) process.env[k] = v;
+    }
+    const opts = loadOptions();
+    await startServer(opts);
+}
+
+main().catch((err) => {
+    console.error("bili: failed to start:", err);
+    process.exit(1);
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,6 @@
 #!/usr/bin/env node
-import { loadOptions } from "./config.js";
-import { startServer } from "./server.js";
-
-const opts = loadOptions();
-startServer(opts).catch((err) => {
-    console.error("failed to start:", err);
-    process.exit(1);
-});
+// Entry point: runs the CLI dispatcher (src/cli.ts).
+// Both `bili` and `bili-proxy` bin aliases point here, and `node dist/index.js`
+// still works.
+import { main } from "./cli.js";
+main();

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -30,6 +30,8 @@ export function configDir(): string {
 
 /** Main config file path. */
 export function configFile(): string {
+    const env = process.env.BILI_CONFIG_FILE;
+    if (env && env.length > 0) return path.resolve(env);
     return path.join(configDir(), "billion-context.json");
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -112,7 +112,7 @@ export async function startServer(opts: ProxyOptions): Promise<http.Server> {
             `acp-proxy listening on http://${opts.host}:${opts.port}` +
                 (Object.keys(opts.routes).length
                     ? ` — routes: ${Object.entries(opts.routes)
-                          .map(([n, u]) => `${n}=${u}`)
+                          .map(([n, u]) => `${n}=${typeof u === "string" ? u : u.url}`)
                           .join(", ")}`
                     : ` → ${opts.upstream}`),
         );


### PR DESCRIPTION
## What
- ** CLI** — new primary command with subcommands and flags. `bili-proxy` kept as alias for backward compat.
- **debug configurable from config file** — `"debug": true` in `billion-context.json` now works (was env-only). Three ways: flag > env > config.
- **README Usage rewritten** — `bili` is the documented entry point; routing examples updated; Debugging section added.

## CLI usage
```bash
bili                              # start (reads ~/.config/billion-context/billion-context.json)
bili --port 9000 --debug          # override port + verbose
bili --config ~/my-bili.json      # use a different config file
bili --help / --version
```

## Files
- `src/cli.ts` (new) — arg parser + command dispatcher
- `src/index.ts` — delegates to cli (both `bili` and `bili-proxy` bins point here)
- `src/paths.ts` — `configFile()` respects `BILI_CONFIG_FILE` env (`--config` flag)
- `src/server.ts` — fix startup banner printing `[object Object]` for `{url,models}` routes
- `package.json` — add `bili` bin, keep `bili-proxy`
- `README.md` — Usage + Debugging sections rewritten

## Verification
- typecheck ✅ (src + full tsc --noEmit 0 errors)
- 145 tests pass
- build ✅
- manual: `bili --help` / `--version` / `start --port` / `--debug` all verified

Follow-up to PR#6 (master after merge).