### PR TITLE
fix: inject response.failed for empty upstream responses (fixes stuck-after-tool UX)

### DIFF
--- a/src/compress-loop-responses.ts
+++ b/src/compress-loop-responses.ts
@@ -311,6 +311,15 @@ function buildCompleted(responseObj: Record<string, unknown> | null): string {
     })}\n\n`;
 }
 
+function buildFailed(responseObj: Record<string, unknown> | null): string {
+    const id = responseObj?.id ?? `resp-failed-${Date.now()}`;
+    const resp = { ...(responseObj ?? {}), id, status: "failed", error: { code: "server_error", message: "upstream returned empty response" } };
+    return `event: response.failed\ndata: ${JSON.stringify({
+        type: "response.failed",
+        response: resp,
+    })}\n\n`;
+}
+
 function responsesJsonOutput(response: Record<string, unknown>): {
     text: string;
     textParts: Array<Record<string, unknown>>;
@@ -558,7 +567,15 @@ export async function* compressLoopResponsesStream(
                 yield Buffer.from(terminalRaw + "\n\n", "utf8");
                 return;
             }
-            if (!completed && contentText.length === 0 && realCalls.length === 0) {
+            // Empty upstream response (no text/tool_call/usage): inject
+            // response.failed so the client retries instead of hanging.
+            const hasUsage = !!(responseObj as Record<string, unknown> | undefined)?.usage;
+            if (contentText.length === 0 && realCalls.length === 0 && customToolCalls === 0 && !hasUsage) {
+                ctx.log("[acp-proxy: empty upstream response (no content/usage) — injecting response.failed for client retry]");
+                yield Buffer.from(buildFailed(responseObj), "utf8");
+                return;
+            }
+            if (!completed) {
                 ctx.log("[acp-proxy: responses stream ended without completion]");
             }
             yield Buffer.from(buildCompleted(responseObj), "utf8");

--- a/tests/proxy-responses-stream.test.ts
+++ b/tests/proxy-responses-stream.test.ts
@@ -179,3 +179,20 @@ test("compressLoopResponsesStream: Codex code_mode custom_tool_call passes throu
     assert.ok(out.includes("Running ls."), "assistant text still emitted");
     assert.ok(out.includes("response.completed"), "completion emitted");
 });
+
+test("compressLoopResponsesStream: empty upstream response (no content/usage) yields response.failed for client retry", async () => {
+    const events = [
+        sse("response.created", { response: { id: "resp_empty", status: "in_progress" } }),
+        sse("response.completed", { response: { id: "resp_empty", status: "completed", output: [] } }),
+    ].join("");
+    const ctx = { ...makeCtx(() => {}), textProtocol: true };
+    const out = await drain(
+        new Response(events).body!,
+        ctx,
+        { model: "gpt-5", input: [{ type: "message", role: "user", content: "hi" }], stream: true },
+        { url: "http://unused", headers: {} },
+    );
+    assert.ok(out.includes("response.failed"), "empty upstream response yields response.failed");
+    assert.ok(!out.includes("response.completed"), "no fake completion for empty response");
+    assert.ok(out.includes("empty response"), "error message included");
+});


### PR DESCRIPTION
## Problem

When the upstream relay (e.g. comfly) returns an empty response — no text content, no tool calls, no usage object — the proxy previously synthesized a fake `response.completed` and forwarded it. The client (codex) received a "completed" response with no useful output and **hung**, manifesting as the "stuck after tool call" UX symptom.

The user eventually triggers a reconnect (`ERROR: Reconnecting... 1/5`), but this takes a timeout to fire, and the reconnect also shifts the request prefix, degrading cache hit to ~21% for 1-2 rounds.

## Fix

In `compress-loop-responses.ts`, after the round completes, check for the empty condition:
- `contentText.length === 0` (no assistant text)
- `realCalls.length === 0` (no function/custom tool calls)
- `customToolCalls === 0`
- `!hasUsage` (no usage object from upstream — distinguishes from legitimate reasoning-only responses)

When all conditions are met, inject `response.failed` with a clear error message instead of `response.completed`. This tells the client the response failed, so it retries **immediately** rather than hanging until a timeout.

The `hasUsage` check is critical: it avoids false positives on legitimate reasoning-only responses (which have a usage object but no text/tool output).

## Root cause context

Diagnosed via multi-round `codex exec` testing. Normal cache hit is 93-98%; the 21% degradation only appears during reconnect recovery. The empty upstream response is the root trigger — this PR makes the proxy handle it gracefully.

**225 tests pass (+1 new), typecheck clean, build OK.**