### PR TITLE
release v0.1.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Release v0.1.7

Ships the auto-update logging fix so the full update cycle is observable in the log file.

### Includes (since v0.1.6)
- **fix: route auto-update logs through the tee logger** (PR #19) — `checkForUpdate` previously used `console.error` (stderr only), so the log file showed nothing about update activity and the periodic check was a silent black box. Now the full cycle (startup announce, throttle-skip with countdown, registry fetch, no-update, new-version-found, installed, failures) goes through `logger.log` → file + stderr.

### Pre-flight
- [x] typecheck: 0 errors
- [x] tests: 141 pass
- [x] build: success

### Release mechanism
Merge triggers `release.yml` → npm publish `--tag latest` + tag `v0.1.7`.

After 0.1.7 is on npm, `bili` (0.1.6) auto-updates and you can observe the full update cycle in `~/.local/state/billion-context/bili.log`.