### PR TITLE
release v0.1.29

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.26",
+  "version": "0.1.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.26",
+      "version": "0.1.29",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Release version bump: 0.1.28 → 0.1.29 (acp-kernel stays 0.0.17, already on npm).

Pure version bump per AGENTS.md §5 — CI auto-publishes on merge.

## Changes since v0.1.28

- **PR #73** — bundle acp-kernel inline; session identity; parseState; route hot-reload; test coverage (corruption, sectionPrefixLength, PUT-reload, affinityToken)
- **PR #75** — `fix(cache): route opaque call items through compression + strip chaining fields` (prevents cache-prefix breaks from opaque tool calls)
- **codex takeover / history sync / embedded web UI** (97190f5)
- **fix(responses)**: pass `custom_tool_call` through in text-protocol mode (ed4d4c4)
- **web**: generic client integration page, per-URL proxy UI, client-access redesign, native `node:sqlite` import + stale DOM ref cleanup
- **codex-provider**: default optional auth/websocket fields for custom providers

## Pre-flight (local)
- `npm run typecheck` ✅
- `npm test` → 224 pass ✅
- `npm run build` → 2.02 MB ✅
