### PR TITLE
fix: retry auto-update on transient install failure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.1",
+  "version": "0.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.1",
+      "version": "0.1.11",
       "license": "MIT",
       "dependencies": {
         "acp-kernel": "0.0.17"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -161,7 +161,7 @@ export async function main(): Promise<void> {
         return;
     }
     if (command === "update") {
-        // Manual one-shot update — bypasses the 6h throttle.
+        // Manual one-shot update — bypasses the throttle.
         await checkForUpdate({ packageName: PACKAGE_NAME, currentVersion: VERSION, autoUpdate: true }, true);
         return;
     }

--- a/src/update.ts
+++ b/src/update.ts
@@ -125,11 +125,11 @@ export async function checkForUpdate(opts: UpdateOptions, force = false): Promis
         loggerLog("info", `[update] new version found: ${opts.currentVersion} → ${latest}, installing…`);
 
         const installed = await installLatest(opts.packageName, latest);
-        notified.add(latest);
         if (installed) {
+            notified.add(latest);
             loggerLog("info", `[update] installed ${opts.packageName} ${opts.currentVersion} → ${latest}. Restart to finish.`);
         } else {
-            loggerLog("warn", `[update] install failed; run manually: npm install -g ${opts.packageName}@${latest}`);
+            loggerLog("warn", `[update] install failed; will retry next cycle. Or: npm install -g ${opts.packageName}@${latest}`);
         }
     } catch (e) {
         loggerLog("warn", `[update] check failed: ${String(e)}`);


### PR DESCRIPTION
## 问题

`notified.add(latest)` 在 `checkForUpdate()` 中**无条件执行**,位于判断 `installLatest()` 是否成功之前。

一次瞬时安装失败(网络抖动 / EACCES / registry 5xx)会导致:
1. `installed = false`,但 `latest` 已被加入 `notified` 集合
2. 当前运行版本未变,`isNewer()` 仍然为 `true`
3. 下个 3 分钟周期命中 `if (notified.has(latest))` → 打印 *"already installed this run"* → 跳过
4. **结果:一次瞬时失败 = 本进程生命周期内永久禁用自动升级**,且日志误导说"已安装"

## 修复

| 文件 | 改动 |
|------|------|
| `src/update.ts:128` | `notified.add(latest)` 从无条件执行移入 `if (installed)` 成功分支,失败时不标记,下个周期自然重试 |
| `src/update.ts:133` | 失败日志改为 `"will retry next cycle"`(原为 `"run manually"`),准确反映行为 |
| `src/cli.ts:164` | 过时注释 `"6h throttle"` → `"the throttle"`(实际 `CHECK_INTERVAL_MS = 3 min`) |
| `package.json` | `0.1.10` → `0.1.11`(patch) |

## 验证

- ✅ Build 成功(tsup 单文件 122KB)
- ✅ 141 个测试全过(0 fail)
- ✅ dist 确认旧 bug 模式消失、新修复模式存在
- ✅ 全局安装验证 `bili --version` → `0.1.11`

## Diff

\`\`\`diff
 const installed = await installLatest(opts.packageName, latest);
-notified.add(latest);
 if (installed) {
+    notified.add(latest);
     loggerLog("info", `[update] installed ...`);
 } else {
-    loggerLog("warn", `[update] install failed; run manually: ...`);
+    loggerLog("warn", `[update] install failed; will retry next cycle. Or: npm install -g ...`);
 }
\`\`\`