### PR TITLE
feat: zero-config routing (/p/ prefix) + auto-fetch context from models.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,41 @@ This installs the `bili` command (`bili-proxy` is kept as an alias).
 
 ## Quickstart
 
-Three steps: **start the proxy → edit the config file → point your client at it**.
+Two ways to use it — pick one:
+
+- **Zero-config (simplest):** prefix your client's baseURL with the proxy
+  origin + `/p/`. No config file needed — context windows are auto-detected
+  from the [models.dev](https://models.dev) registry.
+- **Named providers:** declare providers in a config file, then use shorter
+  `http://localhost:8787/<name>/...` URLs. Better when you manage several
+  endpoints or want explicit per-model context overrides.
+
 Compression is injected automatically — you only configure routing, never
 compression itself.
+
+### Option A — Zero-config (`/p/` prefix)
+
+Start the proxy:
+
+```bash
+bili
+```
+
+Then just prefix your client's existing baseURL with `http://localhost:8787/p/`.
+The full upstream URL is embedded in the path, so the proxy knows where to
+forward without any config:
+
+```
+client baseURL before:  https://api.openai.com/v1
+client baseURL after:   http://localhost:8787/p/https://api.openai.com/v1
+```
+
+That's it — put your real API key in the client config as usual (the proxy
+passes it through untouched). Context windows (gpt-5.1-codex=400K,
+glm-5.2=1M, claude-opus-4=200K, …) are looked up from models.dev
+automatically.
+
+### Option B — Named providers (config file)
 
 ### Step 1 — Start the proxy
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,35 @@ passes it through untouched). Context windows (gpt-5.1-codex=400K,
 glm-5.2=1M, claude-opus-4=200K, …) are looked up from models.dev
 automatically.
 
+#### Examples by client
+
+**OpenCode** — edit `~/.config/opencode/opencode.json`, change the provider's `baseURL`:
+```jsonc
+// before:
+"baseURL": "https://open.bigmodel.cn/api/coding/paas/v4"
+// after (just prepend the proxy origin + /p/):
+"baseURL": "http://localhost:8787/p/https://open.bigmodel.cn/api/coding/paas/v4"
+```
+
+**Codex** — edit `~/.codex/config.toml`, change the provider's `base_url`:
+```toml
+# before:
+base_url = "https://api.openai.com/v1"
+# after:
+base_url = "http://localhost:8787/p/https://api.openai.com/v1"
+```
+
+**Pi** — edit `~/.pi/agent/models.json`, change the provider's `baseUrl`:
+```jsonc
+// before:
+"baseUrl": "https://api.anthropic.com"
+// after:
+"baseUrl": "http://localhost:8787/p/https://api.anthropic.com"
+```
+
+**Other clients (Cursor / Aider / Continue …)** — wherever the upstream URL is
+configured, prepend `http://localhost:8787/p/` to it. Nothing else changes.
+
 ### Option B — Named providers (config file)
 
 ### Step 1 — Start the proxy

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -66,6 +66,34 @@ bili
 
 就这样 —— 真实 API key 照常填在客户端配置里(proxy 原样透传)。context 窗口(gpt-5.1-codex=400K、glm-5.2=1M、claude-opus-4=200K ……)自动从 models.dev 查询。
 
+#### 各客户端示例
+
+**OpenCode** —— 编辑 `~/.config/opencode/opencode.json`,改 provider 的 `baseURL`:
+```jsonc
+// 之前:
+"baseURL": "https://open.bigmodel.cn/api/coding/paas/v4"
+// 之后(前面加上代理地址 + /p/):
+"baseURL": "http://localhost:8787/p/https://open.bigmodel.cn/api/coding/paas/v4"
+```
+
+**Codex** —— 编辑 `~/.codex/config.toml`,改 provider 的 `base_url`:
+```toml
+# 之前:
+base_url = "https://api.openai.com/v1"
+# 之后:
+base_url = "http://localhost:8787/p/https://api.openai.com/v1"
+```
+
+**Pi** —— 编辑 `~/.pi/agent/models.json`,改 provider 的 `baseUrl`:
+```jsonc
+// 之前:
+"baseUrl": "https://api.anthropic.com"
+// 之后:
+"baseUrl": "http://localhost:8787/p/https://api.anthropic.com"
+```
+
+**其他客户端(Cursor / Aider / Continue ……)** —— 只要配置了上游 URL,前面加 `http://localhost:8787/p/` 就行,其他都不用改。
+
 ### 方式 B —— 命名 provider(配置文件)
 
 ### 第 1 步 —— 启动代理

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -42,8 +42,31 @@ npm install -g billion-context
 
 ## 快速上手
 
