### PR TITLE
release v0.1.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Release v0.1.9

Wraps up the cross-platform robustness work.

### Includes (since v0.1.8)
- **m3** logger runtime rotation — track bytesWritten, rotate at 10MB without restart (was startup-only check)
- **m5** SSE drain on shutdown — `server.close(cb)` waits for keep-alive connections to drain before exit (was yanking streams mid-chunk), 10s unref'd timeout as hard fallback
- **M3** host docs — documented the IPv6 (`::`) / container (`0.0.0.0`) override cases with a security warning; **default stays `127.0.0.1` loopback** (no built-in auth)

### Pre-flight
- [x] typecheck: 0 errors
- [x] tests: 141 pass
- [x] build: success

### Release mechanism
Merge triggers `release.yml` → npm publish `--tag latest` + tag `v0.1.9`.

### Cross-platform audit status
All 9 findings (1 CRITICAL, 3 MAJOR, 5 MINOR) resolved. C1/M1/M2/m1/m2/m4 shipped in v0.1.8; m3/m5/M3 ship here.