### PR TITLE
release v0.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Release v0.1.4

Cache-health release. Three prefix-cache killers fixed + durable logging.

### Includes (since v0.1.3)
- **remove `condenseOldToolResults`** (prefix-cache killer) — stubbed old tool results every turn, rewriting stable history bytes
- **fix `isTitleGen` flip** (OpenAI/chat path) — `messages.length<=2` made turn-1 system differ from turn-2+, breaking cache every session
- **preserve Anthropic `cache_control`** through the core round-trip + system block (M2+M3 from audit)
- **tee logger** — logs now persist to `~/.local/state/billion-context/bili.log` by default (file + stderr, 10MB rotate)
- **`[acp-usage]` cache logging on the OpenAI chat path** — previously only the Responses/Codex path logged cache hit %

### Verified cache health


### Pre-flight
- [x] typecheck: 0 errors
- [x] tests: 141 pass
- [x] build: success

### Release mechanism
Merging this PR (commit `release v0.1.4` on `*_release-v*` branch) triggers `release.yml` → npm publish `--tag latest` + git tag `v0.1.4`.

### Tracking
- `reapOrphanBlocks` → acp-kernel move: #12 (not in this release)