### PR TITLE
fix: cache health — remove condense, fix isTitleGen, preserve cache_control

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,6 @@ The config file is a single JSON object. Example:
 | `debug` | `false` | Verbose logging (same as `ACP_DEBUG=1`) |
 | `passthrough` | `false` | Forward without compression (same as `ACP_PASSTHROUGH=1`) |
 | `providers` | *(none)* | Provider routes — see below |
-| `condense` | *(see defaults)* | Tool-result condensing: `{ enabled, keepRecentToolResults, minCharsToCondense, maxKeptChars }` |
 | `compress` | *(see defaults)* | `{ injectTool, injectNudge }` |
 
 ### Providers (URL routing + per-model context)

--- a/README.md
+++ b/README.md
@@ -99,6 +99,23 @@ Verbose mode logs every `processTurn` (tag counts, token usage), the nudge
 decision (growth/usage/pendingT1/shouldInject), client headers, and SSE
 rewrites.
 
+### Log file
+
+All logs are **tee'd to a file by default**: `~/.local/state/billion-context/bili.log`
+(XDG state dir). They also still print to stderr so a foreground `bili start`
+shows them in the terminal.
+
+```bash
+bili start                # logs → ~/.local/state/billion-context/bili.log + terminal
+bili update               # (see below)
+# Config:  "logFile": "/custom/path.log"
+# Env:     ACP_LOG_FILE=/custom/path.log   (or ACP_LOG_FILE=off to disable the file)
+```
+
+The file auto-rotates at 10 MB (renamed to `bili.log.old`). Cache-hit stats
+per request are logged as `[acp-usage] round N input=X cached=Y (cache hit Z%)`
+so you can measure prefix-cache health directly from the log.
+
 ### Self-update
 
 The proxy checks npm for a newer version on startup and every 3 minutes. When a

--- a/src/anthropic.ts
+++ b/src/anthropic.ts
@@ -42,7 +42,6 @@ export type AnthropicRequestBody = {
     [key: string]: unknown;
 };
 
