### PR TITLE
fix: trim old reasoning items to stop Responses-API cache explosion

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ with no file at all).
 | `ACP_AUTO_UPDATE` | `1` | Set `0` to disable background self-update |
 | `ACP_LOG_FILE` | *XDG state path* | Log file path (`off` disables the file, keeps stderr) |
 | `ACP_DUMP_SSE` | *(none)* | Directory to dump SSE for debugging |
-| `ACP_REASONING_KEEP` | `recent` | Responses-API only: how `reasoning` items from previous responses are carried. `recent` keeps only the most recent response's reasoning (drops old chain-of-thought that accumulates every turn and breaks the prompt-cache prefix); `all` re-sends every historical reasoning item (legacy); `none` drops all reasoning. |
+| `ACP_REASONING_KEEP` | `recent` | Responses-API only: how `reasoning` items from previous responses are carried. `recent` keeps only the most recent response's reasoning (drops old chain-of-thought that accumulates every turn — a major context-size reduction); `all` re-sends every historical reasoning item (legacy); `none` drops all reasoning. |
 | `BILI_PERSIST` | `1` | Set `0` to disable session persistence (in-memory only, lost on restart) |
 | `BILI_PERSIST_DEBOUNCE_MS` | `500` | Debounce window for writes to disk (ms) |
 | `BILI_MAX_SESSIONS` | `256` | Max sessions held in memory (LRU eviction; disk is source of truth) |

--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ with no file at all).
 | `ACP_AUTO_UPDATE` | `1` | Set `0` to disable background self-update |
 | `ACP_LOG_FILE` | *XDG state path* | Log file path (`off` disables the file, keeps stderr) |
 | `ACP_DUMP_SSE` | *(none)* | Directory to dump SSE for debugging |
+| `ACP_REASONING_KEEP` | `recent` | Responses-API only: how `reasoning` items from previous responses are carried. `recent` keeps only the most recent response's reasoning (drops old chain-of-thought that accumulates every turn and breaks the prompt-cache prefix); `all` re-sends every historical reasoning item (legacy); `none` drops all reasoning. |
 | `BILI_PERSIST` | `1` | Set `0` to disable session persistence (in-memory only, lost on restart) |
 | `BILI_PERSIST_DEBOUNCE_MS` | `500` | Debounce window for writes to disk (ms) |
 | `BILI_MAX_SESSIONS` | `256` | Max sessions held in memory (LRU eviction; disk is source of truth) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -258,7 +258,7 @@ bili --no-auto-update        # 本次启动禁用自动更新
 | `ACP_AUTO_UPDATE` | `1` | 设 `0` 禁用后台自动更新 |
 | `ACP_LOG_FILE` | *XDG state 路径* | 日志文件路径(`off` 关闭文件,只保留 stderr) |
 | `ACP_DUMP_SSE` | *(无)* | 转储 SSE 用于调试的目录 |
-| `ACP_REASONING_KEEP` | `recent` | 仅 Responses API:控制如何携带历史 `reasoning` 项。`recent` 只保留最近一轮响应的 reasoning(丢弃每轮累积、会破坏 prompt-cache 前缀的旧思维链);`all` 每轮全量重发所有历史 reasoning(旧行为);`none` 丢弃全部 reasoning。 |
+| `ACP_REASONING_KEEP` | `recent` | 仅 Responses API:控制如何携带历史 `reasoning` 项。`recent` 只保留最近一轮响应的 reasoning(丢弃每轮累积的旧思维链,大幅减少上下文体量);`all` 每轮全量重发所有历史 reasoning(旧行为);`none` 丢弃全部 reasoning。 |
 | `BILI_PERSIST` | `1` | 设 `0` 禁用会话持久化(纯内存,重启丢失) |
 | `BILI_PERSIST_DEBOUNCE_MS` | `500` | 写磁盘的防抖窗口(毫秒) |
 | `BILI_MAX_SESSIONS` | `256` | 内存中保留的最大会话数(LRU 淘汰;磁盘是真相源) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -258,6 +258,7 @@ bili --no-auto-update        # 本次启动禁用自动更新
 | `ACP_AUTO_UPDATE` | `1` | 设 `0` 禁用后台自动更新 |
 | `ACP_LOG_FILE` | *XDG state 路径* | 日志文件路径(`off` 关闭文件,只保留 stderr) |
 | `ACP_DUMP_SSE` | *(无)* | 转储 SSE 用于调试的目录 |
