### PR TITLE
fix: use openai_base_url for built-in provider + 426 for WS upgrade (closes #83)

### DIFF
--- a/src/codex-provider.ts
+++ b/src/codex-provider.ts
@@ -283,6 +283,50 @@ export function removeCodexProviderField(text: string, providerId: string, key: 
     return existing ? text.slice(0, existing.lineStart) + text.slice(existing.lineEnd) : text;
 }
 
+export function getTopLevelField(text: string, key: string): ProviderFieldValue | undefined {
+    return rootAssignment(text, key)?.value;
+}
+
+export function getTopLevelFieldSnapshot(text: string, key: string): ProviderFieldSnapshot | undefined {
+    const assignment = rootAssignment(text, key);
+    return assignment ? { value: assignment.value, encoded: assignment.encoded } : undefined;
+}
+
+export function setTopLevelField(
+    text: string,
+    key: string,
+    value: ProviderFieldValue,
+): { text: string; added: boolean } {
+    const existing = rootAssignment(text, key);
+    if (existing) {
+        return {
+            text: text.slice(0, existing.start) + encodeValue(value) + text.slice(existing.end),
+            added: false,
+        };
+    }
+    const eol = preferredEol(text);
+    const firstSection = linesOf(text).find((line) => /^\s*\[/.test(line.content));
+    const insertAt = firstSection?.start ?? text.length;
+    const prefix = insertAt > 0 && !/(?:\r\n|\r|\n)$/.test(text.slice(0, insertAt)) ? eol : "";
+    const line = `${key} = ${encodeValue(value)}${eol}`;
+    return { text: text.slice(0, insertAt) + prefix + line + text.slice(insertAt), added: true };
+}
+
+export function restoreTopLevelField(
+    text: string,
+    key: string,
+    snapshot: ProviderFieldSnapshot,
+): string {
+    const existing = rootAssignment(text, key);
+    if (!existing) throw new Error(`Top-level field "${key}" is missing`);
+    return text.slice(0, existing.start) + snapshot.encoded + text.slice(existing.end);
+}
+
+export function removeTopLevelField(text: string, key: string): string {
+    const existing = rootAssignment(text, key);
+    return existing ? text.slice(0, existing.lineStart) + text.slice(existing.lineEnd) : text;
+}
+
 export function appendCodexProviderSection(
     text: string,
     providerId: string,

--- a/src/codex-takeover.ts
+++ b/src/codex-takeover.ts
@@ -14,21 +14,25 @@ import { createHash, randomUUID } from "node:crypto";
 import path from "node:path";
 import { dataDir } from "./paths.js";
 import {
-    appendCodexProviderSection,
     codexConfigFile,
     getCodexProviderField,
     getCodexProviderFieldSnapshot,
+    getTopLevelField,
+    getTopLevelFieldSnapshot,
     readCodexConfig,
     removeCodexProviderField,
     removeCodexProviderSectionWithPrefixIfEmpty,
+    removeTopLevelField,
     restoreCodexProviderField,
+    restoreTopLevelField,
     resolveActiveCodexProvider,
     setCodexProviderField,
+    setTopLevelField,
     type ActiveCodexProvider,
     type ProviderFieldValue,
 } from "./codex-provider.js";
 
-export const CODEX_ROUTE_STATE_VERSION = 1;
+export const CODEX_ROUTE_STATE_VERSION = 2;
 
 const INSTALLED_BASE_FIELDS: Record<string, ProviderFieldValue> = {
     name: "OpenAI",
@@ -43,7 +47,7 @@ type StoredField = {
 };
 
 export type CodexRouteState = {
-    version: typeof CODEX_ROUTE_STATE_VERSION;
+    version: number;
     active: true;
     pid?: number;
     providerId: string;
@@ -60,6 +64,8 @@ export type CodexRouteState = {
         baseUrl: string;
         supportsWebsockets: false;
     };
+    baseUrlMode: "top-level" | "provider-section";
+    originalTopLevelBaseUrl?: StoredField;
     configHashBefore: string;
     startedAt: string;
     lastRequestAt?: string;
@@ -125,9 +131,9 @@ function atomicWrite(filePath: string, text: string): void {
 function parseState(statePath: string): CodexRouteState | undefined {
     if (!existsSync(statePath)) return undefined;
     try {
-        const value = JSON.parse(readFileSync(statePath, "utf8")) as Partial<CodexRouteState>;
+        const value = JSON.parse(readFileSync(statePath, "utf8")) as Partial<CodexRouteState> & { version?: number };
         if (
-            value.version === CODEX_ROUTE_STATE_VERSION &&
+            (value.version === 1 || value.version === 2) &&
             value.active === true &&
             typeof value.providerId === "string" &&
             typeof value.configPath === "string" &&
@@ -137,7 +143,11 @@ function parseState(statePath: string): CodexRouteState | undefined {
             value.originalFields && typeof value.originalFields === "object" &&
             Array.isArray(value.insertedFields) &&
             typeof value.sectionPrefixLength === "number" && value.sectionPrefixLength >= 0
-        ) return value as CodexRouteState;
+        ) {
+            const migrated = value as unknown as CodexRouteState;
+            if (!migrated.baseUrlMode) migrated.baseUrlMode = "provider-section";
+            return migrated;
+        }
     } catch {
     }
     return undefined;
@@ -172,6 +182,11 @@ function isInstalledBaseUrl(value: string): boolean {
 
 function storedField(text: string, providerId: string, key: string): StoredField {
     const snapshot = getCodexProviderFieldSnapshot(text, providerId, key);
+    return snapshot === undefined ? { present: false } : { present: true, ...snapshot };
+}
+
+function storedTopLevelField(text: string, key: string): StoredField {
+    const snapshot = getTopLevelFieldSnapshot(text, key);
     return snapshot === undefined ? { present: false } : { present: true, ...snapshot };
 }
 
@@ -219,9 +234,14 @@ export function getCodexTakeoverStatus(options: CodexTakeoverPaths = {}): CodexT
         };
     }
     const text = readCodexConfig(paths.configPath);
-    const currentBase = getCodexProviderField(text, state.providerId, "base_url");
-    const currentWebsockets = getCodexProviderField(text, state.providerId, "supports_websockets");
-    const matches = currentBase === state.installed.baseUrl && currentWebsockets === false;
+    const isTopLevel = state.baseUrlMode === "top-level";
+    const currentBase = isTopLevel
+        ? getTopLevelField(text, "openai_base_url")
+        : getCodexProviderField(text, state.providerId, "base_url");
+    const currentWebsockets = isTopLevel
+        ? undefined
+        : getCodexProviderField(text, state.providerId, "supports_websockets");
+    const matches = currentBase === state.installed.baseUrl && (isTopLevel || currentWebsockets === false);
     const port = Number.parseInt(new URL(state.installed.baseUrl).port, 10);
     return {
         state: matches ? "enabled" : "conflict",
@@ -271,19 +291,20 @@ export function enableCodexTakeover(port: number, options: CodexTakeoverPaths = 
     const managedKeys = ["base_url", "supports_websockets"];
     const originalFields: Record<string, StoredField> = {};
     for (const key of managedKeys) originalFields[key] = storedField(before, provider.id, key);
+    const originalTopLevelBaseUrl = !provider.sectionExists
+        ? storedTopLevelField(before, "openai_base_url")
+        : undefined;
     let after = before;
     const insertedFields: string[] = [];
     let sectionAdded = false;
+    let baseUrlMode: "top-level" | "provider-section";
     if (!provider.sectionExists) {
-        sectionAdded = true;
-        const fields = {
-            ...INSTALLED_BASE_FIELDS,
-            base_url: installedUrl,
-            supports_websockets: false,
-        };
-        after = appendCodexProviderSection(after, provider.id, fields);
-        insertedFields.push(...Object.keys(fields));
+        baseUrlMode = "top-level";
+        const result = setTopLevelField(after, "openai_base_url", installedUrl);
+        after = result.text;
+        if (result.added) insertedFields.push("openai_base_url");
     } else {
+        baseUrlMode = "provider-section";
         const baseResult = setCodexProviderField(after, provider.id, "base_url", installedUrl);
         after = baseResult.text;
         if (baseResult.added) insertedFields.push("base_url");
@@ -309,6 +330,8 @@ export function enableCodexTakeover(port: number, options: CodexTakeoverPaths = 
         originalFields,
         original: { baseUrl: provider.baseUrl, supportsWebsockets: provider.supportsWebsockets },
         installed: { baseUrl: installedUrl, supportsWebsockets: false },
+        baseUrlMode,
+        ...(originalTopLevelBaseUrl ? { originalTopLevelBaseUrl } : {}),
         configHashBefore: sha256(before),
         startedAt: new Date().toISOString(),
     };
@@ -328,6 +351,29 @@ export function disableCodexTakeover(options: CodexTakeoverPaths = {}): CodexTak
     if (!state) return getCodexTakeoverStatus(paths);
     let text = readCodexConfig(state.configPath);
     const preserved: string[] = [];
+    if (state.baseUrlMode === "top-level") {
+        const current = getTopLevelField(text, "openai_base_url");
+        if (current === state.installed.baseUrl) {
+            const original = state.originalTopLevelBaseUrl;
+            if (original?.present && original.value !== undefined) {
+                text = typeof original.encoded === "string"
+                    ? restoreTopLevelField(text, "openai_base_url", {
+                        value: original.value,
+                        encoded: original.encoded,
+                    })
+                    : setTopLevelField(text, "openai_base_url", original.value).text;
+            } else {
+                text = removeTopLevelField(text, "openai_base_url");
+            }
+        } else if (current !== undefined) {
+            preserved.push("openai_base_url");
+        }
+        atomicWrite(state.configPath, text);
+        removeState(paths.statePath);
+        const status = getCodexTakeoverStatus({ ...paths, configPath: state.configPath });
+        if (preserved.length > 0) status.detail = `检测到用户修改，已保留：${preserved.join(", ")}`;
+        return status;
+    }
     const installedValues: Record<string, ProviderFieldValue> = {
         ...INSTALLED_BASE_FIELDS,
         base_url: state.installed.baseUrl,

--- a/src/server.ts
+++ b/src/server.ts
@@ -410,7 +410,13 @@ async function handle(
     }
     if (req.method === "GET" && req.url === "/__bili/codex-history") return handleCodexHistoryGet(res);
     if (req.method === "POST" && req.url === "/__bili/codex-history/repair") return handleCodexHistoryRepair(res);
-    if ((req.url === "/codex" || req.url?.startsWith("/codex/") || req.url?.startsWith("/codex?")) && !getCodexRouteState()) {
+    const isCodexPath = req.url === "/codex" || req.url?.startsWith("/codex/") || req.url?.startsWith("/codex?");
+    if (isCodexPath && req.headers.upgrade === "websocket") {
+        res.writeHead(426, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: "WebSocket upgrade is not supported; use HTTP POST" }));
+        return;
+    }
+    if (isCodexPath && !getCodexRouteState()) {
         res.writeHead(503, { "content-type": "application/json" });
         res.end(JSON.stringify({ error: "Codex local route is not enabled; run bili codex enable" }));
         return;

--- a/tests/codex-official.test.ts
+++ b/tests/codex-official.test.ts
@@ -187,3 +187,50 @@ test("Codex official profile uses text protocol and prompt-cache auto stays nati
     assert.equal(isCodexResponsesLite({}, { input: [{ type: "additional_tools", tools: [] }] }), true);
     assert.equal(isCodexResponsesLite({}, { input: [] }), false);
 });
+
+test("WebSocket upgrade to /codex/responses returns 426 so Codex falls back to HTTP POST", async () => {
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    setRegistryForTest({});
+    const opts: ProxyOptions = {
+        port: 0,
+        host: "127.0.0.1",
+        upstream: "http://127.0.0.1",
+        routes: {},
+        modelContextLimit: 400_000,
+        kernelConfig: defaultConfig(400_000),
+        compress: { injectTool: true, injectNudge: true },
+        promptCache: { routing: "auto" },
+        sessionHeader: "x-acp-session",
+        log: false,
+        debug: false,
+        passthrough: false,
+        autoUpdate: false,
+        mitm: { enabled: false, domains: [] },
+    };
+    const proxy = await startServer(opts);
+    await listen(proxy);
+    const proxyPort = (proxy.address() as { port: number }).port;
+    try {
+        const response = await new Promise<{ status: number; body: string }>((resolve, reject) => {
+            const req = http.request(
+                {
+                    hostname: "127.0.0.1",
+                    port: proxyPort,
+                    path: "/codex/responses",
+                    method: "GET",
+                    headers: { upgrade: "websocket", connection: "Upgrade" },
+                },
+                (res) => {
+                    const chunks: Buffer[] = [];
+                    res.on("data", (chunk: Buffer) => chunks.push(chunk));
+                    res.on("end", () => resolve({ status: res.statusCode ?? 0, body: Buffer.concat(chunks).toString("utf8") }));
+                },
+            );
+            req.on("error", reject);
+            req.end();
+        });
+        assert.equal(response.status, 426);
+    } finally {
+        await close(proxy);
+    }
+});

--- a/tests/codex-takeover.test.ts
+++ b/tests/codex-takeover.test.ts
@@ -64,7 +64,7 @@ test("Codex route patches the active provider in place and restores byte-for-byt
     }
 });
 
-test("built-in openai takeover keeps model_provider absent and removes its temporary section", () => {
+test("built-in openai provider uses top-level openai_base_url instead of creating [model_providers.openai]", () => {
     const files = fixture();
     const original = 'model = "gpt-5.4"\n[mcp_servers.keep]\ncommand = "keep"';
     writeFileSync(files.configPath, original, "utf8");
@@ -72,9 +72,8 @@ test("built-in openai takeover keeps model_provider absent and removes its tempo
         const enabled = enableCodexTakeover(9123, files);
         assert.equal(enabled.providerId, "openai");
         const active = readFileSync(files.configPath, "utf8");
-        assert.doesNotMatch(active, /^\s*model_provider\s*=/m);
-        assert.match(active, /\[model_providers\.openai\]/);
-        assert.match(active, /base_url = "http:\/\/127\.0\.0\.1:9123\/codex"/);
+        assert.doesNotMatch(active, /\[model_providers\.openai\]/);
+        assert.match(active, /^openai_base_url = "http:\/\/127\.0\.0\.1:9123\/codex"$/m);
         disableCodexTakeover(files);
         assert.equal(readFileSync(files.configPath, "utf8"), original);
     } finally {
@@ -152,20 +151,18 @@ test("a running bili owner cannot be displaced by another process", () => {
     }
 });
 
-test("comments added to a temporary built-in provider section survive restore", () => {
+test("disable restores original openai_base_url when built-in provider had a pre-existing value", () => {
     const files = fixture();
-    writeFileSync(files.configPath, 'model = "gpt-5.4"\n', "utf8");
+    const original = 'openai_base_url = "https://user-existing.example/v1"\nmodel = "gpt-5.4"\n';
+    writeFileSync(files.configPath, original, "utf8");
     try {
         enableCodexTakeover(8787, files);
-        const active = readFileSync(files.configPath, "utf8").replace(
-            "[model_providers.openai]\n",
-            "[model_providers.openai]\n# user note added while routed\n",
-        );
-        writeFileSync(files.configPath, active, "utf8");
+        const active = readFileSync(files.configPath, "utf8");
+        assert.match(active, /^openai_base_url = "http:\/\/127\.0\.0\.1:8787\/codex"$/m);
+        assert.doesNotMatch(active, /\[model_providers\.openai\]/);
         disableCodexTakeover(files);
         const restored = readFileSync(files.configPath, "utf8");
-        assert.match(restored, /\[model_providers\.openai\]\n# user note added while routed/);
-        assert.doesNotMatch(restored, /base_url|supports_websockets/);
+        assert.match(restored, /^openai_base_url = "https:\/\/user-existing\.example\/v1"$/m);
     } finally {
         rmSync(files.root, { recursive: true, force: true });
     }
@@ -247,6 +244,49 @@ test("non-numeric sectionPrefixLength in state is rejected without wiping config
         assert.doesNotThrow(() => getCodexTakeoverStatus(files));
         assert.equal(getCodexTakeoverStatus(files).state, "disabled", "invalid sectionPrefixLength rejects state");
         assert.equal(readFileSync(files.configPath, "utf8"), configContent, "config.toml not wiped");
+    } finally {
+        rmSync(files.root, { recursive: true, force: true });
+    }
+});
+
+test("migration: old-format v1 state with openai sectionAdded is cleaned up on disable", () => {
+    const files = fixture();
+    const routedConfig = [
+        "[model_providers.openai]",
+        'name = "OpenAI"',
+        'base_url = "http://127.0.0.1:8787/codex"',
+        'wire_api = "responses"',
+        "requires_openai_auth = true",
+        "supports_websockets = false",
+        "",
+    ].join("\n");
+    writeFileSync(files.configPath, routedConfig, "utf8");
+    mkdirSync(path.dirname(files.statePath), { recursive: true });
+    writeFileSync(files.statePath, JSON.stringify({
+        version: 1,
+        active: true,
+        providerId: "openai",
+        configPath: files.configPath,
+        sectionAdded: true,
+        sectionPrefixLength: 0,
+        insertedFields: ["name", "base_url", "wire_api", "requires_openai_auth", "supports_websockets"],
+        originalFields: {
+            base_url: { present: false },
+            supports_websockets: { present: false },
+        },
+        original: { baseUrl: "https://chatgpt.com/backend-api/codex", supportsWebsockets: true },
+        installed: { baseUrl: "http://127.0.0.1:8787/codex", supportsWebsockets: false },
+        configHashBefore: "abc",
+        startedAt: new Date().toISOString(),
+    }), "utf8");
+    try {
+        const status = getCodexTakeoverStatus(files);
+        assert.equal(status.state, "enabled", "migrated v1 state is recognized as enabled");
+        disableCodexTakeover(files);
+        const restored = readFileSync(files.configPath, "utf8");
+        assert.doesNotMatch(restored, /\[model_providers\.openai\]/);
+        assert.doesNotMatch(restored, /base_url|supports_websockets|requires_openai_auth/);
+        assert.equal(existsSync(files.statePath), false);
     } finally {
         rmSync(files.root, { recursive: true, force: true });
     }


### PR DESCRIPTION
Closes #83.

## Problem

`bili codex enable` writes `[model_providers.openai]` which overrides the reserved built-in provider ID `openai`. Recent Codex builds (0.147+, desktop 26.803) reject this:

> "model_providers contains reserved built-in provider IDs: `openai`. Built-in providers cannot be overridden."

Two user-visible failures:
1. **Codex rejects config** → Windows setup stuck / CLI error
2. **Renaming to `openai-custom`** → existing threads/projects disappear (filtered by provider ID)

## Fix (5 parts)

### 1-3. Top-level `openai_base_url` for built-in `openai`
When the active provider is the built-in `openai` (no `[model_providers.openai]` section exists), do NOT create that section. Instead:
- Write the **top-level** `openai_base_url = "http://127.0.0.1:{port}/codex"`
- Preserve `model_provider = "openai"` (untouched — so existing threads stay visible)
- Snapshot/restore the original `openai_base_url` during enable/disable/stale-recovery

Custom providers with an existing section keep the current behavior (`base_url` in the provider section).

### 4. State migration
- `CODEX_ROUTE_STATE_VERSION` bumped 1 → 2
- New `baseUrlMode: "top-level" | "provider-section"` field
- `parseState` accepts both v1 and v2 states
- Old v1 state with `sectionAdded: true` for `openai` defaults to `baseUrlMode: "provider-section"` → next `disable` cleans up the old section via existing logic

### 5. WebSocket 426 for `/codex/responses` upgrade
Built-in `openai` advertises `supports_websockets = true`. Since we no longer create a section to disable it, Codex sends WS upgrade probes. Server now returns **426 Upgrade Required** immediately → Codex's built-in fast-fallback kicks in → immediate HTTP POST (no more repeated 502s).

## New helpers in `codex-provider.ts`
`getTopLevelField`, `getTopLevelFieldSnapshot`, `setTopLevelField`, `restoreTopLevelField`, `removeTopLevelField` — follow the existing TOML editing pattern (index-based string manipulation, `rootAssignment` finds assignments before the first section).

## Tests
- **built-in openai uses top-level `openai_base_url`** (updated existing test): no `[model_providers.openai]` created, `openai_base_url` set at top level
- **disable restores original `openai_base_url`**: snapshot/restore verified
- **migration: old v1 state with openai sectionAdded cleaned up on disable**: v1 state file → disable → section removed
- **426 for WebSocket upgrade to /codex/responses** (codex-official.test.ts): WS upgrade header → 426 response

**227 tests pass, typecheck clean, build OK.**