### PR TITLE
release v0.1.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.11",
+  "version": "0.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.11",
+      "version": "0.1.13",
       "license": "MIT",
       "dependencies": {
         "acp-kernel": "0.0.17"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.11",
+  "version": "0.1.13",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Release v0.1.13

版本号 bump,用于测试自动更新链路:
- 全局安装版本 0.1.12 → 启动后自动检测到 0.1.13 → 自动安装升级
- 验证 Bug A 修复(安装失败重试)在真实场景中工作正常

> npm 包已发布为 `billion-context@0.1.13`,本 PR 为补走规范流程合入 master + 打 tag。