### PR TITLE
feat: hot-reload routes via web UI Apply button

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -113,6 +113,35 @@ export type ProxyOptions = {
     logFile?: string;
 };
 
+/** Re-read ONLY the routes from the current config sources, returning a fresh
+ *  ProviderRoutes object. Used by the web UI's "Apply" (hot-reload) button so
+ *  provider/route changes take effect without restarting bili. Only routes are
+ *  re-read — port/host/upstream can't change on a running server (the listen
+ *  socket is already bound), so those stay as they were at startup. Mirrors the
+ *  exact precedence of loadOptions: external ACP_PROVIDERS path > inline
+ *  providers in the config file. */
+export function loadRoutes(env: NodeJS.ProcessEnv = process.env): ProviderRoutes {
+    const fileConfig = loadConfigFile();
+    const routes: ProviderRoutes = {};
+    const routesPath = env.ACP_PROVIDERS ?? fileConfig.providersPath ?? "";
+    if (routesPath) {
+        const parsed = safeReadJson(routesPath);
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+            for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+                const route = parseRouteEntry(v);
+                if (route) routes[k] = route;
+            }
+        }
+    }
+    if (fileConfig.providers) {
+        for (const [k, v] of Object.entries(fileConfig.providers)) {
+            const route = parseRouteEntry(v);
+            if (route && !routes[k]) routes[k] = route;
+        }
+    }
+    return routes;
+}
+
 export function loadOptions(env: NodeJS.ProcessEnv = process.env): ProxyOptions {
     // --- Source 1: JSON config file (~/.config/billion-context/billion-context.json) ---
     // The canonical, user-editable config. Loaded first so env vars below can

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import { tmpdir } from "node:os";
 import { createCore, type CompressionCore, type Config, type CoreMessage, type NudgeDecision, estimateTokensFast, renderNudgeText, deactivateBlock } from "acp-kernel";
 import type { ProxyOptions } from "./config.js";
+import { loadRoutes } from "./config.js";
 import { resolveContextLimit } from "./config.js";
 import { fetchWithTimeout, MAX_REQUEST_BYTES } from "./fetch-util.js";
 import {
@@ -228,6 +229,7 @@ async function handle(
     }
     if (req.method === "GET" && req.url === "/__acp/config") return handleConfigGet(res);
     if (req.method === "PUT" && req.url === "/__acp/config") return handleConfigPut(req, res);
+    if (req.method === "POST" && req.url === "/__acp/config/reload") return handleConfigReload(opts, res, log);
     let bodyBuffer: Buffer;
     try {
         bodyBuffer = await readBody(req);
@@ -909,6 +911,22 @@ function deriveTitle(messages: CoreMessage[]): string | undefined {
         if (clean) return clean.length > 60 ? clean.slice(0, 57) + "\u2026" : clean;
     }
     return undefined;
+}
+
+function handleConfigReload(opts: ProxyOptions, res: http.ServerResponse, log: (level: string, msg: string) => void): void {
+    // Hot-reload routes from the config file into the running process — no
+    // restart needed. Only routes are re-read; port/host/upstream stay as-is
+    // (the listen socket is already bound). Mutates opts.routes in place so all
+    // in-flight handle() closures that captured `opts` see the new routes.
+    const fresh = loadRoutes();
+    // Clear and refill the SAME object reference so resolveUpstream/resolveContextLimit
+    // (which read opts.routes) pick up the new entries without needing reassignment.
+    for (const k of Object.keys(opts.routes)) delete opts.routes[k];
+    Object.assign(opts.routes, fresh);
+    const names = Object.keys(fresh);
+    log("info", `[acp-web] routes hot-reloaded (${names.length} providers): ${names.join(", ") || "(none)"}`);
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({ ok: true, count: names.length, routes: names }));
 }
 
 function sendStats(res: http.ServerResponse): void {

--- a/src/web.ts
+++ b/src/web.ts
@@ -255,6 +255,7 @@ select { cursor: pointer; }
       <button class="btn" onclick="addProvider()">+ Add provider</button>
     </div>
     <div class="actions">
+      <button class="btn" onclick="applyProviders()">Apply</button>
       <button class="btn primary" onclick="saveProviders()">Save</button>
     </div>
   </div>
@@ -374,8 +375,23 @@ function removeModel(i, j) {
 function checkDirty() {
   var dirty = savedProviders !== null && JSON.stringify(providers) !== savedProviders;
   var n = el("restart-notice");
-  if (dirty) { n.style.display = "block"; n.textContent = "Unsaved changes — click Save to write to the config file, then restart bili to apply."; }
+  if (dirty) { n.style.display = "block"; n.textContent = "Unsaved changes — click Save to write to the config file, then click Apply to activate without restart."; }
   else { n.style.display = "none"; }
+}
+
+// ── apply (hot-reload routes into running process) ──
+async function applyProviders() {
+  // Apply always re-reads the config FILE, so require a Save first if dirty.
+  if (savedProviders !== JSON.stringify(providers)) {
+    toast("Save your changes first", true);
+    return;
+  }
+  try {
+    var r = await fetch("/__acp/config/reload", { method: "POST" });
+    var d = await r.json();
+    if (r.ok) { toast("Applied — " + d.count + " providers active (no restart needed)"); }
+    else { toast("Apply failed: " + (d.error || "unknown"), true); }
+  } catch(e) { toast("Apply failed: " + e, true); }
 }
 
 // ── save ──
@@ -393,7 +409,7 @@ async function saveProviders() {
   try {
     var r = await fetch("/__acp/config", { method: "PUT", headers: { "content-type": "application/json" }, body: JSON.stringify({ providers: obj }) });
     var d = await r.json();
-    if (r.ok) { savedProviders = JSON.stringify(providers); checkDirty(); toast("Saved " + d.count + " providers — restart bili to apply"); }
+    if (r.ok) { savedProviders = JSON.stringify(providers); checkDirty(); toast("Saved " + d.count + " providers — click Apply to activate"); }
     else { toast("Error: " + (d.error || "unknown"), true); }
   } catch(e) { toast("Save failed: " + e, true); }
 }


### PR DESCRIPTION
Save wrote the config file but required a manual bili restart. Users (especially Windows, no interactive terminal) kept using the proxy with stale routes — all requests went to the old upstream.

## Fix
**Apply** button next to Save. Save writes the file (unchanged); Apply hot-loads routes into the running process — no restart.

| | old | new |
|---|---|---|
| Save | writes file, must restart | writes file, toast says 'click Apply' |
| Apply | (didn't exist) | POST /__acp/config/reload → routes live in-process |

## API
`POST /__acp/config/reload` → `{ ok, count, routes: [...] }`. Re-reads routes from config file, clears+refills `opts.routes` in place (so in-flight closures see it). Only routes reload — port/host/upstream stay as-is (listen socket already bound).

## Verification
- typecheck ✅ · 141 test ✅ · build ✅
- End-to-end: PUT new config → health still shows old upstream → POST reload → `routes hot-reloaded (2 providers)` in log → request immediately routes to new upstream, no restart

## UX flow
- dirty → 'click Save then click Apply to activate without restart'
- Save → 'Saved N providers — click Apply to activate'
- Apply (with unsaved edits) → 'Save your changes first' (blocked)
- Apply (clean) → 'Applied — N providers active (no restart needed)'