### PR TITLE
release v0.1.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Release v0.1.21.

## What's new (since v0.1.20)

**Web config UI** — open `http://localhost:8787/__acp/` in a browser:
- Edit providers in a form (add/remove providers + per-model context windows), save writes to config file
- Generate copy-ready client config snippets (Pi / OpenCode / Codex `baseUrl` lines)
- Sessions tab: live table with protocol, label, title, requests, context tokens, cache-hit %, cumulative input/output
- GitHub link in header (logo + button)

**Rich session stats:**
- Cumulative input/output/cached tokens + cache-hit ratio (per session)
- Current context token count
- Title derived from first user message
- Protocol + client label (real session id only, not synthetic)
- All persisted to disk (survives restart, backward-compat with old files)

**Session type refactor** (extensibility):
- Grouped into `meta` / `stats` / `metadata` — adding a field now touches 2 files instead of 8
- `metadata` escape-hatch for future fields
- Persist v2 (grouped), reads v1 (flat) for backward compat

**Docs:**
- README Quickstart split: web UI (primary) + manual JSON (secondary)
- Startup banner prints web UI URL
- GitHub link

## Verification
typecheck ✅ · 141 test ✅ · build ✅

merge → CI publishes v0.1.21 to npm + tags + GitHub Release.