### PR TITLE
release v0.1.22

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
No-op release (version bump only, no code changes).

**Purpose: test the auto-update upgrade path end-to-end.** The running v0.1.21 will auto-update itself to this v0.1.22. If it succeeds, the upgrade mechanism is confirmed working before we ship any changes to that mechanism itself (the Windows fix is staged separately in PR#44 — it ships only after we've verified the upgrade path is healthy).

merge → CI publishes v0.1.22 + tags + GitHub Release.