### PR TITLE
release v0.1.30

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.29",
+      "version": "0.1.30",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Release v0.1.30

Minor release. Changes since v0.1.29:

### PR#84: fix empty upstream response UX
- Inject `response.failed` when upstream returns empty response (no text/tool/usage) instead of fake `response.completed`
- Fixes the "stuck after tool call" symptom — codex now retries immediately instead of hanging
- Prevents reconnect-induced cache prefix degradation

### Full diff
https://github.com/ranxianglei/billion-context/compare/v0.1.29...master

---
**225 tests pass, typecheck clean, build OK.**

Merge to trigger CI auto-publish to npm.