### PR TITLE
fix: admin endpoint security hardening — CSRF, PID recycle, fsync perf

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -274,7 +274,16 @@ function isLoopback(addr: string | undefined): boolean {
     return addr === "::1" || addr === "127.0.0.1" || addr.startsWith("127.") || addr.startsWith("::ffff:127.");
 }
 
-function isTrustedAdminOrigin(origin: string | undefined, host: string | undefined): boolean {
+function isTrustedAdminOrigin(origin: string | undefined, host: string | undefined, secFetchSite: string | undefined): boolean {
+    // DNS-rebinding defense: the Host header must point at loopback. Without
+    // this, a rebinding domain (evil.com -> 127.0.0.1) passes the Origin===Host
+    // check below because both carry the attacker domain.
+    if (host) {
+        const hostname = host.replace(/^\[|\]$/g, "").split(":")[0].toLowerCase();
+        if (hostname !== "127.0.0.1" && hostname !== "localhost" && hostname !== "::1") return false;
+    }
+    // Sec-Fetch-Site is a fetch metadata header that browser JS cannot forge.
+    if (secFetchSite !== undefined && secFetchSite !== "same-origin") return false;
     if (!origin) return true;
     if (!host) return false;
     try {
@@ -306,7 +315,7 @@ async function handle(
         res.end(JSON.stringify({ error: "management endpoints are loopback-only; access denied for " + (req.socket.remoteAddress ?? "unknown") }));
         return;
     }
-    if (isAdminPath && !isTrustedAdminOrigin(req.headers.origin, req.headers.host)) {
+    if (isAdminPath && !isTrustedAdminOrigin(req.headers.origin, req.headers.host, req.headers["sec-fetch-site"] as string | undefined)) {
         res.writeHead(403, { "content-type": "application/json" });
         res.end(JSON.stringify({ error: "management request origin does not match the local bili UI" }));
         return;

--- a/tests/web-routing.test.ts
+++ b/tests/web-routing.test.ts
@@ -141,3 +141,46 @@ test("PUT /__bili/config with providers takes effect without a separate reload c
         rmSync(root, { recursive: true, force: true });
     }
 });
+
+test("admin endpoints reject non-loopback Host and cross-site Sec-Fetch-Site (DNS rebinding defense)", async () => {
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    setRegistryForTest({});
+    const port = await freePort();
+    const opts: ProxyOptions = {
+        port,
+        host: "127.0.0.1",
+        upstream: "http://127.0.0.1:1",
+        routes: {},
+        proxy: "",
+        proxyMode: "direct",
+        proxySource: "direct",
+        modelContextLimit: 400_000,
+        kernelConfig: defaultConfig(400_000),
+        compress: { injectTool: true, injectNudge: true },
+        promptCache: { routing: "auto" },
+        sessionHeader: "x-acp-session",
+        log: false,
+        debug: false,
+        passthrough: false,
+        autoUpdate: false,
+        mitm: { enabled: false, domains: [] },
+    };
+    const proxy = await startServer(opts);
+    if (!proxy.listening) await once(proxy, "listening");
+    try {
+        const evilHostStatus = await new Promise<number>((resolve, reject) => {
+            const req = http.request(`http://127.0.0.1:${port}/__bili/stats`, { headers: { host: "evil.example" } }, (res) => {
+                res.resume();
+                resolve(res.statusCode ?? 0);
+            });
+            req.on("error", reject);
+            req.end();
+        });
+        assert.equal(evilHostStatus, 403, "non-loopback Host header must be rejected");
+
+        const crossSiteStatus = (await fetch(`http://127.0.0.1:${port}/__bili/stats`, { headers: { "sec-fetch-site": "cross-site" } })).status;
+        assert.equal(crossSiteStatus, 403, "cross-site Sec-Fetch-Site must be rejected");
+    } finally {
+        await close(proxy);
+    }
+});


### PR DESCRIPTION
Addresses PR#73 review items **#5/#6/#7** (the medium-priority items deferred from the initial merge).

## #5 DNS-rebinding CSRF defense (`server.ts`)

`isTrustedAdminOrigin` now:
- **Pins Host hostname to loopback** (127.0.0.1 / localhost / ::1). Without this, a rebinding domain (evil.com → 127.0.0.1) passed the `Origin===Host` check because both carried the attacker domain.
- **Checks `Sec-Fetch-Site`**: rejects anything that is not `same-origin`. This is a fetch metadata header that browser JS cannot forge.

Non-browser clients (curl, etc.) send neither Origin nor Sec-Fetch-Site — unaffected.

## #6 PID-recycling defense (`codex-takeover.ts`)

- Stores `pidStartTick` (Linux `/proc/<pid>/stat` field 22) alongside `pid` in route state.
- `pidAlive` now compares the start tick — a dead bili's recycled PID is no longer mistaken for the live owner.
- Non-Linux falls back to `process.kill(pid, 0)` (unchanged).

## #7 Per-request fsync overhead (`codex-takeover.ts`)

- `atomicWrite` / `writeState` gain a `durable` param (default `true`).
- `recordCodexRouteRequest` writes with `durable=false` (skips `fsync`) — the last-seen timestamp is non-critical; atomic rename still guarantees consistency. Critical state (claim/disable) keeps `fsync`.

## Tests

- DNS rebinding: non-loopback Host → 403, cross-site `Sec-Fetch-Site` → 403
- `pidStartTick` presence after `enableCodexTakeover`

**226 tests pass, typecheck clean, build OK.**