### PR TITLE
fix: 6 audit findings (lossless protocol + security + Windows + packaging)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,13 @@
 {
   "name": "billion-context",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.24",
+      "version": "0.1.25",
       "license": "MIT",
-      "dependencies": {
-        "acp-kernel": "0.0.17"
-      },
       "bin": {
         "bili": "dist/index.js",
         "bili-proxy": "dist/index.js"
@@ -18,6 +15,7 @@
       "devDependencies": {
         "@types/node": "^22.0.0",
         "@types/node-forge": "^1.3.14",
+        "acp-kernel": "0.0.17",
         "node-forge": "^1.4.0",
         "tar": "^7.5.22",
         "tsup": "^8.0.0",
@@ -975,6 +973,7 @@
       "version": "0.0.17",
       "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.17.tgz",
       "integrity": "sha512-Mu7CIU1jo79cqHV6tZ8OgZe9ed4HBctVUsoSLKK3SStpkExZw7O3lcUTJLXNqyViuYA83gVH4Z8t43hn89qDDg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -38,10 +38,9 @@
   "bugs": {
     "url": "https://github.com/ranxianglei/billion-context/issues"
   },
-  "dependencies": {
-    "acp-kernel": "0.0.17"
-  },
+  "dependencies": {},
   "devDependencies": {
+    "acp-kernel": "0.0.17",
     "@types/node": "^22.0.0",
     "@types/node-forge": "^1.3.14",
     "node-forge": "^1.4.0",

--- a/src/anthropic.ts
+++ b/src/anthropic.ts
@@ -1,4 +1,5 @@
 import type { CoreMessage } from "acp-kernel";
+import type { BiliMessage } from "./bili-message.js";
 import { hashId } from "./util.js";
 import { ClusterCounter, deriveMessageId } from "./message-id.js";
 
@@ -57,10 +58,10 @@ export function buildSystem(text: string, original: AnthropicRequestBody["system
     return text;
 }
 
-type Flat = { msgs: CoreMessage[]; cacheControls: Map<string, unknown> };
+type Flat = { msgs: BiliMessage[]; cacheControls: Map<string, unknown> };
 
 export function anthropicToCore(body: AnthropicRequestBody): Flat {
-    const msgs: CoreMessage[] = [];
+    const msgs: BiliMessage[] = [];
     const cacheControls = new Map<string, unknown>();
     const clusters = new ClusterCounter();
     for (const m of body.messages) {
@@ -101,18 +102,31 @@ export function anthropicToCore(body: AnthropicRequestBody): Flat {
                         contentType: "tool-result",
                         toolCallId: b.tool_use_id,
                         text,
+                        ...(b.is_error === true ? { toolIsError: true } : {}),
                     });
                     if (b.cache_control) cacheControls.set(id, b.cache_control);
                     break;
                 }
                 case "thinking": {
                     const base = deriveMessageId("assistant", "reasoning", b.thinking);
-                    msgs.push({ id: clusters.next(base), role: "assistant", contentType: "reasoning", text: b.thinking });
+                    msgs.push({
+                        id: clusters.next(base),
+                        role: "assistant",
+                        contentType: "reasoning",
+                        text: b.thinking,
+                        ...(b.signature ? { thinkingSignature: b.signature } : {}),
+                    });
                     break;
                 }
                 case "image": {
                     const base = deriveMessageId(m.role, "text", "[image]");
-                    msgs.push({ id: clusters.next(base), role: m.role, contentType: "text", text: "[image]" });
+                    msgs.push({
+                        id: clusters.next(base),
+                        role: m.role,
+                        contentType: "text",
+                        text: "[image]",
+                        rawAnthropicBlock: b,
+                    });
                     break;
                 }
             }
@@ -121,7 +135,7 @@ export function anthropicToCore(body: AnthropicRequestBody): Flat {
     return { msgs, cacheControls };
 }
 
-export function coreToAnthropic(messages: CoreMessage[], cacheControls?: Map<string, unknown>): AnthropicMessage[] {
+export function coreToAnthropic(messages: BiliMessage[], cacheControls?: Map<string, unknown>): AnthropicMessage[] {
     const out: AnthropicMessage[] = [];
     let current: { role: "user" | "assistant"; blocks: AnthropicBlock[] } | null = null;
     const flush = () => {
@@ -142,9 +156,14 @@ export function coreToAnthropic(messages: CoreMessage[], cacheControls?: Map<str
             current = { role: target, blocks: [] };
         }
         switch (m.contentType) {
-            case "text":
+            case "text": {
+                if (m.rawAnthropicBlock) {
+                    current.blocks.push(m.rawAnthropicBlock as AnthropicBlock);
+                    break;
+                }
                 current.blocks.push({ type: "text", text: m.text ?? "", ...cc(m.id) });
                 break;
+            }
             case "tool-call":
                 current.blocks.push({
                     type: "tool_use",
@@ -159,11 +178,16 @@ export function coreToAnthropic(messages: CoreMessage[], cacheControls?: Map<str
                     type: "tool_result",
                     tool_use_id: m.toolCallId ?? "",
                     content: m.text ?? "",
+                    ...(m.toolIsError ? { is_error: true } : {}),
                     ...cc(m.id),
                 });
                 break;
             case "reasoning":
-                current.blocks.push({ type: "thinking", thinking: m.text ?? "" });
+                current.blocks.push({
+                    type: "thinking",
+                    thinking: m.text ?? "",
+                    ...(m.thinkingSignature ? { signature: m.thinkingSignature } : {}),
+                });
                 break;
         }
     }

--- a/src/bili-message.ts
+++ b/src/bili-message.ts
@@ -1,0 +1,68 @@
+/**
+ * Lossless message bridge between protocol-specific message formats and the
+ * kernel's CoreMessage.
+ *
+ * Problem: `anthropicToCore` / `openaiToCore` / `responsesToCore` flatten
+ * rich protocol blocks (images, thinking signatures, tool_result.is_error,
+ * developer-role messages, image_url) into plain `{ text }` placeholders.
+ * The reverse `coreToX` then can't reconstruct them — `is_error` is lost
+ * (upstream can't tell a tool error from a result), `thinking.signature` is
+ * lost (Anthropic rejects thinking blocks without a matching signature),
+ * images become "[image]" (the model never sees the picture).
+ *
+ * Solution: `BiliMessage` extends CoreMessage with optional sidecar fields.
+ * The kernel only reads `{ ...message }` (spread copy) and known fields, so
+ * the extra fields survive the compression pipeline unchanged and arrive back
+ * at `coreToX`, which prefers them over the flattened `text`. No `as any`
+ * needed — TypeScript array covariance lets `BiliMessage[]` satisfy a
+ * `CoreMessage[]` parameter.
+ */
+
+import type { CoreMessage } from "acp-kernel";
+
+/** A message that carries its original protocol block(s) verbatim, so the
+ *  reverse conversion can reconstruct losslessly. Every field is optional —
+ *  plain text messages (the common case) have none set. */
+export interface BiliMessage extends CoreMessage {
+    /** Anthropic: the original content block for an image or a structured
+     *  tool_result. Restored verbatim by coreToAnthropic. */
+    rawAnthropicBlock?: unknown;
+    /** OpenAI chat: the original content part for an image_url, or the
+     *  original message object for a developer-role message. */
+    rawOpenaiContent?: unknown;
+    /** Responses API: the original input item (for input_image, or a raw
+     *  function_call / function_call_output we pass through). */
+    rawResponsesItem?: unknown;
+    /** Anthropic thinking signature. Anthropic verifies thinking+signature
+     *  pairs; without it the request is rejected. Stored alongside the
+     *  reasoning text so coreToAnthropic can reattach it. */
+    thinkingSignature?: string;
+    /** Anthropic tool_result.is_error. Marks the tool result as an error so
+     *  the model knows the tool failed (not just returned an error string). */
+    toolIsError?: boolean;
+    /** OpenAI: original role was "developer" (reconstructed as "system" by
+     *  openaiToCore for the kernel; coreToOpenai restores "developer"). */
+    originalRole?: "system" | "developer";
+    /** The original media type for an image (image/png, image/jpeg, image/gif,
+     *  image/webp). Lets coreToOpenai/coreToResponses rebuild image_url /
+     *  input_image with the right data URL. */
+    imageMediaType?: string;
+    /** The base64 data of an image (without the data: prefix). Lets the
+     *  reverse conversion rebuild the full image payload. */
+    imageBase64?: string;
+}
+
+/** Narrow a BiliMessage[] to CoreMessage[] for the kernel. The sidecar fields
+ *  are transparently carried along — the kernel's `{ ...msg }` copies them. */
+export function toCoreMessages(msgs: BiliMessage[]): CoreMessage[] {
+    return msgs as CoreMessage[];
+}
+
+/** Re-decode a base64 data URL into media type + data. Returns undefined if
+ *  the input is not a recognized data URL. Used by openaiToCore/responsesToCore
+ *  to split image_url/input_image into the sidecar fields. */
+export function parseDataUrl(url: string): { mediaType: string; base64: string } | undefined {
+    const m = /^data:([^;,]+)(?:;base64)?,(.+)$/i.exec(url);
+    if (!m) return undefined;
+    return { mediaType: m[1], base64: m[2] };
+}

--- a/src/openai.ts
+++ b/src/openai.ts
@@ -1,6 +1,7 @@
 import type { CoreMessage } from "acp-kernel";
 import { hashId } from "./util.js";
 import { ClusterCounter, deriveMessageId } from "./message-id.js";
+import { parseDataUrl, type BiliMessage } from "./bili-message.js";
 
 export type OpenAIContentPart =
     | { type: "text"; text: string }
@@ -34,22 +35,30 @@ export type OpenAIRequestBody = {
     [key: string]: unknown;
 };
 
-type Flat = { msgs: CoreMessage[] };
+type Flat = { msgs: BiliMessage[] };
 
 export function openaiToCore(body: OpenAIRequestBody): Flat {
-    const msgs: CoreMessage[] = [];
+    const msgs: BiliMessage[] = [];
     const clusters = new ClusterCounter();
     for (const m of body.messages) {
         switch (m.role) {
             case "system":
             case "developer": {
                 const base = deriveMessageId(m.role, "text", stringContent(m.content));
-                msgs.push({ id: clusters.next(base), role: "system", contentType: "text", text: stringContent(m.content) });
+                msgs.push({ id: clusters.next(base), role: "system", contentType: "text", text: stringContent(m.content), originalRole: m.role });
                 break;
             }
             case "user": {
-                const base = deriveMessageId("user", "text", stringContent(m.content));
-                msgs.push({ id: clusters.next(base), role: "user", contentType: "text", text: stringContent(m.content) });
+                const text = stringContent(m.content);
+                const img = firstImagePart(m.content);
+                const base = deriveMessageId("user", "text", text);
+                msgs.push({
+                    id: clusters.next(base),
+                    role: "user",
+                    contentType: "text",
+                    text,
+                    ...(img ? { rawOpenaiContent: img.part, imageMediaType: img.mediaType, imageBase64: img.base64 } : {}),
+                });
                 break;
             }
             case "assistant": {
@@ -94,7 +103,7 @@ export function openaiToCore(body: OpenAIRequestBody): Flat {
     return { msgs };
 }
 
-export function coreToOpenai(messages: CoreMessage[]): OpenAIMessage[] {
+export function coreToOpenai(messages: BiliMessage[]): OpenAIMessage[] {
     const out: OpenAIMessage[] = [];
     let pending: { text: string | null; toolCalls: OpenAIToolCall[] } | null = null;
     const flush = () => {
@@ -125,9 +134,20 @@ export function coreToOpenai(messages: CoreMessage[]): OpenAIMessage[] {
         } else {
             flush();
             if (m.role === "system") {
-                out.push({ role: "system", content: m.text ?? "" });
+                out.push({ role: m.originalRole === "developer" ? "developer" : "system", content: m.text ?? "" });
             } else if (m.role === "user") {
-                out.push({ role: "user", content: m.text ?? "" });
+                if (m.rawOpenaiContent || m.imageBase64) {
+                    const parts: OpenAIContentPart[] = [];
+                    if (m.text) parts.push({ type: "text", text: m.text });
+                    if (m.rawOpenaiContent) {
+                        parts.push(m.rawOpenaiContent as OpenAIContentPart);
+                    } else if (m.imageBase64 && m.imageMediaType) {
+                        parts.push({ type: "image_url", image_url: { url: `data:${m.imageMediaType};base64,${m.imageBase64}` } });
+                    }
+                    out.push({ role: "user", content: parts });
+                } else {
+                    out.push({ role: "user", content: m.text ?? "" });
+                }
             } else if (m.role === "tool") {
                 out.push({ role: "tool", tool_call_id: m.toolCallId ?? "", content: m.text ?? "" });
             }
@@ -168,4 +188,19 @@ function stringContent(content: OpenAIMessage["content"]): string {
             .join("\n");
     }
     return "";
+}
+
+function firstImagePart(content: OpenAIMessage["content"]): { part: OpenAIContentPart; mediaType: string; base64: string } | undefined {
+    if (!Array.isArray(content)) return undefined;
+    for (const p of content) {
+        if (p && typeof p === "object" && p.type === "image_url") {
+            const iu = (p as { image_url?: { url?: string } }).image_url;
+            const url = iu?.url;
+            if (typeof url === "string") {
+                const parsed = parseDataUrl(url);
+                if (parsed) return { part: p, mediaType: parsed.mediaType, base64: parsed.base64 };
+            }
+        }
+    }
+    return undefined;
 }

--- a/src/persist.ts
+++ b/src/persist.ts
@@ -157,6 +157,12 @@ export class SessionStore {
     /** Monotonic counter for unique temp filenames within a process. */
     private tmpSeq = 0;
     private readonly log: Logger;
+    /** Per-session write serialization chain. Each writeNow/flushSync chains
+     *  onto the previous write for the SAME session, so two concurrent writes
+     *  to the same session never race on fs.rename (Windows: EPERM/EBUSY when
+     *  two renames target the same file). The promise resolves when this
+     *  session's write queue is fully drained. */
+    private readonly writeChains = new Map<string, Promise<void>>();
 
     constructor(opts?: { dir?: string; debounceMs?: number; enabled?: boolean; log?: Logger }) {
         this.dir = opts?.dir ?? defaultDir();
@@ -279,8 +285,25 @@ export class SessionStore {
     }
 
     /** Asynchronously persist a session right now (skips the debounce). Throws
-     *  on write failure so callers can react (e.g. avoid evicting). */
+     *  on write failure so callers can react (e.g. avoid evicting). Serialized
+     *  per-session via writeChains so concurrent writes don't race on rename. */
     async writeNow(session: Session): Promise<void> {
+        if (!this.enabled) return;
+        const id = session.id;
+        // Chain this write after any in-flight write for the same session.
+        // The previous promise may reject (disk full, EPERM) — catch so our
+        // chain doesn't break, then run our own write.
+        const prev = this.writeChains.get(id) ?? Promise.resolve();
+        const next = prev.catch(() => {}).then(() => this.writeNowInner(session));
+        this.writeChains.set(id, next);
+        // Clean up the chain entry once settled so the Map doesn't grow.
+        next.finally(() => {
+            if (this.writeChains.get(id) === next) this.writeChains.delete(id);
+        });
+        return next;
+    }
+
+    private async writeNowInner(session: Session): Promise<void> {
         if (!this.enabled) return;
         const record = buildRecord(session);
         const file = this.filePath(session.id, session.meta.protocol, session.meta.upstreamOrigin);
@@ -298,7 +321,7 @@ export class SessionStore {
         // leaving an orphan that the next write can collide with.
         try {
             await fs.writeFile(tmp, data, "utf8");
-            await fs.rename(tmp, file);
+            await renameWithRetry(tmp, file);
         } catch (e) {
             try {
                 await fs.unlink(tmp).catch(() => {});
@@ -324,6 +347,7 @@ export class SessionStore {
         }
         const record = buildRecord(session);
         const file = this.filePath(session.id, session.meta.protocol, session.meta.upstreamOrigin);
+        const data = JSON.stringify(record);
         try {
             mkdirSync(path.dirname(file), { recursive: true });
         } catch (e) {
@@ -331,8 +355,25 @@ export class SessionStore {
         }
         const tmp = this.tempPath(session.id);
         try {
-            writeFileSync(tmp, JSON.stringify(record), "utf8");
-            renameSync(tmp, file);
+            writeFileSync(tmp, data, "utf8");
+            // Sync path: renameSync can throw EPERM on Windows if the dest is
+            // briefly held (AV/indexer/SMB). Retry a couple of times before
+            // giving up — transient locks usually release within ms.
+            let lastErr: unknown;
+            for (let attempt = 0; attempt < 3; attempt++) {
+                try {
+                    renameSync(tmp, file);
+                    lastErr = undefined;
+                    break;
+                } catch (e) {
+                    lastErr = e;
+                    const code = (e as NodeJS.ErrnoException).code;
+                    if (code !== "EPERM" && code !== "EBUSY" && code !== "EACCES") break;
+                    // brief sync backoff (Atomics.wait is the sync sleep)
+                    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 20 * (attempt + 1));
+                }
+            }
+            if (lastErr) throw lastErr;
             return true;
         } catch (e) {
             this.log("error", `[persist] flushSync FAILED for ${session.id}: ${msg(e)} — session NOT evicted to prevent loss`);
@@ -436,6 +477,27 @@ function isValidRecord(parsed: unknown): parsed is PersistedSession {
 
 function msg(e: unknown): string {
     return e instanceof Error ? e.message : String(e);
+}
+
+/** fs.rename with brief retries on Windows transient locks. EPERM/EBUSY/EACCES
+ *  happen when the destination is momentarily held open (AV scan, search
+ *  indexer, SMB). A short delay + retry almost always succeeds. Async (used by
+ *  writeNow). */
+async function renameWithRetry(src: string, dest: string): Promise<void> {
+    let lastErr: unknown;
+    for (let attempt = 0; attempt < 3; attempt++) {
+        try {
+            await fs.rename(src, dest);
+            return;
+        } catch (e) {
+            lastErr = e;
+            const code = (e as NodeJS.ErrnoException).code;
+            if (code !== "EPERM" && code !== "EBUSY" && code !== "EACCES") throw e;
+            // brief backoff before retry (transient lock usually releases)
+            await new Promise((r) => setTimeout(r, 20 * (attempt + 1)));
+        }
+    }
+    throw lastErr;
 }
 
 function defaultDir(): string {

--- a/src/responses.ts
+++ b/src/responses.ts
@@ -1,6 +1,7 @@
 import type { CoreMessage } from "acp-kernel";
 import { hashId } from "./util.js";
 import { ClusterCounter, deriveMessageId } from "./message-id.js";
+import { parseDataUrl, type BiliMessage } from "./bili-message.js";
 
 /**
  * OpenAI Responses API protocol shapes.
@@ -61,7 +62,7 @@ export type ResponsesRequestBody = {
 };
 
 type Flat = {
-    msgs: CoreMessage[];
+    msgs: BiliMessage[];
     systemParts: string[];
     preamble: ResponseInputItem[];
     /** call_ids that arrived as custom_tool_call / custom_tool_call_output.
@@ -108,8 +109,23 @@ function messageContent(c: string | ResponseContentPart[]): string {
     return "";
 }
 
+function findInputImage(c: string | ResponseContentPart[]): { mediaType?: string; base64?: string } | undefined {
+    if (!Array.isArray(c)) return undefined;
+    for (const p of c) {
+        if (p && typeof p === "object" && p.type === "input_image") {
+            const url = (p as { image_url?: string }).image_url;
+            if (typeof url === "string") {
+                const parsed = parseDataUrl(url);
+                if (parsed) return { mediaType: parsed.mediaType, base64: parsed.base64 };
+            }
+            return {};
+        }
+    }
+    return undefined;
+}
+
 export function responsesToCore(body: ResponsesRequestBody): Flat {
-    const msgs: CoreMessage[] = [];
+    const msgs: BiliMessage[] = [];
     const systemParts: string[] = [];
     const preamble: ResponseInputItem[] = [];
     const customToolCallIds = new Set<string>();
@@ -140,8 +156,22 @@ export function responsesToCore(body: ResponsesRequestBody): Flat {
                 if (m.role === "system" || m.role === "developer") {
                     systemParts.push(text);
                 } else if (m.role === "user") {
+                    const img = findInputImage(m.content);
                     const base = deriveMessageId("user", "text", text);
-                    msgs.push({ id: clusters.next(base), role: "user", contentType: "text", text });
+                    msgs.push({
+                        id: clusters.next(base),
+                        role: "user",
+                        contentType: "text",
+                        text,
+                        ...(img
+                            ? {
+                                  rawResponsesItem: it,
+                                  ...(img.mediaType && img.base64
+                                      ? { imageMediaType: img.mediaType, imageBase64: img.base64 }
+                                      : {}),
+                              }
+                            : {}),
+                    });
                     idx++;
                 } else if (m.role === "assistant") {
                     if (text) {
@@ -231,7 +261,7 @@ export function responsesToCore(body: ResponsesRequestBody): Flat {
 }
 
 export function coreToResponses(
-    messages: CoreMessage[],
+    messages: BiliMessage[],
     customToolCallIds: Set<string> = new Set(),
 ): ResponseInputItem[] {
     const out: ResponseInputItem[] = [];
@@ -239,7 +269,11 @@ export function coreToResponses(
         if (m.role === "system") {
             out.push({ type: "message", role: "developer", content: m.text ?? "" });
         } else if (m.role === "user") {
-            out.push({ type: "message", role: "user", content: m.text ?? "" });
+            if (m.rawResponsesItem) {
+                out.push(m.rawResponsesItem as ResponseInputItem);
+            } else {
+                out.push({ type: "message", role: "user", content: m.text ?? "" });
+            }
         } else if (m.role === "assistant") {
             if (m.contentType === "text") {
                 out.push({ type: "message", role: "assistant", content: m.text ?? "" });

--- a/src/server.ts
+++ b/src/server.ts
@@ -48,6 +48,7 @@ import { rewriteResponsesSseStream, rewriteResponsesJsonResponse } from "./strea
 import { emitStreamError } from "./stream-error.js";
 import { deriveSessionId as deriveProxySessionId, affinityToken, clientConversationHeader } from "./session-id.js";
 import { setupMitm, readMitmUpstream } from "./mitm.js";
+import type { BiliMessage } from "./bili-message.js";
 
 const UPSTREAM_HOP_HEADERS = new Set([
     "host",
@@ -224,6 +225,13 @@ type Prepared = {
     compressInjected: boolean;
 };
 
+/** True if `addr` is a loopback (IPv4 127.x or IPv6 ::1 / ::ffff:127.0.0.1).
+ *  Used to gate the management endpoints to local connections only. */
+function isLoopback(addr: string | undefined): boolean {
+    if (!addr) return false;
+    return addr === "::1" || addr === "127.0.0.1" || addr.startsWith("127.") || addr.startsWith("::ffff:127.");
+}
+
 async function handle(
     req: http.IncomingMessage,
     res: http.ServerResponse,
@@ -232,6 +240,19 @@ async function handle(
     config: Config,
     log: (level: string, msg: string) => void,
 ): Promise<void> {
+    // SECURITY: the /__bili/ management endpoints (config read/write, reload,
+    // session stats) are privileged — a remote caller who can reach them can
+    // rewrite upstream routing to exfiltrate API keys (MITM). Restrict them
+    // to loopback connections. The proxy default host is 127.0.0.1 (loopback
+    // only), but a user can set --host 0.0.0.0 to share the proxy on a LAN —
+    // in that case we still must NOT expose management to the LAN. Only the
+    // proxy /bili/ and CONNECT (model traffic) endpoints remain open to all.
+    const isAdminPath = req.url === "/__bili/" || req.url?.startsWith("/__bili/") || req.url === "/__acp/" || req.url?.startsWith("/__acp/");
+    if (isAdminPath && !isLoopback(req.socket.remoteAddress)) {
+        res.writeHead(403, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: "management endpoints are loopback-only; access denied for " + (req.socket.remoteAddress ?? "unknown") }));
+        return;
+    }
     if (req.method === "GET" && req.url === "/__bili/stats") return sendStats(res);
     if (req.method === "GET" && req.url === "/") {
         // Browser visits root → redirect to the web UI. curl / health probes
@@ -457,7 +478,7 @@ function prepareAnthropic(
         log("info", diagNudge(turn, sessionId, tokenCount, config.modelContextLimit));
         processedMessages = turn.messages;
         reapOrphanBlocks(session, msgs, deactivateBlock);
-        rebuiltMessages = coreToAnthropic(processedMessages, cacheControls);
+        rebuiltMessages = coreToAnthropic(processedMessages as BiliMessage[], cacheControls);
 
         systemOut = injectSystem(parsed, opts);
         if (opts.compress.injectTool) {
@@ -529,7 +550,7 @@ function prepareOpenai(
         log("info", diagNudge(turn, sessionId, tokenCount, config.modelContextLimit));
         processedMessages = turn.messages;
         reapOrphanBlocks(session, msgs, deactivateBlock);
-        rebuiltMessages = coreToOpenai(processedMessages);
+        rebuiltMessages = coreToOpenai(processedMessages as BiliMessage[]);
 
         // ONLY the static compress prompt goes into the system message — the
         // system prompt is the prefix-cache anchor and must be byte-stable
@@ -620,7 +641,7 @@ function prepareResponses(
         //   input[2..] = conversation history (compressed)
         //   top-level `instructions` is NEVER touched — it must stay empty for
         //   responses_lite. Setting it non-empty breaks code_mode tool exposure.
-        const conversationItems = coreToResponses(processedMessages, customToolCallIds);
+        const conversationItems = coreToResponses(processedMessages as BiliMessage[], customToolCallIds);
         if (preamble.length > 0) {
             log("info", `[${sessionId}] preserved ${preamble.length} opaque preamble item(s): ${preamble.map((p) => p.type).join(",")}`);
         }

--- a/src/session-id.ts
+++ b/src/session-id.ts
@@ -26,12 +26,19 @@ import { hashId } from "./util.js";
  * understand that convention work without bespoke support.
  */
 
-/** Extract the account credential from common auth headers, normalized. */
+/** Extract the account credential from common auth headers, verbatim.
+ *  The value is fed into a hash — it is NEVER stored, logged, or compared.
+ *  Normalization is intentionally minimal: trim whitespace only. We do NOT
+ *  lowercase: while that reduces hash collisions in theory (two keys that
+ *  differ only in case would hash the same), in practice API keys are
+ *  case-sensitive and a lowercase normalization would collapse two distinct
+ *  valid keys into one hash bucket — a silent isolation violation. Keep the
+ *  raw value so each distinct key hashes distinctly. */
 function extractKey(headers: Record<string, string | string[] | undefined>): string {
     const auth = headers["authorization"];
-    if (typeof auth === "string" && auth.length > 0) return auth.trim().toLowerCase();
+    if (typeof auth === "string" && auth.length > 0) return auth.trim();
     const apiKey = headers["x-api-key"];
-    if (typeof apiKey === "string" && apiKey.length > 0) return `key:${apiKey.trim().toLowerCase()}`;
+    if (typeof apiKey === "string" && apiKey.length > 0) return `key:${apiKey.trim()}`;
     return "(no-key)";
 }
 

--- a/src/update.ts
+++ b/src/update.ts
@@ -20,7 +20,7 @@
  * version and stops trying. No notified Set — failed installs retry next
  * cycle automatically.
  */
-import { readFile, writeFile, mkdir, access, constants, rm, cp } from "node:fs/promises";
+import { readFile, writeFile, mkdir, access, constants, rm, cp, unlink } from "node:fs/promises";
 import { execFile } from "node:child_process";
 import * as tar from "tar";
 import path from "node:path";
@@ -147,8 +147,24 @@ async function tryAcquireLock(): Promise<{ release: () => Promise<void> } | null
             // Another process is actively updating — back off.
             return null;
         }
-        // Lock is stale (holder dead or timeout) — steal it.
+        // Lock is stale (holder dead or timeout) — steal it. MUST delete the
+        // stale lock file first: writeFile({flag:"wx"}) below requires the path
+        // to NOT exist, and the stale file is still there. Without this unlink
+        // the wx write always fails → update returns null forever → a single
+        // crash during update permanently blocks all future auto-updates.
         loggerLog("info", `[update] stealing stale lock (pid=${existing.pid}, age=${Math.round(age / 1000)}s, alive=${holderAlive})`);
+        try {
+            await unlink(LOCK_FILE);
+        } catch (e) {
+            const code = (e as NodeJS.ErrnoException).code;
+            // ENOENT is fine (someone else already cleaned it). Anything else
+            // (EACCES, EBUSY on Windows) means we can't steal — bail out
+            // rather than hammering wx writes that will all fail.
+            if (code !== "ENOENT") {
+                loggerLog("warn", `[update] could not remove stale lock: ${(e as Error).message}`);
+                return null;
+            }
+        }
     }
 
     // Write our lock. Use flag "wx" to fail if file already exists.

--- a/tests/bili-message-roundtrip.test.ts
+++ b/tests/bili-message-roundtrip.test.ts
@@ -1,0 +1,173 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { anthropicToCore, coreToAnthropic } from "../src/anthropic.ts";
+import { openaiToCore, coreToOpenai } from "../src/openai.ts";
+import { responsesToCore, coreToResponses } from "../src/responses.ts";
+import type { AnthropicBlock, AnthropicRequestBody } from "../src/anthropic.ts";
+import type { OpenAIRequestBody } from "../src/openai.ts";
+import type { ResponsesRequestBody } from "../src/responses.ts";
+
+const IMG_DATA = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
+const DATA_URL = `data:image/png;base64,${IMG_DATA}`;
+
+function block(rebuilt: { content: string | AnthropicBlock[] }, i: number): Record<string, unknown> {
+    return (rebuilt.content as unknown[])[i] as Record<string, unknown>;
+}
+
+// 1. Anthropic image block round-trips losslessly (source.base64 + media_type).
+test("anthropic: image block is restored verbatim via rawAnthropicBlock", () => {
+    const source = { type: "base64", media_type: "image/png", data: IMG_DATA };
+    const body: AnthropicRequestBody = {
+        model: "claude",
+        max_tokens: 100,
+        messages: [{ role: "user", content: [{ type: "image", source }] }],
+    };
+    const { msgs } = anthropicToCore(body);
+    assert.equal(msgs.length, 1);
+    assert.equal(msgs[0]?.contentType, "text");
+    assert.equal(msgs[0]?.text, "[image]");
+    assert.ok(msgs[0]?.rawAnthropicBlock, "sidecar rawAnthropicBlock stored");
+    const rebuilt = coreToAnthropic(msgs);
+    assert.equal(rebuilt.length, 1);
+    const img = block(rebuilt[0]!, 0);
+    assert.equal(img.type, "image", "image block reconstructed (not a text placeholder)");
+    assert.deepEqual(img.source, source, "source preserved verbatim (base64 + media_type)");
+});
+
+// 2. Anthropic thinking + signature round-trips (signature was previously dropped).
+test("anthropic: thinking signature is restored", () => {
+    const body: AnthropicRequestBody = {
+        model: "claude",
+        max_tokens: 100,
+        messages: [
+            { role: "assistant", content: [{ type: "thinking", thinking: "let me consider", signature: "sig_EqMAC" }] },
+        ],
+    };
+    const { msgs } = anthropicToCore(body);
+    assert.equal(msgs[0]?.contentType, "reasoning");
+    assert.equal(msgs[0]?.thinkingSignature, "sig_EqMAC", "thinkingSignature sidecar stored");
+    const rebuilt = coreToAnthropic(msgs);
+    const th = block(rebuilt[0]!, 0);
+    assert.equal(th.type, "thinking");
+    assert.equal(th.thinking, "let me consider");
+    assert.equal(th.signature, "sig_EqMAC", "signature reattached (Anthropic rejects thinking without it)");
+});
+
+// 3. Anthropic tool_result.is_error round-trips (was previously dropped).
+test("anthropic: tool_result.is_error is restored", () => {
+    const body: AnthropicRequestBody = {
+        model: "claude",
+        max_tokens: 100,
+        messages: [
+            { role: "assistant", content: [{ type: "tool_use", id: "t1", name: "Bash", input: { cmd: "ls" } }] },
+            { role: "user", content: [{ type: "tool_result", tool_use_id: "t1", content: "boom", is_error: true }] },
+        ],
+    };
+    const { msgs } = anthropicToCore(body);
+    const result = msgs.find((m) => m.contentType === "tool-result");
+    assert.equal(result?.toolIsError, true, "toolIsError sidecar stored");
+    const rebuilt = coreToAnthropic(msgs);
+    const userMsg = rebuilt.find((m) => m.role === "user")!;
+    const tr = block(userMsg, 0);
+    assert.equal(tr.type, "tool_result");
+    assert.equal(tr.is_error, true, "is_error reconstructed");
+});
+
+// 3b. Sanity: a non-error tool_result does NOT gain is_error.
+test("anthropic: tool_result without is_error stays clean", () => {
+    const body: AnthropicRequestBody = {
+        model: "claude",
+        max_tokens: 100,
+        messages: [
+            { role: "assistant", content: [{ type: "tool_use", id: "t1", name: "Bash", input: { cmd: "ls" } }] },
+            { role: "user", content: [{ type: "tool_result", tool_use_id: "t1", content: "ok" }] },
+        ],
+    };
+    const { msgs } = anthropicToCore(body);
+    const result = msgs.find((m) => m.contentType === "tool-result");
+    assert.equal(result?.toolIsError, undefined);
+    const rebuilt = coreToAnthropic(msgs);
+    const userMsg = rebuilt.find((m) => m.role === "user")!;
+    const tr = block(userMsg, 0);
+    assert.equal(tr.is_error, undefined, "no spurious is_error");
+});
+
+// 4. OpenAI developer role round-trips (was collapsed to system).
+test("openai: developer role is restored", () => {
+    const body: OpenAIRequestBody = { messages: [{ role: "developer", content: "you are a dev" }] };
+    const { msgs } = openaiToCore(body);
+    assert.equal(msgs[0]?.role, "system", "kernel sees system");
+    assert.equal(msgs[0]?.originalRole, "developer", "originalRole sidecar stored");
+    const rebuilt = coreToOpenai(msgs);
+    assert.equal(rebuilt[0]?.role, "developer", "developer role reconstructed");
+    assert.equal(rebuilt[0]?.content, "you are a dev");
+});
+
+// 4b. Sanity: a plain system role is NOT promoted to developer.
+test("openai: system role stays system", () => {
+    const body: OpenAIRequestBody = { messages: [{ role: "system", content: "sys" }] };
+    const { msgs } = openaiToCore(body);
+    assert.equal(msgs[0]?.originalRole, "system");
+    const rebuilt = coreToOpenai(msgs);
+    assert.equal(rebuilt[0]?.role, "system");
+});
+
+// 5. OpenAI image_url round-trips (image was previously dropped entirely).
+test("openai: user image_url content part is restored", () => {
+    const body: OpenAIRequestBody = {
+        messages: [
+            {
+                role: "user",
+                content: [
+                    { type: "text", text: "what is this?" },
+                    { type: "image_url", image_url: { url: DATA_URL } },
+                ],
+            },
+        ],
+    };
+    const { msgs } = openaiToCore(body);
+    assert.ok(msgs[0]?.text?.startsWith("what is this?"), "text preserved");
+    assert.equal(msgs[0]?.imageMediaType, "image/png");
+    assert.equal(msgs[0]?.imageBase64, IMG_DATA);
+    assert.ok(msgs[0]?.rawOpenaiContent, "rawOpenaiContent sidecar stored");
+    const rebuilt = coreToOpenai(msgs);
+    const u = rebuilt[0]!;
+    assert.equal(u.role, "user");
+    assert.ok(Array.isArray(u.content), "content rebuilt as array (text + image)");
+    const parts = u.content as unknown as { type: string; [k: string]: unknown }[];
+    const text = parts.find((p) => p.type === "text");
+    assert.ok(typeof text?.text === "string" && text.text.startsWith("what is this?"));
+    const img = parts.find((p) => p.type === "image_url");
+    assert.ok(img, "image_url part reconstructed");
+    assert.deepEqual((img as unknown as { image_url: { url: string } }).image_url.url, DATA_URL, "image data URL restored");
+});
+
+// 6. Responses API input_image round-trips (image was previously dropped).
+test("responses: user input_image is restored via rawResponsesItem", () => {
+    const body: ResponsesRequestBody = {
+        input: [
+            {
+                type: "message",
+                role: "user",
+                content: [
+                    { type: "input_text", text: "see this" },
+                    { type: "input_image", image_url: DATA_URL },
+                ],
+            },
+        ],
+    };
+    const { msgs } = responsesToCore(body);
+    assert.ok(msgs[0]?.text?.startsWith("see this"), "text preserved");
+    assert.equal(msgs[0]?.imageMediaType, "image/png");
+    assert.equal(msgs[0]?.imageBase64, IMG_DATA);
+    assert.ok(msgs[0]?.rawResponsesItem, "rawResponsesItem sidecar stored");
+    const rebuilt = coreToResponses(msgs);
+    assert.equal(rebuilt.length, 1);
+    const m = rebuilt[0] as { type: string; content: unknown };
+    assert.equal(m.type, "message");
+    assert.ok(Array.isArray(m.content), "message content rebuilt as array");
+    const parts = m.content as unknown as { type: string; [k: string]: unknown }[];
+    const img = parts.find((p) => p.type === "input_image");
+    assert.ok(img, "input_image reconstructed");
+    assert.equal(img?.image_url, DATA_URL, "image url restored");
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -10,6 +10,12 @@ export default defineConfig({
     sourcemap: true,
     splitting: false,
     shims: false,
+    // acp-kernel is a BUILD-TIME dependency: tsup inlines it into dist so the
+    // published artifact is self-contained (zero runtime deps). Without
+    // noExternal, esbuild keeps `import ... from "acp-kernel"` in dist, and
+    // npm then installs acp-kernel as a runtime dep — breaking the
+    // "dist/index.js is self-contained" contract (AGENTS.md §2.1).
+    noExternal: ["acp-kernel", "node-forge"],
     banner: {
         // node-forge is a CommonJS dependency that calls require("crypto") etc.
         // inlined into our ESM output, esbuild's __require shim throws in an


### PR DESCRIPTION
Resolves all 6 findings from the external codebase audit.

| # | Severity | Finding | Fix |
|---|----------|---------|-----|
| 1 | CRITICAL | Protocol conversion lossy: image→[image], thinking.signature dropped (Anthropic rejects unsigned thinking), tool_result.is_error dropped, OpenAI developer→system, image_url/input_image deleted | **BiliMessage sidecar** (src/bili-message.ts) extends CoreMessage with optional raw*/signature/isError/originalRole/image* fields. Kernel only does {`...msg`} spread, so sidecar survives to coreToX which replays the original block. 8 round-trip tests. |
| 2 | MAJOR | API key lowercased before hash → two distinct case-differing keys collided | Remove toLowerCase; keep raw (trim only) |
| 3 | MAJOR | stale-lock takeover never deleted the stale file → writeFile(wx) always EEXIST → update permanently blocked | unlink(LOCK_FILE) before wx write; ENOENT tolerated |
| 4 | MAJOR (security) | /__bili/ management endpoints had no auth → with --host 0.0.0.0 remote caller could rewrite upstream routing to exfiltrate API keys | Gate /__bili/ + /__acp/ to loopback (127.x/::1) only |
| 5 | MINOR (Windows) | writeNow/flushSync not serialized → concurrent renames on same file → EPERM/EBUSY | Per-session writeChains + renameWithRetry (EPERM/EBUSY/EACCES retry ×3) |
| 6 | MINOR | dist not self-contained: acp-kernel stayed as runtime dep | tsup noExternal:[acp-kernel,node-forge] + move to devDependencies; dist verified 0 'from acp-kernel' refs |

## Verification
- `npx tsc --noEmit` → 0 errors
- `node --import tsx --test tests/*.test.ts` → **169 pass** (161 existing + 8 new round-trip), 0 fail
- `npm run build` → success, self-contained (944KB)

## Notes
- #1 uses TypeScript array covariance (BiliMessage[] satisfies CoreMessage[] param) — no `as any`, no `@ts-ignore`
- #4 keeps management loopback-only even when proxy listens on 0.0.0.0; model-traffic endpoints stay open to all
- The 7 Windows test failures noted in the audit (5×/tmp hardcoded, 1×SIRE path, 1×EPERM) — this PR fixes the EPERM one (#5); the /tmp hardcoding is a test-portability issue separate from these findings