### PR TITLE
release v0.1.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Release v0.1.10

Ships the auto-update reliability fixes.

### Includes (since v0.1.9)
- **fix: startup check ignores stale throttle** — every `bili` process now checks npm on startup (10s after listen) regardless of the cross-process throttle file, so a stale/polluted throttle can't suppress the first check. Subsequent checks share the throttle normally. (PR #25)
- **fix: clearer throttle logs** — `throttled — last checked Ns ago, retry in Ms` (two monotonic axes instead of a single countdown that could look like it's going backwards).

### Pre-flight
- [x] typecheck: 0 errors
- [x] tests: 141 pass
- [x] build: success
- [x] verified locally: startup check fires immediately with no throttle file

### Release mechanism
Merge triggers `release.yml` → npm publish `--tag latest` + tag `v0.1.10`.

After 0.1.10 is on npm, the currently-installed 0.1.9 auto-updates on its next check (startup or 3-min cycle) and notifies once.