-const CONDENSED_TAG = "[acp-proxy: condensed";
 
 export function extractSystem(system: AnthropicRequestBody["system"]): string {
     if (!system) return "";
@@ -157,45 +156,6 @@ export function coreToAnthropic(messages: CoreMessage[]): AnthropicMessage[] {
     }
     flush();
     return out;
-}
-
-export type CondenseOptions = {
-    keepRecent: number;
-    minChars: number;
-    maxKeptChars: number;
-    enabled: boolean;
-};
-
-export type CondenseResult = {
-    messages: CoreMessage[];
-    condensedCount: number;
-    charsSaved: number;
-};
-
-export function condenseOldToolResults(messages: CoreMessage[], opts: CondenseOptions): CondenseResult {
-    if (!opts.enabled) return { messages, condensedCount: 0, charsSaved: 0 };
-    const toolResultIndices: number[] = [];
-    for (let i = 0; i < messages.length; i++) {
-        const m = messages[i];
-        if (m && m.contentType === "tool-result") toolResultIndices.push(i);
-    }
-    if (toolResultIndices.length <= opts.keepRecent) {
-        return { messages, condensedCount: 0, charsSaved: 0 };
-    }
-    const toCondense = new Set(toolResultIndices.slice(0, toolResultIndices.length - opts.keepRecent));
-    let condensedCount = 0;
-    let charsSaved = 0;
-    const out = messages.map((m, i) => {
-        if (!toCondense.has(i)) return m;
-        const text = m.text ?? "";
-        if (text.length < opts.minChars) return m;
-        const head = text.slice(0, opts.maxKeptChars);
-        const stub = `${CONDENSED_TAG} ${text.length.toLocaleString()} chars]\n${head}\n[/acp-proxy]`;
-        charsSaved += text.length - stub.length;
-        condensedCount++;
-        return { ...m, text: stub };
-    });
-    return { messages: out, condensedCount, charsSaved };
 }
 
 /** Extract the conversation dimension for Anthropic: a client-provided

--- a/src/anthropic.ts
+++ b/src/anthropic.ts
@@ -51,16 +51,17 @@ export function extractSystem(system: AnthropicRequestBody["system"]): string {
 
 export function buildSystem(text: string, original: AnthropicRequestBody["system"]): string | AnthropicTextBlock[] {
     if (Array.isArray(original) && original.length > 0) {
-        const cc = original[0]?.cache_control;
-        return [{ type: "text", text, ...(cc ? { cache_control: cc } : {}) }];
+        const ccBlock = original.find((b) => b.cache_control);
+        return [{ type: "text", text, ...(ccBlock ? { cache_control: ccBlock.cache_control } : {}) }];
     }
     return text;
 }
 
-type Flat = { msgs: CoreMessage[] };
+type Flat = { msgs: CoreMessage[]; cacheControls: Map<string, unknown> };
 
 export function anthropicToCore(body: AnthropicRequestBody): Flat {
     const msgs: CoreMessage[] = [];
+    const cacheControls = new Map<string, unknown>();
     const clusters = new ClusterCounter();
     for (const m of body.messages) {
         const blocks = typeof m.content === "string" ? [{ type: "text" as const, text: m.content }] : m.content;
@@ -68,7 +69,9 @@ export function anthropicToCore(body: AnthropicRequestBody): Flat {
             switch (b.type) {
                 case "text": {
                     const base = deriveMessageId(m.role, "text", b.text);
-                    msgs.push({ id: clusters.next(base), role: m.role, contentType: "text", text: b.text });
+                    const id = clusters.next(base);
+                    msgs.push({ id, role: m.role, contentType: "text", text: b.text });
+                    if (b.cache_control) cacheControls.set(id, b.cache_control);
                     break;
                 }
                 case "tool_use": {
@@ -76,26 +79,30 @@ export function anthropicToCore(body: AnthropicRequestBody): Flat {
                         toolCallId: b.id,
                         toolName: b.name,
                     });
+                    const id = clusters.next(base);
                     msgs.push({
-                        id: clusters.next(base),
+                        id,
                         role: "assistant",
                         contentType: "tool-call",
                         toolName: b.name,
                         toolCallId: b.id,
                         text: safeStringify(b.input),
                     });
+                    if (b.cache_control) cacheControls.set(id, b.cache_control);
                     break;
                 }
                 case "tool_result": {
                     const text = typeof b.content === "string" ? b.content : b.content.map((c) => c.text).join("\n");
                     const base = deriveMessageId("tool", "tool-result", text, { toolCallId: b.tool_use_id });
+                    const id = clusters.next(base);
                     msgs.push({
-                        id: clusters.next(base),
+                        id,
                         role: "tool",
                         contentType: "tool-result",
                         toolCallId: b.tool_use_id,
                         text,
                     });
+                    if (b.cache_control) cacheControls.set(id, b.cache_control);
                     break;
                 }
                 case "thinking": {
@@ -111,10 +118,10 @@ export function anthropicToCore(body: AnthropicRequestBody): Flat {
             }
         }
     }
-    return { msgs };
+    return { msgs, cacheControls };
 }
 
-export function coreToAnthropic(messages: CoreMessage[]): AnthropicMessage[] {
+export function coreToAnthropic(messages: CoreMessage[], cacheControls?: Map<string, unknown>): AnthropicMessage[] {
     const out: AnthropicMessage[] = [];
     let current: { role: "user" | "assistant"; blocks: AnthropicBlock[] } | null = null;
     const flush = () => {
@@ -122,6 +129,10 @@ export function coreToAnthropic(messages: CoreMessage[]): AnthropicMessage[] {
             out.push({ role: current.role, content: current.blocks });
         }
         current = null;
+    };
+    const cc = (id: string): { cache_control?: unknown } => {
+        const v = cacheControls?.get(id);
+        return v ? { cache_control: v } : {};
     };
     for (const m of messages) {
         const target: "user" | "assistant" =
@@ -132,7 +143,7 @@ export function coreToAnthropic(messages: CoreMessage[]): AnthropicMessage[] {
         }
         switch (m.contentType) {
             case "text":
-                current.blocks.push({ type: "text", text: m.text ?? "" });
+                current.blocks.push({ type: "text", text: m.text ?? "", ...cc(m.id) });
                 break;
             case "tool-call":
                 current.blocks.push({
@@ -140,6 +151,7 @@ export function coreToAnthropic(messages: CoreMessage[]): AnthropicMessage[] {
                     id: m.toolCallId ?? `call_${m.id}`,
                     name: m.toolName ?? "unknown",
                     input: safeParse(m.text),
+                    ...cc(m.id),
                 });
                 break;
             case "tool-result":
@@ -147,6 +159,7 @@ export function coreToAnthropic(messages: CoreMessage[]): AnthropicMessage[] {
                     type: "tool_result",
                     tool_use_id: m.toolCallId ?? "",
                     content: m.text ?? "",
+                    ...cc(m.id),
                 });
                 break;
             case "reasoning":

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -65,7 +65,7 @@ Options (override config file / env):
   --no-auto-update              disable background self-update this run
 
 Config: ${defaultConfigFile()}
-  Set port/host/debug/providers/condense/compress/autoUpdate there. See README §Configuration.
+  Set port/host/debug/providers/compress/autoUpdate there. See README §Configuration.
   Env vars (ACP_*, BILI_*) also work and override the file; CLI flags win.
 
 Docs: https://github.com/ranxianglei/billion-context

--- a/src/compress-loop-responses.ts
+++ b/src/compress-loop-responses.ts
@@ -9,6 +9,7 @@ import {
 } from "acp-kernel";
 import type { Session } from "./session.js";
 import { parseCompressInput, PROXY_TOOL_NAMES, COMPRESS_TOOL_NAME, ACP_TEXT_OPEN, ACP_TEXT_CLOSE } from "./compress-tool.js";
+import { log as loggerLog } from "./logger.js";
 import { applyRanges } from "./stream.js";
 import { resolveDecompress } from "./decompress-shared.js";
 import { buildVisibilityMarker } from "./compress-loop.js";
@@ -385,7 +386,7 @@ export async function* compressLoopResponsesStream(
                             const prDet = usage.prompt_tokens_details as Record<string, unknown> | undefined;
                             const cached = inDet?.cached_tokens ?? prDet?.cached_tokens ?? "?";
                             const out = usage.output_tokens ?? "?";
-                            console.error(`[acp-usage] round ${loopCount} input=${prompt} cached=${cached} output=${out}${cached !== "?" && cached !== 0 && prompt !== "?" ? ` (cache hit ${Math.round(Number(cached) / Number(prompt) * 100)}%)` : ""}`);
+                            loggerLog("info", `[acp-usage] round ${loopCount} input=${prompt} cached=${cached} output=${out}${cached !== "?" && cached !== 0 && prompt !== "?" ? ` (cache hit ${Math.round(Number(cached) / Number(prompt) * 100)}%)` : ""}`);
                         }
                     }
                 }

--- a/src/compress-loop.ts
+++ b/src/compress-loop.ts
@@ -13,6 +13,7 @@ import { applyRanges } from "./stream.js";
 import { resolveDecompress } from "./decompress-shared.js";
 import { fetchWithTimeout } from "./fetch-util.js";
 import { normalizeSseLineEndings } from "./sse-util.js";
+import { log as loggerLog } from "./logger.js";
 
 interface CompressLoopCtx {
     core: CompressionCore;
@@ -331,6 +332,19 @@ export async function* compressLoopStream(
         const realCalls = toolCalls.filter((tc) => !PROXY_TOOL_NAMES.has(tc.name));
 
         const hasOnlyProxy = proxyCalls.length > 0 && realCalls.length === 0;
+
+        // Log cache-hit stats from the upstream usage object so we can measure
+        // prefix-cache health on the OpenAI chat-completions path (GLM/zhipu).
+        if (usage) {
+            const prompt = (usage.prompt_tokens ?? usage.input_tokens) as number | undefined;
+            const det = (usage.prompt_tokens_details ?? usage.prompt_cache_hit_tokens) as Record<string, unknown> | undefined;
+            const cached = det?.cached_tokens ?? usage.prompt_cache_hit_tokens;
+            const out = usage.completion_tokens ?? usage.output_tokens;
+            if (typeof prompt === "number") {
+                const ch = typeof cached === "number" ? cached : 0;
+                loggerLog("info", `[acp-usage] round ${loopCount} input=${prompt} cached=${typeof cached === "number" ? cached : "?"} output=${out ?? "?"}${ch > 0 ? ` (cache hit ${Math.round(ch / prompt * 100)}%)` : ""}`);
+            }
+        }
 
         if (!hasOnlyProxy) {
             for (const tc of realCalls) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -110,6 +110,7 @@ export type ProxyOptions = {
     dumpSse?: string;
     passthrough: boolean;
     autoUpdate: boolean;
+    logFile?: string;
 };
 
 export function loadOptions(env: NodeJS.ProcessEnv = process.env): ProxyOptions {
@@ -164,6 +165,7 @@ export function loadOptions(env: NodeJS.ProcessEnv = process.env): ProxyOptions 
         dumpSse: env.ACP_DUMP_SSE || fileConfig.dumpSse || undefined,
         passthrough: (env.ACP_PASSTHROUGH ?? (fileConfig.passthrough ? "1" : "0")) === "1",
         autoUpdate: (env.ACP_AUTO_UPDATE ?? (fileConfig.autoUpdate === false ? "0" : "1")) !== "0",
+        logFile: env.ACP_LOG_FILE !== undefined ? (env.ACP_LOG_FILE || undefined) : fileConfig.logFile,
     };
 }
 
@@ -184,6 +186,7 @@ type FileConfig = {
     dumpSse?: string;
     passthrough?: boolean;
     autoUpdate?: boolean;
+    logFile?: string;
     condense?: { enabled?: boolean; keepRecentToolResults?: number; minCharsToCondense?: number; maxKeptChars?: number };
     compress?: { injectTool?: boolean; injectNudge?: boolean };
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -94,12 +94,6 @@ export type ProxyOptions = {
     routes: ProviderRoutes;
     modelContextLimit: number;
     kernelConfig: Config;
-    condense: {
-        keepRecentToolResults: number;
-        minCharsToCondense: number;
-        maxKeptChars: number;
-        enabled: boolean;
-    };
     compress: {
         injectTool: boolean;
         injectNudge: boolean;
@@ -143,10 +137,6 @@ export function loadOptions(env: NodeJS.ProcessEnv = process.env): ProxyOptions 
         }
     }
     const modelContextLimit = parseInt(env.ACP_MODEL_CONTEXT_LIMIT ?? `${fileConfig.modelContextLimit ?? 200000}`, 10);
-    const enabled = (env.ACP_CONDENSE_ENABLED ?? (fileConfig.condense?.enabled === false ? "0" : "1")) !== "0";
-    const keepRecentToolResults = parseInt(env.ACP_KEEP_RECENT_TOOL_RESULTS ?? `${fileConfig.condense?.keepRecentToolResults ?? 6}`, 10);
-    const minCharsToCondense = parseInt(env.ACP_MIN_CHARS_TO_CONDENSE ?? `${fileConfig.condense?.minCharsToCondense ?? 1500}`, 10);
-    const maxKeptChars = parseInt(env.ACP_MAX_KEPT_CHARS ?? `${fileConfig.condense?.maxKeptChars ?? 400}`, 10);
     return {
         port: Number.isFinite(port) ? port : 8787,
         host,
@@ -154,7 +144,6 @@ export function loadOptions(env: NodeJS.ProcessEnv = process.env): ProxyOptions 
         routes,
         modelContextLimit,
         kernelConfig: defaultConfig(modelContextLimit),
-        condense: { enabled, keepRecentToolResults, minCharsToCondense, maxKeptChars },
         compress: {
             injectTool: (env.ACP_COMPRESS_TOOL ?? (fileConfig.compress?.injectTool === false ? "0" : "1")) !== "0",
             injectNudge: (env.ACP_COMPRESS_NUDGE ?? (fileConfig.compress?.injectNudge === false ? "0" : "1")) !== "0",
@@ -187,7 +176,6 @@ type FileConfig = {
     passthrough?: boolean;
     autoUpdate?: boolean;
     logFile?: string;
-    condense?: { enabled?: boolean; keepRecentToolResults?: number; minCharsToCondense?: number; maxKeptChars?: number };
     compress?: { injectTool?: boolean; injectNudge?: boolean };
 };
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,69 @@
+/**
+ * Tee logger: writes every log line to BOTH a file (append, default
+ * ~/.local/state/billion-context/bili.log) and stderr (so a foreground `bili`
+ * still shows output in the terminal).
+ *
+ * The file is the durable record — it persists across restarts and survives a
+ * backgrounded process with no tty. Simple size-based rotation on open keeps
+ * it from growing without bound: when the existing file exceeds MAX_BYTES it
+ * is renamed to <file>.old and a fresh file is started.
+ */
+import { createWriteStream, mkdirSync, statSync, renameSync, type WriteStream } from "node:fs";
+import path from "node:path";
+
+const MAX_BYTES = 10 * 1024 * 1024; // 10 MB → rotate
+
+export type Logger = (level: string, msg: string) => void;
+
+let stream: WriteStream | undefined;
+let logPath: string | undefined;
+
+function open(pathStr: string): WriteStream {
+    mkdirSync(path.dirname(pathStr), { recursive: true });
+    // Rotate if oversized.
+    try {
+        if (statSync(pathStr).size >= MAX_BYTES) {
+            renameSync(pathStr, pathStr + ".old");
+        }
+    } catch {
+        // file doesn't exist yet — fine
+    }
+    return createWriteStream(pathStr, { flags: "a" });
+}
+
+/**
+ * Configure the log file. Call once at startup. When `file` is undefined or
+ * "off", file logging is disabled (stderr only).
+ */
+export function configureLogger(file?: string): string | undefined {
+    if (!file || file === "off") {
+        logPath = undefined;
+        stream = undefined;
+        return undefined;
+    }
+    logPath = file;
+    stream = open(file);
+    return file;
+}
+
+/** Log a line to file + stderr. */
+export const log: Logger = (level, msg) => {
+    const ts = new Date().toISOString();
+    const line = `${ts} [${level}] ${msg}\n`;
+    // stderr (foreground terminal / shell redirect) — never throws.
+    process.stderr.write(line);
+    // file — durable record.
+    if (stream) {
+        stream.write(line);
+    }
+};
+
+/** Flush + close the log file. Call on shutdown. */
+export function closeLogger(): void {
+    stream?.end();
+    stream = undefined;
+}
+
+export function getLogPath(): string | undefined {
+    return logPath;
+}

