### PR TITLE
fix: suppress duplicate auto-update notices within one process

### DIFF
--- a/src/update.ts
+++ b/src/update.ts
@@ -24,6 +24,10 @@ const SEMVER_RE = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z-.]+)?$/;
 
 let timer: ReturnType<typeof setInterval> | undefined;
 let inFlight = false;
+/** Versions we've already installed + notified about this process. Prevents
+ *  repeated reinstall/notify loops every check cycle until the user restarts
+ *  (the running process keeps the old currentVersion until restart). */
+const notified = new Set<string>();
 
 function parseVersion(v: string): number[] {
     return v.replace(/^v/, "").split(".").map((n) => parseInt(n, 10) || 0);
@@ -87,15 +91,19 @@ export async function checkForUpdate(opts: UpdateOptions, force = false): Promis
         const data = (await res.json()) as { version?: string };
         const latest = data.version;
         if (!latest || !isNewer(latest, opts.currentVersion)) return;
+        // Already installed and notified about this version — don't loop.
+        if (notified.has(latest)) return;
 
         const installed = await installLatest(opts.packageName, latest);
         if (installed) {
+            notified.add(latest);
             // Green ✔ — the only notification channel for a headless server.
             // eslint-disable-next-line no-console
             console.error(
                 `\x1b[32m\u2714 ${opts.packageName} auto-updated ${opts.currentVersion} \u2192 ${latest}. Restart bili to finish.\x1b[0m`,
             );
         } else {
+            notified.add(latest);
             // eslint-disable-next-line no-console
             console.error(
                 `\x1b[33m${opts.packageName} ${latest} is available (you have ${opts.currentVersion}). Update with: npm install -g ${opts.packageName}@latest\x1b[0m`,


### PR DESCRIPTION
## Problem

Auto-update worked, but printed the notice 4 times in a row:

```
✔ billion-context auto-updated 0.1.3 → 0.1.4. Restart bili to finish.
✔ billion-context auto-updated 0.1.3 → 0.1.4. Restart bili to finish.
✔ billion-context auto-updated 0.1.3 → 0.1.4. Restart bili to finish.
✔ billion-context auto-updated 0.1.3 → 0.1.5. Restart bili to finish.
```

## Root cause

`checkForUpdate` had no memory of what it had already installed/notified. Every check cycle (startup `setTimeout` + 3-min `setInterval`) re-ran: fetch latest → install → notify, until the user restarted `bili` (which re-reads the bumped version from package.json and stops triggering).

The running process keeps `currentVersion` fixed at startup, so even after `npm install -g` updated the on-disk package, the next check still saw "latest > current" and reinstalled + re-notified.

## Fix

Add a `notified: Set<string>` module-level guard. After the first install/notify of a given `latest` version, subsequent checks for the same version return early. The set resets on process restart (which is exactly when the bumped version takes effect).

```diff\n+ const notified = new Set<string>();
  ...
  if (isNewer(latest, current)) {
+   if (notified.has(latest)) return;  // already done this version
    installed = await installLatest(...);
+   notified.add(latest);
    notify(...);
  }
```

## Pre-flight
- [x] typecheck: 0 errors
- [x] tests: 141 pass
- [x] build: success