+| `ACP_REASONING_KEEP` | `recent` | 仅 Responses API:控制如何携带历史 `reasoning` 项。`recent` 只保留最近一轮响应的 reasoning(丢弃每轮累积、会破坏 prompt-cache 前缀的旧思维链);`all` 每轮全量重发所有历史 reasoning(旧行为);`none` 丢弃全部 reasoning。 |
 | `BILI_PERSIST` | `1` | 设 `0` 禁用会话持久化(纯内存,重启丢失) |
 | `BILI_PERSIST_DEBOUNCE_MS` | `500` | 写磁盘的防抖窗口(毫秒) |
 | `BILI_MAX_SESSIONS` | `256` | 内存中保留的最大会话数(LRU 淘汰;磁盘是真相源) |

--- a/src/responses.ts
+++ b/src/responses.ts
@@ -96,17 +96,18 @@ function isOpaqueItem(it: ResponseInputItem): boolean {
     return OPAQUE_ITEM_TYPES.has(it.type);
 }
 
-/** External-input items (user messages, tool outputs) mark turn boundaries.
- *  Reasoning at or before the LAST one belongs to an old, completed model
- *  response and is dropped (see getReasoningKeepMode). `computer_call_output`
- *  is intentionally excluded: it is itself an opaque item the host
- *  re-injects, not a fresh external input. */
+/** External-input items (user messages and tool outputs) mark turn boundaries
+ *  between model responses. Reasoning at or before the LAST one belongs to an
+ *  old, completed model response and is dropped (see getReasoningKeepMode).
+ *  This mirrors OpenAI's stateless contract: each `reasoning` + `*_call` is a
+ *  discrete response, and only the immediately preceding response's reasoning
+ *  is needed to continue the chain. */
 function isExternalInputItem(it: ResponseInputItem): boolean {
     const t = it.type;
     if (t === "message") {
         return (it as ResponseInputMessage).role === "user";
     }
-    return t === "function_call_output" || t === "custom_tool_call_output";
+    return t === "function_call_output" || t === "custom_tool_call_output" || t === "computer_call_output";
 }
 
 /** Controls how `reasoning` items from previous model responses are handled.

--- a/src/responses.ts
+++ b/src/responses.ts
@@ -70,6 +70,7 @@ type Flat = {
      *  out — a standard `function_call` must NOT be rewritten as
      *  `custom_tool_call` (different Responses API semantics). */
     customToolCallIds: Set<string>;
