### PR TITLE
feat: drop output (max_tokens) from config — no longer needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ to send each request. In the config below, `zhipu` corresponds to:
     "zhipu": {
       "url": "https://open.bigmodel.cn",
       "models": {
-        "glm-5.2": { "context": 1000000, "output": 131072 }
+        "glm-5.2": { "context": 1000000 }
       }
 ```
 
@@ -200,7 +200,7 @@ client's base URL in Step 3.
     "zhipu": {
       "url": "https://open.bigmodel.cn",
       "models": {
-        "glm-5.2": { "context": 1000000, "output": 131072 }
+        "glm-5.2": { "context": 1000000 }
       }
     },
     "anthropic": "https://api.anthropic.com"
@@ -343,8 +343,8 @@ The config file is a single JSON object. Example:
     "zhipu": {
       "url": "https://open.bigmodel.cn",
       "models": {
-        "glm-5.2": { "context": 1000000, "output": 131072 },
-        "glm-5.1": { "context": 200000, "output": 131072 }
+        "glm-5.2": { "context": 1000000 },
+        "glm-5.1": { "context": 200000 }
       }
     },
     "anthropic": "https://api.anthropic.com",
@@ -392,7 +392,7 @@ object with `url` + optional per-model context window (recommended).
   "zhipu": {
     "url": "https://open.bigmodel.cn",
     "models": {
-      "glm-5.2": { "context": 1000000, "output": 131072 },
+      "glm-5.2": { "context": 1000000 },
       "glm-5.1": { "context": 200000 }
     }
   }
@@ -403,7 +403,11 @@ The same model can have a different context window behind different providers
 (e.g. relay wraps a model with a larger window). `context` is the **input
 context limit** (used by the compressor to decide when to nudge); `output` is
 the max output tokens. Both are optional; missing values fall back to the
-built-in model table, then to `modelContextLimit`.
+built-in model table, then to `modelContextLimit`. **`output` is no longer
+needed** — the proxy forwards whatever `max_tokens` the client sends, and
+omits it otherwise so the upstream uses its own default (Anthropic clients
+always send it, so Anthropic routes are covered automatically). An `output`
+field is still accepted for backward compatibility but has no effect.
 
 > **Why declare context at all?** The LLM `/models` API does **not** return
 > context windows (verified across OpenAI, Anthropic, 智谱, comfly). They are

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -141,7 +141,7 @@ base URL 的东西。
     "zhipu": {
       "url": "https://open.bigmodel.cn",
       "models": {
-        "glm-5.2": { "context": 1000000, "output": 131072 }
+        "glm-5.2": { "context": 1000000 }
       }
     },
     "anthropic": "https://api.anthropic.com"
@@ -282,8 +282,8 @@ bili --no-auto-update        # 本次启动禁用自动更新
     "zhipu": {
       "url": "https://open.bigmodel.cn",
       "models": {
-        "glm-5.2": { "context": 1000000, "output": 131072 },
-        "glm-5.1": { "context": 200000, "output": 131072 }
+        "glm-5.2": { "context": 1000000 },
+        "glm-5.1": { "context": 200000 }
       }
     },
     "anthropic": "https://api.anthropic.com",
@@ -329,14 +329,14 @@ bili --no-auto-update        # 本次启动禁用自动更新
   "zhipu": {
     "url": "https://open.bigmodel.cn",
     "models": {
-      "glm-5.2": { "context": 1000000, "output": 131072 },
+      "glm-5.2": { "context": 1000000 },
       "glm-5.1": { "context": 200000 }
     }
   }
 }
 ```
 
-同一个模型在不同 provider 后面可以有不同 context 窗口(例如 relay 把模型包成更大窗口)。`context` 是**输入 context 上限**(压缩器用它判断何时 nudge);`output` 是最大输出 token。两者都可选;缺失值回退到内置模型表,再回退到 `modelContextLimit`。
+同一个模型在不同 provider 后面可以有不同 context 窗口(例如 relay 把模型包成更大窗口)。`context` 是**输入 context 上限**(压缩器用它判断何时 nudge)。可选;缺失值回退到内置模型表,再回退到 `modelContextLimit`。**`output`(最大输出 token)已不再需要** —— proxy 原样透传客户端发的 `max_tokens`,客户端不发就让上游用默认值(Anthropic 客户端总会发,所以 Anthropic 路由自动覆盖)。config 里的 `output` 字段仍兼容接受,但已无效果。
 
 > **为什么要声明 context?** LLM 的 `/models` API **不返回** context 窗口(已跨 OpenAI、Anthropic、智谱、comfly 验证)。它们是文档级信息。值错了(例如把 GLM-5.2 猜成 128K 而非 1M)会导致频繁误触发压缩。按 provider + 模型声明能让代理匹配客户端自己用的注册表。
 

--- a/src/web.ts
+++ b/src/web.ts
@@ -328,7 +328,7 @@ function entries(obj) {
 function entries_models(obj) {
   if (!obj || typeof obj !== "object") return [];
   return Object.keys(obj).map(function(name){
-    return { name: name, context: obj[name].context||0, output: obj[name].output||0 };
+    return { name: name, context: obj[name].context||0 };
   });
 }
 
@@ -345,8 +345,7 @@ function renderProviders() {
       html += '<div class="sub-card">';
       html += '<div class="model-head"><span class="mname mono">'+esc(m.name)+'</span>';
       html += '<button class="btn danger small" onclick="removeModel('+i+','+j+')">Remove</button></div>';
-      html += '<div class="model-row"><label>context</label><input type="number" value="'+m.context+'" onchange="providers['+i+'].models['+j+'].context=parseInt(this.value)||0"></div>';
-      html += '<div class="model-row"><label>output</label><input type="number" value="'+m.output+'" onchange="providers['+i+'].models['+j+'].output=parseInt(this.value)||0"></div>';
+      html += '<div class="model-row"><label>context</label><input type="number" value="'+m.context+'" onchange="providers['+i+'].models['+j+'].context=parseInt(this.value)||0" placeholder="optional"></div>';
       html += '<div class="model-row"><label>name</label><input value="'+esc(m.name)+'" onchange="providers['+i+'].models['+j+'].name=this.value"></div>';
       html += '</div>';
     });
@@ -365,7 +364,7 @@ function removeProvider(i) {
   renderProviders();
 }
 function addModel(i) {
-  providers[i].models.push({ name: "model-name", context: 200000, output: 8192 });
+  providers[i].models.push({ name: "model-name", context: 0 });
   renderProviders();
 }
 function removeModel(i, j) {
@@ -402,7 +401,7 @@ async function saveProviders() {
     if (p.models.length === 0) { obj[p.name] = p.url; }
     else {
       var models = {};
-      p.models.forEach(function(m){ if(m.name) models[m.name] = { context: m.context, output: m.output }; });
+      p.models.forEach(function(m){ if(m.name) models[m.name] = { context: m.context }; });
       obj[p.name] = { url: p.url, models: models };
     }
   });


### PR DESCRIPTION
Research confirmed the proxy never reads the config `output` field — it's a dead value that only added friction.

## Why it's safe to drop
| API | max_tokens optional? |
|---|---|
| OpenAI Chat/Responses, zhipu, DeepSeek, etc | ✅ optional (upstream defaults) |
| Anthropic | required, but its clients always send it |

The proxy forwards whatever `max_tokens` the client sends, and omits it otherwise. So config `output` was never used.

## Changes
- **Web UI**: removed output input row from model editor; addModel/saveProviders drop it
- **README (EN+ZH)**: examples show `{ context: N }` without output; Configuration section explains it's no longer needed
- **ProviderRoute type**: `output` kept optional for backward compat (old configs still parse, value ignored)
- **context window unchanged** — still needed for compression timing

Verification: typecheck ✅ · 141 test ✅ · build ✅