### PR TITLE
refactor: zero-config prefix /p/ → /bili/ + README fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This installs the `bili` command (`bili-proxy` is kept as an alias).
 Two ways to use it — pick one:
 
 - **Zero-config (simplest):** prefix your client's baseURL with the proxy
-  origin + `/p/`. No config file needed — context windows are auto-detected
+  origin + `/bili/`. No config file needed — context windows are auto-detected
   from the [models.dev](https://models.dev) registry.
 - **Named providers:** declare providers in a config file, then use shorter
   `http://localhost:8787/<name>/...` URLs. Better when you manage several
@@ -54,7 +54,7 @@ Two ways to use it — pick one:
 Compression is injected automatically — you only configure routing, never
 compression itself.
 
-### Option A — Zero-config (`/p/` prefix)
+### Option A — Zero-config (`/bili/` prefix)
 
 Start the proxy:
 
@@ -62,13 +62,13 @@ Start the proxy:
 bili
 ```
 
-Then just prefix your client's existing baseURL with `http://localhost:8787/p/`.
+Then just prefix your client's existing baseURL with `http://localhost:8787/bili/`.
 The full upstream URL is embedded in the path, so the proxy knows where to
 forward without any config:
 
 ```
 client baseURL before:  https://api.openai.com/v1
-client baseURL after:   http://localhost:8787/p/https://api.openai.com/v1
+client baseURL after:   http://localhost:8787/bili/https://api.openai.com/v1
 ```
 
 That's it — put your real API key in the client config as usual (the proxy
@@ -82,8 +82,8 @@ automatically.
 ```jsonc
 // before:
 "baseURL": "https://open.bigmodel.cn/api/coding/paas/v4"
-// after (just prepend the proxy origin + /p/):
-"baseURL": "http://localhost:8787/p/https://open.bigmodel.cn/api/coding/paas/v4"
+// after (just prepend the proxy origin + /bili/):
+"baseURL": "http://localhost:8787/bili/https://open.bigmodel.cn/api/coding/paas/v4"
 ```
 
 **Codex** — edit `~/.codex/config.toml`, change the provider's `base_url`:
@@ -91,7 +91,7 @@ automatically.
 # before:
 base_url = "https://api.openai.com/v1"
 # after:
-base_url = "http://localhost:8787/p/https://api.openai.com/v1"
+base_url = "http://localhost:8787/bili/https://api.openai.com/v1"
 ```
 
 **Pi** — edit `~/.pi/agent/models.json`, change the provider's `baseUrl`:
@@ -99,11 +99,11 @@ base_url = "http://localhost:8787/p/https://api.openai.com/v1"
 // before:
 "baseUrl": "https://api.anthropic.com"
 // after:
-"baseUrl": "http://localhost:8787/p/https://api.anthropic.com"
+"baseUrl": "http://localhost:8787/bili/https://api.anthropic.com"
 ```
 
 **Other clients (Cursor / Aider / Continue …)** — wherever the upstream URL is
-configured, prepend `http://localhost:8787/p/` to it. Nothing else changes.
+configured, prepend `http://localhost:8787/bili/` to it. Nothing else changes.
 
 ### Option B — Named providers (config file)
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,10 @@ Two ways to use it — pick one:
 
 - **Zero-config (simplest):** prefix your client's baseURL with the proxy
   origin + `/bili/`. No config file needed — context windows are auto-detected
-  from the [models.dev](https://models.dev) registry.
+  from the [models.dev](https://models.dev) registry. The `/bili/` prefix also
+  doubles as a self-detection signal: billion-context client extensions
+  (billion-context-pi / opencode-acp) can recognize it in their own baseUrl
+  and self-disable, so you never get double compression.
 - **Named providers:** declare providers in a config file, then use shorter
   `http://localhost:8787/<name>/...` URLs. Better when you manage several
   endpoints or want explicit per-model context overrides.
@@ -106,6 +109,8 @@ base_url = "http://localhost:8787/bili/https://api.openai.com/v1"
 configured, prepend `http://localhost:8787/bili/` to it. Nothing else changes.
 
 ### Option B — Named providers (config file)
+
+Three steps: **start the proxy → configure your providers → point your client at it**.
 
 ### Step 1 — Start the proxy
 
@@ -231,9 +236,11 @@ Everything else (`name`, `wire_api`, `env_key`) stays unchanged.
 
 #### Other clients (Cursor / Aider / Continue …)
 
-Not yet supported. The proxy currently speaks the Anthropic, OpenAI
-chat-completions, and OpenAI Responses protocols — if your client uses a
-different protocol or a non-standard auth header, it won't work yet.
+If the client lets you set a base URL, point it at the proxy exactly like the
+examples above (zero-config `/bili/` prefix or named `/<provider>/` prefix).
+The proxy speaks the Anthropic, OpenAI chat-completions, and OpenAI Responses
+protocols — any client using one of those works. A client using a different
+protocol or a non-standard auth header won't work yet.
 
 ### Web UI
 
@@ -243,7 +250,9 @@ Open `http://localhost:8787/__acp/` in a browser while the proxy is running. You
 - **Generate client URLs** — pick a provider, get ready-to-copy config snippets for Pi / OpenCode / Codex (the `baseUrl`/`baseURL`/`base_url` line with the proxy origin + provider name filled in).
 - **View sessions** — live table of active sessions (requests, tokens saved, last seen), auto-refreshing.
 
-Changes to providers require a **restart** to take effect (the UI tells you this).
+Use the **Apply** button to hot-reload provider routes into the running
+process without restarting (only `port`/`host` require a restart, since the
+listen socket is already bound).
 
 ### Manual config file
 
@@ -525,7 +534,7 @@ pass an explicit `x-acp-session` header per conversation to avoid collisions.
 
 ## Status
 
-Early. Protocol handling and compression work against mock tests (141 passing). Real-model integration testing is the next milestone. Expect rough edges.
+Early. Protocol handling and compression work against mock tests (146 passing). Real-model integration testing is the next milestone. Expect rough edges.
 
 See [billion-context-pi](https://github.com/ranxianglei/billion-context-pi) for the pi-extension mode (in-process, tighter integration, the reference implementation).
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -44,12 +44,12 @@ npm install -g billion-context
 
 两种方式 —— 任选其一:
 
-- **零配置(最简单):** 在客户端 baseURL 前面加上代理地址 + `/p/`。无需配置文件 —— context 窗口自动从 [models.dev](https://models.dev) registry 查询。
+- **零配置(最简单):** 在客户端 baseURL 前面加上代理地址 + `/bili/`。无需配置文件 —— context 窗口自动从 [models.dev](https://models.dev) registry 查询。
 - **命名 provider:** 在配置文件里声明 provider,然后用更短的 `http://localhost:8787/<name>/...` URL。适合管理多个端点或需要显式指定按模型 context 的场景。
 
 压缩是自动注入的 —— 你只需配置路由,无需配置压缩本身。
 
-### 方式 A —— 零配置(`/p/` 前缀)
+### 方式 A —— 零配置(`/bili/` 前缀)
 
 启动代理:
 
@@ -57,11 +57,11 @@ npm install -g billion-context
 bili
 ```
 
-然后把客户端现有的 baseURL 前面加上 `http://localhost:8787/p/` 就行。完整上游 URL 嵌在路径里,proxy 无需任何配置就知道转发到哪:
+然后把客户端现有的 baseURL 前面加上 `http://localhost:8787/bili/` 就行。完整上游 URL 嵌在路径里,proxy 无需任何配置就知道转发到哪:
 
 ```
 客户端 baseURL 之前:  https://api.openai.com/v1
-客户端 baseURL 之后:  http://localhost:8787/p/https://api.openai.com/v1
+客户端 baseURL 之后:  http://localhost:8787/bili/https://api.openai.com/v1
 ```
 
 就这样 —— 真实 API key 照常填在客户端配置里(proxy 原样透传)。context 窗口(gpt-5.1-codex=400K、glm-5.2=1M、claude-opus-4=200K ……)自动从 models.dev 查询。
@@ -72,8 +72,8 @@ bili
 ```jsonc
 // 之前:
 "baseURL": "https://open.bigmodel.cn/api/coding/paas/v4"
-// 之后(前面加上代理地址 + /p/):
-"baseURL": "http://localhost:8787/p/https://open.bigmodel.cn/api/coding/paas/v4"
+// 之后(前面加上代理地址 + /bili/):
+"baseURL": "http://localhost:8787/bili/https://open.bigmodel.cn/api/coding/paas/v4"
 ```
 
 **Codex** —— 编辑 `~/.codex/config.toml`,改 provider 的 `base_url`:
@@ -81,7 +81,7 @@ bili
 # 之前:
 base_url = "https://api.openai.com/v1"
 # 之后:
-base_url = "http://localhost:8787/p/https://api.openai.com/v1"
+base_url = "http://localhost:8787/bili/https://api.openai.com/v1"
 ```
 
 **Pi** —— 编辑 `~/.pi/agent/models.json`,改 provider 的 `baseUrl`:
@@ -89,10 +89,10 @@ base_url = "http://localhost:8787/p/https://api.openai.com/v1"
 // 之前:
 "baseUrl": "https://api.anthropic.com"
 // 之后:
-"baseUrl": "http://localhost:8787/p/https://api.anthropic.com"
+"baseUrl": "http://localhost:8787/bili/https://api.anthropic.com"
 ```
 
-**其他客户端(Cursor / Aider / Continue ……)** —— 只要配置了上游 URL,前面加 `http://localhost:8787/p/` 就行,其他都不用改。
+**其他客户端(Cursor / Aider / Continue ……)** —— 只要配置了上游 URL,前面加 `http://localhost:8787/bili/` 就行,其他都不用改。
 
 ### 方式 B —— 命名 provider(配置文件)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -44,7 +44,7 @@ npm install -g billion-context
 
 两种方式 —— 任选其一:
 
-- **零配置(最简单):** 在客户端 baseURL 前面加上代理地址 + `/bili/`。无需配置文件 —— context 窗口自动从 [models.dev](https://models.dev) registry 查询。
+- **零配置(最简单):** 在客户端 baseURL 前面加上代理地址 + `/bili/`。无需配置文件 —— context 窗口自动从 [models.dev](https://models.dev) registry 查询。`/bili/` 前缀还是个自检测信号:billion-context 的客户端扩展(billion-context-pi / opencode-acp)能在自己的 baseUrl 里认出它并自禁用,避免双层压缩。
 - **命名 provider:** 在配置文件里声明 provider,然后用更短的 `http://localhost:8787/<name>/...` URL。适合管理多个端点或需要显式指定按模型 context 的场景。
 
 压缩是自动注入的 —— 你只需配置路由,无需配置压缩本身。
@@ -95,6 +95,8 @@ base_url = "http://localhost:8787/bili/https://api.openai.com/v1"
 **其他客户端(Cursor / Aider / Continue ……)** —— 只要配置了上游 URL,前面加 `http://localhost:8787/bili/` 就行,其他都不用改。
 
 ### 方式 B —— 命名 provider(配置文件)
+
+三步:**启动代理 → 配置 provider → 把客户端指向它**。
 
 ### 第 1 步 —— 启动代理
 
@@ -174,8 +176,7 @@ base_url = "http://localhost:8787/zhipu/api/coding/paas/v4"
 
 #### 其他客户端(Cursor / Aider / Continue …)
 
-暂不支持。代理目前说 Anthropic、OpenAI chat-completions、OpenAI Responses
-三种协议 —— 如果你的客户端用别的协议或非标准 auth header,还用不了。
+只要客户端能设 base URL,就像上面的例子一样指向代理(零配置 `/bili/` 前缀或命名 `/<provider>/` 前缀)。代理说 Anthropic、OpenAI chat-completions、OpenAI Responses 三种协议 —— 用其中任一种的客户端都能工作。用别的协议或非标准 auth header 的客户端暂时还不行。
 
 ### 手动配置文件
 
@@ -220,7 +221,7 @@ acp-proxy listening on http://127.0.0.1:8787 — routes: anthropic=https://api.a
 - **生成客户端 URL** —— 选一个 provider,得到可直接复制的配置片段(Pi / OpenCode / Codex 的 `baseUrl`/`baseURL`/`base_url` 一行,已填好代理地址 + provider 名)。
 - **查看会话** —— 实时会话表(请求数、省的 token、最后活跃时间),自动刷新。
 
-改完 providers 需要**重启 bili** 才生效(UI 会提醒你)。
+用 **Apply** 按钮可以热加载 provider 路由到运行中的进程,无需重启(只有 `port`/`host` 需要重启,因为监听 socket 已经绑了)。
 
 ### 验证
 
@@ -421,7 +422,7 @@ bili --no-auto-update        # 本次启动禁用自动更新
 
 ## 状态
 
-早期。协议处理和压缩已通过 mock 测试(141 项通过)。真实模型集成测试是下一里程碑。预期会有粗糙的地方。
+早期。协议处理和压缩已通过 mock 测试(146 项通过)。真实模型集成测试是下一里程碑。预期会有粗糙的地方。
 
 pi 扩展模式(进程内、更紧密集成、参考实现)见 [billion-context-pi](https://github.com/ranxianglei/billion-context-pi)。
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -59,17 +59,18 @@ const UPSTREAM_HOP_HEADERS = new Set([
 ]);
 
 export function resolveUpstream(opts: ProxyOptions, reqUrl: string): { upstream: string; rewrittenUrl: string; provider: string } | undefined {
-    // Zero-config mode: a request like `/p/https://open.bigmodel.cn/api/anthropic`
-    // embeds the full upstream URL after the `/p/` prefix. Strip the prefix,
+    // Zero-config mode: a request like `/bili/https://open.bigmodel.cn/api/anthropic`
+    // embeds the full upstream URL after the `/bili/` prefix. Strip the prefix,
     // take the rest verbatim as the upstream. This lets users route without any
     // config file at all — they just prefix their client's baseURL with the
-    // proxy origin + `/p/`. The provider name returned is "p" so stats/labels
-    // can tell zero-config requests apart from named-config ones.
-    if (reqUrl.startsWith("/p/http://") || reqUrl.startsWith("/p/https://")) {
-        const full = reqUrl.slice(3); // drop "/p/"
+    // proxy origin + `/bili/`. The `/bili/` prefix doubles as a signal: client-side
+    // billion-context extensions (billion-context-pi / opencode-acp) can detect it
+    // in their own baseUrl and self-disable, avoiding double compression.
+    if (reqUrl.startsWith("/bili/http://") || reqUrl.startsWith("/bili/https://")) {
+        const full = reqUrl.slice(6); // drop "/bili/"
         try {
             const u = new URL(full);
-            return { upstream: `${u.protocol}//${u.host}`, rewrittenUrl: full, provider: "p" };
+            return { upstream: `${u.protocol}//${u.host}`, rewrittenUrl: full, provider: "bili" };
         } catch {
             // malformed embedded URL — fall through to named matching, which will miss
         }
@@ -146,7 +147,7 @@ export async function startServer(opts: ProxyOptions): Promise<http.Server> {
                           .join(", ")}`
                     : ` → ${opts.upstream}`) +
                 ` — web UI: http://${displayHost}:${opts.port}/__acp/` +
-                ` — zero-config: prefix any baseURL with http://${displayHost}:${opts.port}/p/`,
+                ` — zero-config: prefix any baseURL with http://${displayHost}:${opts.port}/bili/`,
         );
     });
     // Listen errors (EADDRINUSE port taken, EACCES privileged port, EAFNOSUPPORT
@@ -306,9 +307,9 @@ async function handle(
         const model = (parsed as { model?: string }).model;
         if (model) {
             let limit = resolveContextLimit(opts.routes, route?.provider, model);
-            // Zero-config routes (provider "p") have no per-model config; try the
+            // Zero-config routes (provider "bili") have no per-model config; try the
             // models.dev registry as a middle layer before the prefix table / default.
-            if (!limit && route?.provider === "p" && route.upstream) {
+            if (!limit && route?.provider === "bili" && route.upstream) {
                 const host = (() => { try { return new URL(route.upstream).host; } catch { return undefined; } })();
                 limit = await contextFromRegistry(model, host) ?? undefined;
             }
@@ -692,7 +693,7 @@ async function forward(
     // Show the final proxied URL (where the request actually lands) as the
     // primary signal. The provider label is appended only for named routes —
     // zero-config (/p/) requests have no meaningful name, so we omit it.
-    log("info", `forward ${req.method} → ${upstreamUrl}${route && route.provider !== "p" ? `  [${route.provider}]` : ""}`);
+    log("info", `forward ${req.method} → ${upstreamUrl}${route && route.provider !== "bili" ? `  [${route.provider}]` : ""}`);
     if (process.env.ACP_DEBUG && prepared) {
         const sid = prepared.session.id;
         const hdrKeys = Object.keys(req.headers);

--- a/tests/zero-config-routing.test.ts
+++ b/tests/zero-config-routing.test.ts
@@ -18,32 +18,32 @@ const BASE_OPTS: ProxyOptions = {
     autoUpdate: false,
 };
 
-test("zero-config /p/ route: strips prefix, uses embedded URL verbatim", () => {
-    const r = resolveUpstream(BASE_OPTS, "/p/https://open.bigmodel.cn/api/anthropic/v1/messages");
+test("zero-config /bili/ route: strips prefix, uses embedded URL verbatim", () => {
+    const r = resolveUpstream(BASE_OPTS, "/bili/https://open.bigmodel.cn/api/anthropic/v1/messages");
     assert.ok(r, "should resolve");
-    assert.equal(r!.provider, "p");
+    assert.equal(r!.provider, "bili");
     assert.equal(r!.rewrittenUrl, "https://open.bigmodel.cn/api/anthropic/v1/messages");
     assert.equal(r!.upstream, "https://open.bigmodel.cn");
 });
 
-test("zero-config /p/ route: works with trailing path segments", () => {
-    const r = resolveUpstream(BASE_OPTS, "/p/https://api.openai.com/v1/chat/completions");
+test("zero-config /bili/ route: works with trailing path segments", () => {
+    const r = resolveUpstream(BASE_OPTS, "/bili/https://api.openai.com/v1/chat/completions");
     assert.ok(r);
     assert.equal(r!.rewrittenUrl, "https://api.openai.com/v1/chat/completions");
     assert.equal(r!.upstream, "https://api.openai.com");
 });
 
-test("zero-config /p/ takes precedence over named route (no name shadowing)", () => {
-    // A provider literally named 'p' must not shadow the zero-config prefix.
-    const opts: ProxyOptions = { ...BASE_OPTS, routes: { p: { url: "https://example.com" } } };
-    const r = resolveUpstream(opts, "/p/https://api.openai.com/v1/responses");
+test("zero-config /bili/ takes precedence over named route (no name shadowing)", () => {
+    // A provider literally named 'bili' must not shadow the zero-config prefix.
+    const opts: ProxyOptions = { ...BASE_OPTS, routes: { bili: { url: "https://example.com" } } };
+    const r = resolveUpstream(opts, "/bili/https://api.openai.com/v1/responses");
     assert.ok(r);
-    assert.equal(r!.provider, "p");
+    assert.equal(r!.provider, "bili");
     assert.equal(r!.rewrittenUrl, "https://api.openai.com/v1/responses");
 });
 
-test("zero-config /p/ ignores malformed embedded URL, falls through", () => {
-    const r = resolveUpstream(BASE_OPTS, "/p/not-a-url");
+test("zero-config /bili/ ignores malformed embedded URL, falls through", () => {
+    const r = resolveUpstream(BASE_OPTS, "/bili/not-a-url");
     // falls through to named matching, which misses → undefined
     assert.equal(r, undefined);
 });


### PR DESCRIPTION
Follow-up to #56 (already merged).

## Changes (2 commits relative to master)

### 1. Rename zero-config prefix `/p/` → `/bili/` (dd88c77)

The `/bili/` prefix doubles as **brand + self-detection signal**: client-side billion-context extensions (billion-context-pi / opencode-acp) can check their own baseUrl for `/bili/` and self-disable, avoiding double compression when a proxy is already in the loop.

- `resolveUpstream`: detect `/bili/<full-url>`, provider tag `bili`
- banner + README (EN + zh-CN): `/p/` → `/bili/` everywhere
- tests updated, all 146 pass
- **no compat shim** (pre-release, pure rename)

### 2. README fixes (2f82deb)

- Web UI: "require restart" → Apply hot-reload (PR#52 shipped `__acp/config/reload`)
- Status: 141 → 146 passing tests
- Option B heading: was empty, now ties Step 1/2/3 to the named-provider path
- Other clients: stop contradicting zero-config; cross-reference instead
- Zero-config intro: note `/bili/` doubles as client-extension self-detection signal

## Verification
- `npm run typecheck` ✅
- `npm test` 146 pass ✅
- `npm run build` ✅
- Real smoke test: `bili-test-claude` through `/bili/` path works (glm-4.6 responds, compression injected)