+    droppedReasoning: number;
 };
 
 /** Item types that are opaque host directives (tool definitions, reasoning,
@@ -93,6 +94,30 @@ const OPAQUE_ITEM_TYPES = new Set([
 
 function isOpaqueItem(it: ResponseInputItem): boolean {
     return OPAQUE_ITEM_TYPES.has(it.type);
+}
+
+/** External-input items (user messages, tool outputs) mark turn boundaries.
+ *  Reasoning at or before the LAST one belongs to an old, completed model
+ *  response and is dropped (see getReasoningKeepMode). `computer_call_output`
+ *  is intentionally excluded: it is itself an opaque item the host
+ *  re-injects, not a fresh external input. */
+function isExternalInputItem(it: ResponseInputItem): boolean {
+    const t = it.type;
+    if (t === "message") {
+        return (it as ResponseInputMessage).role === "user";
+    }
+    return t === "function_call_output" || t === "custom_tool_call_output";
+}
+
+/** Controls how `reasoning` items from previous model responses are handled.
+ *  - "recent" (default): keep only the most recent response's reasoning (after
+ *    the last external input), drop all older reasoning.
+ *  - "all": legacy behaviour — preserve every reasoning item verbatim.
+ *  - "none": drop all reasoning items (maximum context savings). */
+type ReasoningKeepMode = "recent" | "all" | "none";
+function getReasoningKeepMode(): ReasoningKeepMode {
+    const v = (process.env.ACP_REASONING_KEEP ?? "recent").trim().toLowerCase();
+    return v === "all" || v === "none" ? v : "recent";
 }
 
 function partText(p: ResponseContentPart): string {
@@ -129,23 +154,42 @@ export function responsesToCore(body: ResponsesRequestBody): Flat {
     const systemParts: string[] = [];
     const preamble: ResponseInputItem[] = [];
     const customToolCallIds = new Set<string>();
+    let droppedReasoning = 0;
     if (typeof body.instructions === "string" && body.instructions.trim()) {
         systemParts.push(body.instructions);
     }
     let idx = 0;
     const clusters = new ClusterCounter();
     const items = Array.isArray(body.input) ? body.input : [];
+    const reasoningKeep = getReasoningKeepMode();
+    // Index of the last external input (user message or tool output). Reasoning
+    // items at or before this index belong to old, completed model responses
+    // and are dropped (except in "all" mode) to stop unbounded accumulation.
+    let lastExternalInputIdx = -1;
+    if (reasoningKeep === "recent") {
+        for (let i = 0; i < items.length; i++) {
+            if (isExternalInputItem(items[i])) lastExternalInputIdx = i;
+        }
+    }
     if (typeof body.input === "string") {
         const base = deriveMessageId("user", "text", body.input);
         msgs.push({ id: clusters.next(base), role: "user", contentType: "text", text: body.input });
         idx++;
-        return { msgs, systemParts, preamble, customToolCallIds };
+        return { msgs, systemParts, preamble, customToolCallIds, droppedReasoning };
     }
-    for (const it of items) {
+    for (let i = 0; i < items.length; i++) {
+        const it = items[i];
         // Preserve opaque host-directive items verbatim. They are never
         // conversation history: capture them so the caller re-prepends them
-        // unchanged (additional_tools MUST stay at input[0]).
+        // unchanged (additional_tools MUST stay at input[0]). The one exception
+        // is `reasoning`: legacy behaviour re-sent every historical reasoning
+        // item every turn, which balloons context and breaks the upstream
+        // prompt-cache prefix. Trim to the most recent response's reasoning.
         if (isOpaqueItem(it)) {
+            if (it.type === "reasoning") {
+                if (reasoningKeep === "none") { droppedReasoning++; continue; }
+                if (reasoningKeep === "recent" && i <= lastExternalInputIdx) { droppedReasoning++; continue; }
+            }
             preamble.push(it);
             continue;
         }
@@ -257,7 +301,7 @@ export function responsesToCore(body: ResponsesRequestBody): Flat {
                 break;
         }
     }
-    return { msgs, systemParts, preamble, customToolCallIds };
+    return { msgs, systemParts, preamble, customToolCallIds, droppedReasoning };
 }
 
 export function coreToResponses(

--- a/src/server.ts
+++ b/src/server.ts
@@ -623,10 +623,13 @@ function prepareResponses(
     const shouldInject = opts.compress.injectTool;
 
     try {
-        const { msgs, systemParts, preamble, customToolCallIds } = responsesToCore(parsed);
+        const { msgs, systemParts, preamble, customToolCallIds, droppedReasoning } = responsesToCore(parsed);
         originalMessages = msgs;
         if (process.env.ACP_DEBUG) {
             log("info", `[${sessionId}] input items: ${Array.isArray(parsed.input) ? parsed.input.map((i: ResponseInputItem) => i.type).join(",") : "(string)"}`);
+            if (droppedReasoning > 0) {
+                log("info", `[${sessionId}] dropped ${droppedReasoning} old reasoning item(s) (ACP_REASONING_KEEP=${process.env.ACP_REASONING_KEEP ?? "recent"})`);
+            }
         }
         // tokenCount = upstream's real input_tokens from the previous turn
         // (see anthropic branch comment). Never an estimate. systemParts is

--- a/tests/proxy-responses-review.test.ts
+++ b/tests/proxy-responses-review.test.ts
@@ -135,6 +135,22 @@ test("responses: recent mode keeps reasoning when it is the only (most recent) r
     assert.equal(reasoningOf(preamble).length, 2, "reasoning after the only user message is the most recent response and is kept");
 });
 
+test("responses: computer_call_output is a turn boundary (CUA loop)", () => {
+    const body = {
+        model: "computer-use-preview",
+        input: [
+            { type: "message", role: "user", content: "click the button" },
+            { type: "reasoning", id: "rs_cua_old" },
+            { type: "computer_call", call_id: "cc1", action: {}, status: "completed" },
+            { type: "computer_call_output", call_id: "cc1", output: {} },
+            { type: "reasoning", id: "rs_cua_new" },
+        ],
+    };
+    const { preamble } = runWithReasoningKeep(undefined, body);
+    const ids = reasoningOf(preamble).map((r) => (r as { id: string }).id);
+    assert.deepEqual(ids, ["rs_cua_new"], "only reasoning after the last computer_call_output survives");
+});
+
 // Review #2: response.failed terminal is replayed verbatim and NOT followed by
 // a fabricated response.completed (which would contradict the failure).
 test("compressLoopResponsesStream: response.failed is replayed without a contradictory completed", async () => {

--- a/tests/proxy-responses-review.test.ts
+++ b/tests/proxy-responses-review.test.ts
@@ -73,6 +73,68 @@ test("responses: unknown item type is preserved in preamble", () => {
     assert.equal(msgs.length, 1, "only the real message enters compression");
 });
 
+function runWithReasoningKeep(mode: string | undefined, body: unknown) {
+    const prev = process.env.ACP_REASONING_KEEP;
+    if (mode === undefined) delete process.env.ACP_REASONING_KEEP;
+    else process.env.ACP_REASONING_KEEP = mode;
+    try {
+        return responsesToCore(body as never);
+    } finally {
+        if (prev === undefined) delete process.env.ACP_REASONING_KEEP;
+        else process.env.ACP_REASONING_KEEP = prev;
+    }
+}
+
+// Agentic loop across three responses: reasoning from the two oldest responses
+// sits before the last tool output (old, completed); reasoning after the last
+// tool output belongs to the most recent response.
+const reasoningLoopBody = {
+    model: "o4-mini",
+    input: [
+        { type: "additional_tools", tools: [{ name: "shell" }] },
+        { type: "message", role: "user", content: "go" },
+        { type: "reasoning", id: "rs_old_1" },
+        { type: "reasoning", id: "rs_old_2" },
+        { type: "function_call", call_id: "c1", name: "f", arguments: "{}" },
+        { type: "function_call_output", call_id: "c1", output: "out" },
+        { type: "reasoning", id: "rs_new_1" },
+        { type: "reasoning", id: "rs_new_2" },
+    ],
+};
+const reasoningOf = (preamble: { type: string }[]) => preamble.filter((i) => i.type === "reasoning");
+
+test("responses: default (recent) trims old reasoning, keeps most recent response", () => {
+    const { preamble } = runWithReasoningKeep(undefined, reasoningLoopBody);
+    const reasoning = reasoningOf(preamble);
+    assert.equal(preamble.find((i) => i.type === "additional_tools")?.type, "additional_tools", "additional_tools always preserved");
+    assert.deepEqual(reasoning.map((r) => (r as { id: string }).id), ["rs_new_1", "rs_new_2"], "only reasoning after last external input survives");
+});
+
+test("responses: ACP_REASONING_KEEP=all preserves every reasoning item (legacy)", () => {
+    const { preamble } = runWithReasoningKeep("all", reasoningLoopBody);
+    const reasoning = reasoningOf(preamble);
+    assert.equal(reasoning.length, 4, "all four reasoning items preserved");
+});
+
+test("responses: ACP_REASONING_KEEP=none drops all reasoning items", () => {
+    const { preamble } = runWithReasoningKeep("none", reasoningLoopBody);
+    assert.equal(reasoningOf(preamble).length, 0, "no reasoning survives");
+    assert.ok(preamble.find((i) => i.type === "additional_tools"), "additional_tools still preserved in none mode");
+});
+
+test("responses: recent mode keeps reasoning when it is the only (most recent) response", () => {
+    const body = {
+        model: "o4-mini",
+        input: [
+            { type: "message", role: "user", content: "u" },
+            { type: "reasoning", id: "rs_only_1" },
+            { type: "reasoning", id: "rs_only_2" },
+        ],
+    };
+    const { preamble } = runWithReasoningKeep(undefined, body);
+    assert.equal(reasoningOf(preamble).length, 2, "reasoning after the only user message is the most recent response and is kept");
+});
+
 // Review #2: response.failed terminal is replayed verbatim and NOT followed by
 // a fabricated response.completed (which would contradict the failure).
 test("compressLoopResponsesStream: response.failed is replayed without a contradictory completed", async () => {


### PR DESCRIPTION
## Root cause

OpenAI Responses-API `reasoning` items (the model's encrypted chain-of-thought) were treated as **opaque preamble** and re-sent verbatim **every turn**, accumulating without bound.

Observed in `bili (3).log` (reported in dog/billion-context-pi#15):

| turn | preserved preamble items |
|------|--------------------------|
| 1 | 1 (additional_tools) |
| 2 | 2 (+reasoning) |
| … | 9, 11 |
| last | **50** (reasoning×49) |

One large response added ~39 reasoning items in a single jump. Consequences:

- **Context explosion** — 49 encrypted CoT blobs resent every request.
- **Cache prefix broken** — `cached` stuck at `14080` (the static `additional_tools` block) while `input` ballooned 42k→78k; cache hit dropped to 18%. The volatile reasoning sits *before* the conversation, so nothing past `additional_tools` could form a stable cached prefix.
- **Relay dropouts** — `responses stream ended without completion` ×3 from the relay station, triggered by the oversized requests.

Code path:
- `src/responses.ts` — `OPAQUE_ITEM_TYPES` includes `"reasoning"`; `responsesToCore` pushed every reasoning item into `preamble`.
- `src/server.ts` `prepareResponses` — `inputItems = [...preamble]` re-prepended the whole preamble every turn.

## Fix

Keep only the **most recent model response's reasoning** = reasoning items positioned *after* the last external input (user message / `function_call_output` / `custom_tool_call_output`). Reasoning at or before that boundary belongs to old, completed responses → drop it.

- `additional_tools` and all other opaque items are still preserved verbatim (unchanged behavior).
- New env `ACP_REASONING_KEEP` = `recent` (default) | `all` (legacy) | `none` (drop all).
- Debug log: `dropped N old reasoning item(s) (ACP_REASONING_KEEP=recent)`.

## Verification

- `npm run typecheck` ✅
- `npm test` — 173/173 pass (4 new tests for the reasoning trim) ✅
- `npm run build` ✅

## Tests added (`tests/proxy-responses-review.test.ts`)

- default (`recent`) trims old reasoning, keeps most recent response's reasoning
- `ACP_REASONING_KEEP=all` preserves every reasoning item (legacy)
- `ACP_REASONING_KEEP=none` drops all reasoning items
- `recent` keeps reasoning when it is the only (most recent) response

## Note

`version` is **not** bumped (content commit per AGENTS.md §4). If this should ship, it needs to ride a subsequent `*_release-v*` branch.

Refs: dog/billion-context-pi#15