-三步:**启动代理 → 编辑配置文件 → 把客户端指向它**。
+两种方式 —— 任选其一:
+
+- **零配置(最简单):** 在客户端 baseURL 前面加上代理地址 + `/p/`。无需配置文件 —— context 窗口自动从 [models.dev](https://models.dev) registry 查询。
+- **命名 provider:** 在配置文件里声明 provider,然后用更短的 `http://localhost:8787/<name>/...` URL。适合管理多个端点或需要显式指定按模型 context 的场景。
+
 压缩是自动注入的 —— 你只需配置路由,无需配置压缩本身。
+
+### 方式 A —— 零配置(`/p/` 前缀)
+
+启动代理:
+
+```bash
+bili
+```
+
+然后把客户端现有的 baseURL 前面加上 `http://localhost:8787/p/` 就行。完整上游 URL 嵌在路径里,proxy 无需任何配置就知道转发到哪:
+
+```
+客户端 baseURL 之前:  https://api.openai.com/v1
+客户端 baseURL 之后:  http://localhost:8787/p/https://api.openai.com/v1
+```
+
+就这样 —— 真实 API key 照常填在客户端配置里(proxy 原样透传)。context 窗口(gpt-5.1-codex=400K、glm-5.2=1M、claude-opus-4=200K ……)自动从 models.dev 查询。
+
+### 方式 B —— 命名 provider(配置文件)
 
 ### 第 1 步 —— 启动代理
 

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,0 +1,141 @@
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { cacheDir } from "./paths.js";
+import { log as loggerLog } from "./logger.js";
+
+const REGISTRY_URL = "https://models.dev/models.json";
+const CACHE_FILE = path.join(cacheDir(), "models-dev.json");
+const TTL_MS = 24 * 60 * 60 * 1000;
+
+type ModelEntry = { limit?: { context?: number; output?: number } };
+type RegistryShape = Record<string, ModelEntry>;
+
+let cache: RegistryShape | null = null;
+let loading: Promise<RegistryShape | null> | null = null;
+
+function parse(raw: string): RegistryShape | null {
+    try {
+        const parsed = JSON.parse(raw);
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+            return parsed as RegistryShape;
+        }
+    } catch {
+        // malformed — treat as miss
+    }
+    return null;
+}
+
+async function readDiskCache(): Promise<RegistryShape | null> {
+    try {
+        const raw = await readFile(CACHE_FILE, "utf8");
+        return parse(raw);
+    } catch {
+        return null;
+    }
+}
+
+async function writeDiskCache(data: RegistryShape): Promise<void> {
+    try {
+        await mkdir(path.dirname(CACHE_FILE), { recursive: true });
+        await writeFile(CACHE_FILE, JSON.stringify(data), "utf8");
+    } catch {
+        // best-effort
+    }
+}
+
+function diskCacheFresh(): boolean {
+    if (!existsSync(CACHE_FILE)) return false;
+    try {
+        const { mtimeMs } = require("node:fs").statSync(CACHE_FILE);
+        return Date.now() - mtimeMs < TTL_MS;
+    } catch {
+        return false;
+    }
+}
+
+async function fetchFresh(): Promise<RegistryShape | null> {
+    try {
+        const res = await fetch(REGISTRY_URL, {
+            signal: AbortSignal.timeout(15_000),
+            headers: { Accept: "application/json" },
+        });
+        if (!res.ok) return null;
+        const text = await res.text();
+        const parsed = parse(text);
+        if (parsed) await writeDiskCache(parsed);
+        return parsed;
+    } catch {
+        return null;
+    }
+}
+
+export async function loadRegistry(): Promise<RegistryShape | null> {
+    if (cache) return cache;
+    if (diskCacheFresh()) {
+        const disk = await readDiskCache();
+        if (disk) {
+            cache = disk;
+            return cache;
+        }
+    }
+    if (loading) return loading;
+    loading = (async () => {
+        const fresh = await fetchFresh();
+        if (fresh) {
+            cache = fresh;
+            loggerLog("info", `[acp-registry] loaded models.dev (${Object.keys(fresh).length} models)`);
+            return fresh;
+        }
+        const disk = await readDiskCache();
+        if (disk) {
+            cache = disk;
+            loggerLog("info", `[acp-registry] using stale disk cache (${Object.keys(disk).length} models, fetch failed)`);
+            return disk;
+        }
+        loggerLog("warn", `[acp-registry] could not load models.dev registry (offline + no cache)`);
+        return null;
+    })();
+    const result = await loading;
+    loading = null;
+    return result;
+}
+
+const HOST_TO_PROVIDER: Record<string, string> = {
+    "api.anthropic.com": "anthropic",
+    "api.openai.com": "openai",
+    "open.bigmodel.cn": "zhipuai",
+    "open.bigmodel.com": "zhipuai",
+    "coding.dashscope.aliyuncs.com": "dashscope",
+    "api.deepseek.com": "deepseek",
+    "api.moonshot.cn": "moonshot",
+    "generativelanguage.googleapis.com": "google",
+    "ai.comfly.org": "comfly",
+};
+
+export function providerFromHost(host: string): string | undefined {
+    const lower = host.toLowerCase();
+    if (HOST_TO_PROVIDER[lower]) return HOST_TO_PROVIDER[lower];
+    for (const [h, p] of Object.entries(HOST_TO_PROVIDER)) {
+        if (lower.endsWith(h) || h.endsWith(lower)) return p;
+    }
+    return undefined;
+}
+
+export async function contextFromRegistry(model: string, host?: string): Promise<number | undefined> {
+    const reg = await loadRegistry();
+    if (!reg || !model) return undefined;
+    const provider = host ? providerFromHost(host) : undefined;
+    const candidates = provider ? [`${provider}/${model}`, model] : [model];
+    for (const key of candidates) {
+        const entry = reg[key];
+        const ctx = entry?.limit?.context;
+        if (typeof ctx === "number" && ctx > 0) return ctx;
+    }
+    return undefined;
+}
+
+export function _resetForTest(): void {
+    cache = null;
+    loading = null;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -689,7 +689,10 @@ async function forward(
     affinity?: string,
 ): Promise<void> {
     const upstreamUrl = route ? route.rewrittenUrl : opts.upstream + (req.url ?? "");
-    log("info", `forward ${req.method} ${req.url ?? ""} → ${upstreamUrl}${route ? ` (${route.provider})` : ""}`);
+    // Show the final proxied URL (where the request actually lands) as the
+    // primary signal. The provider label is appended only for named routes —
+    // zero-config (/p/) requests have no meaningful name, so we omit it.
+    log("info", `forward ${req.method} → ${upstreamUrl}${route && route.provider !== "p" ? `  [${route.provider}]` : ""}`);
     if (process.env.ACP_DEBUG && prepared) {
         const sid = prepared.session.id;
         const hdrKeys = Object.keys(req.headers);

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,6 +5,7 @@ import { createCore, type CompressionCore, type Config, type CoreMessage, type N
 import type { ProxyOptions } from "./config.js";
 import { loadRoutes } from "./config.js";
 import { resolveContextLimit } from "./config.js";
+import { contextFromRegistry, loadRegistry } from "./registry.js";
 import { fetchWithTimeout, MAX_REQUEST_BYTES } from "./fetch-util.js";
 import {
     anthropicToCore,
@@ -58,6 +59,21 @@ const UPSTREAM_HOP_HEADERS = new Set([
 ]);
 
 export function resolveUpstream(opts: ProxyOptions, reqUrl: string): { upstream: string; rewrittenUrl: string; provider: string } | undefined {
+    // Zero-config mode: a request like `/p/https://open.bigmodel.cn/api/anthropic`
+    // embeds the full upstream URL after the `/p/` prefix. Strip the prefix,
+    // take the rest verbatim as the upstream. This lets users route without any
+    // config file at all — they just prefix their client's baseURL with the
+    // proxy origin + `/p/`. The provider name returned is "p" so stats/labels
+    // can tell zero-config requests apart from named-config ones.
+    if (reqUrl.startsWith("/p/http://") || reqUrl.startsWith("/p/https://")) {
+        const full = reqUrl.slice(3); // drop "/p/"
+        try {
+            const u = new URL(full);
+            return { upstream: `${u.protocol}//${u.host}`, rewrittenUrl: full, provider: "p" };
+        } catch {
+            // malformed embedded URL — fall through to named matching, which will miss
+        }
+    }
     const names = Object.keys(opts.routes);
     if (names.length === 0) return undefined;
     // Provider names that coincide with common API path segments are rejected
@@ -100,6 +116,10 @@ export async function startServer(opts: ProxyOptions): Promise<http.Server> {
     if (filePath) {
         log("info", `[log] writing to ${filePath}`);
     }
+    // Pre-fetch the models.dev registry in the background (non-blocking). Used
+    // as the context-window source for zero-config `/p/` routes that have no
+    // per-model config. A miss falls back to the prefix table + default.
+    void loadRegistry();
     const server = http.createServer(async (req, res) => {
         try {
             await handle(req, res, opts, core, config, log);
@@ -125,7 +145,8 @@ export async function startServer(opts: ProxyOptions): Promise<http.Server> {
                           .map(([n, u]) => `${n}=${typeof u === "string" ? u : u.url}`)
                           .join(", ")}`
                     : ` → ${opts.upstream}`) +
-                ` — web UI: http://${displayHost}:${opts.port}/__acp/`,
+                ` — web UI: http://${displayHost}:${opts.port}/__acp/` +
+                ` — zero-config: prefix any baseURL with http://${displayHost}:${opts.port}/p/`,
         );
     });
     // Listen errors (EADDRINUSE port taken, EACCES privileged port, EAFNOSUPPORT
@@ -284,7 +305,13 @@ async function handle(
     if (parsed && typeof parsed === "object") {
         const model = (parsed as { model?: string }).model;
         if (model) {
-            const limit = resolveContextLimit(opts.routes, route?.provider, model);
+            let limit = resolveContextLimit(opts.routes, route?.provider, model);
+            // Zero-config routes (provider "p") have no per-model config; try the
+            // models.dev registry as a middle layer before the prefix table / default.
+            if (!limit && route?.provider === "p" && route.upstream) {
+                const host = (() => { try { return new URL(route.upstream).host; } catch { return undefined; } })();
+                limit = await contextFromRegistry(model, host) ?? undefined;
+            }
             if (limit && limit !== config.modelContextLimit) {
                 reqConfig = { ...config, modelContextLimit: limit };
             }

--- a/tests/zero-config-routing.test.ts
+++ b/tests/zero-config-routing.test.ts
@@ -1,0 +1,56 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { resolveUpstream } from "../src/server.js";
+import type { ProxyOptions } from "../src/config.js";
+
+const BASE_OPTS: ProxyOptions = {
+    port: 8787,
+    host: "127.0.0.1",
+    upstream: "https://api.anthropic.com",
+    routes: { zhipu: { url: "https://open.bigmodel.cn" } },
+    modelContextLimit: 200000,
+    kernelConfig: { blocks: [], messageRefs: [], nudge: {}, stats: {}, nextBlockId: 0, nextRunId: 0 } as never,
+    compress: { injectTool: true, injectNudge: true },
+    sessionHeader: "",
+    log: false,
+    debug: false,
+    passthrough: false,
+    autoUpdate: false,
+};
+
+test("zero-config /p/ route: strips prefix, uses embedded URL verbatim", () => {
+    const r = resolveUpstream(BASE_OPTS, "/p/https://open.bigmodel.cn/api/anthropic/v1/messages");
+    assert.ok(r, "should resolve");
+    assert.equal(r!.provider, "p");
+    assert.equal(r!.rewrittenUrl, "https://open.bigmodel.cn/api/anthropic/v1/messages");
+    assert.equal(r!.upstream, "https://open.bigmodel.cn");
+});
+
+test("zero-config /p/ route: works with trailing path segments", () => {
+    const r = resolveUpstream(BASE_OPTS, "/p/https://api.openai.com/v1/chat/completions");
+    assert.ok(r);
+    assert.equal(r!.rewrittenUrl, "https://api.openai.com/v1/chat/completions");
+    assert.equal(r!.upstream, "https://api.openai.com");
+});
+
+test("zero-config /p/ takes precedence over named route (no name shadowing)", () => {
+    // A provider literally named 'p' must not shadow the zero-config prefix.
+    const opts: ProxyOptions = { ...BASE_OPTS, routes: { p: { url: "https://example.com" } } };
+    const r = resolveUpstream(opts, "/p/https://api.openai.com/v1/responses");
+    assert.ok(r);
+    assert.equal(r!.provider, "p");
+    assert.equal(r!.rewrittenUrl, "https://api.openai.com/v1/responses");
+});
+
+test("zero-config /p/ ignores malformed embedded URL, falls through", () => {
+    const r = resolveUpstream(BASE_OPTS, "/p/not-a-url");
+    // falls through to named matching, which misses → undefined
+    assert.equal(r, undefined);
+});
+
+test("named route still works alongside zero-config", () => {
+    const r = resolveUpstream(BASE_OPTS, "/zhipu/api/coding/paas/v4/chat/completions");
+    assert.ok(r);
+    assert.equal(r!.provider, "zhipu");
+    assert.equal(r!.rewrittenUrl, "https://open.bigmodel.cn/api/coding/paas/v4/chat/completions");
+});


### PR DESCRIPTION
Implements Issue #50 + #55.

## Zero-config routing
No config file needed. Prefix the client's baseURL with the proxy + `/p/`:
```
http://127.0.0.1:8787/p/https://api.openai.com/v1
```
Three modes coexist, no collision (the `/p/` prefix physically separates zero-config from `/__acp/*` control and `/<name>/*` named routes).

## Auto-fetch context from models.dev
models.dev/models.json (254KB, 301 providers, all models with `limit.context`) is fetched + cached (24h TTL, disk cache for offline). Used as the context source for zero-config routes with no per-model config. Fallback chain: per-model config → registry → prefix table → default.

## Verification
- typecheck ✅ · **146 test ✅** (141 + 5 new zero-config tests)
- registry lookup verified: gpt-5.1-codex=400K, glm-5.2=1M, claude-opus-4-0=200K
- startup banner now shows: `zero-config: prefix any baseURL with http://localhost:8787/p/`

Closes #50, closes #55.