### PR TITLE
release v0.1.23

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Release v0.1.23 — Windows auto-update fix.

## What's new (since v0.1.22)

**fix(windows): cross-platform auto-update** (PR#44, merged into master before this release). Windows had no `tar`/`cp` in PATH, so auto-update failed silently and users were stuck on their installed version forever. Replaced both shell-outs with cross-platform Node APIs:
- `execFile("tar", ...)` → `tar.x()` (tar npm package, pure JS)
- `execFile("cp", ...)` → `fs.cp()` (Node builtin)
`tar` is a build-time dep (bundled by tsup), so runtime footprint unchanged.

## Safety validation (per AGENTS.md §5)
This release ships a change to `src/update.ts` (the auto-update mechanism itself). Per the no-op-release rule:
1. ✅ No-op v0.1.22 (PR#46) was released first and verified end-to-end: running v0.1.21 auto-upgraded to v0.1.22 successfully.
2. ✅ Now shipping the actual updater change in v0.1.23.

If v0.1.22 → v0.1.23 upgrades cleanly (it uses the *new* code path — `tar` lib + `fs.cp`), the Windows fix is proven.

## Verification
typecheck ✅ · 141 test ✅ · build ✅

merge → CI publishes v0.1.23 + tags + GitHub Release.