### PR TITLE
release v0.1.26

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Release v0.1.26 — 6 audit fixes (PR#65).

## What's in it
| # | Fix |
|---|-----|
| 1 | Protocol lossless conversion (BiliMessage sidecar) — image/thinking-signature/is_error/developer/image_url preserved |
| 2 | API key no longer lowercased before hash |
| 3 | Stale update-lock now deleted before wx write (no more permanent update block) |
| 4 | Management endpoints (/__bili/, /__acp/) loopback-only (security) |
| 5 | Windows persist: per-session write serialization + rename EPERM/EBUSY retry |
| 6 | dist self-contained (acp-kernel → devDeps + tsup noExternal) |

## Verified
- tsc 0 errors / 169 tests pass / build OK (944KB, self-contained)
- ZCode end-to-end tested: tokenCount now uses real API input_tokens, nudge logs visible, compression chain confirmed (1 prior session compressed a block)

CI publish on merge.