### PR TITLE
release v0.1.28

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Release v0.1.28

Patch release shipping two client-side context-management fixes: #71 (Codex reasoning/cache explosion) and #72 (Claude Code count_tokens/autocompact).

## What shipped since v0.1.27

### #71 — Route Responses `reasoning` through the compression pipeline (Codex cache explosion)
Responses API `reasoning` items (Codex) were treated as opaque preamble and re-sent verbatim every turn, accumulating without bound — this broke Codex's prompt-cache prefix and blew up context. (Anthropic `thinking` already flowed through the compression pipeline as a tracked, bounded message; only the Responses path was broken.)

Fix: convert each `reasoning` item to a tracked `BiliMessage` (`contentType: "reasoning"`, original item carried verbatim in `rawResponsesItem`). The kernel hides the message once its range is compressed, so old reasoning drops automatically and is never merged into a text summary (which would corrupt the opaque `encrypted_content`). Escape hatch: `ACP_REASONING_KEEP=none` drops all reasoning items.
Refs: dog/billion-context-pi#15

### #72 — Compress `/v1/messages/count_tokens` so Claude Code never trips autocompact
Claude Code sized its autocompact window off a separate `count_tokens` API call that bypassed proxy compression (returned the uncompressed count → CC saw a large count → tripped autocompact mid-task → context-explosion / task-drift). Now `count_tokens` runs through the same read-only compression pipeline as `/v1/messages`, so CC sees the post-compression count and never autocompacts. Includes the review follow-up: hardened read-only snapshot test, `isCountTokensRequest` routing-detection + escape-hatch tests, and comments documenting the cross-repo read-only invariant.
Escape hatch: `ACP_COUNT_TOKENS_PASSTHROUGH=1` restores old behavior.
Refs: upstream ranxianglei/billion-context#68, dog/billion-context-pi#12

## Version bump
- `package.json`: `0.1.27` → `0.1.28` (single line, matches v0.1.27 release convention).
- `acp-kernel` dep unchanged at `0.0.17` (both fixes used existing kernel APIs; no kernel release needed).

## Pre-flight
- `npm run typecheck` ✅
- `npm test`: **183 pass**, 0 fail ✅
- `npm run build` ✅

## After merge
CI auto-publishes v0.1.28 to npm. Verify: `npm view billion-context version` returns `0.1.28`.