### PR TITLE
release v0.1.31

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.30",
+      "version": "0.1.31",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Release v0.1.31

### Changes since v0.1.30

**Breaking:** Removed Codex auto-takeover (CLI `bili codex enable/disable`, web UI toggle, `/codex` route prefix). Use `openai_base_url` + `/bili/` instead (see README).

- **Removed:** `codex-takeover.ts` (398 lines), `codex-provider.ts` (321 lines), `codex-history.ts` (300 lines) — eliminates `node:sqlite` dependency
- **Unified routing:** `/codex` prefix removed; all clients use `/bili/<url>` format uniformly
- **Protocol detection:** URL-path prefix support (`/bili/<protocol>/<url>`)
- **Web UI redesign:** Two-category access page (A: `/bili/` URL override, B: MITM), version display, Fork ribbon, Codex MITM card
- **Docs:** README + README.zh-CN updated (Codex Route → `openai_base_url` approach)
- **Code review fixes:** deleted orphaned files, fixed stale test assertions

### Pre-flight
- [x] typecheck: ✅
- [x] tests: 212 pass / 0 fail
- [x] build: ✅ (4.09 MB)

### Commits
```
81f8bd6 release v0.1.31
```

Merge to trigger CI auto-publish.