### PR TITLE
release v0.1.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "billion-context",
-  "version": "0.1.15",
+  "version": "0.1.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.15",
+      "version": "0.1.18",
       "license": "MIT",
       "dependencies": {
         "acp-kernel": "0.0.17"
       },
       "bin": {
+        "bili": "dist/index.js",
         "bili-proxy": "dist/index.js"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Version bump 0.1.17 → 0.1.18 (based on master, no code changes).

Merge this PR to publish 0.1.18 to npm via CI.

> Note: PR #36 (tarball-based auto-update) is separate, not included in this release.