--- a/src/openai.ts
+++ b/src/openai.ts
@@ -1,5 +1,4 @@
 import type { CoreMessage } from "acp-kernel";
-import { condenseOldToolResults, type CondenseOptions, type CondenseResult } from "./anthropic.js";
 import { hashId } from "./util.js";
 import { ClusterCounter, deriveMessageId } from "./message-id.js";
 
@@ -149,8 +148,6 @@ export function injectOpenaiSystem(messages: OpenAIMessage[], parts: string[]): 
     }
     return [{ role: "system", content: extra }, ...messages];
 }
-
-export { condenseOldToolResults, type CondenseOptions, type CondenseResult };
 
 /** Extract the conversation dimension for OpenAI Chat: a client-provided
  *  session header if present, else a content fingerprint of the first user

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -51,3 +51,13 @@ export function sessionsDir(): string {
 export function cacheDir(): string {
     return path.join(xdg("XDG_CACHE_HOME", ".cache"), "billion-context");
 }
+
+/** Root state dir: log files and other per-host state. */
+export function stateDir(): string {
+    return path.join(xdg("XDG_STATE_HOME", ".local/state"), "billion-context");
+}
+
+/** Default log file path. */
+export function defaultLogFile(): string {
+    return path.join(stateDir(), "bili.log");
+}

