### PR TITLE
fix: route all proxy logs through tee logger (file + stderr)

### DIFF
--- a/src/compress-loop-responses.ts
+++ b/src/compress-loop-responses.ts
@@ -420,7 +420,7 @@ export async function* compressLoopResponsesStream(
         const proxyCalls = allCalls.filter((c) => PROXY_TOOL_NAMES.has(c.name));
         const realCalls = allCalls.filter((c) => !PROXY_TOOL_NAMES.has(c.name));
         // DIAG: log what tools the upstream returned this round.
-        console.error(`[acp-diag] round ${loopCount} allCalls=[${allCalls.map((c) => c.name).join(",")}] realCalls=[${realCalls.map((c) => c.name).join(",")}] text=${JSON.stringify(contentText.slice(0, 120))}`);
+        loggerLog("debug", `[acp-diag] round ${loopCount} allCalls=[${allCalls.map((c) => c.name).join(",")}] realCalls=[${realCalls.map((c) => c.name).join(",")}] text=${JSON.stringify(contentText.slice(0, 120))}`);
         const hasOnlyProxy = proxyCalls.length > 0 && realCalls.length === 0;
 
         if (!hasOnlyProxy) {
@@ -469,11 +469,11 @@ export async function* compressLoopResponsesStream(
             try {
                 args = JSON.parse(fc.arguments) as Record<string, unknown>;
             } catch (e) {
-                console.error(`[acp-compress-args] ${fc.name} JSON.parse failed: ${String(e)}. raw arguments (len=${fc.arguments.length}): ${fc.arguments.slice(0, 300)}`);
+                loggerLog("warn", `[acp-compress-args] ${fc.name} JSON.parse failed: ${String(e)}. raw arguments (len=${fc.arguments.length}): ${fc.arguments.slice(0, 300)}`);
                 args = {};
             }
             if (fc.name === "compress") {
-                console.error(`[acp-compress-args] compress args parsed: ${JSON.stringify(args).slice(0, 400)}`);
+                loggerLog("debug", `[acp-compress-args] compress args parsed: ${JSON.stringify(args).slice(0, 400)}`);
             }
             const result = executeProxyTool(fc.name, args, ctx);
             const preview = result.length > 120 ? result.slice(0, 120) + "..." : result;

--- a/src/compress-tool.ts
+++ b/src/compress-tool.ts
@@ -1,4 +1,5 @@
 import { COMPRESS_PHILOSOPHY, HOW_TO_COMPRESS_RULES } from "acp-kernel";
+import { log as loggerLog } from "./logger.js";
 
 export const COMPRESS_TOOL_NAME = "compress";
 
@@ -44,7 +45,7 @@ export type ParsedRange = {
 
 export function parseCompressInput(input: unknown): ParsedRange[] {
     if (!input || typeof input !== "object") {
-        console.error(`[acp-compress-input] rejected: not object (${typeof input})`);
+        loggerLog("warn", `[acp-compress-input] rejected: not object (${typeof input})`);
         return [];
     }
     const obj = input as Record<string, unknown>;
@@ -52,11 +53,11 @@ export function parseCompressInput(input: unknown): ParsedRange[] {
         const out = obj.content
             .map((r) => toRange(r as Record<string, unknown>))
             .filter((r): r is ParsedRange => r !== null);
-        if (out.length === 0) console.error(`[acp-compress-input] content array but 0 valid ranges. keys per item: ${obj.content.map((c) => Object.keys(c ?? {}).join(",")).join(" | ")}`);
+        if (out.length === 0) loggerLog("warn", `[acp-compress-input] content array but 0 valid ranges. keys per item: ${obj.content.map((c) => Object.keys(c ?? {}).join(",")).join(" | ")}`);
         return out;
     }
     const single = toRange(obj);
-    if (!single) console.error(`[acp-compress-input] no content array, single-parse failed. top keys: ${Object.keys(obj).join(",")}`);
+    if (!single) loggerLog("warn", `[acp-compress-input] no content array, single-parse failed. top keys: ${Object.keys(obj).join(",")}`);
     return single ? [single] : [];
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,7 @@
 import { defaultConfig, type Config } from "acp-kernel";
 import { readFileSync } from "node:fs";
 import { configFile } from "./paths.js";
+import { log as loggerLog } from "./logger.js";
 
 function safeReadJson(path: string): unknown {
     try {
@@ -14,7 +15,7 @@ function safeReadJson(path: string): unknown {
         // a malformed providers file would otherwise run the proxy with
         // defaults and the user would not know why routing is wrong.
         if ((e as NodeJS.ErrnoException).code !== "ENOENT") {
-            console.error(`[acp-config] failed to parse ${path}: ${String(e)}`);
+            loggerLog("error", `[acp-config] failed to parse ${path}: ${String(e)}`);
         }
         return undefined;
     }

--- a/src/persist.ts
+++ b/src/persist.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileS
 import { createHash } from "node:crypto";
 import * as path from "node:path";
 import { sessionsDir } from "./paths.js";
+import { log as loggerLog } from "./logger.js";
 import { createInitialState, type CompressionState } from "acp-kernel";
 import type { Session, BlockContent } from "./session.js";
 
@@ -413,8 +414,10 @@ function persistEnabled(): boolean {
 }
 
 function defaultLogger(level: string, m: string): void {
-    // eslint-disable-next-line no-console
-    console.error(`[${level}] ${m}`);
+    // Route through the tee logger (file + stderr) when available; fall back
+    // to console.error only if the logger hasn't been configured yet (e.g.
+    // during early init or tests).
+    loggerLog(level, m);
 }
 
 /** Singleton store for the running proxy. */
@@ -422,7 +425,7 @@ let _store: SessionStore | null = null;
 
 export function getStore(): SessionStore {
     if (!_store) {
-        _store = new SessionStore({ enabled: persistEnabled() });
+        _store = new SessionStore({ enabled: persistEnabled(), log: defaultLogger });
     }
     return _store;
 }


### PR DESCRIPTION
## 问题

`bili start` 终端输出和文件日志（`~/.local/state/billion-context/bili.log`）不一致。多个模块直接用 `console.error` 输出日志，绕过了 tee logger，导致这些日志只进 stderr 不进文件。

## 修复

| 文件 | 改动 |
|------|------|
| `src/persist.ts` | `getStore()` 传入 tee logger（原回退到 `console.error`）；`defaultLogger` 也改为走 `loggerLog()` |
| `src/compress-loop-responses.ts` | 3 处 `console.error` → `loggerLog`（`[acp-diag]`→debug，`[acp-compress-args]`×2） |
| `src/compress-tool.ts` | 3 处 `console.error` → `loggerLog`（warn，`[acp-compress-input]`） |
| `src/config.ts` | `console.error` → `loggerLog`（error，`[acp-config]`） |

**保留不变**：`cli.ts`（用户可见的 CLI 错误）和 `index.ts`（logger 初始化前的启动崩溃）仍用 `console.error`——它们在 logger 初始化之前运行。

## 验证

- ✅ Build 成功
- ✅ 141 测试全过（0 fail）