### PR TITLE
release v0.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Release v0.1.6

Ships the duplicate auto-update notice fix.

### Includes (since v0.1.5)
- **fix: suppress duplicate auto-update notices within one process** — adds a `notified: Set<string>` guard so each version is installed + notified only once per process run (PR #17). Previously the notice printed repeatedly every check cycle until restart.

### Pre-flight
- [x] typecheck: 0 errors
- [x] tests: 141 pass
- [x] build: success
- [x] verified locally: `bili --version` = 0.1.5 with fix installed

### Release mechanism
Merge triggers `release.yml` → npm publish `--tag latest` + tag `v0.1.6`.

After 0.1.6 is on npm, `bili` (0.1.5) auto-updates once, notifies once, then stops (fix validated).