### PR TITLE
release v0.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Release v0.1.5

Documentation release — ships the README restructure and Chinese translation to npm.

### Includes (since v0.1.4)
- **README: env vars as primary config method** (restructured, env table before config file)
- **README: removed stale condense env vars**, added `ACP_AUTO_UPDATE` / `ACP_LOG_FILE`
- **README: moved Session identity → 'How sessions work'** (own top-level section)
- **README.zh-CN.md** — Chinese translation with cross-language toggle links

No code changes since v0.1.4.

### Pre-flight
- [x] typecheck: 0 errors
- [x] tests: 141 pass
- [x] build: success

### Release mechanism
Merge triggers `release.yml` → npm publish `--tag latest` + tag `v0.1.5`.
After 0.1.5 is on npm, running `bili` (0.1.4) will auto-update to 0.1.5 within 3 min.