### PR TITLE
feat: self-update (auto + manual)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,20 @@ Verbose mode logs every `processTurn` (tag counts, token usage), the nudge
 decision (growth/usage/pendingT1/shouldInject), client headers, and SSE
 rewrites.
 
+### Self-update
+
+The proxy checks npm for a newer version on startup and every 3 minutes. When a
+newer version is found it installs it globally (`npm install -g`) and logs a
+notice — **restart `bili` to pick up the new version**.
+
+```bash
+bili update          # check & install now (manual, bypasses 3min throttle)
+bili --no-auto-update   # disable self-update for this run
+```
+
+Disable permanently via config (`"autoUpdate": false`) or env
+(`ACP_AUTO_UPDATE=0`).
+
 ## Configuration
 
 Configuration is read from a JSON file with env-var overrides. Priority:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,6 +20,7 @@
 import { loadOptions } from "./config.js";
 import { startServer } from "./server.js";
 import { configFile as defaultConfigFile } from "./paths.js";
+import { checkForUpdate, startAutoUpdate } from "./update.js";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
@@ -36,10 +37,21 @@ const VERSION = (() => {
     }
 })();
 
+const PACKAGE_NAME = (() => {
+    try {
+        const here = fileURLToPath(import.meta.url);
+        const pkg = path.join(path.dirname(here), "..", "package.json");
+        return (JSON.parse(readFileSync(pkg, "utf8")).name as string) ?? "billion-context";
+    } catch {
+        return "billion-context";
+    }
+})();
+
 const HELP = `bili ${VERSION} — billion-context proxy
 
 Usage:
   bili [start] [options]        start the proxy (default: reads ${defaultConfigFile()})
+  bili update                   check for & install a newer version now
   bili --version                print version
   bili --help                   show this help
 
@@ -50,16 +62,17 @@ Options (override config file / env):
   --debug                       verbose logging
   --passthrough                 forward without compression
   --no-passthrough              force compression on (overrides config)
+  --no-auto-update              disable background self-update this run
 
 Config: ${defaultConfigFile()}
-  Set port/host/debug/providers/condense/compress there. See README §Configuration.
+  Set port/host/debug/providers/condense/compress/autoUpdate there. See README §Configuration.
   Env vars (ACP_*, BILI_*) also work and override the file; CLI flags win.
 
 Docs: https://github.com/ranxianglei/billion-context
 `;
 
 type Parsed = {
-    command: "start" | "help" | "version";
+    command: "start" | "update" | "help" | "version";
     overrides: Record<string, string | undefined>;
 };
 
@@ -81,6 +94,9 @@ function parseArgs(argv: string[]): Parsed {
                 break;
             case "--debug":
                 overrides.ACP_DEBUG = "1";
+                break;
+            case "--no-auto-update":
+                overrides.ACP_AUTO_UPDATE = "0";
                 break;
             case "--passthrough":
                 overrides.ACP_PASSTHROUGH = "1";
@@ -117,12 +133,14 @@ function parseArgs(argv: string[]): Parsed {
         }
     }
 
