### PR TITLE
fix: logger rotation, SSE drain on shutdown, host docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,15 @@ The config file is a single JSON object. Example:
 | `providers` | *(none)* | Provider routes — see below |
 | `compress` | *(see defaults)* | `{ injectTool, injectNudge }` |
 
+> **Choosing a `host`** (IPv6 / containers): the default `127.0.0.1` is
+> IPv4-only and loopback-only. Use `--host ::` (or `"host": "::"`) to listen
+> on **both** IPv4 and IPv6, which matters if your client resolves
+> `localhost` to `::1` first (some `/etc/hosts` files list `::1` before
+> `127.0.0.1`). Inside a **container**, `127.0.0.1` binds the container's own
+> loopback and is unreachable through a published port — use
+> `--host 0.0.0.0` there. ⚠️ `0.0.0.0` / `::` expose the proxy on **all**
+> interfaces; ensure you're on a trusted network or behind a firewall.
+
 ### Providers (URL routing + per-model context)
 
 `providers` maps a route name to either a bare URL string (simple) or an

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -196,6 +196,14 @@ bili --no-auto-update   # 本次启动禁用自动更新
 | `providers` | *(无)* | Provider 路由 —— 见下文 |
 | `compress` | *(见默认值)* | `{ injectTool, injectNudge }` |
 
+> **选择 `host`**(IPv6 / 容器):默认 `127.0.0.1` 只听 IPv4 且仅
+> loopback。用 `--host ::`(或 `"host": "::"`)可同时听 IPv4 和 IPv6
+> ——当你的客户端把 `localhost` 先解析成 `::1` 时(有些 `/etc/hosts`
+> 把 `::1` 排在 `127.0.0.1` 前)这就很关键。在**容器**内,`127.0.0.1`
+> 绑的是容器自己的 loopback,通过映射端口访问不到——这时用
+> `--host 0.0.0.0`。⚠️ `0.0.0.0` / `::` 会把代理暴露到**所有**网卡;
+> 确保你在可信网络或防火墙后面。
+
 ### Providers(URL 路由 + 按模型 context)
 
 `providers` 把路由名映射到一个纯 URL 字符串(简单)或一个带 `url` + 可选按模型 context 窗口的对象(推荐)。

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -17,18 +17,33 @@ export type Logger = (level: string, msg: string) => void;
 
 let stream: WriteStream | undefined;
 let logPath: string | undefined;
+let bytesWritten = 0; // tracked so we can rotate at runtime, not just at startup
 
 function open(pathStr: string): WriteStream {
     mkdirSync(path.dirname(pathStr), { recursive: true });
     // Rotate if oversized.
+    let existingSize = 0;
     try {
-        if (statSync(pathStr).size >= MAX_BYTES) {
-            renameSync(pathStr, pathStr + ".old");
+        existingSize = statSync(pathStr).size;
+        if (existingSize >= MAX_BYTES) {
+            rotate(pathStr);
+            existingSize = 0;
         }
     } catch {
         // file doesn't exist yet — fine
     }
-    return createWriteStream(pathStr, { flags: "a" });
+    const s = createWriteStream(pathStr, { flags: "a" });
+    bytesWritten = existingSize;
+    return s;
+}
+
+function rotate(pathStr: string): void {
+    try {
+        renameSync(pathStr, pathStr + ".old");
+    } catch {
+        // rename can fail on Windows if .old is held open; best-effort,
+        // we keep writing to the same file and retry next rotation.
+    }
 }
 
 /**
@@ -53,8 +68,17 @@ export const log: Logger = (level, msg) => {
     // stderr (foreground terminal / shell redirect) — never throws.
     process.stderr.write(line);
     // file — durable record.
-    if (stream) {
+    if (stream && logPath) {
+        // Runtime rotation: if we've crossed the threshold since last check,
+        // reopen the file (rotates the old one out). This keeps a long-running
+        // proxy's log bounded without needing a restart.
+        if (bytesWritten >= MAX_BYTES) {
+            stream.end();
+            rotate(logPath);
+            stream = open(logPath);
+        }
         stream.write(line);
+        bytesWritten += Buffer.byteLength(line);
     }
 };
 
@@ -62,6 +86,7 @@ export const log: Logger = (level, msg) => {
 export function closeLogger(): void {
     stream?.end();
     stream = undefined;
+    bytesWritten = 0;
 }
 
 export function getLogPath(): string | undefined {

--- a/src/server.ts
+++ b/src/server.ts
@@ -163,11 +163,24 @@ export async function startServer(opts: ProxyOptions): Promise<http.Server> {
         log("info", `${sig} received — flushing sessions…`);
         // Stop accepting new requests BEFORE flushing, otherwise a late request
         // could mutate state after its snapshot is taken and be lost.
-        server.close();
-        void flushAllSessions().finally(() => {
-            closeLogger();
-            process.exit(0);
+        // server.close(cb) waits for all keep-alive connections to drain
+        // before invoking cb, so in-flight SSE streams get a chance to finish
+        // rather than being yanked mid-chunk.
+        server.close(() => {
+            void flushAllSessions().finally(() => {
+                closeLogger();
+                process.exit(0);
+            });
         });
+        // Hard fallback: if connections hang (client never closes), don't
+        // block shutdown forever — force-exit after a grace window.
+        setTimeout(() => {
+            log("warn", "shutdown grace window elapsed; forcing exit");
+            void flushAllSessions().finally(() => {
+                closeLogger();
+                process.exit(0);
+            });
+        }, 10_000).unref?.();
     };
     process.on("SIGTERM", () => shutdown("SIGTERM"));
     process.on("SIGINT", () => shutdown("SIGINT"));


### PR DESCRIPTION
## What

Remaining cross-platform / robustness fixes from the audit (M3 / m3 / m5). Wraps up the cross-platform work started in PR #21.

### m3 — logger runtime rotation (all platforms)
`logger.ts` only checked file size at startup; a long-running proxy's log grew without bound. Track `bytesWritten` and rotate at runtime when the 10 MB threshold is crossed (reopen the file). Rename failure (Windows `.old` held open by AV/indexer) is best-effort — we keep writing to the same file and retry next rotation.

### m5 — SSE drain on shutdown (all platforms)
Shutdown called `server.close()` fire-and-forget then immediately `process.exit(0)` — yanking in-flight SSE streams mid-chunk. Now `server.close(cb)` waits for keep-alive connections to drain before flushing sessions and exiting. A 10 s `unref`'d timeout forces exit if a client never closes its connection.

### M3 — host docs (no code change to the default)
Default stays **`127.0.0.1` (loopback, no auth)** — billion-context has no built-in auth, so binding to loopback is the safe default. Documented the choice in both READMEs:
- **IPv6**: use `--host ::` if your client resolves `localhost` to `::1` first
- **Container**: use `--host 0.0.0.0` so the published port can reach it
- ⚠️ Both `::` and `0.0.0.0` expose the proxy on all interfaces — only on a trusted network / behind a firewall.

## Pre-flight
- [x] typecheck: 0 errors
- [x] tests: 141 pass
- [x] build: success

## Audit status after this PR
All findings from the cross-platform audit resolved or documented:
- C1, M1, M2, m1, m2, m4 → fixed in #21
- m3, m5, M3 → this PR
- All green ✅