### PR TITLE
release v0.1.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.15",
+  "version": "0.1.17",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Release v0.1.17

Aligns master version with npm (0.1.16 published but master stuck at 0.1.15 due to a CONFLICTING PR#32 that got closed). 0.1.16 package is already on npm and tagged; this release picks up at 0.1.17.

### Pre-flight
- [x] typecheck: 0 errors
- [x] tests: 141 pass
- [x] build: success
- [x] branch based on current master (20f5991) — no conflicts

### Release mechanism
Merge triggers `release.yml` → npm publish `--tag latest` + tag `v0.1.17`.