### PR TITLE
refactor: URL-keyed config (delete named routing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ Two ways to use it — pick one:
   doubles as a self-detection signal: billion-context client extensions
   (billion-context-pi / opencode-acp) can recognize it in their own baseUrl
   and self-disable, so you never get double compression.
-- **Explicit context overrides:** declare per-URL context windows in a config
-  file (or the web UI) for endpoints the registry doesn't know about, or when
-  you want to pin an exact value. Routing is the same `/bili/` prefix either
-  way — the config only changes which context window the proxy uses.
+- **Explicit context-window overrides:** declare per-URL context windows in a
+  config file (or the web UI) for endpoints the registry doesn't know about,
+  or when you want to pin an exact value. Routing is the same `/bili/` prefix
+  either way — the config only changes which context window the proxy uses.
 
 Compression is injected automatically — you only configure routing, never
 compression itself.
@@ -106,173 +106,14 @@ base_url = "http://localhost:8787/bili/https://api.openai.com/v1"
 "baseUrl": "http://localhost:8787/bili/https://api.anthropic.com"
 ```
 
-**Other clients (Cursor / Aider / Continue …)** — wherever the upstream URL is
-configured, prepend `http://localhost:8787/bili/` to it. Nothing else changes.
+**Other clients (Cursor / Aider / Continue …)** — wherever the upstream URL
+is configured, prepend `http://localhost:8787/bili/` to it. Nothing else
+changes.
 
-### Option B — Explicit context windows (config file)
-
-Zero-config (Option A) already auto-detects context windows from
-[models.dev](https://models.dev). You only need a config file when you want to
-**override** that — e.g. a private relay behind a fixed limit, or a model that
-isn't in the registry yet.
-
-Three steps: **start the proxy → declare context overrides → point your client at it**.
-
-### Step 1 — Start the proxy
-
-```bash
-bili
-```
-
-It listens on `http://127.0.0.1:8787`. Keep this terminal open (or run in the
-background; see [Running the proxy](#running-the-proxy)).
-
-Click [http://localhost:8787/__bili/](http://localhost:8787/__bili/) to add your models:
-<img width="2908" height="1787" alt="image" src="https://github.com/user-attachments/assets/cacf4b64-e5c6-41f2-b270-fd2be02eab0c" />
-
-On first run `bili` **auto-creates an empty config file** and tells you where,
-so you don't have to invent the schema from scratch. The startup banner prints
-the web UI URL too:
-
-```
-acp-proxy listening on http://localhost:8787 — web UI: http://localhost:8787/__bili/
-```
-
-### How routing works
-
-There is **one** routing mode: the `/bili/` prefix. The client embeds the
-full upstream URL right there, and the proxy forwards to it verbatim:
-
-```
-client baseURL:  http://localhost:8787/bili/https://open.bigmodel.cn/api/coding/paas/v4
-                  └──────────┬──────────┘└────┬────┘└────────────────┬───────────────────────┘
-                      proxy host       /bili/        upstream URL (forwarded as-is)
-```
-
-The config file does **not** change routing. It only tells the proxy the
-context window for a given upstream URL + model, so it knows when to compress.
-The key is the same upstream URL string the client puts after `/bili/`:
-
-```jsonc
-{
-  "providers": {
-    "https://open.bigmodel.cn/api/coding/paas/v4": {
-      "models": { "glm-5.2": { "context": 1000000 } }
-    }
-  }
-}
-```
-
-A request matches a key when the client's embedded URL **equals the key or
-starts with it** (longest key wins). A shallow key like
-`https://open.bigmodel.cn` overrides every path on that host; a deep key like
-`https://open.bigmodel.cn/api/anthropic` overrides only that endpoint. Models
-not listed in any matching key fall back to models.dev, then the built-in
-prefix table.
-
-### Step 2 — Declare context overrides
-
-The web UI's **Providers** tab lets you add an upstream URL and its per-model
-context windows in a form, then **Save** (writes the config file) and **Apply**
-(hot-reload into the running proxy, no restart).
-<img width="2931" height="1519" alt="image" src="https://github.com/user-attachments/assets/c02278be-bc7a-4f14-8f58-0f2d83784d54" />
-
-> Prefer editing the JSON directly? See [Manual config file](#manual-config-file).
-Full schema is in [Configuration](#configuration).
-
-After Save + Apply the startup banner reflects it:
-
-```
-acp-proxy listening on http://localhost:8787 — web UI: http://localhost:8787/__bili/ — context overrides for 2 upstream URL(s)
-```
-
-### Step 3 — Point your client at the proxy
-
-Edit the client's own config file so it sends requests to
-`http://localhost:8787/bili/<full-upstream-url>`. Put your **real** API key in
-the client's config too — the proxy passes it through untouched.
-
-#### Pi (billion-context-pi)
-
-Open `~/.pi/agent/models.json` and change your existing provider's **`baseUrl` line** — just prepend the proxy origin + `/bili/` to the real URL, leave every other field alone:
-
-```jsonc
-// before:
-"baseUrl": "https://open.bigmodel.cn/api/coding/paas/v4",
-// after:
-"baseUrl": "http://localhost:8787/bili/https://open.bigmodel.cn/api/coding/paas/v4",
-```
-
-`http://localhost:8787/bili/` is the proxy; everything after it is the real
-upstream URL, forwarded as-is. `apiKey`, `api`, and `models` stay unchanged.
-
-| `api` value | upstream |
-|---|---|
-| `openai-completions` | an OpenAI-compatible endpoint (GLM/DeepSeek/OpenAI) |
-| `anthropic-messages` | an Anthropic-compatible endpoint |
-
-> If you use the `billion-context-pi` extension, run Pi in an isolated agent
-dir (`PI_CODING_AGENT_DIR=…`) so the client-side extension doesn't double-
-compress alongside the proxy. The `bili-test-pi` helper does this for you.
-
-#### OpenCode
-
-Open `~/.config/opencode/opencode.json` and change your existing provider's **`baseURL` line** — prepend the proxy origin + `/bili/`:
-
-```jsonc
-// before:
-"baseURL": "https://open.bigmodel.cn/api/coding/paas/v4"
-// after:
-"baseURL": "http://localhost:8787/bili/https://open.bigmodel.cn/api/coding/paas/v4"
-```
-
-Everything else (`apiKey`, `models`) stays unchanged.
-
-#### Codex
-
-Open `~/.codex/config.toml` and change your existing provider's **`base_url` line** — prepend the proxy origin + `/bili/`:
-
-```toml
-# before:
-base_url = "https://open.bigmodel.cn/api/coding/paas/v4"
-# after:
-base_url = "http://localhost:8787/bili/https://open.bigmodel.cn/api/coding/paas/v4"
-```
-
-Everything else (`name`, `wire_api`, `env_key`) stays unchanged.
-
-> Codex's Responses API needs an upstream that speaks the Responses protocol.
-> Most regional OpenAI-compatible endpoints only speak `/chat/completions`; if
-> yours 404s on `/responses`, use a relay that speaks Responses, or the
-> official OpenAI API.
-
-#### Other clients (Cursor / Aider / Continue …)
-
-If the client lets you set a base URL, prepend `http://localhost:8787/bili/`
-to it. The proxy speaks the Anthropic, OpenAI chat-completions, and OpenAI
-Responses protocols — any client using one of those works. A client using a
-different protocol or a non-standard auth header won't work yet.
-
-### Web UI
-
-Open `http://localhost:8787/__bili/` in a browser while the proxy is running. You can:
-
-- **Edit providers** in a form (add/remove providers and per-model context windows) and save — this writes to `billion-context.json` directly.
-- **Generate client URLs** — pick an upstream URL, get ready-to-copy config snippets for Pi / OpenCode / Codex (the `baseUrl`/`baseURL`/`base_url` line with the proxy origin + `/bili/` + the URL filled in).
-- **View sessions** — live table of active sessions (requests, tokens saved, last seen), auto-refreshing.
-
-Use the **Apply** button to hot-reload provider routes into the running
-process without restarting (only `port`/`host` require a restart, since the
-listen socket is already bound).
-
-### Manual config file
-
-Prefer editing JSON by hand — for git-managed configs, scripted deployments, or
-if you just don't want to use the browser? The web UI writes to the same file,
-so you can edit it directly with identical results.
+### Option B — Manual config file & context windows
 
 Open `~/.config/billion-context/billion-context.json` and edit the `providers`
-block. **The key is the upstream URL** — the same string the client puts after
+block. **The key is the upstream URL** — the string the client puts after
 `/bili/`. The value declares per-model context windows for that URL:
 
 ```json
@@ -294,9 +135,10 @@ block. **The key is the upstream URL** — the same string the client puts after
 - The API key is **not** here — it lives in the client; the proxy passes it
   through untouched.
 
-After saving, click **Apply** in the web UI (or **restart `bili`**). (Full
-schema — per-model context windows, optional fields — is in
-[Configuration](#configuration).)
+### Option C — Web UI & context windows
+
+Open [http://localhost:8787/__bili/](http://localhost:8787/__bili/) to
+configure.
 
 ### Verify
 
@@ -457,7 +299,7 @@ The config file is a single JSON object. Example:
 
 ### Providers (per-URL context overrides)
 
-Routing is always the `/bili/` prefix (see [How routing works](#how-routing-works)).
+Routing is always the `/bili/` prefix (see [Option A](#option-a--zero-config-bili-prefix)).
 The `providers` block only declares **context-window overrides** keyed by
 upstream URL. The key is the same string the client puts after `/bili/`:
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ bili
 It listens on `http://127.0.0.1:8787`. Keep this terminal open (or run in the
 background; see [Running the proxy](#running-the-proxy)).
 
-Click [http://localhost:8787/__acp/](http://localhost:8787/__acp/) to add your models:
+Click [http://localhost:8787/__bili/](http://localhost:8787/__bili/) to add your models:
 <img width="2908" height="1787" alt="image" src="https://github.com/user-attachments/assets/cacf4b64-e5c6-41f2-b270-fd2be02eab0c" />
 
 On first run `bili` **auto-creates an empty config file** and tells you where,
@@ -135,7 +135,7 @@ so you don't have to invent the schema from scratch. The startup banner prints
 the web UI URL too:
 
 ```
-acp-proxy listening on http://localhost:8787 — web UI: http://localhost:8787/__acp/
+acp-proxy listening on http://localhost:8787 — web UI: http://localhost:8787/__bili/
 ```
 
 ### How routing works
@@ -183,7 +183,7 @@ Full schema is in [Configuration](#configuration).
 After Save + Apply the startup banner reflects it:
 
 ```
-acp-proxy listening on http://localhost:8787 — web UI: http://localhost:8787/__acp/ — context overrides for 2 upstream URL(s)
+acp-proxy listening on http://localhost:8787 — web UI: http://localhost:8787/__bili/ — context overrides for 2 upstream URL(s)
 ```
 
 ### Step 3 — Point your client at the proxy
@@ -255,7 +255,7 @@ different protocol or a non-standard auth header won't work yet.
 
 ### Web UI
 
-Open `http://localhost:8787/__acp/` in a browser while the proxy is running. You can:
+Open `http://localhost:8787/__bili/` in a browser while the proxy is running. You can:
 
 - **Edit providers** in a form (add/remove providers and per-model context windows) and save — this writes to `billion-context.json` directly.
 - **Generate client URLs** — pick an upstream URL, get ready-to-copy config snippets for Pi / OpenCode / Codex (the `baseUrl`/`baseURL`/`base_url` line with the proxy origin + `/bili/` + the URL filled in).
@@ -305,11 +305,11 @@ first real request shows compression activity in the log:
 
 ```bash
 # Health check (proxy up + where it forwards)
-curl -s http://localhost:8787/__acp/health
+curl -s http://localhost:8787/__bili/health
 # → {"ok":true,"upstream":"https://api.anthropic.com"}
 
 # Live session stats (after a real request)
-curl -s http://localhost:8787/__acp/stats
+curl -s http://localhost:8787/__bili/stats
 ```
 
 Then send one message from your client and watch the log

--- a/README.md
+++ b/README.md
@@ -50,9 +50,10 @@ Two ways to use it — pick one:
   doubles as a self-detection signal: billion-context client extensions
   (billion-context-pi / opencode-acp) can recognize it in their own baseUrl
   and self-disable, so you never get double compression.
-- **Named providers:** declare providers in a config file, then use shorter
-  `http://localhost:8787/<name>/...` URLs. Better when you manage several
-  endpoints or want explicit per-model context overrides.
+- **Explicit context overrides:** declare per-URL context windows in a config
+  file (or the web UI) for endpoints the registry doesn't know about, or when
+  you want to pin an exact value. Routing is the same `/bili/` prefix either
+  way — the config only changes which context window the proxy uses.
 
 Compression is injected automatically — you only configure routing, never
 compression itself.
@@ -108,9 +109,14 @@ base_url = "http://localhost:8787/bili/https://api.openai.com/v1"
 **Other clients (Cursor / Aider / Continue …)** — wherever the upstream URL is
 configured, prepend `http://localhost:8787/bili/` to it. Nothing else changes.
 
-### Option B — Named providers (config file)
+### Option B — Explicit context windows (config file)
 
-Three steps: **start the proxy → configure your providers → point your client at it**.
+Zero-config (Option A) already auto-detects context windows from
+[models.dev](https://models.dev). You only need a config file when you want to
+**override** that — e.g. a private relay behind a fixed limit, or a model that
+isn't in the registry yet.
+
+Three steps: **start the proxy → declare context overrides → point your client at it**.
 
 ### Step 1 — Start the proxy
 
@@ -134,70 +140,76 @@ acp-proxy listening on http://localhost:8787 — web UI: http://localhost:8787/_
 
 ### How routing works
 
-The proxy routes by a **provider name in the URL path** — the first path
-segment after the host. It strips the name and forwards the rest to that
-provider. Everything after the name is passed through untouched:
+There is **one** routing mode: the `/bili/` prefix. The client embeds the
+full upstream URL right there, and the proxy forwards to it verbatim:
 
 ```
-client baseURL:  http://localhost:8787/zhipu/api/coding/paas/v4
-                  └──────────┬──────────┘└────────┬────────┘
-                      proxy host           remaining path
-                      + provider name      (forwarded as-is)
+client baseURL:  http://localhost:8787/bili/https://open.bigmodel.cn/api/coding/paas/v4
+                  └──────────┬──────────┘└────┬────┘└────────────────┬───────────────────────┘
+                      proxy host       /bili/        upstream URL (forwarded as-is)
 ```
 
-This is why Step 2 has you declare named providers, and Step 3 has you put that
-same name at the start of the client's base URL — it's how the proxy knows where
-to send each request. In the config below, `zhipu` corresponds to:
-```json
-    "zhipu": {
-      "url": "https://open.bigmodel.cn",
-      "models": {
-        "glm-5.2": { "context": 1000000 }
-      }
+The config file does **not** change routing. It only tells the proxy the
+context window for a given upstream URL + model, so it knows when to compress.
+The key is the same upstream URL string the client puts after `/bili/`:
+
+```jsonc
+{
+  "providers": {
+    "https://open.bigmodel.cn/api/coding/paas/v4": {
+      "models": { "glm-5.2": { "context": 1000000 } }
+    }
+  }
+}
 ```
 
-### Step 2 — Configure your providers
+A request matches a key when the client's embedded URL **equals the key or
+starts with it** (longest key wins). A shallow key like
+`https://open.bigmodel.cn` overrides every path on that host; a deep key like
+`https://open.bigmodel.cn/api/anthropic` overrides only that endpoint. Models
+not listed in any matching key fall back to models.dev, then the built-in
+prefix table.
 
-Copy the content below:
+### Step 2 — Declare context overrides
+
+The web UI's **Providers** tab lets you add an upstream URL and its per-model
+context windows in a form, then **Save** (writes the config file) and **Apply**
+(hot-reload into the running proxy, no restart).
 <img width="2931" height="1519" alt="image" src="https://github.com/user-attachments/assets/c02278be-bc7a-4f14-8f58-0f2d83784d54" />
 
-> Prefer not to use the web UI? You can also edit the JSON file directly — see
-> [Manual config file](#manual-config-file) below.
+> Prefer editing the JSON directly? See [Manual config file](#manual-config-file).
+Full schema is in [Configuration](#configuration).
 
-Then **restart `bili`** — the startup banner lists your routes:
+After Save + Apply the startup banner reflects it:
 
 ```
-acp-proxy listening on http://localhost:8787 — routes: anthropic=https://api.anthropic.com, zhipu=https://open.bigmodel.cn
+acp-proxy listening on http://localhost:8787 — web UI: http://localhost:8787/__acp/ — context overrides for 2 upstream URL(s)
 ```
-
-That confirms the proxy picked up your config. (Prefer editing the JSON file by
-hand? See [Manual config file](#manual-config-file). Full schema — per-model
-context windows, optional fields — is in [Configuration](#configuration).)
 
 ### Step 3 — Point your client at the proxy
 
 Edit the client's own config file so it sends requests to
-`http://localhost:8787/<provider>/...` (the provider name from Step 2 as the
-first path segment). Put your **real** API key in the client's config too —
-the proxy passes it through untouched.
+`http://localhost:8787/bili/<full-upstream-url>`. Put your **real** API key in
+the client's config too — the proxy passes it through untouched.
 
 #### Pi (billion-context-pi)
 
-Open `~/.pi/agent/models.json` and change your existing provider's **`baseUrl` line** to point at the proxy — leave every other field alone:
+Open `~/.pi/agent/models.json` and change your existing provider's **`baseUrl` line** — just prepend the proxy origin + `/bili/` to the real URL, leave every other field alone:
 
 ```jsonc
 // before:
 "baseUrl": "https://open.bigmodel.cn/api/coding/paas/v4",
-// after (swap the host for the proxy + the provider name you picked):
-"baseUrl": "http://localhost:8787/zhipu/api/coding/paas/v4",
+// after:
+"baseUrl": "http://localhost:8787/bili/https://open.bigmodel.cn/api/coding/paas/v4",
 ```
 
-`http://localhost:8787` is the proxy, `zhipu` is the name from Step 2, and the remaining path `/api/coding/paas/v4` is forwarded as-is to Zhipu. `apiKey`, `api`, and `models` stay unchanged.
+`http://localhost:8787/bili/` is the proxy; everything after it is the real
+upstream URL, forwarded as-is. `apiKey`, `api`, and `models` stay unchanged.
 
-| `api` value | `baseUrl` should point at |
+| `api` value | upstream |
 |---|---|
-| `openai-completions` | an OpenAI-compatible endpoint (GLM/DeepSeek/OpenAI) → `…/zhipu/...` |
-| `anthropic-messages` | an Anthropic-compatible endpoint → `…/anthropic` |
+| `openai-completions` | an OpenAI-compatible endpoint (GLM/DeepSeek/OpenAI) |
+| `anthropic-messages` | an Anthropic-compatible endpoint |
 
 > If you use the `billion-context-pi` extension, run Pi in an isolated agent
 dir (`PI_CODING_AGENT_DIR=…`) so the client-side extension doesn't double-
@@ -205,26 +217,26 @@ compress alongside the proxy. The `bili-test-pi` helper does this for you.
 
 #### OpenCode
 
-Open `~/.config/opencode/opencode.json` and change your existing provider's **`baseURL` line** to point at the proxy:
+Open `~/.config/opencode/opencode.json` and change your existing provider's **`baseURL` line** — prepend the proxy origin + `/bili/`:
 
 ```jsonc
 // before:
 "baseURL": "https://open.bigmodel.cn/api/coding/paas/v4"
 // after:
-"baseURL": "http://localhost:8787/zhipu/api/coding/paas/v4"
+"baseURL": "http://localhost:8787/bili/https://open.bigmodel.cn/api/coding/paas/v4"
 ```
 
-Everything else (`apiKey`, `models`) stays unchanged. For an Anthropic provider, change `baseURL` to `http://localhost:8787/anthropic`.
+Everything else (`apiKey`, `models`) stays unchanged.
 
 #### Codex
 
-Open `~/.codex/config.toml` and change your existing provider's **`base_url` line** to point at the proxy:
+Open `~/.codex/config.toml` and change your existing provider's **`base_url` line** — prepend the proxy origin + `/bili/`:
 
 ```toml
 # before:
 base_url = "https://open.bigmodel.cn/api/coding/paas/v4"
 # after:
-base_url = "http://localhost:8787/zhipu/api/coding/paas/v4"
+base_url = "http://localhost:8787/bili/https://open.bigmodel.cn/api/coding/paas/v4"
 ```
 
 Everything else (`name`, `wire_api`, `env_key`) stays unchanged.
@@ -236,18 +248,17 @@ Everything else (`name`, `wire_api`, `env_key`) stays unchanged.
 
 #### Other clients (Cursor / Aider / Continue …)
 
-If the client lets you set a base URL, point it at the proxy exactly like the
-examples above (zero-config `/bili/` prefix or named `/<provider>/` prefix).
-The proxy speaks the Anthropic, OpenAI chat-completions, and OpenAI Responses
-protocols — any client using one of those works. A client using a different
-protocol or a non-standard auth header won't work yet.
+If the client lets you set a base URL, prepend `http://localhost:8787/bili/`
+to it. The proxy speaks the Anthropic, OpenAI chat-completions, and OpenAI
+Responses protocols — any client using one of those works. A client using a
+different protocol or a non-standard auth header won't work yet.
 
 ### Web UI
 
 Open `http://localhost:8787/__acp/` in a browser while the proxy is running. You can:
 
 - **Edit providers** in a form (add/remove providers and per-model context windows) and save — this writes to `billion-context.json` directly.
-- **Generate client URLs** — pick a provider, get ready-to-copy config snippets for Pi / OpenCode / Codex (the `baseUrl`/`baseURL`/`base_url` line with the proxy origin + provider name filled in).
+- **Generate client URLs** — pick an upstream URL, get ready-to-copy config snippets for Pi / OpenCode / Codex (the `baseUrl`/`baseURL`/`base_url` line with the proxy origin + `/bili/` + the URL filled in).
 - **View sessions** — live table of active sessions (requests, tokens saved, last seen), auto-refreshing.
 
 Use the **Apply** button to hot-reload provider routes into the running
@@ -261,30 +272,31 @@ if you just don't want to use the browser? The web UI writes to the same file,
 so you can edit it directly with identical results.
 
 Open `~/.config/billion-context/billion-context.json` and edit the `providers`
-block. Each entry is a **name → URL** mapping; the name is what you put in the
-client's base URL in Step 3.
+block. **The key is the upstream URL** — the same string the client puts after
+`/bili/`. The value declares per-model context windows for that URL:
 
 ```json
 {
   "providers": {
-    "zhipu": {
-      "url": "https://open.bigmodel.cn",
-      "models": {
-        "glm-5.2": { "context": 1000000 }
-      }
+    "https://open.bigmodel.cn/api/coding/paas/v4": {
+      "models": { "glm-5.2": { "context": 1000000 } }
     },
-    "anthropic": "https://api.anthropic.com"
+    "https://api.anthropic.com": {}
   }
 }
 ```
 
-- Delete providers you don't use.
-- Add others (e.g. `"deepseek": "https://api.deepseek.com"`).
+- A key matches when the client's embedded URL equals it or starts with it
+  (longest key wins). A bare host key covers every path on that host.
+- An empty value `{}` means "this URL exists, no overrides" (context windows
+  come from models.dev / the prefix table).
+- Delete entries you don't use; add others as needed.
 - The API key is **not** here — it lives in the client; the proxy passes it
   through untouched.
 
-After saving, **restart `bili`**. (Full schema — per-model context windows,
-optional fields — is in [Configuration](#configuration).)
+After saving, click **Apply** in the web UI (or **restart `bili`**). (Full
+schema — per-model context windows, optional fields — is in
+[Configuration](#configuration).)
 
 ### Verify
 
@@ -410,15 +422,13 @@ The config file is a single JSON object. Example:
   "port": 8787,
   "host": "127.0.0.1",
   "providers": {
-    "zhipu": {
-      "url": "https://open.bigmodel.cn",
+    "https://open.bigmodel.cn/api/coding/paas/v4": {
       "models": {
         "glm-5.2": { "context": 1000000 },
         "glm-5.1": { "context": 200000 }
       }
     },
-    "anthropic": "https://api.anthropic.com",
-    "deepseek": "https://api.deepseek.com"
+    "https://api.deepseek.com": {}
   }
 }
 ```
@@ -429,12 +439,11 @@ The config file is a single JSON object. Example:
 |------|---------|-------------|
 | `port` | `8787` | Proxy listen port |
 | `host` | `127.0.0.1` | Proxy listen host |
-| `upstream` | `https://api.anthropic.com` | Default upstream when no route matches |
 | `sessionHeader` | `x-acp-session` | Header name clients may send to identify a conversation |
 | `log` | `true` | Enable request logging |
 | `debug` | `false` | Verbose logging (same as `ACP_DEBUG=1`) |
 | `passthrough` | `false` | Forward without compression (same as `ACP_PASSTHROUGH=1`) |
-| `providers` | *(none)* | Provider routes — see below |
+| `providers` | *(none)* | Per-URL context overrides — see below |
 | `compress` | *(see defaults)* | `{ injectTool, injectNudge }` |
 
 > **Choosing a `host`** (IPv6 / containers): the default `127.0.0.1` is
@@ -446,57 +455,52 @@ The config file is a single JSON object. Example:
 > `--host 0.0.0.0` there. ⚠️ `0.0.0.0` / `::` expose the proxy on **all**
 > interfaces; ensure you're on a trusted network or behind a firewall.
 
-### Providers (URL routing + per-model context)
+### Providers (per-URL context overrides)
 
-`providers` maps a route name to either a bare URL string (simple) or an
-object with `url` + optional per-model context window (recommended).
+Routing is always the `/bili/` prefix (see [How routing works](#how-routing-works)).
+The `providers` block only declares **context-window overrides** keyed by
+upstream URL. The key is the same string the client puts after `/bili/`:
 
-**Simple form** — provider name → URL:
-```json
-{ "deepseek": "https://api.deepseek.com" }
-```
-
-**Full form** — provider name → `{ url, models }`:
 ```json
 {
-  "zhipu": {
-    "url": "https://open.bigmodel.cn",
-    "models": {
-      "glm-5.2": { "context": 1000000 },
-      "glm-5.1": { "context": 200000 }
-    }
+  "providers": {
+    "https://open.bigmodel.cn/api/coding/paas/v4": {
+      "models": {
+        "glm-5.2": { "context": 1000000 },
+        "glm-5.1": { "context": 200000 }
+      }
+    },
+    "https://api.deepseek.com": {}
   }
 }
 ```
 
-The same model can have a different context window behind different providers
-(e.g. relay wraps a model with a larger window). `context` is the **input
-context limit** (used by the compressor to decide when to nudge); `output` is
-the max output tokens. Both are optional; missing values fall back to the
-built-in model table, then to `modelContextLimit`. **`output` is no longer
-needed** — the proxy forwards whatever `max_tokens` the client sends, and
-omits it otherwise so the upstream uses its own default (Anthropic clients
-always send it, so Anthropic routes are covered automatically). An `output`
-field is still accepted for backward compatibility but has no effect.
+The same model can have a different context window behind different upstreams
+(e.g. a relay wraps a model with a larger window). `context` is the **input
+context limit** (used by the compressor to decide when to nudge). It is
+optional; missing values fall back to the [models.dev](https://models.dev)
+registry, then the built-in prefix table.
 
 > **Why declare context at all?** The LLM `/models` API does **not** return
 > context windows (verified across OpenAI, Anthropic, 智谱, comfly). They are
 > document-level information. A wrong value (e.g. GLM-5.2 guessed as 128K
 > instead of 1M) causes spurious frequent compression. Declaring it per
-> provider + model makes the proxy match the registry the client itself uses.
+> URL + model makes the proxy match the registry the client itself uses.
+
+### URL key matching rules
+
+- A request matches a key when the client's embedded URL **equals the key or
+  starts with it** (longest key wins).
+- A shallow key like `https://open.bigmodel.cn` overrides every path on that
+  host; a deep key like `https://open.bigmodel.cn/api/anthropic` overrides
+  only that endpoint.
+- Keys never cross hosts (the boundary check requires a `/` or end-of-string
+  after the key), so `https://x.com` does not match `https://x.com.evil`.
+- Models not covered by any matching key fall back to models.dev, then the
+  prefix table, then `modelContextLimit`.
 
 **API keys are never stored in the proxy** — whatever key the agent sends is
 passed through untouched to the upstream.
-
-### Provider name rules
-
-- Must start with a letter, contain only letters/digits/`-`/`_`.
-- Reserved words (`v1`, `chat`, `completions`, `messages`, `models`, `api`)
-  are rejected to avoid colliding with real API path segments.
-- The provider name can appear anywhere in the path; the longest match wins.
-- With **no providers** declared (e.g. you emptied the `providers` block),
-  every request is forwarded to the default `upstream` with its full path —
-  an edge case, not the normal flow.
 
 ## How sessions work
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -45,7 +45,7 @@ npm install -g billion-context
 两种方式 —— 任选其一:
 
 - **零配置(最简单):** 在客户端 baseURL 前面加上代理地址 + `/bili/`。无需配置文件 —— context 窗口自动从 [models.dev](https://models.dev) registry 查询。`/bili/` 前缀还是个自检测信号:billion-context 的客户端扩展(billion-context-pi / opencode-acp)能在自己的 baseUrl 里认出它并自禁用,避免双层压缩。
-- **命名 provider:** 在配置文件里声明 provider,然后用更短的 `http://localhost:8787/<name>/...` URL。适合管理多个端点或需要显式指定按模型 context 的场景。
+- **显式 context 窗口覆盖:** 在配置文件(或网页)里按 URL 声明 context 窗口,用于 registry 不认识的端点,或想钉死一个精确值的场景。两种方式路由都是同一个 `/bili/` 前缀 —— 配置只改变代理用哪个 context 窗口。
 
 压缩是自动注入的 —— 你只需配置路由,无需配置压缩本身。
 
@@ -94,9 +94,11 @@ base_url = "http://localhost:8787/bili/https://api.openai.com/v1"
 
 **其他客户端(Cursor / Aider / Continue ……)** —— 只要配置了上游 URL,前面加 `http://localhost:8787/bili/` 就行,其他都不用改。
 
-### 方式 B —— 命名 provider(配置文件)
+### 方式 B —— 显式 context 窗口(配置文件)
 
-三步:**启动代理 → 配置 provider → 把客户端指向它**。
+零配置(方式 A)已经从 [models.dev](https://models.dev) 自动探测 context 窗口了。只有当你想**覆盖**它时才需要配置文件 —— 例如某个私有中转挂了个固定上限,或某个模型还没进 registry。
+
+三步:**启动代理 → 声明 context 覆盖 → 把客户端指向它**。
 
 ### 第 1 步 —— 启动代理
 
@@ -106,39 +108,74 @@ bili
 
 它监听 `http://127.0.0.1:8787`。保持这个终端开着(或后台运行,见[运行代理](#运行代理))。
 
-点击[http://localhost:8787/__acp/](http://localhost:8787/__acp/) 添加你的模型
+点击 [http://localhost:8787/__acp/](http://localhost:8787/__acp/) 添加你的模型:
 <img width="2908" height="1787" alt="image" src="https://github.com/user-attachments/assets/cacf4b64-e5c6-41f2-b270-fd2be02eab0c" />
 
-### 第 2 步 —— 编辑配置文件
+首次运行时 `bili` 会**自动创建一个空配置文件**并告诉你路径,你不必凭空编 schema。启动横幅也会打印网页地址:
 
-在网页上添加你的 provider,复制以下内容到配置:
+```
+acp-proxy listening on http://localhost:8787 — web UI: http://localhost:8787/__acp/
+```
+
+### 路由怎么工作
+
+只有**一种**路由模式:`/bili/` 前缀。客户端把完整上游 URL 直接嵌在那里,代理原样转发:
+
+```
+客户端 baseURL:  http://localhost:8787/bili/https://open.bigmodel.cn/api/coding/paas/v4
+                  └──────────┬──────────┘└────┬────┘└────────────────┬───────────────────────┘
+                      代理地址         /bili/          上游 URL(原样转发)
+```
+
+配置文件**不改变**路由。它只告诉代理某个上游 URL + 模型的 context 窗口,以便判断何时压缩。key 就是客户端写在 `/bili/` 后面的那个上游 URL 字符串:
+
+```jsonc
+{
+  "providers": {
+    "https://open.bigmodel.cn/api/coding/paas/v4": {
+      "models": { "glm-5.2": { "context": 1000000 } }
+    }
+  }
+}
+```
+
+一个请求在客户端嵌入的 URL **等于 key 或以 key 开头**时匹配(最长 key 优先)。浅 key 如 `https://open.bigmodel.cn` 会覆盖该 host 上的每条路径;深 key 如 `https://open.bigmodel.cn/api/anthropic` 只覆盖那一个端点。未在任何匹配 key 里列出的模型回退到 models.dev,再回退到内置前缀表。
+
+### 第 2 步 —— 声明 context 覆盖
+
+网页的 **Providers** 标签页可以用表单添加上游 URL 及其按模型的 context 窗口,然后点 **Save**(写入配置文件)和 **Apply**(热加载进运行中的代理,无需重启)。
 <img width="2931" height="1519" alt="image" src="https://github.com/user-attachments/assets/c02278be-bc7a-4f14-8f58-0f2d83784d54" />
 
-> 不想用网页?也可以直接手编 JSON 文件,见下文[手动配置文件](#手动配置文件)。
+> 更想直接手编 JSON?见下文[手动配置文件](#手动配置文件)。完整 schema 见[配置](#配置)。
+
+Save + Apply 之后,启动横幅会反映出来:
+
+```
+acp-proxy listening on http://localhost:8787 — web UI: http://localhost:8787/__acp/ — context overrides for 2 upstream URL(s)
+```
 
 ### 第 3 步 —— 把客户端指向代理
 
 编辑客户端自己的配置文件,让它把请求发到
-`http://localhost:8787/<provider>/...`(第 2 步声明的 provider 名作为路径
-第一段)。把你的**真实** API key 也填进客户端配置 —— 代理原样透传。
+`http://localhost:8787/bili/<完整上游 URL>`。把你的**真实** API key 也填进客户端配置 —— 代理原样透传。
 
 #### Pi(billion-context-pi)
 
-打开 `~/.pi/agent/models.json`,把你现有 provider 的 **`baseUrl` 这一行**改成指向代理,其他字段都不用动:
+打开 `~/.pi/agent/models.json`,把你现有 provider 的 **`baseUrl` 这一行**改成指向代理 —— 真实 URL 前面加代理地址 + `/bili/`,其他字段都不用动:
 
 ```jsonc
 // 改之前:
 "baseUrl": "https://open.bigmodel.cn/api/coding/paas/v4",
-// 改之后(把 host 换成代理 + 你起的 provider 名):
-"baseUrl": "http://localhost:8787/zhipu/api/coding/paas/v4",
+// 改之后:
+"baseUrl": "http://localhost:8787/bili/https://open.bigmodel.cn/api/coding/paas/v4",
 ```
 
-`http://localhost:8787` 是代理,`zhipu` 是第 2 步起的名字,剩余路径 `/api/coding/paas/v4` 原样转发到智谱。`apiKey`、`api`、`models` 都不用改。
+`http://localhost:8787/bili/` 是代理,后面整段就是真实上游 URL,原样转发。`apiKey`、`api`、`models` 都不用改。
 
-| `api` 值 | `baseUrl` 应指向 |
+| `api` 值 | 上游 |
 |---|---|
-| `openai-completions` | OpenAI 兼容端点(GLM/DeepSeek/OpenAI)→ `…/zhipu/...` |
-| `anthropic-messages` | Anthropic 兼容端点 → `…/anthropic` |
+| `openai-completions` | OpenAI 兼容端点(GLM/DeepSeek/OpenAI) |
+| `anthropic-messages` | Anthropic 兼容端点 |
 
 > 如果你装了 `billion-context-pi` 扩展,用隔离的 agent 目录跑 Pi
 > (`PI_CODING_AGENT_DIR=…`),免得客户端扩展和 proxy 双重压缩。
@@ -146,26 +183,26 @@ bili
 
 #### OpenCode
 
-打开 `~/.config/opencode/opencode.json`,把你现有 provider 的 **`baseURL` 这一行**改成指向代理:
+打开 `~/.config/opencode/opencode.json`,把你现有 provider 的 **`baseURL` 这一行**改成指向代理 —— 真实 URL 前面加代理地址 + `/bili/`:
 
 ```jsonc
 // 改之前:
 "baseURL": "https://open.bigmodel.cn/api/coding/paas/v4"
 // 改之后:
-"baseURL": "http://localhost:8787/zhipu/api/coding/paas/v4"
+"baseURL": "http://localhost:8787/bili/https://open.bigmodel.cn/api/coding/paas/v4"
 ```
 
-其他字段(`apiKey`、`models`)都不用改。如果要走 Anthropic provider,把 `baseURL` 改为 `http://localhost:8787/anthropic`。
+其他字段(`apiKey`、`models`)都不用改。
 
 #### Codex
 
-打开 `~/.codex/config.toml`,把现有 provider 的 **`base_url` 这一行**改成指向代理:
+打开 `~/.codex/config.toml`,把现有 provider 的 **`base_url` 这一行**改成指向代理 —— 真实 URL 前面加代理地址 + `/bili/`:
 
 ```toml
 # 改之前:
 base_url = "https://open.bigmodel.cn/api/coding/paas/v4"
 # 改之后:
-base_url = "http://localhost:8787/zhipu/api/coding/paas/v4"
+base_url = "http://localhost:8787/bili/https://open.bigmodel.cn/api/coding/paas/v4"
 ```
 
 其他字段(`name`、`wire_api`、`env_key`)都不用改。
@@ -176,52 +213,43 @@ base_url = "http://localhost:8787/zhipu/api/coding/paas/v4"
 
 #### 其他客户端(Cursor / Aider / Continue …)
 
-只要客户端能设 base URL,就像上面的例子一样指向代理(零配置 `/bili/` 前缀或命名 `/<provider>/` 前缀)。代理说 Anthropic、OpenAI chat-completions、OpenAI Responses 三种协议 —— 用其中任一种的客户端都能工作。用别的协议或非标准 auth header 的客户端暂时还不行。
-
-### 手动配置文件
-
-上面用网页配置。如果你不想用网页、想把配置纳入 git 管理、或者用脚本
-自动化部署,也可以直接手编 JSON 文件,效果完全一样。
-
-打开 `~/.config/billion-context/billion-context.json`,编辑 `providers` 块。
-每个条目是一个**名字 → URL** 映射;这个名字就是你在第 3 步里写进客户端
-base URL 的东西。
-
-```json
-{
-  "providers": {
-    "zhipu": {
-      "url": "https://open.bigmodel.cn",
-      "models": {
-        "glm-5.2": { "context": 1000000 }
-      }
-    },
-    "anthropic": "https://api.anthropic.com"
-  }
-}
-```
-
-- 删掉你不用的 provider。
-- 添加其他的(例如 `"deepseek": "https://api.deepseek.com"`)。
-- API key **不**写在这里 —— key 在客户端那边,代理原样透传。
-
-保存后**重启 `bili`**。启动行列出你的路由:
-
-```
-acp-proxy listening on http://127.0.0.1:8787 — routes: anthropic=https://api.anthropic.com, zhipu=https://open.bigmodel.cn
-```
-
-这证明代理读到了你的配置。(完整 schema —— 按模型的 context 窗口、可选字段 —— 见[配置](#配置)。)
+只要客户端能设 base URL,前面加 `http://localhost:8787/bili/` 就行。代理说 Anthropic、OpenAI chat-completions、OpenAI Responses 三种协议 —— 用其中任一种的客户端都能工作。用别的协议或非标准 auth header 的客户端暂时还不行。
 
 ### 网页配置
 
 代理跑着的时候,在浏览器打开 `http://localhost:8787/__acp/`。你可以:
 
 - **编辑 providers** —— 用表单增删 provider 和按模型的 context 窗口,点 Save 直接写入 `billion-context.json`。
-- **生成客户端 URL** —— 选一个 provider,得到可直接复制的配置片段(Pi / OpenCode / Codex 的 `baseUrl`/`baseURL`/`base_url` 一行,已填好代理地址 + provider 名)。
+- **生成客户端 URL** —— 选一个上游 URL,得到可直接复制的配置片段(Pi / OpenCode / Codex 的 `baseUrl`/`baseURL`/`base_url` 一行,已填好代理地址 + `/bili/` + URL)。
 - **查看会话** —— 实时会话表(请求数、省的 token、最后活跃时间),自动刷新。
 
 用 **Apply** 按钮可以热加载 provider 路由到运行中的进程,无需重启(只有 `port`/`host` 需要重启,因为监听 socket 已经绑了)。
+
+### 手动配置文件
+
+不想用网页 —— 想纳入 git 管理、用脚本自动化部署、或者就是不爱用浏览器?网页写的也是这同一个文件,直接手编效果完全一样。
+
+打开 `~/.config/billion-context/billion-context.json`,编辑 `providers` 块。
+**key 就是上游 URL** —— 客户端写在 `/bili/` 后面的那个字符串。value 为该
+URL 声明按模型的 context 窗口:
+
+```json
+{
+  "providers": {
+    "https://open.bigmodel.cn/api/coding/paas/v4": {
+      "models": { "glm-5.2": { "context": 1000000 } }
+    },
+    "https://api.anthropic.com": {}
+  }
+}
+```
+
+- 一个 key 在客户端嵌入的 URL 等于它或以它开头时匹配(最长 key 优先)。纯 host key 覆盖该 host 上的所有路径。
+- 空 value `{}` 表示"这个 URL 存在,无覆盖"(context 窗口来自 models.dev / 前缀表)。
+- 删掉你不用的条目;添加其他的(按需)。
+- API key **不**写在这里 —— key 在客户端那边,代理原样透传。
+
+保存后点网页里的 **Apply**(或**重启 `bili`**)。(完整 schema —— 按模型的 context 窗口、可选字段 —— 见[配置](#配置)。)
 
 ### 验证
 
@@ -331,15 +359,13 @@ bili --no-auto-update        # 本次启动禁用自动更新
   "port": 8787,
   "host": "127.0.0.1",
   "providers": {
-    "zhipu": {
-      "url": "https://open.bigmodel.cn",
+    "https://open.bigmodel.cn/api/coding/paas/v4": {
       "models": {
         "glm-5.2": { "context": 1000000 },
         "glm-5.1": { "context": 200000 }
       }
     },
-    "anthropic": "https://api.anthropic.com",
-    "deepseek": "https://api.deepseek.com"
+    "https://api.deepseek.com": {}
   }
 }
 ```
@@ -350,12 +376,11 @@ bili --no-auto-update        # 本次启动禁用自动更新
 |------|---------|-------------|
 | `port` | `8787` | 代理监听端口 |
 | `host` | `127.0.0.1` | 代理监听地址 |
-| `upstream` | `https://api.anthropic.com` | 无路由匹配时的默认上游 |
 | `sessionHeader` | `x-acp-session` | 客户端可发来标识会话的 header 名 |
 | `log` | `true` | 启用请求日志 |
 | `debug` | `false` | 详细日志(等同 `ACP_DEBUG=1`) |
 | `passthrough` | `false` | 不压缩直接转发(等同 `ACP_PASSTHROUGH=1`) |
-| `providers` | *(无)* | Provider 路由 —— 见下文 |
+| `providers` | *(无)* | 按 URL 的 context 覆盖 —— 见下文 |
 | `compress` | *(见默认值)* | `{ injectTool, injectNudge }` |
 
 > **选择 `host`**(IPv6 / 容器):默认 `127.0.0.1` 只听 IPv4 且仅
@@ -366,41 +391,38 @@ bili --no-auto-update        # 本次启动禁用自动更新
 > `--host 0.0.0.0`。⚠️ `0.0.0.0` / `::` 会把代理暴露到**所有**网卡;
 > 确保你在可信网络或防火墙后面。
 
-### Providers(URL 路由 + 按模型 context)
+### Providers(按 URL 的 context 覆盖)
 
-`providers` 把路由名映射到一个纯 URL 字符串(简单)或一个带 `url` + 可选按模型 context 窗口的对象(推荐)。
+路由始终是 `/bili/` 前缀(见[路由怎么工作](#路由怎么工作))。
+`providers` 块只声明**按 URL 的 context 窗口覆盖**,以上游 URL 为 key。
+key 就是客户端写在 `/bili/` 后面的那个字符串:
 
-**简单形式** —— provider 名 → URL:
-```json
-{ "deepseek": "https://api.deepseek.com" }
-```
-
-**完整形式** —— provider 名 → `{ url, models }`:
 ```json
 {
-  "zhipu": {
-    "url": "https://open.bigmodel.cn",
-    "models": {
-      "glm-5.2": { "context": 1000000 },
-      "glm-5.1": { "context": 200000 }
-    }
+  "providers": {
+    "https://open.bigmodel.cn/api/coding/paas/v4": {
+      "models": {
+        "glm-5.2": { "context": 1000000 },
+        "glm-5.1": { "context": 200000 }
+      }
+    },
+    "https://api.deepseek.com": {}
   }
 }
 ```
 
-同一个模型在不同 provider 后面可以有不同 context 窗口(例如 relay 把模型包成更大窗口)。`context` 是**输入 context 上限**(压缩器用它判断何时 nudge)。可选;缺失值回退到内置模型表,再回退到 `modelContextLimit`。**`output`(最大输出 token)已不再需要** —— proxy 原样透传客户端发的 `max_tokens`,客户端不发就让上游用默认值(Anthropic 客户端总会发,所以 Anthropic 路由自动覆盖)。config 里的 `output` 字段仍兼容接受,但已无效果。
+同一个模型在不同上游后面可以有不同 context 窗口(例如 relay 把模型包成更大窗口)。`context` 是**输入 context 上限**(压缩器用它判断何时 nudge)。可选;缺失值回退到 [models.dev](https://models.dev) registry,再回退到内置前缀表。
 
-> **为什么要声明 context?** LLM 的 `/models` API **不返回** context 窗口(已跨 OpenAI、Anthropic、智谱、comfly 验证)。它们是文档级信息。值错了(例如把 GLM-5.2 猜成 128K 而非 1M)会导致频繁误触发压缩。按 provider + 模型声明能让代理匹配客户端自己用的注册表。
+> **为什么要声明 context?** LLM 的 `/models` API **不返回** context 窗口(已跨 OpenAI、Anthropic、智谱、comfly 验证)。它们是文档级信息。值错了(例如把 GLM-5.2 猜成 128K 而非 1M)会导致频繁误触发压缩。按 URL + 模型声明能让代理匹配客户端自己用的注册表。
+
+### URL key 匹配规则
+
+- 一个请求在客户端嵌入的 URL **等于 key 或以 key 开头**时匹配(最长 key 优先)。
+- 浅 key 如 `https://open.bigmodel.cn` 覆盖该 host 上的每条路径;深 key 如 `https://open.bigmodel.cn/api/anthropic` 只覆盖那一个端点。
+- key 永不跨 host(边界检查要求 key 后面是 `/` 或字符串结尾),所以 `https://x.com` 不会匹配 `https://x.com.evil`。
+- 未被任何匹配 key 覆盖的模型回退到 models.dev,再回退到前缀表,最后回退到 `modelContextLimit`。
 
 **API key 永远不存进代理** —— 助手发什么 key,原样透传给上游。
-
-### Provider 名规则
-
-- 必须以字母开头,只含字母/数字/`-`/`_`。
-- 保留字(`v1`、`chat`、`completions`、`messages`、`models`、`api`)被拒绝,以免与真实 API 路径段冲突。
-- provider 名可出现在路径任意位置;最长匹配优先。
-- **未声明任何 providers**(比如你清空了 `providers` 块)时,每个请求按完整
-  原始路径转发到默认 `upstream` —— 边缘场景,非正常流程。
 
 ## 会话机制
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -94,140 +94,8 @@ base_url = "http://localhost:8787/bili/https://api.openai.com/v1"
 
 **其他客户端(Cursor / Aider / Continue ……)** —— 只要配置了上游 URL,前面加 `http://localhost:8787/bili/` 就行,其他都不用改。
 
-### 方式 B —— 显式 context 窗口(配置文件)
 
-零配置(方式 A)已经从 [models.dev](https://models.dev) 自动探测 context 窗口了。只有当你想**覆盖**它时才需要配置文件 —— 例如某个私有中转挂了个固定上限,或某个模型还没进 registry。
-
-三步:**启动代理 → 声明 context 覆盖 → 把客户端指向它**。
-
-### 第 1 步 —— 启动代理
-
-```bash
-bili
-```
-
-它监听 `http://127.0.0.1:8787`。保持这个终端开着(或后台运行,见[运行代理](#运行代理))。
-
-点击 [http://localhost:8787/__bili/](http://localhost:8787/__bili/) 添加你的模型:
-<img width="2908" height="1787" alt="image" src="https://github.com/user-attachments/assets/cacf4b64-e5c6-41f2-b270-fd2be02eab0c" />
-
-首次运行时 `bili` 会**自动创建一个空配置文件**并告诉你路径,你不必凭空编 schema。启动横幅也会打印网页地址:
-
-```
-acp-proxy listening on http://localhost:8787 — web UI: http://localhost:8787/__bili/
-```
-
-### 路由怎么工作
-
-只有**一种**路由模式:`/bili/` 前缀。客户端把完整上游 URL 直接嵌在那里,代理原样转发:
-
-```
-客户端 baseURL:  http://localhost:8787/bili/https://open.bigmodel.cn/api/coding/paas/v4
-                  └──────────┬──────────┘└────┬────┘└────────────────┬───────────────────────┘
-                      代理地址         /bili/          上游 URL(原样转发)
-```
-
-配置文件**不改变**路由。它只告诉代理某个上游 URL + 模型的 context 窗口,以便判断何时压缩。key 就是客户端写在 `/bili/` 后面的那个上游 URL 字符串:
-
-```jsonc
-{
-  "providers": {
-    "https://open.bigmodel.cn/api/coding/paas/v4": {
-      "models": { "glm-5.2": { "context": 1000000 } }
-    }
-  }
-}
-```
-
-一个请求在客户端嵌入的 URL **等于 key 或以 key 开头**时匹配(最长 key 优先)。浅 key 如 `https://open.bigmodel.cn` 会覆盖该 host 上的每条路径;深 key 如 `https://open.bigmodel.cn/api/anthropic` 只覆盖那一个端点。未在任何匹配 key 里列出的模型回退到 models.dev,再回退到内置前缀表。
-
-### 第 2 步 —— 声明 context 覆盖
-
-网页的 **Providers** 标签页可以用表单添加上游 URL 及其按模型的 context 窗口,然后点 **Save**(写入配置文件)和 **Apply**(热加载进运行中的代理,无需重启)。
-<img width="2931" height="1519" alt="image" src="https://github.com/user-attachments/assets/c02278be-bc7a-4f14-8f58-0f2d83784d54" />
-
-> 更想直接手编 JSON?见下文[手动配置文件](#手动配置文件)。完整 schema 见[配置](#配置)。
-
-Save + Apply 之后,启动横幅会反映出来:
-
-```
-acp-proxy listening on http://localhost:8787 — web UI: http://localhost:8787/__bili/ — context overrides for 2 upstream URL(s)
-```
-
-### 第 3 步 —— 把客户端指向代理
-
-编辑客户端自己的配置文件,让它把请求发到
-`http://localhost:8787/bili/<完整上游 URL>`。把你的**真实** API key 也填进客户端配置 —— 代理原样透传。
-
-#### Pi(billion-context-pi)
-
-打开 `~/.pi/agent/models.json`,把你现有 provider 的 **`baseUrl` 这一行**改成指向代理 —— 真实 URL 前面加代理地址 + `/bili/`,其他字段都不用动:
-
-```jsonc
-// 改之前:
-"baseUrl": "https://open.bigmodel.cn/api/coding/paas/v4",
-// 改之后:
-"baseUrl": "http://localhost:8787/bili/https://open.bigmodel.cn/api/coding/paas/v4",
-```
-
-`http://localhost:8787/bili/` 是代理,后面整段就是真实上游 URL,原样转发。`apiKey`、`api`、`models` 都不用改。
-
-| `api` 值 | 上游 |
-|---|---|
-| `openai-completions` | OpenAI 兼容端点(GLM/DeepSeek/OpenAI) |
-| `anthropic-messages` | Anthropic 兼容端点 |
-
-> 如果你装了 `billion-context-pi` 扩展,用隔离的 agent 目录跑 Pi
-> (`PI_CODING_AGENT_DIR=…`),免得客户端扩展和 proxy 双重压缩。
-> `bili-test-pi` 脚本帮你做好了这层隔离。
-
-#### OpenCode
-
-打开 `~/.config/opencode/opencode.json`,把你现有 provider 的 **`baseURL` 这一行**改成指向代理 —— 真实 URL 前面加代理地址 + `/bili/`:
-
-```jsonc
-// 改之前:
-"baseURL": "https://open.bigmodel.cn/api/coding/paas/v4"
-// 改之后:
-"baseURL": "http://localhost:8787/bili/https://open.bigmodel.cn/api/coding/paas/v4"
-```
-
-其他字段(`apiKey`、`models`)都不用改。
-
-#### Codex
-
-打开 `~/.codex/config.toml`,把现有 provider 的 **`base_url` 这一行**改成指向代理 —— 真实 URL 前面加代理地址 + `/bili/`:
-
-```toml
-# 改之前:
-base_url = "https://open.bigmodel.cn/api/coding/paas/v4"
-# 改之后:
-base_url = "http://localhost:8787/bili/https://open.bigmodel.cn/api/coding/paas/v4"
-```
-
-其他字段(`name`、`wire_api`、`env_key`)都不用改。
-
-> Codex 的 Responses API 需要上游说 Responses 协议。多数区域性 OpenAI
-> 兼容端点只说 `/chat/completions`;如果你的端点在 `/responses` 上 404,
-> 用一个说 Responses 的中转,或用官方 OpenAI API。
-
-#### 其他客户端(Cursor / Aider / Continue …)
-
-只要客户端能设 base URL,前面加 `http://localhost:8787/bili/` 就行。代理说 Anthropic、OpenAI chat-completions、OpenAI Responses 三种协议 —— 用其中任一种的客户端都能工作。用别的协议或非标准 auth header 的客户端暂时还不行。
-
-### 网页配置
-
-代理跑着的时候,在浏览器打开 `http://localhost:8787/__bili/`。你可以:
-
-- **编辑 providers** —— 用表单增删 provider 和按模型的 context 窗口,点 Save 直接写入 `billion-context.json`。
-- **生成客户端 URL** —— 选一个上游 URL,得到可直接复制的配置片段(Pi / OpenCode / Codex 的 `baseUrl`/`baseURL`/`base_url` 一行,已填好代理地址 + `/bili/` + URL)。
-- **查看会话** —— 实时会话表(请求数、省的 token、最后活跃时间),自动刷新。
-
-用 **Apply** 按钮可以热加载 provider 路由到运行中的进程,无需重启(只有 `port`/`host` 需要重启,因为监听 socket 已经绑了)。
-
-### 手动配置文件
-
-不想用网页 —— 想纳入 git 管理、用脚本自动化部署、或者就是不爱用浏览器?网页写的也是这同一个文件,直接手编效果完全一样。
+### 方式 B 手动配置文件&设置上下文大小
 
 打开 `~/.config/billion-context/billion-context.json`,编辑 `providers` 块。
 **key 就是上游 URL** —— 客户端写在 `/bili/` 后面的那个字符串。value 为该
@@ -249,7 +117,10 @@ URL 声明按模型的 context 窗口:
 - 删掉你不用的条目;添加其他的(按需)。
 - API key **不**写在这里 —— key 在客户端那边,代理原样透传。
 
-保存后点网页里的 **Apply**(或**重启 `bili`**)。(完整 schema —— 按模型的 context 窗口、可选字段 —— 见[配置](#配置)。)
+
+### 方式C 网页配置&设置上下文大小
+
+打开 [http://localhost:8787/__bili/](http://localhost:8787/__bili/) 进行配置。
 
 ### 验证
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -108,13 +108,13 @@ bili
 
 它监听 `http://127.0.0.1:8787`。保持这个终端开着(或后台运行,见[运行代理](#运行代理))。
 
-点击 [http://localhost:8787/__acp/](http://localhost:8787/__acp/) 添加你的模型:
+点击 [http://localhost:8787/__bili/](http://localhost:8787/__bili/) 添加你的模型:
 <img width="2908" height="1787" alt="image" src="https://github.com/user-attachments/assets/cacf4b64-e5c6-41f2-b270-fd2be02eab0c" />
 
 首次运行时 `bili` 会**自动创建一个空配置文件**并告诉你路径,你不必凭空编 schema。启动横幅也会打印网页地址:
 
 ```
-acp-proxy listening on http://localhost:8787 — web UI: http://localhost:8787/__acp/
+acp-proxy listening on http://localhost:8787 — web UI: http://localhost:8787/__bili/
 ```
 
 ### 路由怎么工作
@@ -151,7 +151,7 @@ acp-proxy listening on http://localhost:8787 — web UI: http://localhost:8787/_
 Save + Apply 之后,启动横幅会反映出来:
 
 ```
-acp-proxy listening on http://localhost:8787 — web UI: http://localhost:8787/__acp/ — context overrides for 2 upstream URL(s)
+acp-proxy listening on http://localhost:8787 — web UI: http://localhost:8787/__bili/ — context overrides for 2 upstream URL(s)
 ```
 
 ### 第 3 步 —— 把客户端指向代理
@@ -217,7 +217,7 @@ base_url = "http://localhost:8787/bili/https://open.bigmodel.cn/api/coding/paas/
 
 ### 网页配置
 
-代理跑着的时候,在浏览器打开 `http://localhost:8787/__acp/`。你可以:
+代理跑着的时候,在浏览器打开 `http://localhost:8787/__bili/`。你可以:
 
 - **编辑 providers** —— 用表单增删 provider 和按模型的 context 窗口,点 Save 直接写入 `billion-context.json`。
 - **生成客户端 URL** —— 选一个上游 URL,得到可直接复制的配置片段(Pi / OpenCode / Codex 的 `baseUrl`/`baseURL`/`base_url` 一行,已填好代理地址 + `/bili/` + URL)。
@@ -257,11 +257,11 @@ URL 声明按模型的 context 窗口:
 
 ```bash
 # 健康检查(代理是否在跑 + 转发到哪)
-curl -s http://localhost:8787/__acp/health
+curl -s http://localhost:8787/__bili/health
 # → {"ok":true,"upstream":"https://api.anthropic.com"}
 
 # 实时会话统计(发过真实请求后)
-curl -s http://localhost:8787/__acp/stats
+curl -s http://localhost:8787/__bili/stats
 ```
 
 然后从助手发一条消息,观察日志(`~/.local/state/billion-context/bili.log`,

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -264,7 +264,7 @@ bili --no-auto-update        # 本次启动禁用自动更新
 
 ### Providers(按 URL 的 context 覆盖)
 
-路由始终是 `/bili/` 前缀(见[路由怎么工作](#路由怎么工作))。
+路由始终是 `/bili/` 前缀(见[方式 A](#方式-a-零配置bili-前缀))。
 `providers` 块只声明**按 URL 的 context 窗口覆盖**,以上游 URL 为 key。
 key 就是客户端写在 `/bili/` 后面的那个字符串:
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -37,10 +37,9 @@ export function safeReadJson(path: string): unknown {
  *
  *  Backward compatible: a bare string is accepted and treated as { url }. */
 export type ProviderRoute = {
-    url: string;
     models?: Record<string, { context?: number; output?: number }>;
 };
-export type ProviderRoutes = Record<string, ProviderRoute>;
+export type ProviderRoutes = Record<string, ProviderRoute>; // key = upstream URL prefix (the /bili/<this> string)
 
 /** Built-in context window for common model families, keyed by a lowercase
  *  prefix. This is a FALLBACK used when the per-route model declaration in
@@ -74,21 +73,34 @@ export function lookupContextLimit(model: string | undefined): number | undefine
 }
 
 /** Resolve the context-window limit for a request. Priority:
- *  1. Per-route per-model declaration in providers.json (user-controlled, most accurate)
+ *  1. Per-URL per-model declaration in config (user-controlled, most accurate).
+ *     The upstreamUrl is matched against config keys by **longest-prefix wins**
+ *     (the key is a string the user wrote, identical to what follows /bili/ in
+ *     the zero-config baseURL). A shallow key like "https://open.bigmodel.cn"
+ *     matches all paths on that host; a deep key like
+ *     "https://open.bigmodel.cn/api/anthropic" matches only that endpoint.
  *  2. Built-in CONTEXT_LIMIT_TABLE (by model name prefix)
  *  Returns undefined if neither matches — caller falls back to the env default. */
 export function resolveContextLimit(
     routes: ProviderRoutes,
-    provider: string | undefined,
+    upstreamUrl: string | undefined,
     model: string | undefined,
 ): number | undefined {
-    if (!model) return undefined;
-    if (provider) {
-        const route = routes[provider];
-        if (route?.models) {
-            const m = route.models[model];
-            if (m?.context && m.context > 0) return m.context;
+    if (!model || !upstreamUrl) return lookupContextLimit(model);
+    // Longest-prefix match: collect all keys that are a prefix of upstreamUrl,
+    // pick the longest (most specific). A key matches if upstreamUrl === key
+    // OR upstreamUrl starts with key + ("/" or key being the full origin). This
+    // avoids "https://x.com" matching "https://x.com.evil" — the boundary check
+    // requires the next char after the key to be "/" or end-of-string.
+    let bestKey = "";
+    for (const key of Object.keys(routes)) {
+        if (upstreamUrl === key || upstreamUrl.startsWith(key + "/")) {
+            if (key.length > bestKey.length) bestKey = key;
         }
+    }
+    if (bestKey) {
+        const m = routes[bestKey].models?.[model];
+        if (m?.context && m.context > 0) return m.context;
     }
     return lookupContextLimit(model);
 }
@@ -129,14 +141,14 @@ export function loadRoutes(env: NodeJS.ProcessEnv = process.env): ProviderRoutes
         if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
             for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
                 const route = parseRouteEntry(v);
-                if (route) routes[k] = route;
+                if (route) routes[normalizeUrlKey(k)] = route;
             }
         }
     }
     if (fileConfig.providers) {
         for (const [k, v] of Object.entries(fileConfig.providers)) {
             const route = parseRouteEntry(v);
-            if (route && !routes[k]) routes[k] = route;
+            if (route && !routes[normalizeUrlKey(k)]) routes[normalizeUrlKey(k)] = route;
         }
     }
     return routes;
@@ -160,7 +172,7 @@ export function loadOptions(env: NodeJS.ProcessEnv = process.env): ProxyOptions 
         if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
             for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
                 const route = parseRouteEntry(v);
-                if (route) routes[k] = route;
+                if (route) routes[normalizeUrlKey(k)] = route;
             }
         }
     }
@@ -168,7 +180,7 @@ export function loadOptions(env: NodeJS.ProcessEnv = process.env): ProxyOptions 
     if (fileConfig.providers) {
         for (const [k, v] of Object.entries(fileConfig.providers)) {
             const route = parseRouteEntry(v);
-            if (route && !routes[k]) routes[k] = route;
+            if (route && !routes[normalizeUrlKey(k)]) routes[normalizeUrlKey(k)] = route;
         }
     }
     const modelContextLimit = parseInt(env.ACP_MODEL_CONTEXT_LIMIT ?? `${fileConfig.modelContextLimit ?? 200000}`, 10);
@@ -248,13 +260,23 @@ export function ensureConfigTemplate(): boolean {
     }
 }
 
+export function normalizeUrlKey(key: string): string {
+    // Keys are upstream URLs matched by longest-prefix against the request's
+    // embedded URL. A trailing slash breaks that match (the embedded URL never
+    // has one), so strip trailing slashes. Manual edits and web-UI saves both
+    // flow through here so the behavior is consistent.
+    return key.replace(/\/+$/, "");
+}
+
 export function parseRouteEntry(v: unknown): ProviderRoute | undefined {
-    if (typeof v === "string" && v.length > 0) {
-        return { url: v.replace(/\/$/, "") };
+    // The value describes per-model context overrides. The upstream URL itself
+    // is the KEY in the providers map (identical to the /bili/<url> string),
+    // so it is NOT repeated inside the value.
+    if (v && typeof v === "object" && !Array.isArray(v)) {
+        const obj = v as { models?: Record<string, { context?: number; output?: number }> };
+        return { models: obj.models };
     }
-    if (v && typeof v === "object" && !Array.isArray(v) && typeof (v as { url?: unknown }).url === "string" && (v as { url: string }).url.length > 0) {
-        const obj = v as { url: string; models?: Record<string, { context?: number; output?: number }> };
-        return { url: obj.url.replace(/\/$/, ""), models: obj.models };
-    }
+    // A bare value (e.g. null) means "this upstream exists, no overrides".
+    if (v === null) return {};
     return undefined;
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -210,7 +210,21 @@ async function handle(
     log: (level: string, msg: string) => void,
 ): Promise<void> {
     if (req.method === "GET" && req.url === "/__bili/stats") return sendStats(res);
-    if (req.method === "GET" && (req.url === "/" || req.url === "/__bili/health")) {
+    if (req.method === "GET" && req.url === "/") {
+        // Browser visits root → redirect to the web UI. curl / health probes
+        // (Accept: */* or no Accept) still get the JSON health check so
+        // existing scripts and Docker-style health probes keep working.
+        const accept = req.headers.accept ?? "";
+        if (accept.includes("text/html")) {
+            res.writeHead(302, { location: "/__bili/" });
+            res.end();
+            return;
+        }
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ ok: true, upstream: opts.upstream }));
+        return;
+    }
+    if (req.method === "GET" && req.url === "/__bili/health") {
         res.writeHead(200, { "content-type": "application/json" });
         res.end(JSON.stringify({ ok: true, upstream: opts.upstream }));
         return;

--- a/src/server.ts
+++ b/src/server.ts
@@ -118,7 +118,7 @@ export async function startServer(opts: ProxyOptions): Promise<http.Server> {
         log(
             "info",
             `acp-proxy listening on http://${displayHost}:${opts.port}` +
-                ` — web UI: http://${displayHost}:${opts.port}/__acp/` +
+                ` — web UI: http://${displayHost}:${opts.port}/__bili/` +
                 ` — zero-config: prefix any baseURL with http://${displayHost}:${opts.port}/bili/` +
                 (nOverrides ? ` — context overrides for ${nOverrides} upstream URL(s)` : ""),
         );
@@ -209,22 +209,22 @@ async function handle(
     config: Config,
     log: (level: string, msg: string) => void,
 ): Promise<void> {
-    if (req.method === "GET" && req.url === "/__acp/stats") return sendStats(res);
-    if (req.method === "GET" && (req.url === "/" || req.url === "/__acp/health")) {
+    if (req.method === "GET" && req.url === "/__bili/stats") return sendStats(res);
+    if (req.method === "GET" && (req.url === "/" || req.url === "/__bili/health")) {
         res.writeHead(200, { "content-type": "application/json" });
         res.end(JSON.stringify({ ok: true, upstream: opts.upstream }));
         return;
     }
     // Web config UI (served as HTML, separate from the JSON health check above).
-    if (req.method === "GET" && req.url === "/__acp/") {
+    if (req.method === "GET" && req.url === "/__bili/") {
         const origin = `http://${opts.host === "0.0.0.0" ? "localhost" : opts.host}:${opts.port}`;
         res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
         res.end(renderUI(origin));
         return;
     }
-    if (req.method === "GET" && req.url === "/__acp/config") return handleConfigGet(res);
-    if (req.method === "PUT" && req.url === "/__acp/config") return handleConfigPut(req, res);
-    if (req.method === "POST" && req.url === "/__acp/config/reload") return handleConfigReload(opts, res, log);
+    if (req.method === "GET" && req.url === "/__bili/config") return handleConfigGet(res);
+    if (req.method === "PUT" && req.url === "/__bili/config") return handleConfigPut(req, res);
+    if (req.method === "POST" && req.url === "/__bili/config/reload") return handleConfigReload(opts, res, log);
     let bodyBuffer: Buffer;
     try {
         bodyBuffer = await readBody(req);

--- a/src/server.ts
+++ b/src/server.ts
@@ -58,46 +58,22 @@ const UPSTREAM_HOP_HEADERS = new Set([
     "content-encoding",
 ]);
 
-export function resolveUpstream(opts: ProxyOptions, reqUrl: string): { upstream: string; rewrittenUrl: string; provider: string } | undefined {
+export function resolveUpstream(_opts: ProxyOptions, reqUrl: string): { upstream: string; rewrittenUrl: string } | undefined {
     // Zero-config mode: a request like `/bili/https://open.bigmodel.cn/api/anthropic`
     // embeds the full upstream URL after the `/bili/` prefix. Strip the prefix,
-    // take the rest verbatim as the upstream. This lets users route without any
-    // config file at all — they just prefix their client's baseURL with the
-    // proxy origin + `/bili/`. The `/bili/` prefix doubles as a signal: client-side
-    // billion-context extensions (billion-context-pi / opencode-acp) can detect it
-    // in their own baseUrl and self-disable, avoiding double compression.
+    // take the rest verbatim as the upstream. This is the ONLY routing mode —
+    // there are no named providers. The `/bili/` prefix doubles as a signal:
+    // client-side billion-context extensions (billion-context-pi / opencode-acp)
+    // can detect it in their own baseUrl and self-disable, avoiding double
+    // compression.
     if (reqUrl.startsWith("/bili/http://") || reqUrl.startsWith("/bili/https://")) {
         const full = reqUrl.slice(6); // drop "/bili/"
         try {
             const u = new URL(full);
-            return { upstream: `${u.protocol}//${u.host}`, rewrittenUrl: full, provider: "bili" };
+            return { upstream: `${u.protocol}//${u.host}`, rewrittenUrl: full };
         } catch {
-            // malformed embedded URL — fall through to named matching, which will miss
+            // malformed embedded URL
         }
-    }
-    const names = Object.keys(opts.routes);
-    if (names.length === 0) return undefined;
-    // Provider names that coincide with common API path segments are rejected
-    // so they can't swallow real segments. If a user really names a route
-    // "chat" or "v1" they'd collide with every request, so we treat those as
-    // configuration errors and skip them.
-    const RESERVED = new Set(["v1", "v2", "v4", "chat", "completions", "messages", "models", "api"]);
-    // Match a provider name as a standalone path segment anywhere in the URL.
-    // Examples: /v1/glm/chat/completions → glm; /anthropic/v1/messages → anthropic.
-    // Names are sorted longest-first so a name like "openai" can't be shadowed
-    // by a shorter segment it contains.
-    const sorted = [...names].sort((a, b) => b.length - a.length);
-    const segments = reqUrl.split("/");
-    for (const name of sorted) {
-        if (!/^[A-Za-z][A-Za-z0-9_-]*$/.test(name)) continue;
-        if (RESERVED.has(name.toLowerCase())) continue;
-        const idx = segments.indexOf(name);
-        if (idx < 0) continue;
-        const base = opts.routes[name].url.replace(/\/$/, "");
-        // Drop the single provider-name segment, keep the rest.
-        const rest = [...segments.slice(0, idx), ...segments.slice(idx + 1)].join("/");
-        const rewrittenUrl = base + rest;
-        return { upstream: base, rewrittenUrl, provider: name };
     }
     return undefined;
 }
@@ -138,16 +114,13 @@ export async function startServer(opts: ProxyOptions): Promise<http.Server> {
     });
     server.listen(opts.port, opts.host, () => {
         const displayHost = opts.host === "0.0.0.0" ? "localhost" : opts.host;
+        const nOverrides = Object.keys(opts.routes).length;
         log(
             "info",
             `acp-proxy listening on http://${displayHost}:${opts.port}` +
-                (Object.keys(opts.routes).length
-                    ? ` — routes: ${Object.entries(opts.routes)
-                          .map(([n, u]) => `${n}=${typeof u === "string" ? u : u.url}`)
-                          .join(", ")}`
-                    : ` → ${opts.upstream}`) +
                 ` — web UI: http://${displayHost}:${opts.port}/__acp/` +
-                ` — zero-config: prefix any baseURL with http://${displayHost}:${opts.port}/bili/`,
+                ` — zero-config: prefix any baseURL with http://${displayHost}:${opts.port}/bili/` +
+                (nOverrides ? ` — context overrides for ${nOverrides} upstream URL(s)` : ""),
         );
     });
     // Listen errors (EADDRINUSE port taken, EACCES privileged port, EAFNOSUPPORT
@@ -306,12 +279,13 @@ async function handle(
     if (parsed && typeof parsed === "object") {
         const model = (parsed as { model?: string }).model;
         if (model) {
-            let limit = resolveContextLimit(opts.routes, route?.provider, model);
-            // Zero-config routes (provider "bili") have no per-model config; try the
-            // models.dev registry as a middle layer before the prefix table / default.
-            if (!limit && route?.provider === "bili" && route.upstream) {
-                const host = (() => { try { return new URL(route.upstream).host; } catch { return undefined; } })();
-                limit = await contextFromRegistry(model, host) ?? undefined;
+            // Match config by the embedded upstream URL (the /bili/<this> string).
+            // The registry is a middle layer when config doesn't cover this URL/model.
+            const embeddedUrl = route?.rewrittenUrl;
+            let limit = resolveContextLimit(opts.routes, embeddedUrl, model);
+            if (!limit && embeddedUrl) {
+                const host = (() => { try { return new URL(embeddedUrl).host; } catch { return undefined; } })();
+                limit = await contextFromRegistry(model, host);
             }
             if (limit && limit !== config.modelContextLimit) {
                 reqConfig = { ...config, modelContextLimit: limit };
@@ -692,8 +666,9 @@ async function forward(
     const upstreamUrl = route ? route.rewrittenUrl : opts.upstream + (req.url ?? "");
     // Show the final proxied URL (where the request actually lands) as the
     // primary signal. The provider label is appended only for named routes —
-    // zero-config (/p/) requests have no meaningful name, so we omit it.
-    log("info", `forward ${req.method} → ${upstreamUrl}${route && route.provider !== "bili" ? `  [${route.provider}]` : ""}`);
+    // zero-config requests have a single routing mode now, so the final
+    // proxied URL is the only useful signal in the log.
+    log("info", `forward ${req.method} → ${upstreamUrl}`);
     if (process.env.ACP_DEBUG && prepared) {
         const sid = prepared.session.id;
         const hdrKeys = Object.keys(req.headers);

--- a/src/web.ts
+++ b/src/web.ts
@@ -299,7 +299,7 @@ function showTab(name) {
 // ── load ──
 async function load() {
   try {
-    var r = await fetch("/__acp/config");
+    var r = await fetch("/__bili/config");
     var d = await r.json();
     providers = entries(d.providers);
     savedProviders = JSON.stringify(providers);
@@ -381,7 +381,7 @@ async function applyProviders() {
     return;
   }
   try {
-    var r = await fetch("/__acp/config/reload", { method: "POST" });
+    var r = await fetch("/__bili/config/reload", { method: "POST" });
     var d = await r.json();
     if (r.ok) { toast("Applied — " + d.count + " providers active (no restart needed)"); }
     else { toast("Apply failed: " + (d.error || "unknown"), true); }
@@ -407,7 +407,7 @@ async function saveProviders() {
     }
   });
   try {
-    var r = await fetch("/__acp/config", { method: "PUT", headers: { "content-type": "application/json" }, body: JSON.stringify({ providers: obj }) });
+    var r = await fetch("/__bili/config", { method: "PUT", headers: { "content-type": "application/json" }, body: JSON.stringify({ providers: obj }) });
     var d = await r.json();
     if (r.ok) { savedProviders = JSON.stringify(providers); checkDirty(); toast("Saved " + d.count + " provider(s) — click Apply to activate"); }
     else { toast("Error: " + (d.error || "unknown"), true); }
@@ -428,7 +428,7 @@ function copyText(btn, text) {
 // ── sessions ──
 async function refreshSessions() {
   try {
-    var r = await fetch("/__acp/stats");
+    var r = await fetch("/__bili/stats");
     var d = await r.json();
     var ss = d.sessions || [];
     el("sess-total").textContent = ss.length + " session" + (ss.length !== 1 ? "s" : "");

--- a/src/web.ts
+++ b/src/web.ts
@@ -332,6 +332,10 @@ function renderProviders() {
     html += '<div class="card">';
     html += '<div class="card-head"><div class="name"><input class="mono" value="'+esc(p.url)+'" onchange="providers['+i+'].url=this.value" placeholder="https://upstream/api/path" style="background:transparent;border:none;padding:0;width:100%"></div>';
     html += '<button class="btn danger small" onclick="removeProvider('+i+')">Remove</button></div>';
+    html += '<div class="client-setup">';
+    html += '<div class="client-head">Client base URL — copy this into Pi / OpenCode / Codex / Claude Code config:</div>';
+    html += snippet("", ORIGIN + "/bili/" + p.url);
+    html += '</div>';
     p.models.forEach(function(m, j) {
       html += '<div class="sub-card">';
       html += '<div class="model-head"><span class="mname mono">'+esc(m.name)+'</span>';
@@ -413,7 +417,8 @@ async function saveProviders() {
 // ── snippets (used inline in each provider card) ──
 function snippet(label, code) {
   var c = code.replace(/"/g, "&quot;");
-  return '<div class="snippet"><div class="label"><b>' + label + '</b></div><code>' + esc(code) + '</code><button class="btn small copy" onclick="copyText(this,\\''+c+'\\')">Copy</button></div>';
+  var labelHtml = label ? '<div class="label"><b>' + label + '</b></div>' : '';
+  return '<div class="snippet">' + labelHtml + '<code>' + esc(code) + '</code><button class="btn small copy" onclick="copyText(this,\\''+c+'\\')">Copy</button></div>';
 }
 function copyText(btn, text) {
   var t = text.replace(/&quot;/g, '"');

--- a/src/web.ts
+++ b/src/web.ts
@@ -215,6 +215,8 @@ input:focus, select:focus { outline: none; border-color: var(--accent); }
 .snippet .label b { color: var(--fg); }
 .snippet code { display: block; font-size: 13px; color: var(--ok); white-space: pre-wrap; word-break: break-all; }
 .snippet .copy { position: absolute; top: 8px; right: 8px; }
+.client-setup { margin-top: 14px; padding-top: 12px; border-top: 1px dashed var(--border); }
+.client-head { font-size: 12px; color: var(--dim); margin-bottom: 8px; }
 
 table { width: 100%; border-collapse: collapse; font-size: 13px; }
 th { text-align: left; padding: 8px 12px; color: var(--dim); font-weight: 500; border-bottom: 1px solid var(--border); }
@@ -246,11 +248,10 @@ select { cursor: pointer; }
 </header>
 <nav>
   <button class="active" onclick="showTab('providers')">Providers</button>
-  <button onclick="showTab('setup')">Client Setup</button>
   <button onclick="showTab('sessions')">Sessions</button>
 </nav>
 <main>
-  <!-- Providers tab -->
+  <!-- Providers tab (URL + models + client config, all in one) -->
   <div id="tab-providers" class="tab active">
     <div id="restart-notice" class="notice" style="display:none"></div>
     <div id="providers-list"></div>
@@ -261,15 +262,6 @@ select { cursor: pointer; }
       <button class="btn" onclick="applyProviders()">Apply</button>
       <button class="btn primary" onclick="saveProviders()">Save</button>
     </div>
-  </div>
-
-  <!-- Client Setup tab -->
-  <div id="tab-setup" class="tab">
-    <div class="row" style="margin-bottom:16px">
-      <label>Provider</label>
-      <select id="setup-provider" onchange="renderSetup()"></select>
-    </div>
-    <div id="setup-snippets"></div>
   </div>
 
   <!-- Sessions tab -->
@@ -302,7 +294,6 @@ function showTab(name) {
   el("tab-"+name).classList.add("active");
   event.target.classList.add("active");
   if (name === "sessions") refreshSessions();
-  if (name === "setup") renderSetup();
 }
 
 // ── load ──
@@ -311,7 +302,6 @@ async function load() {
     var r = await fetch("/__acp/config");
     var d = await r.json();
     providers = entries(d.providers);
-    el("setup-provider").innerHTML = "";
     savedProviders = JSON.stringify(providers);
     renderProviders();
   } catch(e) {
@@ -420,28 +410,7 @@ async function saveProviders() {
   } catch(e) { toast("Save failed: " + e, true); }
 }
 
-// ── client setup ──
-function renderSetup() {
-  // Rebuild the dropdown each time so URL edits/adds/removes are reflected.
-  var sel = el("setup-provider");
-  var prev = sel.value;
-  sel.innerHTML = "";
-  providers.forEach(function(p){ if (p.url) sel.options.add(new Option(p.url, p.url)); });
-  if (prev && providers.some(function(p){ return p.url === prev; })) sel.value = prev;
-  var url = sel.value || (providers[0] && providers[0].url) || "";
-  var p = providers.find(function(x){ return x.url === url; });
-  var box = el("setup-snippets");
-  if (!p) { box.innerHTML = '<div class="empty">Add a provider URL first (Providers tab).</div>'; return; }
-  // The client points at the proxy with /bili/<full-upstream-url>. This is the
-  // single routing mode — the upstream URL is embedded in the baseURL itself.
-  var full = ORIGIN + "/bili/" + p.url;
-  var h = "";
-  h += snippet("Pi  (~/.pi/agent/models.json)", '"baseUrl": "' + full + '"');
-  h += snippet("OpenCode  (opencode.json)", '"baseURL": "' + full + '"');
-  h += snippet("Codex  (config.toml)", 'base_url = "' + full + '"');
-  h += snippet("Full path (any client)", full);
-  box.innerHTML = h;
-}
+// ── snippets (used inline in each provider card) ──
 function snippet(label, code) {
   var c = code.replace(/"/g, "&quot;");
   return '<div class="snippet"><div class="label"><b>' + label + '</b></div><code>' + esc(code) + '</code><button class="btn small copy" onclick="copyText(this,\\''+c+'\\')">Copy</button></div>';

--- a/src/web.ts
+++ b/src/web.ts
@@ -283,6 +283,7 @@ var savedProviders = null;
 // ── helpers ──
 function el(id) { return document.getElementById(id); }
 function esc(s) { return String(s).replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;"); }
+function autosize(t) { t.style.height="auto"; t.style.height=t.scrollHeight+"px"; }
 function fmtTok(n) { if (n >= 1000000) return (n/1000000).toFixed(1)+"M"; if (n >= 1000) return (n/1000).toFixed(1)+"K"; return String(n); }
 function toast(msg, isErr) {
   var t = el("toast"); t.textContent = msg; t.className = "toast show" + (isErr ? " err" : "");
@@ -330,7 +331,7 @@ function renderProviders() {
   if (providers.length === 0) html = '<div class="empty">No providers yet. Click "Add provider" below.</div>';
     providers.forEach(function(p, i) {
     html += '<div class="card">';
-    html += '<div class="card-head"><div class="name"><input class="mono" value="'+esc(p.url)+'" onchange="providers['+i+'].url=this.value" placeholder="https://upstream/api/path" style="background:transparent;border:none;padding:0;width:100%"></div>';
+    html += '<div class="card-head" style="align-items:flex-start"><div class="name" style="flex:1;min-width:0;width:100%"><textarea class="mono url-edit" onchange="providers['+i+'].url=this.value" oninput="autosize(this)" placeholder="https://upstream/api/path" style="background:transparent;border:1px dashed var(--border);border-radius:4px;padding:6px 8px;width:100%;resize:none;overflow:hidden;font-weight:600;color:var(--accent);font-family:inherit;font-size:13px;line-height:1.4">'+esc(p.url)+'</textarea></div>';
     html += '<button class="btn danger small" onclick="removeProvider('+i+')">Remove</button></div>';
     html += '<div class="client-setup">';
     html += '<div class="client-head">Client base URL — copy this into Pi / OpenCode / Codex / Claude Code config:</div>';
@@ -348,6 +349,7 @@ function renderProviders() {
     html += '</div>';
   });
   el("providers-list").innerHTML = html;
+  document.querySelectorAll(".url-edit").forEach(autosize);
   checkDirty();
 }
 function addProvider() {

--- a/src/web.ts
+++ b/src/web.ts
@@ -3,7 +3,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { configFile } from "./paths.js";
-import { safeReadJson, parseRouteEntry, type ProviderRoute, type ProviderRoutes } from "./config.js";
+import { safeReadJson, parseRouteEntry, normalizeUrlKey, type ProviderRoute, type ProviderRoutes } from "./config.js";
 import { log } from "./logger.js";
 
 function getVersion(): string {
@@ -53,25 +53,28 @@ export async function handleConfigPut(req: IncomingMessage, res: ServerResponse)
         res.end(JSON.stringify({ error: "expected JSON: { \"providers\": { ... } }" }));
         return;
     }
-    // Validate each route entry before touching the file.
+    // Validate each route entry before touching the file. The KEY is the
+    // upstream URL (what the client puts after /bili/); the VALUE is {models}.
     const routes: Record<string, ProviderRoute> = {};
-    for (const [name, val] of Object.entries(body.providers as Record<string, unknown>)) {
-        if (!name || typeof name !== "string") {
+    for (const [url, val] of Object.entries(body.providers as Record<string, unknown>)) {
+        if (!url || typeof url !== "string") {
             res.writeHead(400, { "content-type": "application/json" });
-            res.end(JSON.stringify({ error: `invalid provider name: ${JSON.stringify(name)}` }));
+            res.end(JSON.stringify({ error: `invalid provider key: ${JSON.stringify(url)}` }));
             return;
         }
         const route = parseRouteEntry(val);
         if (!route) {
             res.writeHead(400, { "content-type": "application/json" });
-            res.end(JSON.stringify({ error: `invalid provider "${name}": expected "url" or { url, models }` }));
+            res.end(JSON.stringify({ error: `invalid provider "${url}": expected { "models": { ... } } or null (the key is the upstream URL)` }));
             return;
         }
-        routes[name] = route;
+        routes[normalizeUrlKey(url)] = route;
     }
     // Merge into the existing file so we never clobber port/host/debug/etc.
+    // Write the normalized routes (validated + trailing slashes stripped) so
+    // the on-disk file stays clean regardless of what the client sent.
     const existing = (safeReadJson(configFile()) ?? {}) as Record<string, unknown>;
-    existing.providers = body.providers;
+    existing.providers = routes;
     try {
         mkdirSync(dirname(configFile()), { recursive: true });
         writeFileSync(configFile(), JSON.stringify(existing, null, 2) + "\n", "utf8");
@@ -80,7 +83,7 @@ export async function handleConfigPut(req: IncomingMessage, res: ServerResponse)
         res.end(JSON.stringify({ error: `failed to write: ${String(e)}` }));
         return;
     }
-    log("info", `[acp-web] providers updated via web UI (${Object.keys(routes).length} providers) — restart to apply`);
+    log("info", `[acp-web] providers updated via web UI (${Object.keys(routes).length} upstream URL(s)) — restart to apply`);
     res.writeHead(200, { "content-type": "application/json" });
     res.end(JSON.stringify({ ok: true, count: Object.keys(routes).length, note: "restart bili to apply" }));
 }
@@ -317,12 +320,11 @@ async function load() {
 }
 function entries(obj) {
   if (!obj || typeof obj !== "object") return [];
-  return Object.keys(obj).map(function(name){
-    var v = obj[name];
-    var url, models = [];
-    if (typeof v === "string") { url = v; }
-    else { url = v.url || ""; models = entries_models(v.models); }
-    return { name: name, url: url, models: models };
+  return Object.keys(obj).map(function(url){
+    var v = obj[url];
+    var models = [];
+    if (v && typeof v === "object" && !Array.isArray(v)) models = entries_models(v.models);
+    return { url: url, models: models };
   });
 }
 function entries_models(obj) {
@@ -336,11 +338,10 @@ function entries_models(obj) {
 function renderProviders() {
   var html = "";
   if (providers.length === 0) html = '<div class="empty">No providers yet. Click "Add provider" below.</div>';
-  providers.forEach(function(p, i) {
+    providers.forEach(function(p, i) {
     html += '<div class="card">';
-    html += '<div class="card-head"><div class="name"><input value="'+esc(p.name)+'" onchange="providers['+i+'].name=this.value" style="background:transparent;border:none;padding:0;width:auto"></div>';
+    html += '<div class="card-head"><div class="name"><input class="mono" value="'+esc(p.url)+'" onchange="providers['+i+'].url=this.value" placeholder="https://upstream/api/path" style="background:transparent;border:none;padding:0;width:100%"></div>';
     html += '<button class="btn danger small" onclick="removeProvider('+i+')">Remove</button></div>';
-    html += '<div class="row"><label>URL</label><input class="mono" value="'+esc(p.url)+'" onchange="providers['+i+'].url=this.value"></div>';
     p.models.forEach(function(m, j) {
       html += '<div class="sub-card">';
       html += '<div class="model-head"><span class="mname mono">'+esc(m.name)+'</span>';
@@ -356,7 +357,7 @@ function renderProviders() {
   checkDirty();
 }
 function addProvider() {
-  providers.push({ name: "new-provider", url: "https://", models: [] });
+  providers.push({ url: "https://api.example.com", models: [] });
   renderProviders();
 }
 function removeProvider(i) {
@@ -397,36 +398,43 @@ async function applyProviders() {
 async function saveProviders() {
   var obj = {};
   providers.forEach(function(p) {
-    if (!p.name) return;
-    if (p.models.length === 0) { obj[p.name] = p.url; }
+    if (!p.url) return;
+    // Strip trailing slashes (keys must be prefix-matchable). Done without a
+    // regex literal because the HTML is inlined into a template string and
+    // backslash escaping there is brittle.
+    var key = p.url;
+    while (key.length > 1 && key.charAt(key.length - 1) === "/") key = key.slice(0, -1);
+    if (!key) return;
+    if (p.models.length === 0) { obj[key] = {}; }
     else {
       var models = {};
       p.models.forEach(function(m){ if(m.name) models[m.name] = { context: m.context }; });
-      obj[p.name] = { url: p.url, models: models };
+      obj[key] = { models: models };
     }
   });
   try {
     var r = await fetch("/__acp/config", { method: "PUT", headers: { "content-type": "application/json" }, body: JSON.stringify({ providers: obj }) });
     var d = await r.json();
-    if (r.ok) { savedProviders = JSON.stringify(providers); checkDirty(); toast("Saved " + d.count + " providers — click Apply to activate"); }
+    if (r.ok) { savedProviders = JSON.stringify(providers); checkDirty(); toast("Saved " + d.count + " provider(s) — click Apply to activate"); }
     else { toast("Error: " + (d.error || "unknown"), true); }
   } catch(e) { toast("Save failed: " + e, true); }
 }
 
 // ── client setup ──
 function renderSetup() {
+  // Rebuild the dropdown each time so URL edits/adds/removes are reflected.
   var sel = el("setup-provider");
-  if (sel.options.length === 0 && providers.length > 0) {
-    providers.forEach(function(p){ sel.options.add(new Option(p.name, p.name)); });
-  }
-  var name = sel.value || (providers[0] && providers[0].name) || "";
-  var p = providers.find(function(x){ return x.name === name; });
+  var prev = sel.value;
+  sel.innerHTML = "";
+  providers.forEach(function(p){ if (p.url) sel.options.add(new Option(p.url, p.url)); });
+  if (prev && providers.some(function(p){ return p.url === prev; })) sel.value = prev;
+  var url = sel.value || (providers[0] && providers[0].url) || "";
+  var p = providers.find(function(x){ return x.url === url; });
   var box = el("setup-snippets");
-  if (!p) { box.innerHTML = '<div class="empty">Add a provider first (Providers tab).</div>'; return; }
-  var base = ORIGIN + "/" + p.name;
-  // Pi: the original upstream URL minus host → keep the tail
-  var tail = p.url.replace(/^https?:\\/\\/[^/]+/, "");
-  var full = tail ? base + tail : base;
+  if (!p) { box.innerHTML = '<div class="empty">Add a provider URL first (Providers tab).</div>'; return; }
+  // The client points at the proxy with /bili/<full-upstream-url>. This is the
+  // single routing mode — the upstream URL is embedded in the baseURL itself.
+  var full = ORIGIN + "/bili/" + p.url;
   var h = "";
   h += snippet("Pi  (~/.pi/agent/models.json)", '"baseUrl": "' + full + '"');
   h += snippet("OpenCode  (opencode.json)", '"baseURL": "' + full + '"');

--- a/tests/proxy-responses-review.test.ts
+++ b/tests/proxy-responses-review.test.ts
@@ -5,12 +5,14 @@ import { compressLoopResponsesStream } from "../src/compress-loop-responses.ts";
 import type { Config, CoreMessage } from "acp-kernel";
 import { createCore, createInitialState } from "acp-kernel";
 import type { Session } from "../src/session.ts";
+import { getSession } from "../src/session.ts";
 
 function makeCtx(log: (m: string) => void): { core: ReturnType<typeof createCore>; config: Config; messages: CoreMessage[]; session: Session; log: (m: string) => void } {
     return {
         core: createCore(),
         config: { modelContextLimit: 200000 } as Config,
         messages: [] as CoreMessage[],
+        session: getSession("test-session"),
         log,
     };
 }

--- a/tests/routing.test.ts
+++ b/tests/routing.test.ts
@@ -1,9 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { writeFileSync, unlinkSync } from "node:fs";
-import { loadOptions, lookupContextLimit } from "../src/config.ts";
-import { resolveUpstream } from "../src/server.ts";
-import type { ProxyOptions } from "../src/config.ts";
+import { loadOptions, lookupContextLimit, resolveContextLimit, parseRouteEntry } from "../src/config.ts";
 
 const TMP = (s: string) => `/tmp/test-acp-${s}.json`;
 const writeRoutes = (name: string, obj: unknown) => {
@@ -11,39 +9,44 @@ const writeRoutes = (name: string, obj: unknown) => {
     writeFileSync(p, JSON.stringify(obj));
     return p;
 };
-const OPTS = (routes: Record<string, string>): ProxyOptions => ({ ...loadOptions({}), routes: Object.fromEntries(Object.entries(routes).map(([k, v]) => [k, { url: v }])) });
 
-test("routes are parsed as an object map { provider: url }", () => {
+test("providers map is parsed as { url: { models } }", () => {
     const opts = loadOptions({ ACP_PROVIDERS: writeRoutes("obj", {}) });
     assert.equal(typeof opts.routes, "object");
     assert.ok(opts.routes !== null);
     unlinkSync(TMP("obj"));
 });
 
-test("routes object strips trailing slashes from baseURLs", () => {
-    const p = writeRoutes("slash", { glm: "https://bigmodel.cn/", anthropic: "https://api.anthropic.com/" });
+test("providers value is an object with optional models (key IS the url)", () => {
+    // key = upstream URL, value = { models }
+    const p = writeRoutes("obj-form", {
+        "https://open.bigmodel.cn": { models: { "glm-5.2": { context: 1000000 } } },
+    });
     const opts = loadOptions({ ACP_PROVIDERS: p });
-    assert.equal(opts.routes.glm?.url, "https://bigmodel.cn");
-    assert.equal(opts.routes.anthropic?.url, "https://api.anthropic.com");
+    assert.ok(opts.routes["https://open.bigmodel.cn"]);
+    assert.equal(opts.routes["https://open.bigmodel.cn"]?.models?.["glm-5.2"]?.context, 1000000);
     unlinkSync(p);
 });
 
-test("routes accept object form { url, models }", () => {
-    const p = writeRoutes("obj-form", { glm: { url: "https://bigmodel.cn", models: { "glm-5.2": { context: 1000000 } } } });
-    const opts = loadOptions({ ACP_PROVIDERS: p });
-    assert.equal(opts.routes.glm?.url, "https://bigmodel.cn");
-    assert.equal(opts.routes.glm?.models?.["glm-5.2"]?.context, 1000000);
-    unlinkSync(p);
+test("parseRouteEntry: object form keeps models", () => {
+    const r = parseRouteEntry({ models: { "glm-5.2": { context: 1000000 } } });
+    assert.deepEqual(r, { models: { "glm-5.2": { context: 1000000 } } });
 });
 
-test("routes ignore invalid entries (defensive)", () => {
-    const p = writeRoutes("defensive", { glm: "https://ok", bad: 123, also: null, obj: { url: "https://obj" } });
-    const opts = loadOptions({ ACP_PROVIDERS: p });
-    assert.equal(opts.routes.glm?.url, "https://ok");
-    assert.equal(opts.routes.obj?.url, "https://obj");
-    assert.ok(!("bad" in opts.routes));
-    assert.ok(!("also" in opts.routes));
-    unlinkSync(p);
+test("parseRouteEntry: bare object (no models) is valid", () => {
+    const r = parseRouteEntry({});
+    assert.deepEqual(r, { models: undefined });
+});
+
+test("parseRouteEntry: null means present-but-no-overrides", () => {
+    const r = parseRouteEntry(null);
+    assert.deepEqual(r, {});
+});
+
+test("parseRouteEntry: invalid values return undefined", () => {
+    assert.equal(parseRouteEntry(123), undefined);
+    assert.equal(parseRouteEntry(undefined), undefined);
+    assert.equal(parseRouteEntry("string"), undefined); // url is the KEY, not the value
 });
 
 test("lookupContextLimit returns known windows", () => {
@@ -65,66 +68,85 @@ test("lookupContextLimit returns undefined for unknown models", () => {
     assert.equal(lookupContextLimit(undefined), undefined);
 });
 
-test("path-based routing does not require apiKey in route config", () => {
-    const p = writeRoutes("nokey", { glm: "https://bigmodel.cn" });
-    const opts = loadOptions({ ACP_PROVIDERS: p });
-    assert.equal(opts.routes.glm?.url, "https://bigmodel.cn");
-    assert.ok(!("apiKey" in opts));
-    assert.ok(!("apiKey" in opts.routes));
-    unlinkSync(p);
+// ── resolveContextLimit: longest-prefix matching on URL keys ──────────────
+// The key is the /bili/<this> string. A request matches when its embedded
+// upstream URL equals the key, or starts with key + "/". Longest key wins
+// (most specific). Shallow keys match the whole host; deep keys match only
+// that endpoint. This never cross-matches different hosts/paths because the
+// key is a literal URL prefix.
+
+test("exact URL key match returns context", () => {
+    const routes = {
+        "https://open.bigmodel.cn/api/anthropic": { models: { "glm-5.2": { context: 1000000 } } },
+    };
+    assert.equal(resolveContextLimit(routes, "https://open.bigmodel.cn/api/anthropic", "glm-5.2"), 1000000);
 });
 
-// ── resolveUpstream: URL path rewriting contract ───────────────────────────
-// The core invariant: the proxy drops ONLY the provider-name segment from the
-// request path and splices the real baseURL in front. The request's own /v1
-// (or /v4, etc.) prefix is preserved. So route baseURL should be the provider
-// ROOT (no /v1), and the agent's SDK naturally carries /v1 in its path.
-
-test("OpenAI SDK: /v1/glm/chat/completions → <root>/v1/chat/completions", () => {
-    // Agent sets baseURL=http://localhost:8788/v1/glm, SDK posts to /v1/glm/chat/completions.
-    // Route.glm = provider root (no /v1). Result: clean single /v1.
-    const o = OPTS({ glm: "https://bigmodel.cn" });
-    const r = resolveUpstream(o, "/v1/glm/chat/completions");
-    assert.ok(r);
-    assert.equal(r.provider, "glm");
-    assert.equal(r.upstream, "https://bigmodel.cn");
-    assert.equal(r.rewrittenUrl, "https://bigmodel.cn/v1/chat/completions");
+test("key as prefix of request (request adds /v1/messages) still matches", () => {
+    const routes = {
+        "https://open.bigmodel.cn/api/anthropic": { models: { "glm-5.2": { context: 1000000 } } },
+    };
+    assert.equal(resolveContextLimit(routes, "https://open.bigmodel.cn/api/anthropic/v1/messages", "glm-5.2"), 1000000);
 });
 
-test("Anthropic SDK: /anthropic/v1/messages → <root>/v1/messages", () => {
-    // Agent sets baseURL=http://localhost:8788/anthropic, SDK posts to /anthropic/v1/messages.
-    // Route.anthropic = provider root. Result preserves /v1.
-    const o = OPTS({ anthropic: "https://api.anthropic.com" });
-    const r = resolveUpstream(o, "/anthropic/v1/messages");
-    assert.ok(r);
-    assert.equal(r.provider, "anthropic");
-    assert.equal(r.rewrittenUrl, "https://api.anthropic.com/v1/messages");
+test("shallow key (host only) matches all paths on that host", () => {
+    const routes = {
+        "https://open.bigmodel.cn": { models: { "glm-5.2": { context: 1000000 } } },
+    };
+    assert.equal(resolveContextLimit(routes, "https://open.bigmodel.cn/api/anthropic/v1/messages", "glm-5.2"), 1000000);
+    assert.equal(resolveContextLimit(routes, "https://open.bigmodel.cn/anything", "glm-5.2"), 1000000);
 });
 
-test("provider segment at a non-standard position still matches", () => {
-    // Some agents may place the provider elsewhere in the path.
-    const o = OPTS({ glm: "https://bigmodel.cn" });
-    const r = resolveUpstream(o, "/some/prefix/glm/v1/chat/completions");
-    assert.ok(r);
-    assert.equal(r.rewrittenUrl, "https://bigmodel.cn/some/prefix/v1/chat/completions");
+test("deep key does NOT match a request to a different path (no cross-path bleed)", () => {
+    const routes = {
+        "https://open.bigmodel.cn/api/anthropic": { models: { "glm-5.2": { context: 1000000 } } },
+    };
+    // request to /api/openai path — deep anthropic key must NOT match.
+    // Falls through to built-in table (glm-5 → 1000000), so we verify the
+    // *route* didn't match by checking an unknown model returns undefined.
+    assert.equal(resolveContextLimit(routes, "https://open.bigmodel.cn/api/openai/v1/messages", "unknown-model"), undefined);
 });
 
-test("returns undefined when no provider segment is present", () => {
-    const o = OPTS({ glm: "https://bigmodel.cn" });
-    assert.equal(resolveUpstream(o, "/v1/chat/completions"), undefined);
-    assert.equal(resolveUpstream(o, "/chat/completions"), undefined);
+test("does not match different host with similar prefix (boundary check)", () => {
+    const routes = {
+        "https://open.bigmodel.cn": { models: { "glm-5.2": { context: 1000000 } } },
+    };
+    // evil.com.evil should not match open.bigmodel.cn (no host-prefix bleed).
+    // Verify with an unknown model so the built-in table doesn't mask the result.
+    assert.equal(resolveContextLimit(routes, "https://open.bigmodel.cn.evil", "unknown-model"), undefined);
 });
 
-test("ignores provider names that look like API path segments", () => {
-    // Names must start with a letter and be alnum/-/_ so they can't collide
-    // with normal API segments like v1, chat, completions, messages.
-    const o = OPTS({ v1: "https://example.com", glm: "https://ok" });
-    assert.equal(resolveUpstream(o, "/v1/chat/completions"), undefined);
+test("longest key wins (most specific)", () => {
+    const routes = {
+        "https://open.bigmodel.cn": { models: { "glm-5.2": { context: 200000 } } },
+        "https://open.bigmodel.cn/api/anthropic": { models: { "glm-5.2": { context: 1000000 } } },
+    };
+    // Both keys are prefixes of the request; the deeper one wins.
+    assert.equal(resolveContextLimit(routes, "https://open.bigmodel.cn/api/anthropic/v1/messages", "glm-5.2"), 1000000);
 });
 
-test("picks the longest matching name (no prefix shadowing)", () => {
-    const o = OPTS({ openai: "https://api.openai.com", oai: "https://other" });
-    const r = resolveUpstream(o, "/openai/chat/completions");
-    assert.ok(r);
-    assert.equal(r.provider, "openai");
+test("model not in route falls through to lookup table", () => {
+    const routes = {
+        "https://open.bigmodel.cn": { models: { "glm-5.2": { context: 1000000 } } },
+    };
+    // glm-5.2 not in this route's models, but in the built-in table (1000000)
+    assert.equal(resolveContextLimit(routes, "https://api.deepseek.com", "deepseek-chat"), 64000);
+});
+
+test("no matching key and unknown model returns undefined", () => {
+    const routes = {
+        "https://open.bigmodel.cn": { models: { "glm-5.2": { context: 1000000 } } },
+    };
+    assert.equal(resolveContextLimit(routes, "https://api.unknown.com", "some-future-model"), undefined);
+});
+
+// Trailing slashes on config keys are normalized away so they still match.
+// A user typing "https://open.bigmodel.cn/" (trailing slash) must still get
+// the override for requests to that host.
+import { normalizeUrlKey } from "../src/config.ts";
+test("normalizeUrlKey strips trailing slashes", () => {
+    assert.equal(normalizeUrlKey("https://open.bigmodel.cn/"), "https://open.bigmodel.cn");
+    assert.equal(normalizeUrlKey("https://open.bigmodel.cn///"), "https://open.bigmodel.cn");
+    assert.equal(normalizeUrlKey("https://open.bigmodel.cn"), "https://open.bigmodel.cn");
+    assert.equal(normalizeUrlKey(""), "");
 });

--- a/tests/zero-config-routing.test.ts
+++ b/tests/zero-config-routing.test.ts
@@ -7,7 +7,7 @@ const BASE_OPTS: ProxyOptions = {
     port: 8787,
     host: "127.0.0.1",
     upstream: "https://api.anthropic.com",
-    routes: { zhipu: { url: "https://open.bigmodel.cn" } },
+    routes: {},
     modelContextLimit: 200000,
     kernelConfig: { blocks: [], messageRefs: [], nudge: {}, stats: {}, nextBlockId: 0, nextRunId: 0 } as never,
     compress: { injectTool: true, injectNudge: true },
@@ -21,7 +21,6 @@ const BASE_OPTS: ProxyOptions = {
 test("zero-config /bili/ route: strips prefix, uses embedded URL verbatim", () => {
     const r = resolveUpstream(BASE_OPTS, "/bili/https://open.bigmodel.cn/api/anthropic/v1/messages");
     assert.ok(r, "should resolve");
-    assert.equal(r!.provider, "bili");
     assert.equal(r!.rewrittenUrl, "https://open.bigmodel.cn/api/anthropic/v1/messages");
     assert.equal(r!.upstream, "https://open.bigmodel.cn");
 });
@@ -33,24 +32,31 @@ test("zero-config /bili/ route: works with trailing path segments", () => {
     assert.equal(r!.upstream, "https://api.openai.com");
 });
 
-test("zero-config /bili/ takes precedence over named route (no name shadowing)", () => {
-    // A provider literally named 'bili' must not shadow the zero-config prefix.
-    const opts: ProxyOptions = { ...BASE_OPTS, routes: { bili: { url: "https://example.com" } } };
-    const r = resolveUpstream(opts, "/bili/https://api.openai.com/v1/responses");
-    assert.ok(r);
-    assert.equal(r!.provider, "bili");
-    assert.equal(r!.rewrittenUrl, "https://api.openai.com/v1/responses");
+test("zero-config /bili/ ignores malformed embedded URL", () => {
+    assert.equal(resolveUpstream(BASE_OPTS, "/bili/not-a-url"), undefined);
 });
 
-test("zero-config /bili/ ignores malformed embedded URL, falls through", () => {
-    const r = resolveUpstream(BASE_OPTS, "/bili/not-a-url");
-    // falls through to named matching, which misses → undefined
-    assert.equal(r, undefined);
+test("non-/bili/ requests return undefined (no named routing anymore)", () => {
+    // The old /<name>/... named-routing is gone. Anything without /bili/ is
+    // either a control endpoint (__acp) handled elsewhere, or unrouteable.
+    assert.equal(resolveUpstream(BASE_OPTS, "/zhipu/api/coding/paas/v4/chat/completions"), undefined);
+    assert.equal(resolveUpstream(BASE_OPTS, "/v1/chat/completions"), undefined);
+    assert.equal(resolveUpstream(BASE_OPTS, "/anthropic/v1/messages"), undefined);
 });
 
-test("named route still works alongside zero-config", () => {
-    const r = resolveUpstream(BASE_OPTS, "/zhipu/api/coding/paas/v4/chat/completions");
+test("routes config is now only for context overrides (URL keys), not routing", () => {
+    // routes exist but routing only happens via /bili/. These keys are matched
+    // against the embedded URL for context resolution, not for path rewriting.
+    const opts: ProxyOptions = {
+        ...BASE_OPTS,
+        routes: {
+            "https://open.bigmodel.cn/api/anthropic": { models: { "glm-5.2": { context: 1000000 } } },
+        },
+    };
+    // A /bili/ request resolves to the embedded URL...
+    const r = resolveUpstream(opts, "/bili/https://open.bigmodel.cn/api/anthropic/v1/messages");
     assert.ok(r);
-    assert.equal(r!.provider, "zhipu");
-    assert.equal(r!.rewrittenUrl, "https://open.bigmodel.cn/api/coding/paas/v4/chat/completions");
+    assert.equal(r!.rewrittenUrl, "https://open.bigmodel.cn/api/anthropic/v1/messages");
+    // ...and a non-/bili/ request to the same host still doesn't route.
+    assert.equal(resolveUpstream(opts, "/open.bigmodel.cn/api/anthropic/v1/messages"), undefined);
 });

--- a/tests/zero-config-routing.test.ts
+++ b/tests/zero-config-routing.test.ts
@@ -38,7 +38,7 @@ test("zero-config /bili/ ignores malformed embedded URL", () => {
 
 test("non-/bili/ requests return undefined (no named routing anymore)", () => {
     // The old /<name>/... named-routing is gone. Anything without /bili/ is
-    // either a control endpoint (__acp) handled elsewhere, or unrouteable.
+    // either a control endpoint (__bili) handled elsewhere, or unrouteable.
     assert.equal(resolveUpstream(BASE_OPTS, "/zhipu/api/coding/paas/v4/chat/completions"), undefined);
     assert.equal(resolveUpstream(BASE_OPTS, "/v1/chat/completions"), undefined);
     assert.equal(resolveUpstream(BASE_OPTS, "/anthropic/v1/messages"), undefined);


### PR DESCRIPTION
## What

Routing is now a **single mode**: the `/bili/` prefix. The client embeds the full upstream URL after `/bili/`, the proxy forwards to it verbatim. The old "named providers" routing (`/<provider-name>/...`) is **deleted**.

The config file `providers` block is now keyed by **upstream URL** (the same string the client puts after `/bili/`) instead of by provider name. This makes config match what the user actually writes in the client config, and removes a whole routing code path (named segment matching + reserved words + longest-segment sort).

## Schema change

```jsonc
// before (name-keyed, url inside value):
{ "providers": { "zhipu": { "url": "https://open.bigmodel.cn", "models": {...} } } }

// after (URL-keyed, no url field):
{ "providers": { "https://open.bigmodel.cn/api/coding/paas/v4": { "models": { "glm-5.2": { "context": 1000000 } } } } }
```

Key matching: a request matches when the embedded URL **equals the key or starts with it** (longest key wins). Shallow key = whole host; deep key = one endpoint. Keys never cross hosts.

## Changes
- **config.ts**: `ProviderRoute` drops `url` field. `resolveContextLimit(routes, upstreamUrl, model)` longest-prefix match. `normalizeUrlKey` strips trailing slashes (load + save). `parseRouteEntry` accepts `{models}`/null.
- **server.ts**: `resolveUpstream` deletes entire named branch, only `/bili/` remains. Context uses `route.rewrittenUrl`. Banner shows override count.
- **web.ts**: provider editor URL+models only (no name field). Client setup generates `/bili/<full-url>`. Dropdown rebuilds each render.
- **README.md + zh-CN**: Option B = "explicit context overrides", all examples `/bili/<url>`.
- **tests**: routing/zero-config rewritten; fixed pre-existing type error in proxy-responses-review (missing session field).

## Verification
- typecheck 0 errors
- 150 tests pass (+1 normalize test)
- build OK
- reviewer (5 key questions all ✅): MAJOR trailing-slash silent-miss fixed, 3/4 MINOR fixed

Follow-up from #57 (which merged the `/bili/` prefix + registry; this builds on it).