-    // First positional (if any) is the command. Only "start" is recognized;
+    // First positional (if any) is the command. "start" | "update" are recognized;
     // an unknown command is an error.
     if (positional.length > 0) {
         const cmd = positional[0]!;
         if (cmd === "start") {
             command = command === "help" || command === "version" ? command : "start";
+        } else if (cmd === "update") {
+            command = "update";
         } else {
             console.error(`bili: unknown command "${cmd}" (try "bili --help")`);
             process.exit(2);
@@ -142,6 +160,11 @@ export async function main(): Promise<void> {
         process.stdout.write(VERSION + "\n");
         return;
     }
+    if (command === "update") {
+        // Manual one-shot update — bypasses the 6h throttle.
+        await checkForUpdate({ packageName: PACKAGE_NAME, currentVersion: VERSION, autoUpdate: true }, true);
+        return;
+    }
 
     // CLI flags override env (which overrides the config file inside
     // loadOptions). Merge into process.env so loadOptions picks them up.
@@ -150,4 +173,10 @@ export async function main(): Promise<void> {
     }
     const opts = loadOptions();
     await startServer(opts);
+
+    // Start background auto-update after the server is listening so a slow
+    // registry check never delays startup or races the listen socket.
+    if (opts.autoUpdate) {
+        startAutoUpdate({ packageName: PACKAGE_NAME, currentVersion: VERSION, autoUpdate: true });
+    }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -109,6 +109,7 @@ export type ProxyOptions = {
     debug: boolean;
     dumpSse?: string;
     passthrough: boolean;
+    autoUpdate: boolean;
 };
 
 export function loadOptions(env: NodeJS.ProcessEnv = process.env): ProxyOptions {
@@ -162,6 +163,7 @@ export function loadOptions(env: NodeJS.ProcessEnv = process.env): ProxyOptions 
         debug: (env.ACP_DEBUG ?? (fileConfig.debug ? "1" : "0")) === "1",
         dumpSse: env.ACP_DUMP_SSE || fileConfig.dumpSse || undefined,
         passthrough: (env.ACP_PASSTHROUGH ?? (fileConfig.passthrough ? "1" : "0")) === "1",
+        autoUpdate: (env.ACP_AUTO_UPDATE ?? (fileConfig.autoUpdate === false ? "0" : "1")) !== "0",
     };
 }
 
@@ -181,6 +183,7 @@ type FileConfig = {
     debug?: boolean;
     dumpSse?: string;
     passthrough?: boolean;
+    autoUpdate?: boolean;
     condense?: { enabled?: boolean; keepRecentToolResults?: number; minCharsToCondense?: number; maxKeptChars?: number };
     compress?: { injectTool?: boolean; injectNudge?: boolean };
 };

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -46,3 +46,8 @@ export function sessionsDir(): string {
     if (env && env.length > 0) return path.resolve(env);
     return path.join(dataDir(), "sessions");
 }
+
+/** Root cache dir: transient/ephemeral data (update-check throttle, etc.). */
+export function cacheDir(): string {
+    return path.join(xdg("XDG_CACHE_HOME", ".cache"), "billion-context");
+}

--- a/src/update.ts
+++ b/src/update.ts
@@ -1,0 +1,148 @@
+/**
+ * Auto-update: periodically checks the npm registry for a newer version of
+ * billion-context and installs it globally when one is found.
+ *
+ * Design notes (differs from the billion-context-pi extension updater):
+ *  - The proxy is a long-running server, so we check on startup and then every
+ *    few hours (not per-LLM-call like the extension).
+ *  - The package is installed globally (`npm install -g`), not into a host
+ *    extension dir.
+ *  - There is no TUI to show a notification in, so results are logged to the
+ *    console (the terminal where `bili` runs, or /tmp/bili-proxy.log for
+ *    background test runs). After a successful install the *running* process
+ *    is still old code; we log a clear "restart to finish" message.
+ */
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { execFile } from "node:child_process";
+import path from "node:path";
+import { cacheDir } from "./paths.js";
+
+const REGISTRY_BASE = "https://registry.npmjs.org";
+const CHECK_INTERVAL_MS = 3 * 60 * 1000;
+const THROTTLE_FILE = path.join(cacheDir(), ".update-check");
+const SEMVER_RE = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z-.]+)?$/;
+
+let timer: ReturnType<typeof setInterval> | undefined;
+let inFlight = false;
+
+function parseVersion(v: string): number[] {
+    return v.replace(/^v/, "").split(".").map((n) => parseInt(n, 10) || 0);
+}
+
+function isNewer(latest: string, current: string): boolean {
+    const l = parseVersion(latest);
+    const c = parseVersion(current);
+    for (let i = 0; i < 3; i++) {
+        const lv = l[i] ?? 0;
+        const cv = c[i] ?? 0;
+        if (lv > cv) return true;
+        if (lv < cv) return false;
+    }
+    return false;
+}
+
+async function readLastCheck(): Promise<number> {
+    try {
+        const data = await readFile(THROTTLE_FILE, "utf-8");
+        return parseInt(data.trim(), 10) || 0;
+    } catch {
+        return 0;
+    }
+}
+
+async function writeLastCheck(ts: number): Promise<void> {
+    try {
+        await mkdir(path.dirname(THROTTLE_FILE), { recursive: true });
+        await writeFile(THROTTLE_FILE, String(ts), "utf-8");
+    } catch {
+        // best-effort
+    }
+}
+
+export type UpdateOptions = {
+    /** Package name, e.g. "billion-context". */
+    packageName: string;
+    /** Currently running version. */
+    currentVersion: string;
+    /** Enable auto-install when a newer version is found. */
+    autoUpdate: boolean;
+};
+
+/** Run a single check (throttled unless `force`). Safe to call frequently. */
+export async function checkForUpdate(opts: UpdateOptions, force = false): Promise<void> {
+    if (!opts.autoUpdate && !force) return;
+    if (inFlight) return;
+    inFlight = true;
+    try {
+        const now = Date.now();
+        if (!force && now - (await readLastCheck()) < CHECK_INTERVAL_MS) return;
+        await writeLastCheck(now);
+
+        const url = `${REGISTRY_BASE}/${opts.packageName}/latest`;
+        const res = await fetch(url, {
+            signal: AbortSignal.timeout(5000),
+            headers: { Accept: "application/json" },
+        });
+        if (!res.ok) return;
+        const data = (await res.json()) as { version?: string };
+        const latest = data.version;
+        if (!latest || !isNewer(latest, opts.currentVersion)) return;
+
+        const installed = await installLatest(opts.packageName, latest);
+        if (installed) {
+            // Green ✔ — the only notification channel for a headless server.
+            // eslint-disable-next-line no-console
+            console.error(
+                `\x1b[32m\u2714 ${opts.packageName} auto-updated ${opts.currentVersion} \u2192 ${latest}. Restart bili to finish.\x1b[0m`,
+            );
+        } else {
+            // eslint-disable-next-line no-console
+            console.error(
+                `\x1b[33m${opts.packageName} ${latest} is available (you have ${opts.currentVersion}). Update with: npm install -g ${opts.packageName}@latest\x1b[0m`,
+            );
+        }
+    } catch {
+        // network/registry error — silent, will retry next interval
+    } finally {
+        inFlight = false;
+    }
+}
+
+async function installLatest(packageName: string, latest: string): Promise<boolean> {
+    // Reject anything that isn't a strict semver before handing it to npm.
+    if (!SEMVER_RE.test(latest)) return false;
+    try {
+        const code = await new Promise<number>((resolve) => {
+            execFile(
+                "npm",
+                ["install", "-g", `${packageName}@${latest}`, "--silent", "--no-audit", "--no-fund"],
+                { timeout: 120_000, shell: process.platform === "win32" },
+                (err) => resolve(err ? 1 : 0),
+            );
+        });
+        return code === 0;
+    } catch {
+        return false;
+    }
+}
+
+/** Start the periodic check loop. Checks once shortly after start, then every 6h. */
+export function startAutoUpdate(opts: UpdateOptions): void {
+    // First check after a short delay (don't block startup / don't race the
+    // listening socket).
+    setTimeout(() => {
+        void checkForUpdate(opts);
+    }, 10_000);
+    timer = setInterval(() => {
+        void checkForUpdate(opts);
+    }, CHECK_INTERVAL_MS);
+    timer.unref?.();
+}
+
+/** Stop the periodic check loop (for tests / clean shutdown). */
+export function stopAutoUpdate(): void {
+    if (timer) {
+        clearInterval(timer);
+        timer = undefined;
+    }
+}


