### PR TITLE
release v0.1.22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.21",
+      "version": "0.1.22",
       "license": "MIT",
       "dependencies": {
         "acp-kernel": "0.0.17"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.20",
+      "version": "0.1.21",
       "license": "MIT",
       "dependencies": {
         "acp-kernel": "0.0.17"
@@ -17,6 +17,7 @@
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
+        "tar": "^7.5.22",
         "tsup": "^8.0.0",
         "tsx": "^4.0.0",
         "typescript": "^5.5.0"
@@ -465,6 +466,19 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -1003,6 +1017,16 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -1183,6 +1207,29 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/mlly": {
@@ -1420,6 +1467,23 @@
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/thenify": {
@@ -2069,6 +2133,16 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
+    "tar": "^7.5.22",
     "tsup": "^8.0.0",
     "tsx": "^4.0.0",
     "typescript": "^5.5.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/update.ts
+++ b/src/update.ts
@@ -20,8 +20,9 @@
  * version and stops trying. No notified Set — failed installs retry next
  * cycle automatically.
  */
-import { readFile, writeFile, mkdir, access, constants, rm } from "node:fs/promises";
+import { readFile, writeFile, mkdir, access, constants, rm, cp } from "node:fs/promises";
 import { execFile } from "node:child_process";
+import * as tar from "tar";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { cacheDir } from "./paths.js";
@@ -311,29 +312,21 @@ async function installViaTarball(
     }
 
     // Extract to a temp staging dir (NOT directly over install dir).
+    // Uses the `tar` npm package (pure JS, cross-platform) instead of
+    // shelling out to the `tar` binary, which is absent or inconsistent on
+    // Windows. `--strip-components=1` maps to `strip: 1` (npm tarballs wrap
+    // files in a `package/` dir).
     const stagingDir = path.join(cacheDir(), `.update-staging-${version}`);
     try {
         // Clean any leftover staging dir from a previous failed attempt.
         await rm(stagingDir, { recursive: true, force: true });
         await mkdir(stagingDir, { recursive: true });
 
-        const { code, stderr } = await new Promise<{ code: number; stderr: string }>((resolve) => {
-            execFile(
-                "tar",
-                ["xzf", tmpFile, "-C", stagingDir, "--strip-components=1"],
-                { timeout: 30_000 },
-                (err, _stdout, stderr) => {
-                    if (err) {
-                        resolve({ code: 1, stderr: stderr || err.message });
-                    } else {
-                        resolve({ code: 0, stderr: stderr || "" });
-                    }
-                },
-            );
+        await tar.x({
+            file: tmpFile,
+            cwd: stagingDir,
+            strip: 1,
         });
-        if (code !== 0) {
-            return { ok: false, error: `extraction failed (tar exit ${code})${stderr.trim() ? `: ${stderr.trim()}` : ""}` };
-        }
 
         // Verify the staging dir has a valid package.json with the right version.
         const stagingVersion = await readDiskVersion(stagingDir);
@@ -346,26 +339,12 @@ async function installViaTarball(
         await rm(tmpFile, { force: true });
     }
 
-    // Copy staging over install dir.
-    // `cp -r staging/. installDir/` merges without creating a nested dir.
+    // Copy staging over install dir using Node's built-in fs.cp (Node 16.7+).
+    // Cross-platform — no dependency on the `cp` binary (absent on Windows).
+    // `recursive: true` + the trailing `/.` semantics: fs.cp copies the
+    // *contents* of stagingDir into installDir, merging without nesting.
     try {
-        const { code, stderr } = await new Promise<{ code: number; stderr: string }>((resolve) => {
-            execFile(
-                "cp",
-                ["-r", stagingDir + "/.", installDir + "/"],
-                { timeout: 30_000 },
-                (err, _stdout, stderr) => {
-                    if (err) {
-                        resolve({ code: 1, stderr: stderr || err.message });
-                    } else {
-                        resolve({ code: 0, stderr: stderr || "" });
-                    }
-                },
-            );
-        });
-        if (code !== 0) {
-            return { ok: false, error: `failed to copy to install dir (cp exit ${code})${stderr.trim() ? `: ${stderr.trim()}` : ""}` };
-        }
+        await cp(stagingDir, installDir, { recursive: true, force: true });
     } catch (e) {
         return { ok: false, error: `failed to copy to install dir: ${String(e)}` };
     } finally {


### PR DESCRIPTION
Release v0.1.22 — includes the Windows auto-update fix (cherry-picked from PR#44).

## What's new
**fix(windows): cross-platform auto-update** — Windows had no `tar`/`cp` in PATH, so auto-update failed silently and users were stuck on their installed version forever. Replaced both shell-outs with cross-platform Node APIs (`tar` npm package + Node builtin `fs.cp`). `tar` is a build-time dep (bundled by tsup), so runtime footprint unchanged.

This release is also the **self-test**: the running v0.1.21 will auto-update itself to v0.1.22 using the *new* code path — if it succeeds, the Windows fix is proven end-to-end.

## Verification
typecheck ✅ · 141 test ✅ · build ✅

merge → CI publishes v0.1.22 + tags + GitHub Release.