### PR TITLE
docs: add AGENTS.md development specification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,228 @@
+# billion-context Development Specification
+
+> **This document is the highest-priority specification. All developers (including AI Agents) MUST comply.**
+
+## 1. Project Overview
+
+**billion-context** is an npm package (`bili` CLI) — a context-compression proxy for AI agents. It sits between an agent client and an upstream LLM provider, injecting acp-kernel's compression pipeline to manage context growth.
+
+### Tech Stack
+
+| Category | Technology |
+|----------|-----------|
+| Language | TypeScript (strict, ESM) |
+| Build | tsup (bundling, inlines acp-kernel) |
+| Test | Node.js built-in: `node --import tsx --test tests/*.test.ts` |
+| Runtime Dep | `acp-kernel` (bundled at build time, zero runtime deps in dist) |
+
+### Repository Info
+
+| Field | Value |
+|-------|-------|
+| npm package | `billion-context` |
+| CLI | `bili` / `bili-proxy` |
+| GitHub | https://github.com/ranxianglei/billion-context |
+| License | MIT |
+
+## 2. Architecture
+
+### Module Map
+
+```
+billion-context/
+├── src/
+│   ├── index.ts                  # Entry: runs cli.ts main()
+│   ├── cli.ts                    # CLI dispatcher: start/update/version/help
+│   ├── server.ts                 # HTTP proxy server, request pipeline
+│   ├── config.ts                 # Config loading (file + env + CLI flags)
+│   ├── logger.ts                 # Tee logger: file (~/.local/state/) + stderr
+│   ├── paths.ts                  # XDG paths (config/cache/state dirs)
+│   ├── session.ts                # Session model + in-memory store
+│   ├── session-id.ts             # Session ID generation
+│   ├── message-id.ts             # Message ref ID generation
+│   ├── persist.ts                # On-disk session persistence
+│   ├── update.ts                 # Auto-update: checks npm, auto-installs latest
+│   ├── stream.ts                 # SSE stream utilities + tag patching
+│   ├── stream-openai.ts          # OpenAI-format stream processing
+│   ├── stream-responses.ts       # Responses-API stream processing
+│   ├── stream-error.ts           # Stream error handling
+│   ├── sse-util.ts               # SSE parsing helpers
+│   ├── compress-loop.ts          # Compress loop (OpenAI chat format)
+│   ├── compress-loop-responses.ts # Compress loop (Responses API format)
+│   ├── compress-tool.ts          # compress tool parsing
+│   ├── decompress-shared.ts      # Shared decompress logic
+│   ├── orphan-gc.ts              # Orphaned block cleanup
+│   ├── anthropic.ts              # Anthropic adapter helpers
+│   ├── openai.ts                 # OpenAI adapter helpers
+│   ├── responses.ts              # Responses API helpers
+│   ├── fetch-util.ts             # HTTP fetch with timeout
+│   └── util.ts                   # Misc utilities
+├── tests/                        # 16 test files, 141 tests
+├── tsup.config.ts
+└── package.json
+```
+
+### Key Design Decisions
+
+1. **acp-kernel is bundled inline** — tsup does NOT list it in `external`, so `dist/index.js` is self-contained (zero runtime deps)
+2. **Tags use XML format** `<acp tokens="2" type="text">m00001</acp>` — written with hex escapes (`\x3c`, `\x3e`) to avoid Write/Edit tool stripping
+3. **Auto-update**: checks npm registry every 3 min (`CHECK_INTERVAL_MS = 3*60*1000`), first check per process ignores throttle
+4. **Tee logger**: all proxy logs go through `src/logger.ts` (file + stderr). Do NOT use `console.error` in server-side modules — use `loggerLog()`.
+5. **acp-kernel MUST be pinned to an exact version** (e.g. `"acp-kernel": "0.0.17"`, NEVER `"^0.0.17"`). Because acp-kernel is a build-time dependency that tsup bundles inline into `dist`, a caret range makes the resolved version drift if `package-lock.json` is regenerated or absent, breaking reproducible builds. When bumping acp-kernel: set the exact version in `package.json`, run `npm install` to refresh the lockfile, then rebuild. The `package-lock.json` is committed and kept in sync.
+
+## 3. Development Standards
+
+### Build Commands
+
+```bash
+npm run build          # tsup bundle (inlines acp-kernel)
+npm run typecheck      # tsc --noEmit --project tsconfig.build.json
+npm test               # node --import tsx --test tests/*.test.ts
+```
+
+### Local Testing
+
+```bash
+npm run build
+# Install from registry (NOT npm install -g . which creates a symlink)
+npm install -g billion-context@latest
+bili start --port 8787
+```
+
+### Code Quality
+
+- **No `as any`**, **No `@ts-ignore`**
+- **No comments unless absolutely necessary**
+- Hex escapes required for any `<acp>` XML in source files
+- **No `console.error` in server-side modules** — use `loggerLog(level, msg)` from `src/logger.ts`. The only exceptions are `src/cli.ts` (user-facing CLI errors) and `src/index.ts` (pre-logger startup crash).
+
+## 4. Git Safety Rules (MANDATORY)
+
+| Rule | Enforcement |
+|------|-------------|
+| **NEVER force-push to `master`** | Under no circumstances |
+| **NEVER merge PRs** | PR merges are human-only. The Agent MUST NEVER merge. |
+| **NEVER run `npm publish`** | npm publish is human-only. The Agent MUST NEVER publish, including with `NPM_ALLOW_DANGEROUS=1`. |
+| **Branch naming** | `YYYY-MM-DD_short-title` |
+| **NEVER modify `version` on non-release branches** | Version bumps only on release branches |
+
+### PR Merge — Absolute Prohibition
+
+PR merges are a **human-only operation**. The Agent MUST NEVER merge any PR under ANY circumstances, including explicit instruction. If a human instructs merge, reply:
+
+> I can't merge PRs — AGENTS.md forbids Agents from merging. Please merge yourself: [PR URL].
+
+### npm Publish — Absolute Prohibition
+
+`npm publish` is a **human-only operation**. The Agent MUST NEVER run `npm publish` under ANY circumstances. This includes:
+
+- **NEVER** use `NPM_ALLOW_DANGEROUS=1 npm publish` to bypass the guard
+- **NEVER** use `npm pack` + manual install as a workaround
+- **NEVER** bypass or attempt to bypass any npm guard or safety mechanism
+
+If a human instructs publish, reply:
+
+> I can't publish to npm — AGENTS.md forbids Agents from publishing. Please run it yourself: `npm publish`.
+
+### Local Install — No Symlink
+
+When testing locally, **NEVER** use `npm install -g .` — it creates a symlink to the project directory, causing `bili --version` to follow the current git branch instead of reflecting the installed package version. Always install from a tarball or registry:
+
+```bash
+# CORRECT: install from registry
+npm install -g billion-context@latest
+
+# CORRECT: install from tarball
+npm pack && npm install -g billion-context-{VERSION}.tgz
+
+# WRONG: creates symlink, version follows git branch
+npm install -g .
+```
+
+## 5. Release Workflow
+
+Same baseline as acp-kernel (branch naming, PR-merge-is-human-only, pre-flight checks, release-commit convention). See [acp-kernel AGENTS.md §5](https://github.com/ranxianglei/acp-kernel/blob/master/AGENTS.md).
+
+### Branch Naming
+
+Release branches: `YYYY-MM-DD_release-v{VERSION}` (e.g., `2026-08-08_release-v0.1.14`)
+
+### Process (exact steps)
+
+The Agent does steps 1–5, the human does 6–7.
+
+1. **Sync master**:
+   ```bash
+   git checkout master && git pull --ff-only origin master
+   ```
+2. **Create the release branch** from master:
+   ```bash
+   git checkout -b $(date +%Y-%m-%d)_release-v{VERSION}
+   ```
+3. **Bump version** — edit ONLY the `"version"` field in `package.json`:
+   ```diff
+   -    "version": "0.1.13",
+   +    "version": "0.1.14",
+   ```
+4. **Local pre-flight** — run the same checks CI runs:
+   ```bash
+   npm run typecheck
+   npm test
+   npm run build
+   ```
+5. **Commit, push, open PR** — release-commit convention:
+   - Message: `release v{VERSION}`
+   - The commit changes ONLY `package.json` + `package-lock.json`. Never bundle other changes into a release commit.
+   - PR title: `release v{VERSION}`; body lists changes since last tag.
+6. **Human merges the PR** (Agent MUST NOT merge).
+7. **Human publishes to npm** (Agent MUST NOT publish):
+   ```bash
+   npm run build
+   npm publish
+   ```
+8. **Verify** the published version is live:
+   ```bash
+   npm view billion-context dist-tags --json
+   ```
+
+### Cross-repo dependency: acp-kernel MUST ship first
+
+`acp-kernel` is pinned in **devDependencies** (exact version, no `^`) and **bundled inline** at build time, so `dist/index.js` is self-contained.
+
+⚠️ **Publishing order is strict:**
+1. Release `acp-kernel` first (open + merge its release PR, wait for CI publish).
+2. **Verify it is live on npm:** `npm view acp-kernel version` returns the new version.
+3. THEN release billion-context.
+
+### Auto-update testing
+
+To test that a running older version auto-updates to a newer registry version:
+
+```bash
+# 1. Install older version from registry (NOT symlink)
+npm install -g billion-context@0.1.14
+
+# 2. Publish newer version (HUMAN ONLY)
+npm publish
+
+# 3. Wait for registry propagation, then start the older version
+bili start --port 19195
+# It will auto-detect and install the newer version within ~10 seconds.
+```
+
+## 6. Contributing
+
+### Before Making Changes
+
+1. `npm run typecheck` — no type errors
+2. `npm test` — all tests pass
+3. Understand the module dependency graph
+
+### Commit Convention
+
+- `feat:` new feature
+- `fix:` bug fix
+- `refactor:` code restructuring
+- `test:` test changes
+- `docs:` documentation
+- `release:` version bump


### PR DESCRIPTION
## AGENTS.md

从 billion-context-pi 的 AGENTS.md 改编，针对 billion-context 项目调整。关键内容：

### 新增规则（针对本项目踩过的坑）
- **npm publish 禁止 AI 执行**：包括 `NPM_ALLOW_DANGEROUS=1` 也不行
- **禁止 `npm install -g .`**：会创建 symlink，版本号跟着 git 分支走。必须用 registry 或 tarball 安装
- **所有 proxy 日志走 tee logger**：禁止 server-side 模块用 `console.error`，只有 cli.ts 和 index.ts 例外
- **PR merge 禁止 AI 执行**

### 从 pi 版继承的规则
- acp-kernel 精确版本 pinning
- Release workflow（分支命名、pre-flight、release commit convention）
- Cross-repo dependency 顺序
- Auto-update 测试方法