### PR TITLE
release v0.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -151,8 +151,3 @@ export async function main(): Promise<void> {
     const opts = loadOptions();
     await startServer(opts);
 }
-
-main().catch((err) => {
-    console.error("bili: failed to start:", err);
-    process.exit(1);
-});

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,4 +3,7 @@
 // Both `bili` and `bili-proxy` bin aliases point here, and `node dist/index.js`
 // still works.
 import { main } from "./cli.js";
-main();
+main().catch((err) => {
+    console.error("bili: failed to start:", err);
+    process.exit(1);
+});


### PR DESCRIPTION
## Hotfix release v0.1.3

### Fix
**Double-start bug (EADDRINUSE)** — `bili start` started the server twice and the second `listen()` crashed.

Root cause: `src/cli.ts` had a leftover top-level `main().catch(...)` from when it was the standalone entry. After `src/index.ts` became the real entry and tsup bundled cli.ts into index.js, both call sites fired → `main()` ran twice → two `startServer()` → two `listen()` on the same port.

Fix:
- Removed the top-level `main().catch()` from `src/cli.ts` (it's a library module now, not an entry).
- Moved the error-handler to `src/index.ts` (the actual entry): `main().catch(...)`.

### Verified
```
2026-08-08T...Z [info] [persist] enabled          ← once now (was twice)
2026-08-08T...Z [info] acp-proxy listening on ...  ← once, no EADDRINUSE
```

typecheck ✅ / 145 tests ✅ / build ✅

### Release mechanism
Merge with **Create a merge commit** (not squash) so the `release v0.1.3` commit + branch name `*_release-v*` trigger `release.yml` → npm publish + tag + GitHub Release.