### PR TITLE
release v0.1.24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.21",
+  "version": "0.1.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.21",
+      "version": "0.1.24",
       "license": "MIT",
       "dependencies": {
         "acp-kernel": "0.0.17"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Version bump 0.1.23 → 0.1.24.

## What's in this release (from PR#58)

- **URL-keyed config (delete named routing):** single routing mode /bili/<full-upstream-url>. Config providers key is now the upstream URL (was provider name); resolveContextLimit does longest-prefix match. /zhipu/... etc. named routes removed.
- **Web UI:** merged Client Setup tab into Providers (each card shows client baseURL snippet + Copy); provider URL editor is now an autosize textarea (full URL visible); GET / browser visits redirect to /__bili/.
- **Brand alignment:** control path /__acp/ → /__bili/.
- **README:** EN + ZH aligned to simplified 3-Option Quickstart (A zero-config / B manual config / C web UI); dead anchors fixed; screenshots dropped.

## Pre-flight
- typecheck ✅
- 150 test pass ✅
- build ✅ (268.91 KB)

## Publish
Merge this PR → CI (release.yml) detects the release v0.1.24 commit → publishes billion-context@0.1.24 to npm.