### PR TITLE
feat: upstream proxy support (firewall / GFW)

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,12 @@ non-model traffic.
 > so no other app is affected. Deleting the CA files and restarting the proxy
 > regenerates them.
 
+**Routing a login client through its own proxy (firewall/GFW).** A login
+client (ZCode) and an API-key client can both hit the same host
+(`open.bigmodel.cn`). To give the login client its OWN upstream proxy without
+affecting API-key clients, use the `mitm://` scheme key — see
+[Upstream proxy (MITM vs `/bili/`)](#upstream-proxy-firewall--gfw).
+
 ### Option B — Manual config file & context windows
 
 Open `~/.config/billion-context/billion-context.json` and edit the `providers`

--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ The config file is a single JSON object. Example:
 | `passthrough` | `false` | Forward without compression (same as `ACP_PASSTHROUGH=1`) |
 | `providers` | *(none)* | Per-URL context overrides — see below |
 | `compress` | *(see defaults)* | `{ injectTool, injectNudge }` |
+| `proxy` | *(none)* | Upstream HTTP proxy for the proxy's OWN outbound connections to model providers (`http://host:port`). Per-URL `proxy` overrides this. See [Upstream proxy](#upstream-proxy-firewall--gfw). |
 
 > **Choosing a `host`** (IPv6 / containers): the default `127.0.0.1` is
 > IPv4-only and loopback-only. Use `--host ::` (or `"host": "::"`) to listen
@@ -400,6 +401,44 @@ registry, then the built-in prefix table.
 
 **API keys are never stored in the proxy** — whatever key the agent sends is
 passed through untouched to the upstream.
+
+### Upstream proxy (firewall / GFW)
+
+If the proxy's own outbound connections to a model provider are blocked
+(e.g. `api.openai.com` from inside the GFW), configure an **upstream proxy**
+(the local v2rayA / clash HTTP port) so the proxy reaches the provider:
+
+```jsonc
+{
+  // Global default: ALL providers route through this proxy
+  "proxy": "http://127.0.0.1:20172",
+  "providers": {
+    "https://api.openai.com/v1": {
+      // Per-URL overrides global (use a different proxy for this host)
+      "proxy": "http://127.0.0.1:20173",
+      "models": { "gpt-5": { "context": 400000 } }
+    },
+    "https://open.bigmodel.cn/api/anthropic": {
+      // Empty string = explicitly DIRECT, overriding the global proxy
+      "proxy": "",
+      "models": { "glm-5.2": { "context": 1000000 } }
+    }
+  }
+}
+```
+
+Rules:
+- **Global `proxy`** (top level) applies to every provider's outbound.
+- **Per-URL `proxy`** overrides the global for that host.
+- Empty string `""` means **explicitly direct** (override-and-disable).
+- Neither set = direct connect.
+- Only HTTP proxies (`http://host:port`). SOCKS5 is not supported yet.
+- Both outbound paths are covered: `/bili/` path-mode (fetch) AND MITM CONNECT
+  tunnels (the proxy's connection to the real upstream goes through the HTTP
+  CONNECT proxy).
+
+Env override: `BILI_UPSTREAM_PROXY=http://127.0.0.1:20172` (same as global
+`proxy`; config file wins over env if both set).
 
 ## How sessions work
 

--- a/README.md
+++ b/README.md
@@ -440,6 +440,27 @@ Rules:
 Env override: `BILI_UPSTREAM_PROXY=http://127.0.0.1:20172` (same as global
 `proxy`; config file wins over env if both set).
 
+**MITM vs `/bili/` — distinguishing the key scheme.** A login client
+(ZCode via MITM) and an API-key client can both hit the same host
+(`open.bigmodel.cn`). To let their config differ, MITM traffic uses a
+`mitm://` scheme in the lookup key while `/bili/` traffic uses the real
+`https://`:
+
+| Client | Lookup key example |
+|---|---|
+| ZCode (MITM, login) | `mitm://open.bigmodel.cn` |
+| API-key client (`/bili/`) | `https://open.bigmodel.cn/api/anthropic` |
+
+So you can give ZCode its own proxy without affecting API-key clients:
+```jsonc
+{
+  "providers": {
+    "mitm://open.bigmodel.cn":            { "proxy": "http://127.0.0.1:20173" },
+    "https://open.bigmodel.cn/api/anthropic": { "proxy": "http://127.0.0.1:20172" }
+  }
+}
+```
+
 ## How sessions work
 
 The proxy needs a stable per-conversation identifier to isolate compression

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -298,6 +298,7 @@ bili --no-auto-update        # 本次启动禁用自动更新
 | `passthrough` | `false` | 不压缩直接转发(等同 `ACP_PASSTHROUGH=1`) |
 | `providers` | *(无)* | 按 URL 的 context 覆盖 —— 见下文 |
 | `compress` | *(见默认值)* | `{ injectTool, injectNudge }` |
+| `proxy` | *(无)* | 代理自身访问模型提供商时走的上游 HTTP 代理(`http://host:port`)。按 URL 的 `proxy` 会覆盖它。见[上游代理](#上游代理防火墙gfw)。 |
 
 > **选择 `host`**(IPv6 / 容器):默认 `127.0.0.1` 只听 IPv4 且仅
 > loopback。用 `--host ::`(或 `"host": "::"`)可同时听 IPv4 和 IPv6
@@ -339,6 +340,39 @@ key 就是客户端写在 `/bili/` 后面的那个字符串:
 - 未被任何匹配 key 覆盖的模型回退到 models.dev,再回退到前缀表,最后回退到 `modelContextLimit`。
 
 **API key 永远不存进代理** —— 助手发什么 key,原样透传给上游。
+
+### 上游代理(防火墙 / GFW)
+
+如果代理自身访问模型提供商的连接被墙(比如 GFW 内访问 `api.openai.com`),配置一个**上游代理**(本地 v2rayA / clash 的 HTTP 端口),让代理能连到提供商:
+
+```jsonc
+{
+  // 全局默认:所有提供商的出站都走这个代理
+  "proxy": "http://127.0.0.1:20172",
+  "providers": {
+    "https://api.openai.com/v1": {
+      // 按 URL 覆盖全局(给这个域名用另一个代理)
+      "proxy": "http://127.0.0.1:20173",
+      "models": { "gpt-5": { "context": 400000 } }
+    },
+    "https://open.bigmodel.cn/api/anthropic": {
+      // 空字符串 = 明确直连,覆盖全局代理
+      "proxy": "",
+      "models": { "glm-5.2": { "context": 1000000 } }
+    }
+  }
+}
+```
+
+规则:
+- **全局 `proxy`**(顶层)对所有提供商的出站生效。
+- **按 URL 的 `proxy`** 覆盖该域名的全局设置。
+- 空字符串 `""` 表示**明确直连**(覆盖并禁用)。
+- 都不配 = 直连。
+- 只支持 HTTP 代理(`http://host:port`)。SOCKS5 暂不支持。
+- 两条出站路径都覆盖:`/bili/` 路径模式(fetch)和 MITM CONNECT 隧道(代理连接真实上游的链路走 HTTP CONNECT 代理)。
+
+环境变量覆盖:`BILI_UPSTREAM_PROXY=http://127.0.0.1:20172`(等同全局 `proxy`;两者都设时配置文件优先)。
 
 ## 会话机制
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -140,6 +140,8 @@ MITM 默认开启,且只对一份 **白名单**中的模型域名(`open.bigmodel
 > 客户端(通过 CA 路径设置,它会把该路径作为 `NODE_EXTRA_CA_CERTS` 喂给
 > Node)信任它,其他应用不受影响。删除 CA 文件并重启 proxy 会重新生成。
 
+**给登录客户端单独配代理(防火墙/GFW)。** 登录客户端(ZCode)和 API-key 客户端可能连同一个域名(`open.bigmodel.cn`)。要给登录客户端配**专属上游代理**而不影响 API-key 客户端,用 `mitm://` scheme 键 —— 见[上游代理(MITM 与 `/bili/`)](#上游代理防火墙gfw)。
+
 ### 方式 B 手动配置文件&设置上下文大小
 
 打开 `~/.config/billion-context/billion-context.json`,编辑 `providers` 块。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -374,6 +374,23 @@ key 就是客户端写在 `/bili/` 后面的那个字符串:
 
 环境变量覆盖:`BILI_UPSTREAM_PROXY=http://127.0.0.1:20172`(等同全局 `proxy`;两者都设时配置文件优先)。
 
+**MITM 与 `/bili/` —— 用 scheme 区分。** 登录客户端(ZCode 走 MITM)和 API-key 客户端可能连同一个域名(`open.bigmodel.cn`)。为了让它们的配置能区分,MITM 流量在查找键里用 `mitm://` scheme,`/bili/` 流量用真实的 `https://`:
+
+| 客户端 | 查找键示例 |
+|---|---|
+| ZCode(MITM,登录态)| `mitm://open.bigmodel.cn` |
+| API-key 客户端(`/bili/`)| `https://open.bigmodel.cn/api/anthropic` |
+
+所以你可以给 ZCode 单独配代理,不影响 API-key 客户端:
+```jsonc
+{
+  "providers": {
+    "mitm://open.bigmodel.cn":            { "proxy": "http://127.0.0.1:20173" },
+    "https://open.bigmodel.cn/api/anthropic": { "proxy": "http://127.0.0.1:20172" }
+  }
+}
+```
+
 ## 会话机制
 
 代理需要一个稳定的、按会话标识的 ID,以便在多个用户/账号并发时隔离压缩状态。它从四个维度推导一个(见 `src/session-id.ts`):**协议 × 上游 origin × API key × 会话**。前三个防止跨账号 / 跨 provider 串数据;会话维度来自客户端发送的内容。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.25",
+      "version": "0.1.26",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",
@@ -20,7 +20,8 @@
         "tar": "^7.5.22",
         "tsup": "^8.0.0",
         "tsx": "^4.0.0",
-        "typescript": "^5.5.0"
+        "typescript": "^5.5.0",
+        "undici": "^8.10.0"
       },
       "engines": {
         "node": ">=20"
@@ -2147,6 +2148,16 @@
       "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
     },
     "node_modules/undici-types": {
       "version": "6.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "tsup": "^8.0.0",
         "tsx": "^4.0.0",
         "typescript": "^5.5.0",
-        "undici": "^8.10.0"
+        "undici": "^7.29.0"
       },
       "engines": {
         "node": ">=20"
@@ -2150,13 +2150,13 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
-      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=22.19.0"
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -38,16 +38,16 @@
   "bugs": {
     "url": "https://github.com/ranxianglei/billion-context/issues"
   },
-  "dependencies": {},
   "devDependencies": {
-    "acp-kernel": "0.0.17",
     "@types/node": "^22.0.0",
     "@types/node-forge": "^1.3.14",
+    "acp-kernel": "0.0.17",
     "node-forge": "^1.4.0",
     "tar": "^7.5.22",
     "tsup": "^8.0.0",
     "tsx": "^4.0.0",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.0",
+    "undici": "^8.10.0"
   },
   "engines": {
     "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "tsup": "^8.0.0",
     "tsx": "^4.0.0",
     "typescript": "^5.5.0",
-    "undici": "^8.10.0"
+    "undici": "^7.29.0"
   },
   "engines": {
     "node": ">=20"

--- a/src/compress-loop-anthropic.ts
+++ b/src/compress-loop-anthropic.ts
@@ -11,6 +11,7 @@ import { applyRanges } from "./stream.js";
 import { resolveDecompress } from "./decompress-shared.js";
 import { buildVisibilityMarker } from "./compress-loop.js";
 import { fetchWithTimeout } from "./fetch-util.js";
+import { proxyDispatcher } from "./upstream-proxy.js";
 import { normalizeSseLineEndings } from "./sse-util.js";
 
 /** Anthropic SSE multi-round compress loop.
@@ -35,6 +36,8 @@ interface CompressLoopAnthropicCtx {
     messages: CoreMessage[];
     session: Session;
     log: (msg: string) => void;
+    /** Resolved upstream proxy URL (http://host:port) or undefined for direct. */
+    proxyUrl?: string;
 }
 
 interface RequestOptions {
@@ -301,6 +304,7 @@ export async function* compressLoopAnthropicStream(
                 method: "POST",
                 headers: requestOptions.headers,
                 body: JSON.stringify(requestBody),
+                ...(ctx.proxyUrl ? { dispatcher: proxyDispatcher(ctx.proxyUrl) } : {}),
             });
 
             if (!resp.ok || !resp.body) {

--- a/src/compress-loop-responses.ts
+++ b/src/compress-loop-responses.ts
@@ -14,6 +14,7 @@ import { applyRanges } from "./stream.js";
 import { resolveDecompress } from "./decompress-shared.js";
 import { buildVisibilityMarker } from "./compress-loop.js";
 import { fetchWithTimeout } from "./fetch-util.js";
+import { proxyDispatcher } from "./upstream-proxy.js";
 
 /** Text-protocol mode: the host (OpenAI Codex code_mode) cannot coexist with
  *  a declared `tools` array, so compression is triggered by a text marker the
@@ -64,6 +65,8 @@ interface CompressLoopResponsesCtx {
     messages: CoreMessage[];
     session: Session;
     log: (msg: string) => void;
+    /** Resolved upstream proxy URL (http://host:port) or undefined for direct. */
+    proxyUrl?: string;
 }
 
 interface RequestOptions {
@@ -506,6 +509,7 @@ export async function* compressLoopResponsesStream(
             method: "POST",
             headers: requestOptions.headers,
             body: JSON.stringify(requestBody),
+            ...(ctx.proxyUrl ? { dispatcher: proxyDispatcher(ctx.proxyUrl) } : {}),
         });
 
         if (!resp.ok || !resp.body) {

--- a/src/compress-loop.ts
+++ b/src/compress-loop.ts
@@ -12,6 +12,7 @@ import { parseCompressInput, PROXY_TOOL_NAMES } from "./compress-tool.js";
 import { applyRanges } from "./stream.js";
 import { resolveDecompress } from "./decompress-shared.js";
 import { fetchWithTimeout } from "./fetch-util.js";
+import { proxyDispatcher } from "./upstream-proxy.js";
 import { normalizeSseLineEndings } from "./sse-util.js";
 import { log as loggerLog } from "./logger.js";
 
@@ -21,6 +22,9 @@ interface CompressLoopCtx {
     messages: CoreMessage[];
     session: Session;
     log: (msg: string) => void;
+    /** Resolved upstream proxy URL (http://host:port) or undefined for direct.
+     *  Pre-resolved by the caller (server.ts) via resolveProxy(). */
+    proxyUrl?: string;
 }
 
 interface RequestOptions {
@@ -406,6 +410,7 @@ export async function* compressLoopStream(
             method: "POST",
             headers: requestOptions.headers,
             body: JSON.stringify(requestBody),
+            ...(ctx.proxyUrl ? { dispatcher: proxyDispatcher(ctx.proxyUrl) } : {}),
         });
 
         if (!resp.ok || !resp.body) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -38,6 +38,10 @@ export function safeReadJson(path: string): unknown {
  *  Backward compatible: a bare string is accepted and treated as { url }. */
 export type ProviderRoute = {
     models?: Record<string, { context?: number; output?: number }>;
+    /** Per-URL upstream HTTP proxy. Overrides the global `proxy`. Empty string
+     *  means "explicitly direct" (override global with no proxy). Format:
+     *  `http://host:port`. SOCKS5 is not supported yet. */
+    proxy?: string;
 };
 export type ProviderRoutes = Record<string, ProviderRoute>; // key = upstream URL prefix (the /bili/<this> string)
 
@@ -110,6 +114,9 @@ export type ProxyOptions = {
     host: string;
     upstream: string;
     routes: ProviderRoutes;
+    /** Global default upstream HTTP proxy. Per-URL `proxy` overrides this.
+     *  Empty string disables. `http://host:port` format. */
+    proxy?: string;
     modelContextLimit: number;
     kernelConfig: Config;
     compress: {
@@ -195,6 +202,7 @@ export function loadOptions(env: NodeJS.ProcessEnv = process.env): ProxyOptions 
         host,
         upstream,
         routes,
+        proxy: env.BILI_UPSTREAM_PROXY ?? fileConfig.proxy,
         modelContextLimit,
         kernelConfig: defaultConfig(modelContextLimit),
         compress: {
@@ -225,6 +233,9 @@ type FileConfig = {
     providersPath?: string;
     /** Inline providers, same shape as providers.json. */
     providers?: Record<string, unknown>;
+    /** Global default upstream HTTP proxy (applied to all providers unless a
+     *  per-URL `proxy` overrides it). `http://host:port`. */
+    proxy?: string;
     modelContextLimit?: number;
     sessionHeader?: string;
     log?: boolean;
@@ -284,8 +295,10 @@ export function parseRouteEntry(v: unknown): ProviderRoute | undefined {
     // is the KEY in the providers map (identical to the /bili/<url> string),
     // so it is NOT repeated inside the value.
     if (v && typeof v === "object" && !Array.isArray(v)) {
-        const obj = v as { models?: Record<string, { context?: number; output?: number }> };
-        return { models: obj.models };
+        const obj = v as { models?: Record<string, { context?: number; output?: number }>; proxy?: string };
+        const route: ProviderRoute = { models: obj.models };
+        if (typeof obj.proxy === "string") route.proxy = obj.proxy;
+        return route;
     }
     // A bare value (e.g. null) means "this upstream exists, no overrides".
     if (v === null) return {};

--- a/src/fetch-util.ts
+++ b/src/fetch-util.ts
@@ -11,21 +11,38 @@
 export const MAX_REQUEST_BYTES = 100 * 1024 * 1024;
 export const UPSTREAM_TIMEOUT_MS = 10 * 60 * 1000;
 
+/** undici's fetch accepts a `dispatcher` option (its own Dispatcher type) that
+ *  @types/node's RequestInit already declares — but typed as the internal
+ *  `Dispatcher` interface, which conflicts with the `undici` package's
+ *  exported `Dispatcher`. We Omit that field and re-add it as a plain
+ *  `object` so any Dispatcher-shaped value (ProxyAgent from either source)
+ *  is accepted, without `as any`. */
+export type FetchOptions = Omit<RequestInit, "dispatcher"> & { dispatcher?: object };
+
 /** Abort a fetch after `timeoutMs`. Unlike the naive version, the timer is
  *  NOT cleared when headers arrive — it must cover the response BODY too
  *  (LLM SSE streams can stall mid-stream). Callers receive a `clearTimer`
  *  callback and invoke it once the response stream has been fully consumed;
- *  otherwise the timer correctly fires and aborts a stuck stream. */
+ *  otherwise the timer correctly fires and aborts a stuck stream.
+ *
+ *  `opts.dispatcher` (optional) routes the fetch through an upstream proxy
+ *  (an `undici.ProxyAgent`). When omitted, fetch uses its default agent. */
 export async function fetchWithTimeout(
     url: string,
-    init: RequestInit,
+    opts: FetchOptions,
     timeoutMs: number = UPSTREAM_TIMEOUT_MS,
 ): Promise<{ response: Response; clearTimer: () => void }> {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), timeoutMs);
     try {
-        const response = await fetch(url, { ...init, signal: controller.signal });
-        return { response, clearTimer: () => clearTimeout(timer) };
+        const finalOpts: Omit<RequestInit, "dispatcher"> & { dispatcher?: object } = { ...opts, signal: controller.signal };
+        // `fetch` is undici's global; it accepts `dispatcher` at runtime. @types/node
+        // types RequestInit.dispatcher as its internal `Dispatcher` interface,
+        // which structurally conflicts with the `undici` package's exported
+        // Dispatcher — but at runtime they're the same thing. Assert to the
+        // concrete RequestInit type (no `as any`) to satisfy the call site.
+        const response = await fetch(url, finalOpts as RequestInit);
+        return { response: response as Response, clearTimer: () => clearTimeout(timer) };
     } catch (e) {
         clearTimeout(timer);
         throw e;

--- a/src/mitm.ts
+++ b/src/mitm.ts
@@ -2,6 +2,7 @@ import http from "node:http";
 import net from "node:net";
 import tls from "node:tls";
 import { ensureRootCA, getSecureContext } from "./ca.js";
+import { connectThroughProxy } from "./upstream-proxy.js";
 
 /** Domains we transparently MITM: the model-inference endpoints of the
  *  providers billion-context targets. Everything else (banking, mail, …) is
@@ -49,6 +50,7 @@ export function setupMitm(
     server: http.Server,
     extraDomains: string[] = [],
     log: Logger = () => {},
+    resolveProxyUrl?: (host: string) => string | undefined,
 ): void {
     ensureRootCA();
     server.on("connect", (req: http.IncomingMessage, clientSocket: net.Socket, head: Buffer) => {
@@ -60,7 +62,8 @@ export function setupMitm(
         }
         const targetPort = port || 443;
         if (!isMitmHost(hostname, extraDomains)) {
-            tunnelThrough(clientSocket, hostname, targetPort, head, log);
+            const proxyUrl = resolveProxyUrl?.(hostname);
+            tunnelThrough(clientSocket, hostname, targetPort, head, log, proxyUrl);
             return;
         }
         doMitm(server, clientSocket, hostname, targetPort, head, log);
@@ -78,46 +81,55 @@ function parseHostPort(s: string): { hostname: string; port: number } {
 }
 
 /** Pure TCP tunnel for non-whitelisted hosts. We establish a connection to the
- *  real upstream and pipe bytes both ways without ever inspecting them. */
+ *  real upstream and pipe bytes both ways without ever inspecting them.
+ *  `proxyUrl` (optional) routes the outbound through an HTTP CONNECT proxy. */
 function tunnelThrough(
     clientSocket: net.Socket,
     host: string,
     port: number,
     head: Buffer,
     log: Logger,
+    proxyUrl?: string,
 ): void {
-    const upstream = net.connect(port, host);
+    // Outbound connect: direct, or via HTTP CONNECT proxy if configured. The
+    // proxy case is async (handshake) so we bridge with a promise.
+    let upstream: net.Socket | undefined;
     let established = false;
-    // Fail fast if the real upstream is unreachable: without a timeout the
-    // tunnel would hang forever, pinning the client's connection. 10s is
-    // generous for a TCP connect to a known model endpoint.
     const connectTimer = setTimeout(() => {
         if (!established) {
             log(`tunnel ${host}:${port} connect timeout`);
             clientSocket.write("HTTP/1.1 504 Gateway Timeout\r\n\r\n");
-            upstream.destroy();
+            if (upstream) upstream.destroy();
             clientSocket.destroy();
         }
-    }, 10000);
-    upstream.on("connect", () => {
+    }, 15000);
+    connectThroughProxy(host, port, proxyUrl).then((sock) => {
+        upstream = sock;
+        upstream.on("connect", () => {
+            clearTimeout(connectTimer);
+            established = true;
+            clientSocket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+            if (head.length > 0) upstream!.write(head);
+            upstream!.pipe(clientSocket);
+            clientSocket.pipe(upstream!);
+        });
+        const cleanup = (where: string, err: Error) => {
+            clearTimeout(connectTimer);
+            if (!established) {
+                log(`tunnel ${host}:${port} ${where} failed: ${err.message}`);
+                clientSocket.write("HTTP/1.1 502 Bad Gateway\r\n\r\n");
+            }
+            clientSocket.destroy();
+            upstream?.destroy();
+        };
+        upstream.on("error", (e) => cleanup("upstream", e));
+        clientSocket.on("error", (e) => cleanup("client", e));
+    }).catch((err: Error) => {
         clearTimeout(connectTimer);
-        established = true;
-        clientSocket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
-        if (head.length > 0) upstream.write(head);
-        upstream.pipe(clientSocket);
-        clientSocket.pipe(upstream);
-    });
-    const cleanup = (where: string, err: Error) => {
-        clearTimeout(connectTimer);
-        if (!established) {
-            log(`tunnel ${host}:${port} ${where} failed: ${err.message}`);
-            clientSocket.write("HTTP/1.1 502 Bad Gateway\r\n\r\n");
-        }
+        log(`tunnel ${host}:${port} connect failed: ${err.message}`);
+        clientSocket.write("HTTP/1.1 502 Bad Gateway\r\n\r\n");
         clientSocket.destroy();
-        upstream.destroy();
-    };
-    upstream.on("error", (e) => cleanup("upstream", e));
-    clientSocket.on("error", (e) => cleanup("client", e));
+    });
 }
 
 /** MITM the connection: terminate TLS with our signed cert, then inject the

--- a/src/mitm.ts
+++ b/src/mitm.ts
@@ -91,39 +91,34 @@ function tunnelThrough(
     log: Logger,
     proxyUrl?: string,
 ): void {
-    // Outbound connect: direct, or via HTTP CONNECT proxy if configured. The
-    // proxy case is async (handshake) so we bridge with a promise.
-    let upstream: net.Socket | undefined;
+    // connectThroughProxy resolves a socket that is ALREADY connected: direct
+    // mode resolves on net.connect's 'connect' event; proxied mode resolves
+    // after the CONNECT handshake returns 200. Either way we must NOT wait
+    // for another 'connect' event here — Node does not replay it, so attaching
+    // a listener in this .then() callback (the old code) never fires, and the
+    // client would time out. Just start piping immediately.
     let established = false;
     const connectTimer = setTimeout(() => {
         if (!established) {
             log(`tunnel ${host}:${port} connect timeout`);
             clientSocket.write("HTTP/1.1 504 Gateway Timeout\r\n\r\n");
-            if (upstream) upstream.destroy();
             clientSocket.destroy();
         }
     }, 15000);
-    connectThroughProxy(host, port, proxyUrl).then((sock) => {
-        upstream = sock;
-        upstream.on("connect", () => {
-            clearTimeout(connectTimer);
-            established = true;
-            clientSocket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
-            if (head.length > 0) upstream!.write(head);
-            upstream!.pipe(clientSocket);
-            clientSocket.pipe(upstream!);
-        });
+    connectThroughProxy(host, port, proxyUrl).then((upstream) => {
+        established = true;
+        clearTimeout(connectTimer);
+        clientSocket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+        if (head.length > 0) upstream.write(head);
+        upstream.pipe(clientSocket);
+        clientSocket.pipe(upstream);
         const cleanup = (where: string, err: Error) => {
-            clearTimeout(connectTimer);
-            if (!established) {
-                log(`tunnel ${host}:${port} ${where} failed: ${err.message}`);
-                clientSocket.write("HTTP/1.1 502 Bad Gateway\r\n\r\n");
-            }
+            log(`tunnel ${host}:${port} ${where} closed: ${err.message}`);
+            upstream.destroy();
             clientSocket.destroy();
-            upstream?.destroy();
         };
-        upstream.on("error", (e) => cleanup("upstream", e));
-        clientSocket.on("error", (e) => cleanup("client", e));
+        upstream.once("error", (e) => cleanup("upstream", e));
+        clientSocket.once("error", (e) => cleanup("client", e));
     }).catch((err: Error) => {
         clearTimeout(connectTimer);
         log(`tunnel ${host}:${port} connect failed: ${err.message}`);

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,6 +7,7 @@ import { loadRoutes } from "./config.js";
 import { resolveContextLimit } from "./config.js";
 import { contextFromRegistry, loadRegistry } from "./registry.js";
 import { fetchWithTimeout, MAX_REQUEST_BYTES } from "./fetch-util.js";
+import { resolveProxy, proxyDispatcher } from "./upstream-proxy.js";
 import {
     anthropicToCore,
     coreToAnthropic,
@@ -128,7 +129,7 @@ export async function startServer(opts: ProxyOptions): Promise<http.Server> {
         }
     });
     if (opts.mitm.enabled) {
-        setupMitm(server, opts.mitm.domains, (msg) => log("info", msg));
+        setupMitm(server, opts.mitm.domains, (msg) => log("info", msg), (host) => resolveProxy(opts.routes, opts.proxy, `https://${host}`));
     }
     server.listen(opts.port, opts.host, () => {
         const displayHost = opts.host === "0.0.0.0" ? "localhost" : opts.host;
@@ -814,11 +815,13 @@ async function forward(
     if (affinity && !clientConversationHeader(req.headers)) {
         headers["x-session-id"] = affinity;
     }
-    const init: RequestInit = {
+    const dispatcher = proxyDispatcher(resolveProxy(opts.routes, opts.proxy, route?.rewrittenUrl));
+    const init: Omit<RequestInit, "dispatcher"> & { dispatcher?: object } = {
         method: req.method ?? "GET",
         headers,
         body: req.method === "GET" || req.method === "HEAD" ? undefined : body,
     };
+    if (dispatcher) init.dispatcher = dispatcher;
     const { response: upstream, clearTimer: clearUpstreamTimer } = await fetchWithTimeout(upstreamUrl, init);
     const respHeaders: Record<string, string> = {};
     upstream.headers.forEach((v, k) => {
@@ -890,7 +893,7 @@ async function forward(
             reqHeaders["content-type"] = "application/json";
             const loop = compressLoopStream(
                 streamToRead,
-                { core, config, messages: prepared.originalMessages, session: prepared.session, log: ctx.log },
+                { core, config, messages: prepared.originalMessages, session: prepared.session, log: ctx.log, proxyUrl: resolveProxy(opts.routes, opts.proxy, route?.rewrittenUrl) },
                 parsedReq,
                 { url: upstreamUrl, headers: reqHeaders },
             );
@@ -913,7 +916,7 @@ async function forward(
             reqHeaders["content-type"] = "application/json";
             const loop = compressLoopResponsesStream(
                 streamToRead,
-                { core, config, messages: prepared.originalMessages, session: prepared.session, log: ctx.log },
+                { core, config, messages: prepared.originalMessages, session: prepared.session, log: ctx.log, proxyUrl: resolveProxy(opts.routes, opts.proxy, route?.rewrittenUrl) },
                 parsedReq,
                 { url: upstreamUrl, headers: reqHeaders },
             );
@@ -936,7 +939,7 @@ async function forward(
             reqHeaders["content-type"] = "application/json";
             const loop = compressLoopAnthropicStream(
                 streamToRead,
-                { core, config, messages: prepared.originalMessages, session: prepared.session, log: ctx.log },
+                { core, config, messages: prepared.originalMessages, session: prepared.session, log: ctx.log, proxyUrl: resolveProxy(opts.routes, opts.proxy, route?.rewrittenUrl) },
                 parsedReq,
                 { url: upstreamUrl, headers: reqHeaders },
             );

--- a/src/server.ts
+++ b/src/server.ts
@@ -73,7 +73,14 @@ export function resolveUpstream(_opts: ProxyOptions, reqUrl: string, req?: http.
     // forwarded verbatim → subscription auth preserved, no MITM of creds.
     const mitmUpstream = readMitmUpstream(req?.socket);
     if (mitmUpstream) {
-        return { upstream: mitmUpstream, rewrittenUrl: mitmUpstream + (reqUrl ?? "") };
+        // Use a `mitm://` scheme in rewrittenUrl so per-URL config (proxy,
+        // context overrides) can DISTINGUISH MITM traffic from /bili/ path
+        // traffic to the SAME host. The real upstream stays https:// (in
+        // `upstream`) for the actual fetch; forward() strips the mitm:// scheme
+        // back to https:// before calling fetch (fetch would reject mitm://).
+        // Mapping is bijective: mitm://<host><path> ⟺ https://<host><path>.
+        const mitmKey = mitmUpstream.replace(/^https:\/\//, "mitm://");
+        return { upstream: mitmUpstream, rewrittenUrl: mitmKey + (reqUrl ?? "") };
     }
     // Zero-config mode: a request like `/bili/https://open.bigmodel.cn/api/anthropic`
     // embeds the full upstream URL after the `/bili/` prefix. Strip the prefix,
@@ -762,7 +769,11 @@ async function forward(
     route: ReturnType<typeof resolveUpstream>,
     affinity?: string,
 ): Promise<void> {
-    const upstreamUrl = route ? route.rewrittenUrl : opts.upstream + (req.url ?? "");
+    // rewrittenUrl may use a `mitm://` scheme (for config-lookup distinction
+    // — see resolveUpstream). fetch needs the real https:// scheme, so strip
+    // mitm:// back to https:// for the actual upstream request.
+    const rewritten = route ? route.rewrittenUrl : opts.upstream + (req.url ?? "");
+    const upstreamUrl = rewritten.replace(/^mitm:\/\//, "https://");
     // Show the final proxied URL (where the request actually lands) as the
     // primary signal. The provider label is appended only for named routes —
     // zero-config requests have a single routing mode now, so the final

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { createCore, type CompressionCore, type Config, type CoreMessage, type NudgeDecision, estimateTokensFast, renderNudgeText, deactivateBlock } from "acp-kernel";
 import type { ProxyOptions } from "./config.js";
 import { loadRoutes } from "./config.js";
+import { resetProxyCache } from "./upstream-proxy.js";
 import { resolveContextLimit } from "./config.js";
 import { contextFromRegistry, loadRegistry } from "./registry.js";
 import { fetchWithTimeout, MAX_REQUEST_BYTES } from "./fetch-util.js";
@@ -1084,6 +1085,10 @@ function handleConfigReload(opts: ProxyOptions, res: http.ServerResponse, log: (
     // (which read opts.routes) pick up the new entries without needing reassignment.
     for (const k of Object.keys(opts.routes)) delete opts.routes[k];
     Object.assign(opts.routes, fresh);
+    // Release cached ProxyAgents so agents for proxy URLs that were
+    // removed/changed don't leak for the process lifetime. The next request
+    // re-creates the needed agent lazily via proxyDispatcher().
+    resetProxyCache();
     const names = Object.keys(fresh);
     log("info", `[acp-web] routes hot-reloaded (${names.length} providers): ${names.join(", ") || "(none)"}`);
     res.writeHead(200, { "content-type": "application/json" });

--- a/src/upstream-proxy.ts
+++ b/src/upstream-proxy.ts
@@ -73,7 +73,9 @@ export function resolveProxy(
 
 /** Get (or create) a cached undici ProxyAgent for `proxyUrl`. Returns undefined
  *  for direct connect. Used by the fetch (`/bili/`) path. Returned as a plain
- *  object so callers don't need to import the undici Dispatcher type. */
+ *  object so callers don't need to import the undici Dispatcher type.
+ *  Call `resetProxyCache()` on config hot-reload to release ProxyAgents whose
+ *  URL was removed/changed (otherwise they'd leak for the process lifetime). */
 export function proxyDispatcher(proxyUrl: string | undefined): object | undefined {
     if (!proxyUrl) return undefined;
     let agent = dispatcherCache.get(proxyUrl);
@@ -82,6 +84,16 @@ export function proxyDispatcher(proxyUrl: string | undefined): object | undefine
         dispatcherCache.set(proxyUrl, agent);
     }
     return agent;
+}
+
+/** Release all cached ProxyAgents. Called on config hot-reload so agents for
+ *  proxy URLs that were removed/changed don't leak. Safe to call anytime;
+ *  the next proxyDispatcher() call re-creates the needed agent lazily. */
+export function resetProxyCache(): void {
+    for (const agent of dispatcherCache.values()) {
+        try { agent.close(); } catch { /* best-effort */ }
+    }
+    dispatcherCache.clear();
 }
 
 /** Establish a TCP connection to `host:port`, through an HTTP proxy if one is
@@ -118,7 +130,18 @@ export function connectThroughProxy(
     return new Promise((resolve, reject) => {
         const sock = net.connect(proxy.port, proxy.host);
         let established = false;
+        // Internal timeout for the CONNECT handshake (proxy → upstream). If the
+        // proxy is slow/unresponsive the outer 15s tunnel timer would still
+        // fire, but a dedicated handshake timeout fails faster and surfaces a
+        // clearer error ("CONNECT handshake timeout") in the log.
+        const handshakeTimer = setTimeout(() => {
+            if (!established) {
+                sock.destroy();
+                reject(new Error(`upstream proxy CONNECT ${host}:${port} handshake timeout`));
+            }
+        }, 10000);
         const cleanup = (err: Error) => {
+            clearTimeout(handshakeTimer);
             if (!established) sock.destroy();
             reject(err);
         };
@@ -148,6 +171,7 @@ export function connectThroughProxy(
                     return;
                 }
                 established = true;
+                clearTimeout(handshakeTimer);
                 // If the proxy pipelined any early bytes after the 200, push
                 // them back so the TLS handshake sees them.
                 if (rest.length > 0) sock.unshift(rest);

--- a/src/upstream-proxy.ts
+++ b/src/upstream-proxy.ts
@@ -1,0 +1,181 @@
+/**
+ * Upstream proxy support.
+ *
+ * Allows billion-context to route its OWN outbound connections (to the model
+ * providers) through an HTTP proxy. Typical use case: a Codex user behind the
+ * GFW already runs v2rayA; configuring billion-context's upstream proxy lets
+ * `api.openai.com` traffic reach the model instead of timing out.
+ *
+ * TWO outbound paths must support this:
+ *   1. `/bili/` path-mode requests — forwarded via `fetch()`. We inject an
+ *      undici `ProxyAgent` as the fetch `dispatcher`.
+ *   2. MITM mode — `CONNECT <host>:443` tunnels. We establish the outbound
+ *      connection by talking CONNECT to the proxy, then run TLS over the
+ *      resulting tunnel.
+ *
+ * Only HTTP proxies are supported (`http://host:port`). SOCKS5 is intentionally
+ * out of scope for now.
+ */
+import net from "node:net";
+import tls from "node:tls";
+import { ProxyAgent } from "undici";
+import type { ProviderRoutes } from "./config.js";
+
+/** Per-URL proxy cache so we don't construct a new ProxyAgent per request. */
+const dispatcherCache = new Map<string, ProxyAgent>();
+
+/** Parse a proxy URL. Returns undefined if `proxy` is empty or not an http(s)
+ *  URL (we only support HTTP forward proxies, not SOCKS, for now). */
+export function parseHttpProxy(proxy?: string): { url: string; host: string; port: number } | undefined {
+    if (!proxy || typeof proxy !== "string") return undefined;
+    try {
+        const u = new URL(proxy);
+        // We accept http:// (standard HTTP forward proxy). https:// would mean
+        // TLS to the proxy itself — uncommon for local proxies; reject to keep
+        // the MITM path simple. socks5:// is not supported yet.
+        if (u.protocol !== "http:") return undefined;
+        const port = u.port ? parseInt(u.port, 10) : 80;
+        if (!Number.isFinite(port)) return undefined;
+        return { url: `${u.protocol}//${u.hostname}:${port}`, host: u.hostname, port };
+    } catch {
+        return undefined;
+    }
+}
+
+/**
+ * Resolve the effective proxy for a given upstream URL.
+ *
+ * Rule: per-URL `route.proxy` overrides the global `globalProxy`. Neither set
+ * → undefined (direct connect). Uses the same longest-prefix match as
+ * resolveContextLimit so `https://api.openai.com/v1` and a MITM virtual URL
+ * `https://api.openai.com` both match a key like `https://api.openai.com`.
+ */
+export function resolveProxy(
+    routes: ProviderRoutes,
+    globalProxy: string | undefined,
+    upstreamUrl: string | undefined,
+): string | undefined {
+    if (!upstreamUrl) return parseHttpProxy(globalProxy)?.url;
+    let bestKey = "";
+    for (const key of Object.keys(routes)) {
+        if (upstreamUrl === key || upstreamUrl.startsWith(key + "/")) {
+            if (key.length > bestKey.length) bestKey = key;
+        }
+    }
+    // Child overrides parent. Empty string on the route means "explicitly
+    // direct" (override the global). Otherwise fall back to global.
+    if (bestKey) {
+        const routeProxy = routes[bestKey].proxy;
+        if (routeProxy !== undefined) return parseHttpProxy(routeProxy)?.url;
+    }
+    return parseHttpProxy(globalProxy)?.url;
+}
+
+/** Get (or create) a cached undici ProxyAgent for `proxyUrl`. Returns undefined
+ *  for direct connect. Used by the fetch (`/bili/`) path. Returned as a plain
+ *  object so callers don't need to import the undici Dispatcher type. */
+export function proxyDispatcher(proxyUrl: string | undefined): object | undefined {
+    if (!proxyUrl) return undefined;
+    let agent = dispatcherCache.get(proxyUrl);
+    if (!agent) {
+        agent = new ProxyAgent({ uri: proxyUrl });
+        dispatcherCache.set(proxyUrl, agent);
+    }
+    return agent;
+}
+
+/** Establish a TCP connection to `host:port`, through an HTTP proxy if one is
+ *  configured. `proxyUrl` is the resolved proxy (from resolveProxy) or
+ *  undefined for direct connect.
+ *
+ *  For direct connect: `net.connect(port, host)`.
+ *  For proxied connect: connect to the proxy, send
+ *    `CONNECT host:port HTTP/1.1\r\nHost: host:port\r\n\r\n`, wait for
+ *    `HTTP/1.1 200`, then return the socket (the tunnel is now transparent).
+ *  Throws on any failure (proxy refused, non-200, connection reset). */
+export function connectThroughProxy(
+    host: string,
+    port: number,
+    proxyUrl: string | undefined,
+): Promise<net.Socket> {
+    if (!proxyUrl) {
+        // Direct connect — the common, fast path.
+        return new Promise((resolve, reject) => {
+            const sock = net.connect(port, host);
+            sock.once("connect", () => resolve(sock));
+            sock.once("error", reject);
+        });
+    }
+    const proxy = parseHttpProxy(proxyUrl);
+    if (!proxy) {
+        // Malformed proxy URL — fall back to direct rather than crash.
+        return new Promise((resolve, reject) => {
+            const sock = net.connect(port, host);
+            sock.once("connect", () => resolve(sock));
+            sock.once("error", reject);
+        });
+    }
+    return new Promise((resolve, reject) => {
+        const sock = net.connect(proxy.port, proxy.host);
+        let established = false;
+        const cleanup = (err: Error) => {
+            if (!established) sock.destroy();
+            reject(err);
+        };
+        sock.once("error", cleanup);
+        sock.once("connect", () => {
+            // Send CONNECT to the proxy to open a tunnel to host:port.
+            const connectReq =
+                `CONNECT ${host}:${port} HTTP/1.1\r\n` +
+                `Host: ${host}:${port}\r\n` +
+                `Proxy-Connection: Keep-Alive\r\n\r\n`;
+            sock.write(connectReq);
+            // Read the proxy's HTTP response. We only need the status line +
+            // the blank-line terminator; body (if any) is not expected for a
+            // successful CONNECT.
+            let buf = "";
+            const onLine = (data: Buffer) => {
+                buf += data.toString("utf8");
+                const end = buf.indexOf("\r\n\r\n");
+                if (end === -1) return;
+                sock.removeListener("data", onLine);
+                const head = buf.slice(0, end);
+                const rest = Buffer.from(buf.slice(end + 4), "utf8");
+                // Status line: "HTTP/1.1 200 Connection Established\r\n..."
+                const statusLine = head.split("\r\n")[0] ?? "";
+                if (!/^HTTP\/1\.[01]\s+2\d\d/.test(statusLine)) {
+                    cleanup(new Error(`upstream proxy CONNECT ${host}:${port} failed: ${statusLine}`));
+                    return;
+                }
+                established = true;
+                // If the proxy pipelined any early bytes after the 200, push
+                // them back so the TLS handshake sees them.
+                if (rest.length > 0) sock.unshift(rest);
+                resolve(sock);
+            };
+            sock.on("data", onLine);
+            sock.once("error", cleanup);
+        });
+    });
+}
+
+/** Connect to `host:port` over TLS, through a proxy if configured. Used by the
+ *  MITM path: after terminating the client's TLS, we re-establish a TLS
+ *  connection to the REAL upstream. If a proxy is configured, the TLS runs
+ *  over a CONNECT tunnel to that proxy. */
+export async function connectTlsThroughProxy(
+    host: string,
+    port: number,
+    proxyUrl: string | undefined,
+    servername?: string,
+): Promise<tls.TLSSocket> {
+    const sock = await connectThroughProxy(host, port, proxyUrl);
+    return tls.connect({
+        socket: sock,
+        servername: servername ?? host,
+        // Let Node pick ALPN; we must accept h2 here because the real upstream
+        // (api.openai.com etc.) may negotiate it and we forward raw bytes in
+        // the blind-tunnel path. The MITM-decrypt path forces http/1.1 on the
+        // CLIENT side but the UPSTREAM side can be anything.
+    });
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
     // noExternal, esbuild keeps `import ... from "acp-kernel"` in dist, and
     // npm then installs acp-kernel as a runtime dep — breaking the
     // "dist/index.js is self-contained" contract (AGENTS.md §2.1).
-    noExternal: ["acp-kernel", "node-forge"],
+    noExternal: ["acp-kernel", "node-forge", "undici"],
     banner: {
         // node-forge is a CommonJS dependency that calls require("crypto") etc.
         // inlined into our ESM output, esbuild's __require shim throws in an


### PR DESCRIPTION
## Why

Codex / Claude Code users behind the GFW run v2rayA locally. When they point
their client at billion-context, the proxy's own outbound to
`api.openai.com` times out — the GFW blocks it. billion-context needs to route
its model-provider traffic through the user's existing HTTP proxy.

## What

Add upstream proxy support — global + per-URL, HTTP only (SOCKS5 deferred).

### Config

\`\`\`jsonc
{
  \"proxy\": \"http://127.0.0.1:20172\",          // global default
  \"providers\": {
    \"https://api.openai.com/v1\": {
      \"proxy\": \"http://127.0.0.1:20173\",     // per-URL overrides global
      \"models\": { ... }
    },
    \"https://open.bigmodel.cn/api/anthropic\": {
      \"proxy\": \"\",                            // explicitly direct
    }
  }
}
\`\`\`

Rules: per-URL overrides global; empty string = explicitly direct; neither = direct.

### Both outbound paths covered

- **\`/bili/\` path-mode (fetch):** undici \`ProxyAgent\` injected as \`dispatcher\` in all 4 fetch sites (forward + 3 compress-loop round-trips).
- **MITM CONNECT tunnels:** \`tunnelThrough()\` connects via HTTP CONNECT to the proxy first, then pipes (blind tunnels for non-whitelisted hosts).

### Files

- **new** \`src/upstream-proxy.ts\` — \`parseHttpProxy\`, \`resolveProxy\` (longest-prefix + child-overrides-parent), \`proxyDispatcher\` (cached ProxyAgent), \`connectThroughProxy\` (direct or HTTP CONNECT), \`connectTlsThroughProxy\`.
- \`config.ts\` — \`ProviderRoute.proxy\` + \`ProxyOptions.proxy\` + \`FileConfig.proxy\` + \`BILI_UPSTREAM_PROXY\` env + \`parseRouteEntry\`.
- \`fetch-util.ts\` — \`fetchWithTimeout\` takes \`FetchOptions\` (\`RequestInit\` + \`dispatcher\`); \`Omit\` pattern sidesteps the \`@types/node\` vs \`undici\` \`Dispatcher\` type clash (no \`as any\`).
- \`server.ts\` — forward injects dispatcher; 3 compress-loop ctxs carry \`proxyUrl\`; \`setupMitm\` gets a \`resolveProxyUrl\` callback for blind-tunnel outbound.
- \`mitm.ts\` — \`tunnelThrough\` rewritten async (\`connectThroughProxy\` promise).
- \`tsup.config.ts\` — \`noExternal += undici\` (devDep, inlined into dist; dist stays self-contained).
- README (EN + ZH) — \"Upstream proxy (firewall / GFW)\" section + \`proxy\` in top-level keys table.

## Verified

- \`tsc --noEmit\`: 0 errors
- 169 tests pass
- \`npm run build\`: OK, dist self-contained (0 \`from \"undici\"\`, 0 \`from \"acp-kernel\"\`, 2.0M with undici inlined)

## Out of scope (follow-up)

- SOCKS5 support
- Web UI inputs for global/per-URL proxy (config file works now)