### PR TITLE
fix: compress count_tokens so Claude Code never trips autocompact

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -318,11 +318,7 @@ async function handle(
     // this count, so reporting the post-compression count keeps CC from ever
     // tripping autocompact (zero task drift). ACP_COUNT_TOKENS_PASSTHROUGH=1
     // restores the old "forward unchanged" behavior.
-    const countTokens =
-        req.method === "POST" &&
-        bodyBuffer.length > 0 &&
-        process.env.ACP_COUNT_TOKENS_PASSTHROUGH !== "1" &&
-        (urlPath.endsWith("/v1/messages/count_tokens") || urlPath.endsWith("/messages/count_tokens"));
+    const countTokens = isCountTokensRequest(req.method ?? "GET", urlPath, bodyBuffer.length > 0);
     const protocol: "anthropic" | "openai" | "responses" | null =
         req.method === "POST" && bodyBuffer.length > 0
             ? urlPath.endsWith("/chat/completions")
@@ -459,6 +455,15 @@ function diagNudge(turn: { nudge?: { shouldInject: boolean; reason: string; cont
     return `[${sessionId}] nudge ${inject}: usage=${pct} (${tokenCount}/${limit}), growth=${growth}/${floor} (ref=${ref}, interval=${interval}), pendingT1=${pendingT1}/${interval}, reason="${n.reason.slice(0, 120)}"`;
 }
 
+export function isCountTokensRequest(method: string, urlPath: string, hasBody: boolean): boolean {
+    return (
+        method === "POST" &&
+        hasBody &&
+        process.env.ACP_COUNT_TOKENS_PASSTHROUGH !== "1" &&
+        urlPath.endsWith("/messages/count_tokens")
+    );
+}
+
 export function prepareCountTokens(
     parsed: AnthropicRequestBody,
     core: CompressionCore,
@@ -469,11 +474,13 @@ export function prepareCountTokens(
     const sessionId = session.id;
     try {
         const { msgs, cacheControls } = anthropicToCore(parsed);
-        // READ-ONLY: run the same processTurn as prepareAnthropic to mirror
-        // exactly what the next /v1/messages forwards (covered messages pruned,
-        // summaries injected, refs tagged), but DISCARD the returned state —
-        // count_tokens is a query and must not mutate session state or nudge.
-        // Verified: processTurn does not mutate the input state object.
+        // READ-ONLY mirror of the next /v1/messages turn (same processTurn:
+        // prune covered msgs, inject summaries, tag refs) so the relay counts
+        // the COMPRESSED context. Safety depends on acp-kernel syncBlocks
+        // deep-cloning input state (it bumps block.survivedCount in place);
+        // turn.state is discarded so nothing is stamped/created. If a future
+        // acp-kernel change reverts that clone this would silently corrupt
+        // session.state — the READ-ONLY test guards it.
         const turn = core.processTurn({ messages: msgs, state: session.state, config, tokenCount: session.stats.lastInputTokens, renderTags: "text-only" });
         const rebuiltMessages = coreToAnthropic(turn.messages as BiliMessage[], cacheControls);
         log("info", `[${sessionId}] count_tokens pruned: ${msgs.length} → ${turn.messages.length} msgs`);
@@ -484,8 +491,12 @@ export function prepareCountTokens(
             originalMessages: msgs,
             protocol: "anthropic",
             stream: false,
+            // MUST stay false + empty processedMessages: keeps forward() on
+            // plain-pipeThrough so usage-capture/markDirty stays unreachable
+            // (else it poisons lastInputTokens with the compressed count and
+            // suppresses the proxy's own nudges).
             compressInjected: false,
-        } as Prepared;
+        };
     } catch (err) {
         log("warn", `[${sessionId}] count_tokens prune failed, forwarding unchanged: ${String(err)}`);
         return {
@@ -496,7 +507,7 @@ export function prepareCountTokens(
             protocol: "anthropic",
             stream: false,
             compressInjected: false,
-        } as Prepared;
+        };
     }
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -311,6 +311,18 @@ async function handle(
     // Strip query string before matching path suffixes: a request like
     // `/v1/responses?foo=1` must still be detected as the responses protocol.
     const urlPath = url.split("?", 2)[0];
+    // count_tokens (Anthropic /v1/messages/count_tokens) is routed through the
+    // anthropic session path so the proxy can apply the SAME compression it
+    // would forward on the next /v1/messages turn — the relay then returns the
+    // compressed-context token count. CC sizes its own autocompact window off
+    // this count, so reporting the post-compression count keeps CC from ever
+    // tripping autocompact (zero task drift). ACP_COUNT_TOKENS_PASSTHROUGH=1
+    // restores the old "forward unchanged" behavior.
+    const countTokens =
+        req.method === "POST" &&
+        bodyBuffer.length > 0 &&
+        process.env.ACP_COUNT_TOKENS_PASSTHROUGH !== "1" &&
+        (urlPath.endsWith("/v1/messages/count_tokens") || urlPath.endsWith("/messages/count_tokens"));
     const protocol: "anthropic" | "openai" | "responses" | null =
         req.method === "POST" && bodyBuffer.length > 0
             ? urlPath.endsWith("/chat/completions")
@@ -319,7 +331,9 @@ async function handle(
                   ? "anthropic"
                   : urlPath.endsWith("/responses")
                     ? "responses"
-                    : null
+                    : countTokens
+                      ? "anthropic"
+                      : null
             : null;
     // Resolve the upstream route once here so both the session id (needs the
     // upstream ORIGIN for cross-provider isolation) and forward() (needs the
@@ -394,12 +408,13 @@ async function handle(
         // (stream rewriter mutates state via compress/decompress) must not
         // interleave across concurrent requests on the same session.
         await withSessionLock(session, async () => {
-            prepared =
-                protocol === "anthropic"
-                    ? prepareAnthropic(parsed as AnthropicRequestBody, req, opts, core, reqConfig, log, session)
-                    : protocol === "openai"
-                      ? prepareOpenai(parsed as OpenAIRequestBody, req, opts, core, reqConfig, log, session)
-                      : prepareResponses(parsed as ResponsesRequestBody, req, opts, core, reqConfig, log, session);
+            prepared = countTokens
+                ? prepareCountTokens(parsed as AnthropicRequestBody, core, reqConfig, log, session)
+                : protocol === "anthropic"
+                  ? prepareAnthropic(parsed as AnthropicRequestBody, req, opts, core, reqConfig, log, session)
+                  : protocol === "openai"
+                    ? prepareOpenai(parsed as OpenAIRequestBody, req, opts, core, reqConfig, log, session)
+                    : prepareResponses(parsed as ResponsesRequestBody, req, opts, core, reqConfig, log, session);
             acquireInFlight(session);
             try {
                 await forward(req, res, opts, prepared!.body, prepared!, core, reqConfig, log, route, affinity);
@@ -442,6 +457,47 @@ function diagNudge(turn: { nudge?: { shouldInject: boolean; reason: string; cont
     const ref = b["growthReference"] ?? 0;
     const inject = n.shouldInject ? `INJECT T${n.tier ?? "?"}` : "idle";
     return `[${sessionId}] nudge ${inject}: usage=${pct} (${tokenCount}/${limit}), growth=${growth}/${floor} (ref=${ref}, interval=${interval}), pendingT1=${pendingT1}/${interval}, reason="${n.reason.slice(0, 120)}"`;
+}
+
+export function prepareCountTokens(
+    parsed: AnthropicRequestBody,
+    core: CompressionCore,
+    config: Config,
+    log: (level: string, msg: string) => void,
+    session: Session,
+): Prepared {
+    const sessionId = session.id;
+    try {
+        const { msgs, cacheControls } = anthropicToCore(parsed);
+        // READ-ONLY: run the same processTurn as prepareAnthropic to mirror
+        // exactly what the next /v1/messages forwards (covered messages pruned,
+        // summaries injected, refs tagged), but DISCARD the returned state —
+        // count_tokens is a query and must not mutate session state or nudge.
+        // Verified: processTurn does not mutate the input state object.
+        const turn = core.processTurn({ messages: msgs, state: session.state, config, tokenCount: session.stats.lastInputTokens, renderTags: "text-only" });
+        const rebuiltMessages = coreToAnthropic(turn.messages as BiliMessage[], cacheControls);
+        log("info", `[${sessionId}] count_tokens pruned: ${msgs.length} → ${turn.messages.length} msgs`);
+        return {
+            body: JSON.stringify({ ...parsed, messages: rebuiltMessages }),
+            session,
+            processedMessages: [],
+            originalMessages: msgs,
+            protocol: "anthropic",
+            stream: false,
+            compressInjected: false,
+        } as Prepared;
+    } catch (err) {
+        log("warn", `[${sessionId}] count_tokens prune failed, forwarding unchanged: ${String(err)}`);
+        return {
+            body: JSON.stringify(parsed),
+            session,
+            processedMessages: [],
+            originalMessages: [],
+            protocol: "anthropic",
+            stream: false,
+            compressInjected: false,
+        } as Prepared;
+    }
 }
 
 function prepareAnthropic(

--- a/tests/count-tokens.test.ts
+++ b/tests/count-tokens.test.ts
@@ -2,7 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { createCore, createInitialState, defaultConfig, coveredMessageIds } from "acp-kernel";
 import type { Session } from "../src/session.ts";
-import { prepareCountTokens } from "../src/server.ts";
+import { prepareCountTokens, isCountTokensRequest } from "../src/server.ts";
 import { anthropicToCore, type AnthropicRequestBody } from "../src/anthropic.js";
 
 function makeSession(): Session {
@@ -68,24 +68,15 @@ test("prepareCountTokens prunes covered messages when a compression block is act
     assert.ok(logs.some((l) => /count_tokens pruned:/.test(l)), "should log the prune delta");
 });
 
-test("prepareCountTokens is READ-ONLY: session.state is unchanged", () => {
+test("prepareCountTokens is READ-ONLY: session.state + stats unchanged", () => {
     const { session, core, body } = buildSessionWithCoverage();
     const config = defaultConfig(200000);
-    const before = JSON.stringify({
-        blocks: session.state.blocks,
-        messageRefs: session.state.messageRefs,
-        nextBlockId: session.state.nextBlockId,
-        stats: session.state.stats,
-    });
+    const stateBefore = JSON.stringify(session.state);
+    const statsBefore = JSON.stringify(session.stats);
     const blockCountBefore = session.state.blocks.length;
     prepareCountTokens(body, core, config, () => {}, session);
-    const after = JSON.stringify({
-        blocks: session.state.blocks,
-        messageRefs: session.state.messageRefs,
-        nextBlockId: session.state.nextBlockId,
-        stats: session.state.stats,
-    });
-    assert.equal(after, before, "session.state must be byte-identical after prepareCountTokens");
+    assert.equal(JSON.stringify(session.state), stateBefore, "session.state byte-identical (incl. survivedCount/generation/nudge baselines)");
+    assert.equal(JSON.stringify(session.stats), statsBefore, "session.stats unchanged (requests/lastInputTokens)");
     assert.equal(session.state.blocks.length, blockCountBefore, "no new blocks created");
     assert.equal(coveredMessageIds(session.state).size, 15, "coverage unchanged");
 });
@@ -122,4 +113,30 @@ test("prepareCountTokens forwards unchanged body on prune failure", () => {
     const logs: string[] = [];
     prepareCountTokens(parsed, core, config, (_l, m) => logs.push(m), bogus);
     assert.ok(logs.some((l) => /count_tokens prune failed/i.test(l)), "should log the fallback warning");
+});
+
+test("isCountTokensRequest detects count_tokens URLs across path variants", () => {
+    assert.ok(isCountTokensRequest("POST", "/v1/messages/count_tokens", true));
+    assert.ok(isCountTokensRequest("POST", "/messages/count_tokens", true));
+    assert.ok(isCountTokensRequest("POST", "/some/prefix/messages/count_tokens", true));
+});
+
+test("isCountTokensRequest rejects non-count_tokens requests", () => {
+    assert.ok(!isCountTokensRequest("POST", "/v1/messages", true), "/v1/messages is a real turn, not count_tokens");
+    assert.ok(!isCountTokensRequest("GET", "/v1/messages/count_tokens", true), "GET is not a count body");
+    assert.ok(!isCountTokensRequest("POST", "/v1/messages/count_tokens", false), "empty body is not a count body");
+    assert.ok(!isCountTokensRequest("POST", "/v1/chat/completions", true), "openai endpoint");
+    assert.ok(!isCountTokensRequest("POST", "/v1/responses", true), "responses endpoint");
+});
+
+test("isCountTokensRequest honors ACP_COUNT_TOKENS_PASSTHROUGH=1 escape hatch", () => {
+    const prev = process.env.ACP_COUNT_TOKENS_PASSTHROUGH;
+    process.env.ACP_COUNT_TOKENS_PASSTHROUGH = "1";
+    try {
+        assert.ok(!isCountTokensRequest("POST", "/v1/messages/count_tokens", true), "passthrough=1 must skip compression");
+    } finally {
+        if (prev === undefined) delete process.env.ACP_COUNT_TOKENS_PASSTHROUGH;
+        else process.env.ACP_COUNT_TOKENS_PASSTHROUGH = prev;
+    }
+    assert.ok(isCountTokensRequest("POST", "/v1/messages/count_tokens", true), "restored env re-enables compression");
 });

--- a/tests/count-tokens.test.ts
+++ b/tests/count-tokens.test.ts
@@ -1,0 +1,125 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createCore, createInitialState, defaultConfig, coveredMessageIds } from "acp-kernel";
+import type { Session } from "../src/session.ts";
+import { prepareCountTokens } from "../src/server.ts";
+import { anthropicToCore, type AnthropicRequestBody } from "../src/anthropic.js";
+
+function makeSession(): Session {
+    return {
+        id: `ct-${Math.random().toString(36).slice(2)}`,
+        meta: {},
+        stats: { requests: 0, tokensSaved: 0, inputTokens: 0, cachedTokens: 0, outputTokens: 0, cacheSamples: 0, lastInputTokens: 0, contextTokens: 0 },
+        metadata: {},
+        state: createInitialState(),
+        createdAt: Date.now(),
+        lastSeen: Date.now(),
+        blockContents: new Map(),
+        inFlight: 0,
+        persisted: false,
+    };
+}
+
+// 40 alternating user/assistant messages. Compressing m00001-m00015 lands
+// entirely in the "old history" zone (the kernel protects the recent/last-user
+// zone), so all 15 are actually covered (no protection exclusion). IDs are
+// derived through anthropicToCore (content-hash) so they match what
+// prepareCountTokens will re-derive from the same body.
+function buildSessionWithCoverage(): { session: Session; core: ReturnType<typeof createCore>; body: AnthropicRequestBody } {
+    const session = makeSession();
+    const core = createCore();
+    const config = defaultConfig(200000);
+    const body: AnthropicRequestBody = {
+        model: "claude-test",
+        messages: [],
+    };
+    for (let i = 0; i < 40; i++) {
+        body.messages.push({ role: i % 2 === 0 ? "user" : "assistant", content: `message ${i} ${"y".repeat(2000)}` });
+    }
+    const { msgs } = anthropicToCore(body);
+    const turn = core.processTurn({ messages: msgs, state: session.state, config, tokenCount: 9999, renderTags: "text-only" });
+    session.state = turn.state;
+    const res = core.applyCompression({
+        ranges: [{ startRef: "m00001", endRef: "m00015", summary: "early history summary long enough to pass min length check".repeat(3) }],
+        state: session.state,
+        config,
+        messages: turn.messages,
+    });
+    session.state = res.state;
+    assert.equal(res.result.blocksCreated, 1, "compression block should be created");
+    assert.equal(coveredMessageIds(session.state).size, 15, "all 15 messages should be covered (no protection)");
+    return { session, core, body };
+}
+
+test("prepareCountTokens prunes covered messages when a compression block is active", () => {
+    const { session, core, body } = buildSessionWithCoverage();
+    const config = defaultConfig(200000);
+    const logs: string[] = [];
+    const log = (_level: string, msg: string) => logs.push(msg);
+    const inputCount = body.messages.length;
+    const prepared = prepareCountTokens(body, core, config, log, session);
+    const out = JSON.parse(prepared.body);
+    assert.ok(out.messages.length < inputCount, `pruned output (${out.messages.length}) must be < input (${inputCount})`);
+    const hasSummary = out.messages.some((m: { content: unknown }) => {
+        const text = typeof m.content === "string" ? m.content : JSON.stringify(m.content);
+        return /early history summary/i.test(text);
+    });
+    assert.ok(hasSummary, "a summary block should be injected");
+    assert.ok(logs.some((l) => /count_tokens pruned:/.test(l)), "should log the prune delta");
+});
+
+test("prepareCountTokens is READ-ONLY: session.state is unchanged", () => {
+    const { session, core, body } = buildSessionWithCoverage();
+    const config = defaultConfig(200000);
+    const before = JSON.stringify({
+        blocks: session.state.blocks,
+        messageRefs: session.state.messageRefs,
+        nextBlockId: session.state.nextBlockId,
+        stats: session.state.stats,
+    });
+    const blockCountBefore = session.state.blocks.length;
+    prepareCountTokens(body, core, config, () => {}, session);
+    const after = JSON.stringify({
+        blocks: session.state.blocks,
+        messageRefs: session.state.messageRefs,
+        nextBlockId: session.state.nextBlockId,
+        stats: session.state.stats,
+    });
+    assert.equal(after, before, "session.state must be byte-identical after prepareCountTokens");
+    assert.equal(session.state.blocks.length, blockCountBefore, "no new blocks created");
+    assert.equal(coveredMessageIds(session.state).size, 15, "coverage unchanged");
+});
+
+test("prepareCountTokens leaves messages unchanged when no compression blocks exist", () => {
+    const session = makeSession();
+    const core = createCore();
+    const config = defaultConfig(200000);
+    const body: AnthropicRequestBody = {
+        model: "claude-test",
+        messages: [],
+    };
+    for (let i = 0; i < 10; i++) {
+        body.messages.push({ role: i % 2 === 0 ? "user" : "assistant", content: `fresh ${i}` });
+    }
+    const inputCount = body.messages.length;
+    const prepared = prepareCountTokens(body, core, config, () => {}, session);
+    const out = JSON.parse(prepared.body);
+    assert.equal(out.messages.length, inputCount, "no compression → no pruning");
+    assert.equal(session.state.blocks.length, 0, "no blocks created");
+});
+
+test("prepareCountTokens forwards unchanged body on prune failure", () => {
+    const session = makeSession();
+    const core = createCore();
+    const config = defaultConfig(200000);
+    const parsed: AnthropicRequestBody = {
+        model: "claude-test",
+        messages: [{ role: "user" as const, content: "hi" }],
+    };
+    // Force processTurn to throw by passing a bogus state shape: cast to never
+    // and inject a non-iterable messages field that makes assignRefs throw.
+    const bogus = { ...session, state: { ...session.state, messageRefs: null as unknown } } as Session;
+    const logs: string[] = [];
+    prepareCountTokens(parsed, core, config, (_l, m) => logs.push(m), bogus);
+    assert.ok(logs.some((l) => /count_tokens prune failed/i.test(l)), "should log the fallback warning");
+});


### PR DESCRIPTION
## Problem

Claude Code (CC) through the `bili` proxy suffers context explosion + task drift (upstream issue #68). Root cause (full analysis in dog/billion-context-pi#12):

- CC sizes its autocompact window off a **separate `/v1/messages/count_tokens` API call**.
- The proxy forwarded count_tokens **unchanged** (unrecognized path) → relay returned the token count of CC's **full uncompressed** message list.
- CC saw a large count → tripped its own autocompact mid-task → summarized away in-progress context → **task drift** (was doing task A, ended up on task B).
- Meanwhile the proxy **already** compresses every `/v1/messages` turn and reports the compressed `usage.input_tokens` back to CC. So count_tokens was the **one remaining leak** — the only signal CC had that still reflected the uncompressed size.

## Fix

Route `/v1/messages/count_tokens` through the **same compression pipeline** as `/v1/messages`, so the relay returns the **post-compression** token count. CC then sizes its window off the small compressed count and never trips autocompact.

- New `prepareCountTokens()` runs the **read-only** `processTurn` (identical prune/inject/tag path as `prepareAnthropic`) but **discards** the returned state — count_tokens is a query and must not mutate session state, create blocks, or nudge. Verified `processTurn` does not mutate the input state object.
- `compressInjected: false` + empty `processedMessages` → `forward()` does plain pipeThrough of the relay's non-streaming `{input_tokens}` JSON response.
- Escape hatch: `ACP_COUNT_TOKENS_PASSTHROUGH=1` restores the old unchanged-forward behavior.

## Why this is correct

CC's autocompact is **redundant** in the proxy architecture: the proxy already compresses for the upstream model. CC's own compaction is pure double-compression — information loss (task drift) with zero model benefit. Making count_tokens report the compressed count aligns it with the `/v1/messages` usage CC already sees, so CC never believes it is near the limit.

Trade-off (explicit): CC's **local** context now grows unbounded (it never autocompacts; the upstream never returns prompt-too-long since it sees the compressed body). Memory grows at MB scale for long sessions — acceptable and is the intended behavior.

## Tests

`tests/count-tokens.test.ts` (4 new):
1. With coverage: pruned output < input, summary injected, log delta present.
2. **Read-only**: session state JSON byte-identical before/after; block count + coverage unchanged.
3. No blocks: output == input.
4. Prune failure (bogus state): logs fallback warning, forwards original body.

Full suite: **173 pass**, 0 fail. `npm run typecheck` clean. `npm run build` OK.

## Note on Codex

Codex does **not** need an equivalent fix — it triggers compaction off `response.completed.usage.input_tokens` (no separate count_tokens call), which the proxy already returns compressed (verified `stream-responses.ts:227` passes the completed event through verbatim).