### PR TITLE
fix: route Responses reasoning through compression pipeline (Codex cache explosion)

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ with no file at all).
 | `ACP_SESSION_HEADER` | `x-acp-session` | Conversation-id header name |
 | `ACP_COMPRESS_TOOL` | `1` | Set `0` to disable injecting the compress tool |
 | `ACP_COMPRESS_NUDGE` | `1` | Set `0` to disable compression nudges |
+| `ACP_REASONING_KEEP` | *(default)* | Responses API only: set `none` to drop all reasoning items. Default routes reasoning through the compression pipeline so it is hidden automatically once its turn is summarized (prevents the unbounded accumulation that broke Codex's prompt-cache prefix). |
 | `ACP_DEBUG` | `0` | Set `1` for verbose logging |
 | `ACP_PASSTHROUGH` | `0` | Set `1` to forward without compression |
 | `ACP_AUTO_UPDATE` | `1` | Set `0` to disable background self-update |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -253,6 +253,7 @@ bili --no-auto-update        # 本次启动禁用自动更新
 | `ACP_SESSION_HEADER` | `x-acp-session` | 会话标识 header 名 |
 | `ACP_COMPRESS_TOOL` | `1` | 设 `0` 禁止注入 compress 工具 |
 | `ACP_COMPRESS_NUDGE` | `1` | 设 `0` 禁止压缩 nudge |
+| `ACP_REASONING_KEEP` | *(默认)* | 仅 Responses API：设 `none` 丢弃全部 reasoning。默认走压缩管线，turn 被压缩时自动隐藏（防止 reasoning 无限累积撑爆 Codex 的 prompt-cache 前缀）。 |
 | `ACP_DEBUG` | `0` | 设 `1` 打开详细日志 |
 | `ACP_PASSTHROUGH` | `0` | 设 `1` 不压缩直接转发 |
 | `ACP_AUTO_UPDATE` | `1` | 设 `0` 禁用后台自动更新 |

--- a/src/responses.ts
+++ b/src/responses.ts
@@ -70,17 +70,25 @@ type Flat = {
      *  out — a standard `function_call` must NOT be rewritten as
      *  `custom_tool_call` (different Responses API semantics). */
     customToolCallIds: Set<string>;
+    /** Reasoning items dropped because ACP_REASONING_KEEP=none. 0 by default —
+     *  reasoning is normally routed through the compression pipeline so it is
+     *  hidden automatically once its turn is summarized. */
+    droppedReasoning: number;
 };
 
-/** Item types that are opaque host directives (tool definitions, reasoning,
- *  computer calls, ...) and must be preserved verbatim — they are NOT
- *  conversation history and must never be compressed or rewritten.
- *  `additional_tools` in particular carries the Codex code_mode exec/wait
- *  tool definitions and MUST stay at input[0] (see openai/codex client.rs
- *  splice(0..0, prefix)). */
+/** Item types that are opaque host directives (tool definitions, computer
+ *  calls, ...) and must be preserved verbatim — they are NOT conversation
+ *  history and must never be compressed or rewritten. `additional_tools` in
+ *  particular carries the Codex code_mode exec/wait tool definitions and MUST
+ *  stay at input[0] (see openai/codex client.rs splice(0..0, prefix)).
+ *
+ *  `reasoning` is intentionally NOT opaque: it IS conversation history (a
+ *  prior response's chain-of-thought) and is converted to a tracked
+ *  BiliMessage so the compression pipeline hides it once its turn is
+ *  summarized — preventing the unbounded accumulation that broke Codex's
+ *  prompt-cache prefix. See the `reasoning` case in responsesToCore. */
 const OPAQUE_ITEM_TYPES = new Set([
     "additional_tools",
-    "reasoning",
     "computer_call",
     "computer_call_output",
     "file_search_call",
@@ -93,6 +101,14 @@ const OPAQUE_ITEM_TYPES = new Set([
 
 function isOpaqueItem(it: ResponseInputItem): boolean {
     return OPAQUE_ITEM_TYPES.has(it.type);
+}
+
+/** Escape hatch: when ACP_REASONING_KEEP=none, drop reasoning items entirely
+ *  instead of routing them through compression. Default (any other value)
+ *  keeps reasoning until its turn is summarized, preserving chain-of-thought
+ *  continuity for the responses that are still live. */
+function shouldDropAllReasoning(): boolean {
+    return (process.env.ACP_REASONING_KEEP ?? "").trim().toLowerCase() === "none";
 }
 
 function partText(p: ResponseContentPart): string {
@@ -129,6 +145,7 @@ export function responsesToCore(body: ResponsesRequestBody): Flat {
     const systemParts: string[] = [];
     const preamble: ResponseInputItem[] = [];
     const customToolCallIds = new Set<string>();
+    let droppedReasoning = 0;
     if (typeof body.instructions === "string" && body.instructions.trim()) {
         systemParts.push(body.instructions);
     }
@@ -139,7 +156,7 @@ export function responsesToCore(body: ResponsesRequestBody): Flat {
         const base = deriveMessageId("user", "text", body.input);
         msgs.push({ id: clusters.next(base), role: "user", contentType: "text", text: body.input });
         idx++;
-        return { msgs, systemParts, preamble, customToolCallIds };
+        return { msgs, systemParts, preamble, customToolCallIds, droppedReasoning };
     }
     for (const it of items) {
         // Preserve opaque host-directive items verbatim. They are never
@@ -150,6 +167,34 @@ export function responsesToCore(body: ResponsesRequestBody): Flat {
             continue;
         }
         switch (it.type) {
+            case "reasoning": {
+                // Route reasoning through the compression pipeline (like
+                // Anthropic thinking) so it is hidden once its turn is
+                // summarized — NOT preserved verbatim in the preamble, which
+                // caused unbounded accumulation and broke the prompt-cache
+                // prefix. encrypted_content is opaque to us, so we carry the
+                // raw item in rawResponsesItem and re-emit it verbatim while
+                // the turn is still live. The `text` is only a stable identity
+                // for ref-id derivation (the reasoning item's own id).
+                if (shouldDropAllReasoning()) {
+                    droppedReasoning++;
+                    break;
+                }
+                const rid =
+                    typeof (it as { id?: unknown }).id === "string"
+                        ? String((it as { id?: string }).id)
+                        : hashId(JSON.stringify(it));
+                const base = deriveMessageId("assistant", "reasoning", rid);
+                msgs.push({
+                    id: clusters.next(base),
+                    role: "assistant",
+                    contentType: "reasoning",
+                    text: rid,
+                    rawResponsesItem: it,
+                });
+                idx++;
+                break;
+            }
             case "message": {
                 const m = it as ResponseInputMessage;
                 const text = messageContent(m.content);
@@ -257,7 +302,7 @@ export function responsesToCore(body: ResponsesRequestBody): Flat {
                 break;
         }
     }
-    return { msgs, systemParts, preamble, customToolCallIds };
+    return { msgs, systemParts, preamble, customToolCallIds, droppedReasoning };
 }
 
 export function coreToResponses(
@@ -298,6 +343,14 @@ export function coreToResponses(
                         name: m.toolName ?? "unknown",
                         arguments: m.text ?? "",
                     });
+                }
+            } else if (m.contentType === "reasoning") {
+                // Re-emit the carried raw reasoning item verbatim (with its
+                // encrypted_content). Only reached for reasoning whose turn has
+                // NOT been compressed — compressed reasoning is hidden by the
+                // kernel and never gets here.
+                if (m.rawResponsesItem) {
+                    out.push(m.rawResponsesItem as ResponseInputItem);
                 }
             }
         } else if (m.role === "tool") {

--- a/tests/bili-message-roundtrip.test.ts
+++ b/tests/bili-message-roundtrip.test.ts
@@ -231,3 +231,79 @@ test("responses: ACP_REASONING_KEEP=none drops all reasoning", () => {
         else process.env.ACP_REASONING_KEEP = prev;
     }
 });
+
+// 10. Reasoning VANISHES from the rebuilt input once its turn is covered by a
+// compression block — the central guarantee of the fix (issue #15). The kernel
+// drops covered message ids before coreToResponses runs; simulating that prune
+// here, the reasoning item must disappear while ordinary messages survive.
+test("responses: reasoning is dropped from output after its turn is compressed", () => {
+    const body: ResponsesRequestBody = {
+        input: [
+            { type: "reasoning", id: "rs_abc", encrypted_content: "ENC" },
+            { type: "message", role: "user", content: "hi" },
+            { type: "message", role: "assistant", content: "hello" },
+        ],
+    };
+    const { msgs } = responsesToCore(body);
+    const reasoningId = msgs.find((m) => m.contentType === "reasoning")!.id;
+    const pruned = msgs.filter((m) => m.id !== reasoningId);
+    const rebuilt = coreToResponses(pruned);
+    const gone = rebuilt.find((i) => (i as { type?: string }).type === "reasoning");
+    assert.equal(gone, undefined, "reasoning item disappears once its turn is compressed");
+    assert.equal(rebuilt.length, 2, "user + assistant messages survive");
+});
+
+// 11. Reasoning id is stable across turns — Codex re-sends the same reasoning
+// items every turn, so the same input item must yield the same BiliMessage id
+// or the kernel would accumulate phantom duplicates.
+test("responses: reasoning id is stable across turns (same item → same id)", () => {
+    const body = (): ResponsesRequestBody => ({
+        input: [
+            { type: "reasoning", id: "rs_abc", summary: [{ type: "summary_text", text: "t" }] },
+            { type: "message", role: "user", content: "hi" },
+        ],
+    });
+    const a = responsesToCore(body()).msgs.find((m) => m.contentType === "reasoning")!.id;
+    const b = responsesToCore(body()).msgs.find((m) => m.contentType === "reasoning")!.id;
+    assert.equal(a, b, "same reasoning item yields the same message id across turns");
+});
+
+// 12. Multiple reasoning items in one turn each get distinct ids and survive
+// round-trip in order.
+test("responses: multiple reasoning items keep distinct ids and order", () => {
+    const body: ResponsesRequestBody = {
+        input: [
+            { type: "reasoning", id: "rs_1", encrypted_content: "A" },
+            { type: "reasoning", id: "rs_2", encrypted_content: "B" },
+            { type: "message", role: "user", content: "hi" },
+        ],
+    };
+    const { msgs } = responsesToCore(body);
+    const rs = msgs.filter((m) => m.contentType === "reasoning");
+    assert.equal(rs.length, 2);
+    assert.notEqual(rs[0]!.id, rs[1]!.id, "distinct ids");
+    const rebuilt = coreToResponses(msgs);
+    const ids = rebuilt
+        .filter((i) => (i as { type?: string }).type === "reasoning")
+        .map((i) => (i as { id?: string }).id);
+    assert.deepEqual(ids, ["rs_1", "rs_2"], "order + ids preserved on rebuild");
+});
+
+// 13. Reasoning without encrypted_content (older API shape) still round-trips
+// via rawResponsesItem.
+test("responses: reasoning without encrypted_content round-trips", () => {
+    const body: ResponsesRequestBody = {
+        input: [
+            { type: "reasoning", id: "rs_x", summary: [{ type: "summary_text", text: "t" }] },
+            { type: "message", role: "user", content: "hi" },
+        ],
+    };
+    const { msgs } = responsesToCore(body);
+    const rebuilt = coreToResponses(msgs);
+    const out = rebuilt.find((i) => (i as { id?: string }).id === "rs_x") as
+        | { type: string; encrypted_content?: string }
+        | undefined;
+    assert.ok(out, "reasoning without encrypted_content still rebuilt");
+    assert.equal(out!.type, "reasoning");
+    assert.equal(out!.encrypted_content, undefined);
+});

--- a/tests/bili-message-roundtrip.test.ts
+++ b/tests/bili-message-roundtrip.test.ts
@@ -171,3 +171,63 @@ test("responses: user input_image is restored via rawResponsesItem", () => {
     assert.ok(img, "input_image reconstructed");
     assert.equal(img?.image_url, DATA_URL, "image url restored");
 });
+
+// 7. Responses reasoning is routed into the compression pipeline (NOT the
+// opaque preamble) so the kernel hides it once its turn is summarized. The raw
+// item — including encrypted_content — round-trips verbatim via
+// rawResponsesItem while the turn is still live.
+test("responses: reasoning enters msgs[] as a tracked reasoning message (not preamble)", () => {
+    const body: ResponsesRequestBody = {
+        input: [
+            { type: "reasoning", id: "rs_abc", summary: [{ type: "summary_text", text: "thinking" }], encrypted_content: "ENC_BLOB" },
+            { type: "message", role: "user", content: "hi" },
+        ],
+    };
+    const { msgs, preamble } = responsesToCore(body);
+    assert.equal(preamble.length, 0, "reasoning is NOT in the opaque preamble");
+    const r = msgs.find((m) => m.contentType === "reasoning");
+    assert.ok(r, "reasoning entered msgs[] as contentType reasoning");
+    assert.ok(r?.rawResponsesItem, "raw reasoning item carried in rawResponsesItem");
+    const rebuilt = coreToResponses(msgs);
+    const out = rebuilt.find((i) => (i as { id?: string }).id === "rs_abc") as { type: string; encrypted_content?: string };
+    assert.ok(out, "reasoning item rebuilt");
+    assert.equal(out.type, "reasoning");
+    assert.equal(out.encrypted_content, "ENC_BLOB", "encrypted_content preserved verbatim");
+});
+
+// 8. additional_tools (and other opaque host directives) still go to the
+// preamble verbatim — only reasoning was promoted into compression.
+test("responses: additional_tools stays in the opaque preamble", () => {
+    const body: ResponsesRequestBody = {
+        input: [
+            { type: "additional_tools", tools: [{ name: "exec" }] },
+            { type: "reasoning", id: "rs_1" },
+            { type: "message", role: "user", content: "hi" },
+        ],
+    };
+    const { msgs, preamble } = responsesToCore(body);
+    assert.equal(preamble.length, 1, "only additional_tools is opaque");
+    assert.equal(preamble[0]?.type, "additional_tools");
+    assert.ok(msgs.find((m) => m.contentType === "reasoning"), "reasoning went to msgs[], not preamble");
+});
+
+// 9. ACP_REASONING_KEEP=none drops reasoning entirely (escape hatch).
+test("responses: ACP_REASONING_KEEP=none drops all reasoning", () => {
+    const prev = process.env.ACP_REASONING_KEEP;
+    process.env.ACP_REASONING_KEEP = "none";
+    try {
+        const body: ResponsesRequestBody = {
+            input: [
+                { type: "reasoning", id: "rs_abc", encrypted_content: "ENC" },
+                { type: "message", role: "user", content: "hi" },
+            ],
+        };
+        const { msgs, preamble, droppedReasoning } = responsesToCore(body);
+        assert.equal(preamble.length, 0);
+        assert.ok(!msgs.find((m) => m.contentType === "reasoning"), "no reasoning in msgs[]");
+        assert.equal(droppedReasoning, 1, "droppedReasoning counted");
+    } finally {
+        if (prev === undefined) delete process.env.ACP_REASONING_KEEP;
+        else process.env.ACP_REASONING_KEEP = prev;
+    }
+});


### PR DESCRIPTION
## Problem

Closes the root cause of dog/billion-context-pi#15 — the universal `bili` proxy made Codex/Responses-API `reasoning` items explode context and break Codex's prompt-cache prefix.

## Root cause

`reasoning` items were treated as **opaque preamble** (`OPAQUE_ITEM_TYPES` in `src/responses.ts`) and re-sent **verbatim every turn**, accumulating without bound:

- Log evidence (`bili (3).log`): preserved preamble items grew 1 → 2 → 3 → 9 → 11 → **50 (reasoning×49)**; input grew 42k → 78k tokens while `cached` stayed pinned at **14080** (the `additional_tools` prefix); 3× `responses stream ended without completion` (relay dropping oversized streams).

Only the Responses path was broken. Anthropic `thinking` already flows through the compression pipeline as a tracked message (`src/anthropic.ts`) and is bounded — which is why other clients are fine.

## Fix

Route `reasoning` the same way `thinking` already goes: convert each item to a tracked `BiliMessage` (`contentType: "reasoning"`) that carries the original item verbatim in `rawResponsesItem`. The kernel hides the message once its range is **compressed**, so old reasoning drops automatically and never needs to be merged into a text summary (which would corrupt the opaque `encrypted_content`).

- Removed `reasoning` from `OPAQUE_ITEM_TYPES` (kept `additional_tools` there — Codex requires it at `input[0]`).
- `additional_tools` still preserved verbatim at the front of every request.
- Escape hatch: `ACP_REASONING_KEEP=none` drops all reasoning items.

## Why this is better than the closed #70

#70 was a positional band-aid (keep only the most-recent-response reasoning by index). It solved **size** but not **cache**. This PR routes reasoning through the kernel like every other message, so it is hidden exactly when its turn is summarized — uniform with the Anthropic path and no hand-rolled index logic.

## Verification

- `npm run typecheck` ✅
- `npm test` → 172/172 pass (169 + 3 new round-trip tests)
- `npm run build` ✅
- No `as any` / `@ts-ignore`.

## New env var

`ACP_REASONING_KEEP` — documented in both READMEs.