### PR TITLE
release v0.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Release v0.1.2

First npm release with the new `bili` CLI and release CI infrastructure.

### Includes (since v0.1.1)
- `bili` command (new primary entry, `bili-proxy` kept as alias) — PR#7
- `--port/--host/--config/--debug/--passthrough` flags
- Release CI workflow (this PR triggers it) — PR#8
- `publishConfig` (public access)
- README Usage + Debugging rewrite

### Pre-flight
- [x] typecheck: 0 errors
- [x] tests: 145 pass
- [x] build: success

### Release mechanism
Merging this PR (commit message `release v0.1.2` on `*_release-v*` branch) triggers `release.yml` → npm publish `--tag latest` + git tag `v0.1.2` + GitHub Release.

⚠️ **Requires `NPM_TOKEN` secret configured in repo Settings.**