### PR TITLE
feat: release CI (npm auto-publish on release branch)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,88 @@
+name: Release
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      - name: Check if release branch merge
+        id: check
+        run: |
+          COMMIT_MSG=$(git log -1 --pretty=%B)
+          MERGE_BRANCH=$(echo "$COMMIT_MSG" | sed -n 's/^Merge pull request #[0-9]* from [^/]*\/\(.*\)$/\1/p' || echo "")
+          if echo "$MERGE_BRANCH" | grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2}_release-v'; then
+            echo "is_release=true" >> $GITHUB_OUTPUT
+          elif echo "$COMMIT_MSG" | grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2}_release-v'; then
+            echo "is_release=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_release=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Setup
+        if: steps.check.outputs.is_release == 'true'
+        run: npm ci
+
+      - name: Build and test
+        if: steps.check.outputs.is_release == 'true'
+        run: |
+          npm run typecheck
+          npm test
+          npm run build
+
+      - name: Read version
+        if: steps.check.outputs.is_release == 'true'
+        id: version
+        run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+
+      - name: Check if prerelease
+        if: steps.check.outputs.is_release == 'true'
+        id: pre
+        run: |
+          if echo "${{ steps.version.outputs.version }}" | grep -q '-'; then
+            echo "tag=dev" >> $GITHUB_OUTPUT
+            echo "prerelease=true" >> $GITHUB_OUTPUT
+          else
+            echo "tag=latest" >> $GITHUB_OUTPUT
+            echo "prerelease=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create tag
+        if: steps.check.outputs.is_release == 'true'
+        run: |
+          git tag "v${{ steps.version.outputs.version }}" || true
+          git push origin "v${{ steps.version.outputs.version }}" || true
+
+      - name: Publish
+        if: steps.check.outputs.is_release == 'true'
+        run: npm publish --tag ${{ steps.pre.outputs.tag }} --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Release
+        if: steps.check.outputs.is_release == 'true'
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ steps.version.outputs.version }}
+          release_name: v${{ steps.version.outputs.version }}
+          prerelease: ${{ steps.pre.outputs.prerelease }}
+          body: |
+            ## Release v${{ steps.version.outputs.version }}
+
+            See [commits since last tag](https://github.com/${{ github.repository }}/compare/$(git describe --tags --abbrev=0 v${{ steps.version.outputs.version }}^ 2>/dev/null || echo HEAD~10)...v${{ steps.version.outputs.version }})

--- a/package.json
+++ b/package.json
@@ -54,5 +54,9 @@
     "dist",
     "README.md",
     "LICENSE"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  }
 }


### PR DESCRIPTION
## What

Adds GitHub Actions workflow that auto-publishes to npm when a `*_release-v*` branch merges to master (same pattern as acp-kernel / bili-pi).

```
push to master
  → check commit/branch name matches *_release-v*
  → npm ci + typecheck + test + build
  → npm publish --tag latest (or dev if prerelease)
  → git tag v{version} + GitHub Release
```

Also adds `publishConfig` (public access).

## Prereq (owner action)

**Add `NPM_TOKEN` secret to the repo** (Settings → Secrets and variables → Actions → New repository secret). Without it the publish step will fail.

## After merge

To cut a release, open `YYYY-MM-DD_release-v{VERSION}` branch, bump `version` in package.json, commit `release v{VERSION}`, open PR, merge. CI publishes automatically.

## Checklist
- [x] typecheck pass
- [x] 47 tests pass
- [x] build pass