--- a/src/persist.ts
+++ b/src/persist.ts
@@ -59,7 +59,6 @@ interface PersistedSession {
     upstreamOrigin?: string;
     createdAt: number;
     requests: number;
-    condensedToolResults: number;
     tokensSaved: number;
     state: CompressionState;
     /** blockContents serialized as a plain record (Maps do not survive JSON). */
@@ -343,7 +342,6 @@ function buildRecord(session: Session): PersistedSession {
         upstreamOrigin: session.upstreamOrigin,
         createdAt: session.createdAt,
         requests: session.requests,
-        condensedToolResults: session.condensedToolResults,
         tokensSaved: session.tokensSaved,
         state: session.state,
         blockContents: Object.fromEntries(session.blockContents),
@@ -363,7 +361,6 @@ function buildSession(parsed: PersistedSession): Session {
         createdAt: parsed.createdAt ?? Date.now(),
         lastSeen: Date.now(),
         requests: parsed.requests ?? 0,
-        condensedToolResults: parsed.condensedToolResults ?? 0,
         tokensSaved: parsed.tokensSaved ?? 0,
         blockContents,
         inFlight: 0,

--- a/src/responses.ts
+++ b/src/responses.ts
@@ -1,5 +1,4 @@
 import type { CoreMessage } from "acp-kernel";
-import { condenseOldToolResults, type CondenseOptions, type CondenseResult } from "./anthropic.js";
 import { hashId } from "./util.js";
 import { ClusterCounter, deriveMessageId } from "./message-id.js";
 
@@ -300,8 +299,6 @@ export function injectResponsesInstructions(
         instructions: existing ? `${existing}\n\n---\n\n${extra}` : extra,
     };
 }
-
-export { condenseOldToolResults, type CondenseOptions, type CondenseResult };
 
 /** Extract the conversation dimension for Responses: a client-provided
  *  session header if present, else the previous_response_id chain (Responses'

--- a/src/server.ts
+++ b/src/server.ts
@@ -17,8 +17,6 @@ import {
     coreToOpenai,
     injectOpenaiSystem,
     conversationSignalOpenai,
-    condenseOldToolResults,
-    type CondenseOptions,
     type OpenAIRequestBody,
     type OpenAITool,
 } from "./openai.js";
@@ -154,31 +152,6 @@ type Prepared = {
     stream: boolean;
     compressInjected: boolean;
 };
-
-/**
- * Apply condense to the kernel-processed messages and record stats on the
- * session. Previously `opts.condense` and `condenseOldToolResults` were wired
- * into config but never invoked — leaving a whole feature as dead code. This
- * is the single integration point for both protocols.
- */
-function applyCondense(
-    messages: CoreMessage[],
-    opts: ProxyOptions,
-    session: Session,
-): CoreMessage[] {
-    const condenseOpts: CondenseOptions = {
-        enabled: opts.condense.enabled,
-        keepRecent: opts.condense.keepRecentToolResults,
-        minChars: opts.condense.minCharsToCondense,
-        maxKeptChars: opts.condense.maxKeptChars,
-    };
-    const { messages: out, condensedCount, charsSaved } = condenseOldToolResults(messages, condenseOpts);
-    if (condensedCount > 0) {
-        session.condensedToolResults += condensedCount;
-        session.tokensSaved += Math.ceil(charsSaved / 4);
-    }
-    return out;
-}
 
 async function handle(
     req: http.IncomingMessage,
@@ -350,7 +323,7 @@ function prepareAnthropic(
         session.state = turn.state;
         log("info", diagTagSummary(turn.messages, sessionId, "text-only"));
         log("info", diagNudge(turn, sessionId, tokenCount, config.modelContextLimit));
-        processedMessages = applyCondense(turn.messages, opts, session);
+        processedMessages = turn.messages;
         reapOrphanBlocks(session, msgs, deactivateBlock);
         rebuiltMessages = coreToAnthropic(processedMessages);
 
@@ -407,7 +380,7 @@ function prepareOpenai(
         session.state = turn.state;
         log("info", diagTagSummary(turn.messages, sessionId, "text-only"));
         log("info", diagNudge(turn, sessionId, tokenCount, config.modelContextLimit));
-        processedMessages = applyCondense(turn.messages, opts, session);
+        processedMessages = turn.messages;
         reapOrphanBlocks(session, msgs, deactivateBlock);
         rebuiltMessages = coreToOpenai(processedMessages);
 
@@ -472,7 +445,7 @@ function prepareResponses(
         session.state = turn.state;
         log("info", diagTagSummary(turn.messages, sessionId, "text-only"));
         log("info", diagNudge(turn, sessionId, tokenCount, config.modelContextLimit));
-        processedMessages = applyCondense(turn.messages, opts, session);
+        processedMessages = turn.messages;
         reapOrphanBlocks(session, msgs, deactivateBlock);
         // Rebuild input preserving the responses_lite contract:
         //   input[0]   = additional_tools (host directive, verbatim)
@@ -844,7 +817,6 @@ function sendStats(res: http.ServerResponse): void {
     const sessions = listSessions().map((s) => ({
         id: s.id,
         requests: s.requests,
-        condensedToolResults: s.condensedToolResults,
         tokensSaved: s.tokensSaved,
         lastSeen: new Date(s.lastSeen).toISOString(),
     }));

--- a/src/server.ts
+++ b/src/server.ts
@@ -370,7 +370,13 @@ function prepareOpenai(
     let toolsOut = parsed.tools;
 
     const maxTokens = typeof parsed.max_tokens === "number" ? parsed.max_tokens : 8192;
-    const isTitleGen = maxTokens <= 200 || parsed.messages.length <= 2;
+    // Title-generation requests (tiny max_tokens) get no compress tooling so
+    // the model produces a clean short title. We do NOT key this off message
+    // count: a 2-message request is just turn 1 of a real conversation, and
+    // flipping shouldInject false→true between turn 1 and turn 2+ rewrites the
+    // system prompt bytes (compress prompt added/removed) — which breaks the
+    // provider prefix cache for every subsequent turn.
+    const isTitleGen = maxTokens <= 200;
     const shouldInject = opts.compress.injectTool && !isTitleGen;
 
     try {

--- a/src/server.ts
+++ b/src/server.ts
@@ -36,6 +36,8 @@ import { rewriteSseStream, rewriteJsonResponse, type RewriteCtx } from "./stream
 import { reapOrphanBlocks } from "./orphan-gc.js";
 import { getStore } from "./persist.js";
 import { compressLoopStream } from "./compress-loop.js";
+import { log as loggerLog, configureLogger, getLogPath, closeLogger } from "./logger.js";
+import { defaultLogFile } from "./paths.js";
 import { compressLoopResponsesStream } from "./compress-loop-responses.js";
 import { rewriteOpenaiJsonResponse } from "./stream-openai.js";
 import { rewriteResponsesSseStream, rewriteResponsesJsonResponse } from "./stream-responses.js";
@@ -83,6 +85,9 @@ export function resolveUpstream(opts: ProxyOptions, reqUrl: string): { upstream:
 }
 
 export async function startServer(opts: ProxyOptions): Promise<http.Server> {
+    // Configure the tee logger (file + stderr) BEFORE any logging so the very
+    // first line (persist status) lands in the file too.
+    const filePath = configureLogger(opts.logFile ?? defaultLogFile());
     const core = createCore();
     const config: Config = opts.kernelConfig;
     const log = (level: string, msg: string) => logMsg(opts, level, msg);
@@ -91,6 +96,9 @@ export async function startServer(opts: ProxyOptions): Promise<http.Server> {
     // re-send oversized raw history and hang).
     await initSessions();
     log("info", `[persist] ${getStore().enabled ? "enabled" : "disabled"}`);
+    if (filePath) {
+        log("info", `[log] writing to ${filePath}`);
+    }
     const server = http.createServer(async (req, res) => {
         try {
             await handle(req, res, opts, core, config, log);
@@ -129,6 +137,7 @@ export async function startServer(opts: ProxyOptions): Promise<http.Server> {
         // could mutate state after its snapshot is taken and be lost.
         server.close();
         void flushAllSessions().finally(() => {
+            closeLogger();
             process.exit(0);
         });
     };
@@ -886,6 +895,5 @@ export function readBody(req: http.IncomingMessage): Promise<Buffer> {
 
 function logMsg(opts: ProxyOptions, level: string, msg: string): void {
     if (!opts.log) return;
-    const ts = new Date().toISOString();
-    console.error(`${ts} [${level}] ${msg}`);
+    loggerLog(level, msg);
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -317,7 +317,7 @@ function prepareAnthropic(
     let toolsOut = parsed.tools;
 
     try {
-        const { msgs } = anthropicToCore(parsed);
+        const { msgs, cacheControls } = anthropicToCore(parsed);
         const tokenCount = estimateTokensFast(msgs.map((m) => m.text ?? "").join("\n"));
         const turn = core.processTurn({ messages: msgs, state: session.state, config, tokenCount, renderTags: "text-only" });
         session.state = turn.state;
@@ -325,7 +325,7 @@ function prepareAnthropic(
         log("info", diagNudge(turn, sessionId, tokenCount, config.modelContextLimit));
         processedMessages = turn.messages;
         reapOrphanBlocks(session, msgs, deactivateBlock);
-        rebuiltMessages = coreToAnthropic(processedMessages);
+        rebuiltMessages = coreToAnthropic(processedMessages, cacheControls);
 
         systemOut = injectSystem(parsed, opts);
         if (opts.compress.injectTool) {

--- a/src/session.ts
+++ b/src/session.ts
@@ -18,7 +18,6 @@ export type Session = {
     createdAt: number;
     lastSeen: number;
     requests: number;
-    condensedToolResults: number;
     tokensSaved: number;
     /** Original content of compressed blocks, captured at compress time when
      *  the source messages are still present in the request. decompress reads
@@ -102,7 +101,6 @@ export function getSession(id: string, meta?: { protocol?: Session["protocol"]; 
         createdAt: Date.now(),
         lastSeen: Date.now(),
         requests: 0,
-        condensedToolResults: 0,
         tokensSaved: 0,
         blockContents: new Map(),
         inFlight: 0,

--- a/tests/basic.test.ts
+++ b/tests/basic.test.ts
@@ -3,7 +3,6 @@ import assert from "node:assert/strict";
 import {
     anthropicToCore,
     coreToAnthropic,
-    condenseOldToolResults,
     conversationSignalAnthropic,
     type AnthropicRequestBody,
 } from "../src/anthropic.js";
@@ -51,39 +50,6 @@ test("anthropicToCore + coreToAnthropic round-trips tool_use and tool_result", (
     const tr = (rebuilt[2]?.content as unknown[])[0] as { type: string; tool_use_id: string };
     assert.equal(tr.type, "tool_result");
     assert.equal(tr.tool_use_id, "t1");
-});
-
-test("condenseOldToolResults condenses large old tool results, keeps recent verbatim", () => {
-    const { msgs } = anthropicToCore(bigToolResult("x".repeat(5000)));
-    const res = condenseOldToolResults(msgs, { keepRecent: 0, minChars: 1500, maxKeptChars: 400, enabled: true });
-    assert.equal(res.condensedCount, 1);
-    const tr = res.messages[2];
-    assert.ok(tr?.text?.includes("[acp-proxy: condensed"));
-});
-
-test("condenseOldToolResults leaves small tool results untouched", () => {
-    const { msgs } = anthropicToCore(bigToolResult("short"));
-    const res = condenseOldToolResults(msgs, { keepRecent: 0, minChars: 1500, maxKeptChars: 400, enabled: true });
-    assert.equal(res.condensedCount, 0);
-});
-
-test("condenseOldToolResults respects keepRecent", () => {
-    const body: AnthropicRequestBody = {
-        messages: [
-            { role: "user" as const, content: "go" },
-            { role: "assistant" as const, content: [{ type: "tool_use", id: "a", name: "Bash", input: {} }] },
-            { role: "user" as const, content: [{ type: "tool_result", tool_use_id: "a", content: "y".repeat(3000) }] },
-            { role: "assistant" as const, content: [{ type: "tool_use", id: "b", name: "Bash", input: {} }] },
-            { role: "user" as const, content: [{ type: "tool_result", tool_use_id: "b", content: "z".repeat(3000) }] },
-        ],
-    };
-    const { msgs } = anthropicToCore(body);
-    const res = condenseOldToolResults(msgs, { keepRecent: 1, minChars: 1500, maxKeptChars: 100, enabled: true });
-    assert.equal(res.condensedCount, 1);
-    const first = res.messages[2]?.text ?? "";
-    const second = res.messages[4]?.text ?? "";
-    assert.ok(first.includes("[acp-proxy: condensed"));
-    assert.ok(!second.includes("[acp-proxy: condensed"));
 });
 
 test("conversationSignalAnthropic is stable for same first message, differs otherwise", () => {

--- a/tests/basic.test.ts
+++ b/tests/basic.test.ts
@@ -52,6 +52,38 @@ test("anthropicToCore + coreToAnthropic round-trips tool_use and tool_result", (
     assert.equal(tr.tool_use_id, "t1");
 });
 
+test("cache_control survives the anthropicToCore → coreToAnthropic round-trip", () => {
+    const body: AnthropicRequestBody = {
+        messages: [
+            { role: "user" as const, content: [{ type: "text", text: "hello", cache_control: { type: "ephemeral" } }] },
+            { role: "assistant" as const, content: [{ type: "tool_use", id: "t1", name: "Bash", input: { cmd: "ls" }, cache_control: { type: "ephemeral" } }] },
+            { role: "user" as const, content: [{ type: "tool_result", tool_use_id: "t1", content: "ok", cache_control: { type: "ephemeral" } }] },
+        ],
+    };
+    const { msgs, cacheControls } = anthropicToCore(body);
+    assert.equal(cacheControls.size, 3);
+    for (const m of msgs) {
+        assert.ok(cacheControls.has(m.id), `message ${m.id} should have cache_control`);
+    }
+    const rebuilt = coreToAnthropic(msgs, cacheControls);
+    const textBlock = (rebuilt[0]!.content as unknown[])[0] as { cache_control?: unknown };
+    assert.deepEqual(textBlock.cache_control, { type: "ephemeral" });
+    const tuBlock = (rebuilt[1]!.content as unknown[])[0] as { cache_control?: unknown };
+    assert.deepEqual(tuBlock.cache_control, { type: "ephemeral" });
+    const trBlock = (rebuilt[2]!.content as unknown[])[0] as { cache_control?: unknown };
+    assert.deepEqual(trBlock.cache_control, { type: "ephemeral" });
+});
+
+test("coreToAnthropic without cacheControls produces no cache_control", () => {
+    const body: AnthropicRequestBody = {
+        messages: [{ role: "user" as const, content: [{ type: "text", text: "hi" }] }],
+    };
+    const { msgs } = anthropicToCore(body);
+    const rebuilt = coreToAnthropic(msgs);
+    const block = (rebuilt[0]!.content as unknown[])[0] as { cache_control?: unknown };
+    assert.equal(block.cache_control, undefined);
+});
+
 test("conversationSignalAnthropic is stable for same first message, differs otherwise", () => {
     const body = bigToolResult("hello");
     const a = conversationSignalAnthropic(body);

--- a/tests/proxy-basic.test.ts
+++ b/tests/proxy-basic.test.ts
@@ -3,7 +3,6 @@ import assert from "node:assert/strict";
 import {
     anthropicToCore,
     coreToAnthropic,
-    condenseOldToolResults,
     conversationSignalAnthropic,
     type AnthropicRequestBody,
 } from "../src/anthropic.js";
@@ -51,39 +50,6 @@ test("anthropicToCore + coreToAnthropic round-trips tool_use and tool_result", (
     const tr = (rebuilt[2]?.content as unknown[])[0] as { type: string; tool_use_id: string };
     assert.equal(tr.type, "tool_result");
     assert.equal(tr.tool_use_id, "t1");
-});
-
-test("condenseOldToolResults condenses large old tool results, keeps recent verbatim", () => {
-    const { msgs } = anthropicToCore(bigToolResult("x".repeat(5000)));
-    const res = condenseOldToolResults(msgs, { keepRecent: 0, minChars: 1500, maxKeptChars: 400, enabled: true });
-    assert.equal(res.condensedCount, 1);
-    const tr = res.messages[2];
-    assert.ok(tr?.text?.includes("[acp-proxy: condensed"));
-});
-
-test("condenseOldToolResults leaves small tool results untouched", () => {
-    const { msgs } = anthropicToCore(bigToolResult("short"));
-    const res = condenseOldToolResults(msgs, { keepRecent: 0, minChars: 1500, maxKeptChars: 400, enabled: true });
-    assert.equal(res.condensedCount, 0);
-});
-
-test("condenseOldToolResults respects keepRecent", () => {
-    const body: AnthropicRequestBody = {
-        messages: [
-            { role: "user" as const, content: "go" },
-            { role: "assistant" as const, content: [{ type: "tool_use", id: "a", name: "Bash", input: {} }] },
-            { role: "user" as const, content: [{ type: "tool_result", tool_use_id: "a", content: "y".repeat(3000) }] },
-            { role: "assistant" as const, content: [{ type: "tool_use", id: "b", name: "Bash", input: {} }] },
-            { role: "user" as const, content: [{ type: "tool_result", tool_use_id: "b", content: "z".repeat(3000) }] },
-        ],
-    };
-    const { msgs } = anthropicToCore(body);
-    const res = condenseOldToolResults(msgs, { keepRecent: 1, minChars: 1500, maxKeptChars: 100, enabled: true });
-    assert.equal(res.condensedCount, 1);
-    const first = res.messages[2]?.text ?? "";
-    const second = res.messages[4]?.text ?? "";
-    assert.ok(first.includes("[acp-proxy: condensed"));
-    assert.ok(!second.includes("[acp-proxy: condensed"));
 });
 
 test("deriveSessionId is stable for same first message, differs otherwise", () => {

--- a/tests/proxy-orphan-gc.test.ts
+++ b/tests/proxy-orphan-gc.test.ts
@@ -11,7 +11,6 @@ function makeSession(): Session {
         createdAt: Date.now(),
         lastSeen: Date.now(),
         requests: 0,
-        condensedToolResults: 0,
         tokensSaved: 0,
         blockContents: new Map(),
         inFlight: 0,

--- a/tests/proxy-persist.test.ts
+++ b/tests/proxy-persist.test.ts
@@ -27,7 +27,6 @@ function makeSession(id: string): Session {
         createdAt: Date.now(),
         lastSeen: Date.now(),
         requests: 0,
-        condensedToolResults: 0,
         tokensSaved: 0,
         blockContents: new Map(),
         inFlight: 0,

--- a/tests/proxy-responses-no-trigger.test.ts
+++ b/tests/proxy-responses-no-trigger.test.ts
@@ -16,7 +16,6 @@ function makeCtx(log: (m: string) => void): { core: ReturnType<typeof createCore
             createdAt: Date.now(),
             lastSeen: Date.now(),
             requests: 0,
-            condensedToolResults: 0,
             tokensSaved: 0,
             blockContents: new Map(),
             inFlight: 0,

--- a/tests/proxy-responses-review.test.ts
+++ b/tests/proxy-responses-review.test.ts
@@ -11,7 +11,6 @@ function makeCtx(log: (m: string) => void): { core: ReturnType<typeof createCore
         core: createCore(),
         config: { modelContextLimit: 200000 } as Config,
         messages: [] as CoreMessage[],
-        session: { id: "test", state: createInitialState(), createdAt: Date.now(), lastSeen: Date.now(), requests: 0, condensedToolResults: 0, tokensSaved: 0, blockContents: new Map(), inFlight: 0, persisted: false },
         log,
     };
 }

--- a/tests/proxy-responses-stream.test.ts
+++ b/tests/proxy-responses-stream.test.ts
@@ -16,7 +16,6 @@ function makeCtx(log: (m: string) => void): { core: ReturnType<typeof createCore
             createdAt: Date.now(),
             lastSeen: Date.now(),
             requests: 0,
-            condensedToolResults: 0,
             tokensSaved: 0,
             blockContents: new Map(),
             inFlight: 0,


### PR DESCRIPTION
## What

Three cache-health fixes + a logger, recovered from commits that did not make it into the PR#11 merge.

### 1. Remove condenseOldToolResults (prefix-cache killer) ⭐
`condenseOldToolResults` stubbed old tool results every turn (sliding window). Each stub rewrite changed stable history bytes → provider prefix cache broke from that point on. Removed entirely. The model-driven compress tool (kernel) does this job better and is cache-friendly (folded once, then stable).

### 2. Fix isTitleGen flip (cache killer on OpenAI/chat path)
`isTitleGen = maxTokens<=200 || messages.length<=2` flipped `shouldInject` false→true between turn 1 (2 msgs) and turn 2+, rewriting the system prompt bytes (compress prompt added) — breaking the prefix cache for every subsequent turn. Now only keys off `maxTokens<=200` (a real title-gen signal).

### 3. Preserve Anthropic cache_control (M2 + M3)
`coreToAnthropic` rebuilt every block without `cache_control`, silently dropping the breakpoints opencode/Claude Code set for Anthropic prompt caching. Also `buildSystem` merged multi-block system into one, keeping only the first block's breakpoint. Fixed:
- `anthropicToCore` now returns a `cacheControls: Map<coreId, cc>` side-channel
- `coreToAnthropic` receives it and restores `cache_control` by message id
- `buildSystem` uses `original.find(b => b.cache_control)` (any block, not just first)

Messages dropped by compression naturally lose their breakpoint (content changed) — correct behavior.

### 4. Tee logger + chat-path cache logging
- New `src/logger.ts`: every log line → file (`~/.local/state/billion-context/bili.log`, XDG state, 10MB rotate) AND stderr. Default-on.
- `[acp-usage] round N input=X cached=Y (cache hit Z%)` added to the OpenAI chat-completions path (previously only Responses/Codex path logged cache stats) — now you can measure cache health on the pi→glm route directly.

## Config
- `ACP_LOG_FILE` / `logFile` config overrides log path (`off` disables file).

## Pre-flight
- [x] typecheck: 0 errors
- [x] tests: 141 pass (145 - 6 condense tests removed + 2 cache_control tests added)
- [x] build: success

## Tracking
- M1 (`reapOrphanBlocks` should move to kernel): tracked in #12 (not urgent, does not affect cache)