### PR TITLE
release v0.1.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "license": "MIT",
       "dependencies": {
         "acp-kernel": "0.0.17"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Release v0.1.12

包含 PR #27 (fix: retry auto-update on transient install failure) 的修复:

- **Bug A 修复**: `notified.add(latest)` 移入 `if (installed)` 成功分支,安装失败时下个周期自动重试
- **注释修复**: `cli.ts:164` 过时的 "6h throttle" → "the throttle"
- **版本号**: 0.1.10 → 0.1.11 → 0.1.12

已在 npm 发布 (`billion-context@0.1.12`) 并验证自动更新链路正常。

> 注:本次发布时 npm 包已先行发布,此 PR 为补走规范流程将版本号变更合入 master 并打 tag。