### PR TITLE
fix(cache): route opaque call items through compression + strip chaining fields

### DIFF
--- a/src/responses.ts
+++ b/src/responses.ts
@@ -76,27 +76,22 @@ type Flat = {
     droppedReasoning: number;
 };
 
-/** Item types that are opaque host directives (tool definitions, computer
- *  calls, ...) and must be preserved verbatim — they are NOT conversation
- *  history and must never be compressed or rewritten. `additional_tools` in
- *  particular carries the Codex code_mode exec/wait tool definitions and MUST
- *  stay at input[0] (see openai/codex client.rs splice(0..0, prefix)).
+/** Item types that are host DIRECTIVES (tool/definition listings), not
+ *  conversation history: preserved verbatim and re-prepended at input[0..].
+ *  `additional_tools` carries the Codex code_mode exec/wait tool definitions
+ *  and MUST stay at input[0] (see openai/codex client.rs splice(0..0, prefix)).
+ *  `mcp_list_tools` is a stable per-session tool listing.
  *
- *  `reasoning` is intentionally NOT opaque: it IS conversation history (a
- *  prior response's chain-of-thought) and is converted to a tracked
- *  BiliMessage so the compression pipeline hides it once its turn is
- *  summarized — preventing the unbounded accumulation that broke Codex's
- *  prompt-cache prefix. See the `reasoning` case in responsesToCore. */
+ *  Only definitions belong here. Output/action items from a prior response
+ *  (reasoning, computer_call, function_call, mcp_call, ...) ARE conversation
+ *  history and are routed as tracked BiliMessages via pushVerbatimItem /
+ *  the message/function cases, so the compression pipeline hides them once
+ *  their turn is summarized — preserving them verbatim in the preamble instead
+ *  made them accumulate unbounded every turn and broke Codex's prompt-cache
+ *  prefix. */
 const OPAQUE_ITEM_TYPES = new Set([
     "additional_tools",
-    "computer_call",
-    "computer_call_output",
-    "file_search_call",
-    "web_search_call",
-    "image_generation_call",
-    "code_interpreter_call",
     "mcp_list_tools",
-    "mcp_call",
 ]);
 
 function isOpaqueItem(it: ResponseInputItem): boolean {
@@ -109,6 +104,36 @@ function isOpaqueItem(it: ResponseInputItem): boolean {
  *  continuity for the responses that are still live. */
 function shouldDropAllReasoning(): boolean {
     return (process.env.ACP_REASONING_KEEP ?? "").trim().toLowerCase() === "none";
+}
+
+/** Route an opaque Responses output item — reasoning, or a tool-call-shaped
+ *  action item (computer_call / file_search_call / mcp_call / ...) — through
+ *  the compression pipeline so it is hidden once its turn is summarized. The
+ *  item's own structure is opaque to us, so we carry it verbatim in
+ *  rawResponsesItem and re-emit it unchanged via coreToResponses while the turn
+ *  is still live. `kind` only namespaces the derived id (so reasoning and call
+ *  items never collide). contentType "reasoning" is the only safe bucket: the
+ *  kernel filters/pairs tool-call & tool-result by toolCallId and injects ACP
+ *  tags into text, while reasoning items pass through untouched (no tag, no
+ *  filtering) and are still covered by compression blocks. */
+function pushVerbatimItem(
+    msgs: BiliMessage[],
+    clusters: ClusterCounter,
+    it: ResponseInputItem,
+    kind: string,
+): void {
+    const rawId =
+        typeof (it as { id?: unknown }).id === "string"
+            ? String((it as { id?: string }).id)
+            : hashId(JSON.stringify(it));
+    const base = deriveMessageId("assistant", kind, rawId);
+    msgs.push({
+        id: clusters.next(base),
+        role: "assistant",
+        contentType: "reasoning",
+        text: rawId,
+        rawResponsesItem: it,
+    });
 }
 
 function partText(p: ResponseContentPart): string {
@@ -168,30 +193,27 @@ export function responsesToCore(body: ResponsesRequestBody): Flat {
         }
         switch (it.type) {
             case "reasoning": {
-                // Route reasoning through the compression pipeline (like
-                // Anthropic thinking) so it is hidden once its turn is
-                // summarized — NOT preserved verbatim in the preamble, which
-                // caused unbounded accumulation and broke the prompt-cache
-                // prefix. encrypted_content is opaque to us, so we carry the
-                // raw item in rawResponsesItem and re-emit it verbatim while
-                // the turn is still live. The `text` is only a stable identity
-                // for ref-id derivation (the reasoning item's own id).
                 if (shouldDropAllReasoning()) {
                     droppedReasoning++;
                     break;
                 }
-                const rid =
-                    typeof (it as { id?: unknown }).id === "string"
-                        ? String((it as { id?: string }).id)
-                        : hashId(JSON.stringify(it));
-                const base = deriveMessageId("assistant", "reasoning", rid);
-                msgs.push({
-                    id: clusters.next(base),
-                    role: "assistant",
-                    contentType: "reasoning",
-                    text: rid,
-                    rawResponsesItem: it,
-                });
+                pushVerbatimItem(msgs, clusters, it, "reasoning");
+                idx++;
+                break;
+            }
+            // Prior-response action items whose structure is opaque to us.
+            // Routed through compression (same mechanism as reasoning) instead
+            // of being pinned in the preamble, which made them pile up every
+            // turn and break the prompt-cache prefix. Re-emitted verbatim via
+            // rawResponsesItem while their turn is live.
+            case "computer_call":
+            case "computer_call_output":
+            case "file_search_call":
+            case "web_search_call":
+            case "image_generation_call":
+            case "code_interpreter_call":
+            case "mcp_call": {
+                pushVerbatimItem(msgs, clusters, it, "responses-call");
                 idx++;
                 break;
             }
@@ -345,10 +367,11 @@ export function coreToResponses(
                     });
                 }
             } else if (m.contentType === "reasoning") {
-                // Re-emit the carried raw reasoning item verbatim (with its
-                // encrypted_content). Only reached for reasoning whose turn has
-                // NOT been compressed — compressed reasoning is hidden by the
-                // kernel and never gets here.
+                // Re-emit the carried raw item verbatim (reasoning's
+                // encrypted_content, or an opaque call item like
+                // computer_call / mcp_call). Only reached for items whose turn
+                // has NOT been compressed — compressed items are hidden by the
+                // kernel and never get here.
                 if (m.rawResponsesItem) {
                     out.push(m.rawResponsesItem as ResponseInputItem);
                 }

--- a/src/responses.ts
+++ b/src/responses.ts
@@ -193,6 +193,10 @@ export function responsesToCore(body: ResponsesRequestBody): Flat {
         }
         switch (it.type) {
             case "reasoning": {
+                // shouldDropAllReasoning() is checked ONLY here, not in the
+                // call-item cases below: dropping chain-of-thought is safe, but
+                // a computer_call/mcp_call is replay-critical. Call items reuse
+                // "reasoning" only as a compression-safe contentType bucket.
                 if (shouldDropAllReasoning()) {
                     droppedReasoning++;
                     break;

--- a/src/server.ts
+++ b/src/server.ts
@@ -756,6 +756,16 @@ function prepareResponses(
     }
 
     const rebuilt: ResponsesRequestBody = { ...parsed, input: rebuiltInput, tools: toolsOut };
+    // This adapter is stateless: we replay the FULL conversation in `input`.
+    // Strip Responses' native chaining fields so the upstream does not resolve
+    // stored server-side state on top of the input we already sent. Forwarding
+    // previous_response_id would make the prefix shift every turn (as the id
+    // advances) and duplicate history — breaking prompt-cache. `instructions`
+    // was already lifted into the developer message at input[1], so forwarding
+    // it again here double-sends it and violates the responses_lite contract
+    // (top-level instructions must stay empty for code_mode tool exposure).
+    delete rebuilt.previous_response_id;
+    delete rebuilt.instructions;
     // Log the final tools we forward upstream so we can confirm ACP tools are
     // present. Distinguishes "compress" (top-level function) from Codex
     // namespace items (type:namespace/custom).

--- a/tests/bili-message-roundtrip.test.ts
+++ b/tests/bili-message-roundtrip.test.ts
@@ -371,3 +371,29 @@ test("responses: call item and reasoning keep distinct ids in the same turn", ()
     assert.equal(ids.length, 2);
     assert.notEqual(ids[0], ids[1], "same raw id does not collide across kinds");
 });
+
+// 17. ACP_REASONING_KEEP=none drops chain-of-thought but MUST preserve call
+// items: call items reuse the "reasoning" contentType only as a compression
+// bucket, not because they are reasoning. Dropping a computer_call would
+// corrupt the Responses conversation replay.
+test("responses: ACP_REASONING_KEEP=none drops reasoning but keeps call items", () => {
+    const prev = process.env.ACP_REASONING_KEEP;
+    process.env.ACP_REASONING_KEEP = "none";
+    try {
+        const body: ResponsesRequestBody = {
+            input: [
+                { type: "reasoning", id: "rs_1", encrypted_content: "E" },
+                { type: "computer_call", id: "cc_1", action: { type: "screenshot" } } as ResponseInputItem,
+                { type: "mcp_call", id: "mc_1", name: "n", arguments: "{}" } as ResponseInputItem,
+            ],
+        };
+        const { msgs } = responsesToCore(body);
+        const reasoning = msgs.filter((m) => (m.rawResponsesItem as { type?: string }).type === "reasoning");
+        const calls = msgs.filter((m) => (m.rawResponsesItem as { type?: string }).type !== "reasoning" && m.contentType === "reasoning");
+        assert.equal(reasoning.length, 0, "chain-of-thought is dropped under ACP_REASONING_KEEP=none");
+        assert.equal(calls.length, 2, "computer_call + mcp_call survive (replay-critical)");
+    } finally {
+        if (prev === undefined) delete process.env.ACP_REASONING_KEEP;
+        else process.env.ACP_REASONING_KEEP = prev;
+    }
+});

--- a/tests/bili-message-roundtrip.test.ts
+++ b/tests/bili-message-roundtrip.test.ts
@@ -307,3 +307,67 @@ test("responses: reasoning without encrypted_content round-trips", () => {
     assert.equal(out!.type, "reasoning");
     assert.equal(out!.encrypted_content, undefined);
 });
+
+// 14. Prior-response ACTION items (computer_call, mcp_call, ...) are routed
+// through the compression pipeline (NOT the opaque preamble) so they don't
+// accumulate unbounded every turn and break the prompt-cache prefix. They
+// round-trip verbatim via rawResponsesItem while their turn is live.
+test("responses: call items (computer_call/mcp_call) enter msgs[] not preamble", () => {
+    const body: ResponsesRequestBody = {
+        input: [
+            { type: "additional_tools", tools: [] } as ResponseInputItem,
+            { type: "mcp_list_tools", server_label: "s" } as ResponseInputItem,
+            { type: "computer_call", id: "cc_1", action: { type: "screenshot" } } as ResponseInputItem,
+            { type: "mcp_call", id: "mc_1", name: "search", arguments: "{}" } as ResponseInputItem,
+            { type: "message", role: "user", content: "go" },
+        ],
+    };
+    const { msgs, preamble } = responsesToCore(body);
+    assert.deepEqual(
+        preamble.map((p) => p.type),
+        ["additional_tools", "mcp_list_tools"],
+        "only definitions stay in the preamble",
+    );
+    const calls = msgs.filter((m) => m.contentType === "reasoning" && m.rawResponsesItem);
+    assert.equal(calls.length, 2, "both call items routed into msgs[]");
+    const rebuilt = coreToResponses(msgs);
+    const types = rebuilt.map((i) => i.type);
+    assert.ok(types.includes("computer_call"), "computer_call round-trips verbatim");
+    assert.ok(types.includes("mcp_call"), "mcp_call round-trips verbatim");
+});
+
+// 15. Call items are hidden once their turn is compressed (same prune
+// semantics as reasoning).
+test("responses: call items drop from output after their turn is compressed", () => {
+    const body: ResponsesRequestBody = {
+        input: [
+            { type: "computer_call", id: "cc_1", action: { type: "screenshot" } } as ResponseInputItem,
+            { type: "message", role: "user", content: "hi" },
+        ],
+    };
+    const { msgs } = responsesToCore(body);
+    const callMsg = msgs.find((m) => m.contentType === "reasoning" && (m.rawResponsesItem as { type?: string }).type === "computer_call");
+    assert.ok(callMsg, "computer_call entered msgs[]");
+    const pruned = msgs.filter((m) => m.id !== callMsg!.id);
+    const rebuilt = coreToResponses(pruned);
+    assert.equal(
+        rebuilt.find((i) => i.type === "computer_call"),
+        undefined,
+        "computer_call disappears once its turn is compressed",
+    );
+});
+
+// 16. A call item is given a distinct id namespace from reasoning, so the two
+// never collide even when present in the same turn.
+test("responses: call item and reasoning keep distinct ids in the same turn", () => {
+    const body: ResponsesRequestBody = {
+        input: [
+            { type: "reasoning", id: "shared", encrypted_content: "E" },
+            { type: "mcp_call", id: "shared", name: "n", arguments: "{}" } as ResponseInputItem,
+        ],
+    };
+    const { msgs } = responsesToCore(body);
+    const ids = msgs.filter((m) => m.contentType === "reasoning").map((m) => m.id);
+    assert.equal(ids.length, 2);
+    assert.notEqual(ids[0], ids[1], "same raw id does not collide across kinds");
+});


### PR DESCRIPTION
## 背景

Issue dog/billion-context-pi#15 用户反馈「缓存命不中」问题持续存在（即便 reasoning 修复 PR #71 已合并）。全面审计后排除了 ACP tag 漂移（tag 是确定性函数，字节稳定），找到 2 个真正持续破坏 prompt-cache 前缀的根因。

## 根因

### Fix 1: 7 种 call/action item 被错误钉在 preamble（与 reasoning 同类 bug）

`OPAQUE_ITEM_TYPES`（src/responses.ts:90）之前把 `computer_call`、`computer_call_output`、`file_search_call`、`web_search_call`、`image_generation_call`、`code_interpreter_call`、`mcp_call` 当作「宿主指令」原样钉在 `input[0]` 永不压缩。但它们其实是上一轮 response 的输出，属于**对话历史** → 每轮原样累积 → prompt-cache 前缀无限增长 → 缓存永远 miss。

这与 PR #71 修的 reasoning 是同一类 bug，只是 item 类型不同。

**影响面：**
- 纯 code_mode Codex → 用 `custom_tool_call`（本来就分类正确）→ 潜伏，不踩
- Codex + MCP 工具 → 发 `mcp_call` → 会踩，累积爆炸
- Codex + computer-use → 发 `computer_call` → 会踩

**不是 Codex 的锅**：Codex 重发这些 item 是 Responses API 正常行为，是中转站分错了类。

### Fix 2: `previous_response_id` + `instructions` 没剥（server.ts:691）

adapter 是无状态的（把完整对话 replay 进 input），但转发 body 时仍保留 `previous_response_id` → 上游既解析服务端存储的状态、又拿到完整 rebuilt input → 内容重复 + 前缀每轮漂移 → 缓存破坏。`instructions` 已被 responsesToCore 提升进 input[1] developer message（server.ts:660-661），再次转发 = 重复发送 + 违反 responses_lite 契约（顶层 instructions 对 code_mode 必须留空以暴露工具）。

## 改动

**src/responses.ts:**
- `OPAQUE_ITEM_TYPES` 只留 `additional_tools` + `mcp_list_tools`（真·定义），移除 7 种 call 类型。
- 新增 helper `pushVerbatimItem(msgs, clusters, it, kind)`：从 `it.id` 或 `hashId(JSON.stringify(it))` 派生 id，push `{role:\"assistant\", contentType:\"reasoning\", text:rawId, rawResponsesItem:it}`。`kind` 命名空间（\"reasoning\" vs \"responses-call\"）保证 id 永不冲突。
- reasoning case 重构为调用 `pushVerbatimItem(..., \"reasoning\")`；新增 7 个 call 类型的显式 switch 分支 → `pushVerbatimItem(..., \"responses-call\")`。

**为什么复用 contentType \"reasoning\" 是唯一安全桶**（核验 node_modules/acp-kernel/dist/index.js）：kernel 对 tool-call/tool-result 按 toolCallId 做 filter/pair（call item 会被错误丢弃/配对）；reasoning item 在 text-only 策略下 `renderMessage` 原样返回不注入 tag，且被压缩块覆盖（coveredMessageIds）。`MessageContentType` union（types.d.ts:2）是固定的，新增值需要 as-any（被 AGENTS.md 禁止）。

**src/server.ts:691:** `delete rebuilt.previous_response_id; delete rebuilt.instructions;`

**tests/bili-message-roundtrip.test.ts:** +3 测试（//14 call items 进入 msgs[] 不进 preamble + 原样 round-trip；//15 压缩 prune 后 call items 被隐藏；//16 call item 与 reasoning id 命名空间隔离，同 raw id 不冲突）。

## 验证

- 186 tests pass / 0 fail
- typecheck + build clean
- default case（未知 item 类型）保守保留 push 到 preamble（前向兼容安全），oracle Finding 3 暂缓

## 需要线上核验的点

1. Codex 是否真的发 `previous_response_id`？（防御性删除零副作用）
2. `additional_tools`（input[0]）字节是否稳定？（代理侧盲区，依赖客户端稳定）
3. reasoning 的 `encrypted_content` 是否每 response 轮转？（影响 reasoning 自身字节稳定性）