### PR TITLE
release v0.1.20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "license": "MIT",
       "dependencies": {
         "acp-kernel": "0.0.17"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Small release: first-run auto-creates an empty config file (was a fake placeholder template), README Quickstart rewrite (stepped 3-step guide, per-client one-line baseUrl edit, drop env vars + untested Claude Code).

Pre-flight: typecheck ✅ · 141 test ✅ · build ✅

merge → CI publishes to npm + tags v0.1.20.