### PR DESCRIPTION
## What

Adds self-update, modeled on billion-context-pi's updater but adapted for a long-running server process.

### How it works
- **On startup** (10s after listen) and **every 6h**: fetch `https://registry.npmjs.org/billion-context/latest`
- If newer → `npm install -g billion-context@latest` (global, user-level — no sudo on this box)
- **Notify**: green `✔ billion-context auto-updated 0.1.3 → 0.1.4. Restart bili to finish.` logged to console (the terminal where `bili` runs, or `/tmp/bili-proxy.log` for background test runs)
- Running process keeps serving old code until restart

### Controls
| Method | Effect |
|---|---|
| `bili update` | manual one-shot (bypasses 6h throttle) |
| `bili --no-auto-update` | disable for this run |
| `"autoUpdate": false` in config | disable permanently |
| `ACP_AUTO_UPDATE=0` | disable via env |

### Why console log instead of TUI?
The proxy is a headless server — the only output channel is stdout/stderr. There's no TUI to pop a notification into. Logging to the terminal (or its log file) is the honest, reliable channel. The message persists in the log so the user sees it whenever they check.

### Throttle
6h (`~/.cache/billion-context/.update-check`), vs 3min for the pi extension (which fires per-LLM-call). A long-running server doesn't need frequent checks.

## Pre-flight
- [x] typecheck: 0 errors
- [x] tests: 145 pass
- [x] build: success
- [x] `bili --help` shows new `update` command + `--no-auto-update`
- [x] `bili update` runs clean (exit 0, no output when already latest)