### PR TITLE
fix(responses): read-only proxy tools no longer drive the compress loop (炸锅)

### DIFF
--- a/UNIFIED_LOOP_SPEC.md
+++ b/UNIFIED_LOOP_SPEC.md
@@ -1,0 +1,170 @@
+# Unified Compress-Loop — Design Spec (Phase 1+2)
+
+## Problem
+The generic billion-context proxy's three `compress-loop-*.ts` files have an **injection-persistence** bug: the philosophy prompt (injected as a conversation message, not a transient system prompt) and accumulated proxy-tool records PERSIST across re-request rounds, re-priming the model → on rare model paths the model loops `acp_status`/`search_context` until the loop-limit fires a degenerate empty completion (the 炸锅). Root cause confirmed by the user.
+
+`executeProxyTool` is also copy-pasted ×3 (compress-loop.ts:47, compress-loop-anthropic.ts:59, compress-loop-responses.ts:85).
+
+## Reference (the ONLY behavioral reference)
+**billion-context-pi** (`/home/dog/projects/billion-context-pi/src/`), the Pi adapter. It uses an **executor model** (one tool call = one Pi turn, no loop). Key principles to mirror in the loop:
+- `wireSystemPrompt` (index.ts:229-235): philosophy is a **transient system prompt** returned via Pi's `before_agent_start` event — rebuilt fresh each turn, NOT in message history, does NOT accumulate.
+- `wireContextTransform` (index.ts:103-227): runs `core.processTurn({messages, state, config, tokenCount})` once per LLM call; nudge is a **per-turn append** (comment index.ts:178-179: "the next context event rebuilds the array from scratch, so it does NOT permanently pollute context").
+- Kernel `hideConsumedCompressCalls(state, messages)` runs inside processTurn each turn (hide-consumed.ts, exported index.ts:51) — hides consumed/failed compress records, keeps active-block compress calls ("压缩成功留着"), rewrites kept compress text to live ranges.
+- Kernel `protected.ts`: `ALWAYS_PROTECTED_TOOLS=["compress"]`, recent-zone + last-user protection.
+
+**Alignment goal**: the proxy's loop must apply the SAME per-turn hygiene bili-pi gets for free (transient philosophy + hideConsumed), but per ROUND of the loop.
+
+## Architecture: protocol-agnostic core + thin adapters
+
+### Core message type (acp-kernel, types.d.ts:3-10)
+```ts
+interface CoreMessage { id: string; role: "user"|"assistant"|"system"|"tool"; contentType: "text"|"tool-call"|"tool-result"|"reasoning"; text?: string; toolName?: string; toolCallId?: string; }
+```
+
+### Loop context (mirrors existing CompressLoopResponsesCtx)
+```ts
+interface LoopCtx {
+  core: CompressionCore;       // acp-kernel
+  config: Config;
+  messages: CoreMessage[];     // original (pre-loop) messages from processTurn
+  session: Session;            // has .state (CompressionState), .stats
+  log: (msg: string) => void;
+  proxyUrl?: string;
+  textProtocol?: boolean;
+}
+```
+
+### Parsed stream event (what an adapter yields from the upstream stream)
+```ts
+type ParsedStreamEvent =
+  | { kind: "text"; delta: string }
+  | { kind: "tool_call"; name: string; callId: string; arguments: string }
+  | { kind: "usage"; inputTokens?: number; outputTokens?: number; cachedTokens?: number }
+  | { kind: "done"; finishReason?: string };
+```
+
+### Adapter interface (protocol-specific; one per protocol)
+```ts
+interface CompressLoopAdapter {
+  // Build native upstream request body from CoreMessage[] + TRANSIENT system prompt.
+  // The system prompt MUST NOT be added to coreMessages — it is passed fresh each round.
+  buildRequest(coreMessages: CoreMessage[], systemPrompt: string, requestBody: Record<string, unknown>): Record<string, unknown>;
+  // Parse upstream SSE stream → ParsedStreamEvent (extract text deltas, tool calls, usage, done)
+  parseStream(upstream: ReadableStream<Uint8Array>): AsyncGenerator<ParsedStreamEvent>;
+  // Emit downstream (client-facing) events as SSE Buffers
+  emitText(delta: string): Buffer;
+  emitToolCall(call: { name: string; callId: string; arguments: string }): Buffer;   // real-tool passthrough
+  emitMarker(toolName: string, result: string): Buffer;                              // proxy-tool result visibility
+  emitCompletion(opts?: { finishReason?: string; usage?: { inputTokens?: number; outputTokens?: number; cachedTokens?: number } }): Buffer;
+  emitError(message: string): Buffer;
+  // (Optional) extract text-protocol triggers (<acp_compress>...</acp_compress>) from assistant text
+  extractTextTriggers?(text: string): { clean: string; calls: { name: string; callId: string; arguments: string }[] };
+}
+```
+
+### Core loop (protocol-agnostic)
+```ts
+async function* runCompressLoop(
+  upstream: ReadableStream<Uint8Array>,   // round-1 stream already fetched by server
+  ctx: LoopCtx,
+  requestBody: Record<string, unknown>,   // original client request (for tools, model, etc.)
+  requestOptions: { url: string; headers: Record<string, string> },
+  adapter: CompressLoopAdapter,
+  systemPrompt: string,                   // TRANSIENT philosophy (never added to coreMessages)
+): AsyncGenerator<Buffer>
+```
+
+Round logic (per bili-pi hygiene):
+1. `for round in 1..MAX_ROUNDS` (MAX_ROUNDS = 10):
+   - Parse `upstream` stream via `adapter.parseStream`.
+   - Accumulate assistant text; for each tool_call:
+     - If PROXY tool (compress/decompress/search_context/acp_status): execute via shared `executeProxyTool`, `yield adapter.emitMarker(...)`, append `{assistant,tool-call}` + `{tool,tool-result}` to a LOCAL coreMessages copy.
+       - Track `sawMutating` if name ∈ {compress, decompress}.
+     - Else (real tool): `yield adapter.emitToolCall(...)`, increment `realCalls`.
+   - After stream done: run `hideConsumedCompressCalls(ctx.session.state, coreMessages)` (per-round hygiene).
+   - Decision: if `sawMutating && realCalls === 0` → re-request: rebuild body via `adapter.buildRequest(coreMessages, systemPrompt, requestBody)`, fetch new upstream, loop. Else → `yield adapter.emitCompletion(...)`, return.
+2. Limit reached: `yield adapter.emitCompletion(...)` **gracefully** (NOT a degenerate empty completion). Log it. This is the key fix — never discard the turn.
+
+### Shared executeProxyTool (de-dup ×3 → ×1)
+```ts
+function executeProxyTool(name: string, args: Record<string, unknown>, ctx: LoopCtx): string
+```
+Dispatch (identical to current 3 copies):
+- `compress` → `applyRanges(parseCompressInput(args), ctx)` (stream.ts applyRanges mutates ctx.session.state)
+- `decompress` → `resolveDecompress(args, ctx)` (decompress-shared.ts)
+- `search_context` → `ctx.core.search(query, state).slice(limit)` → formatted lines
+- `acp_status` → `buildStatusReport(state, messages, estimateTokensFast)`
+
+## File structure (NEW files; keep originals as baseline)
+```
+src/loop/
+├── core.ts              # runCompressLoop + LoopCtx + shared executeProxyTool + ParsedStreamEvent + CompressLoopAdapter interface
+├── adapter-responses.ts # responses adapter (parseStream/emit*/buildRequest)
+├── adapter-openai.ts    # openai /chat/completions adapter
+├── adapter-anthropic.ts # anthropic /v1/messages adapter
+└── index.ts             # exports: runCompressLoop + a factory pickAdapter(protocol)
+```
+Originals (`src/compress-loop.ts`, `src/compress-loop-anthropic.ts`, `src/compress-loop-responses.ts`) stay UNTOUCHED as baseline.
+
+## Feature-flag wiring (server.ts)
+In `server.ts:1131-1200`, gate on `process.env.ACP_LOOP_V2 === "1"`:
+- if set → use `runCompressLoop(...)` with `pickAdapter(protocol)`.
+- else → existing baseline loops (unchanged).
+This allows A/B comparison in live tests (`ACP_LOOP_V2=1 bili-test-pi ...`).
+
+The transient `systemPrompt` = `buildCompressSystemPrompt()` (or `buildCompressTextSystemPrompt()` when `ctx.textProtocol`). Import from compress-tool.ts. Pass as the `systemPrompt` arg — do NOT inject into requestBody.input/messages in core (the adapter places it per-protocol).
+
+## Per-protocol adapter notes
+
+### responses (`/response-input`-style `input[]`)
+- `buildRequest`: convert CoreMessage[] → ResponseInputItem[] via existing `coreToResponses` (responses.ts:324). Place systemPrompt as a developer message at the head of input (skip leading additional_tools; mirror `injectResponsesDeveloperMessage` responses.ts:362-372). Top-level `instructions` MUST stay empty/absent (code_mode requirement, server.ts:803-804). Preserve `requestBody.tools`, `model`, etc.
+- `parseStream`: responses SSE events (`response.output_text.delta`, `response.function_call_arguments.done` / `response.output_item.added` with function_call, `response.completed` with usage, `response.done`). Reference existing `stream-responses.ts` helpers (buildMessageItemSequence, buildCompleted) + the baseline `compress-loop-responses.ts:454+` stream parsing for the exact event names/shapes.
+- `emitText`/`emitToolCall`/`emitMarker`/`emitCompletion`: reuse `stream-responses.ts` SSE builders.
+- text-protocol: `extractTextTriggers` detects `<acp_compress>...</acp_compress>` (ACP_TEXT_OPEN/CLOSE from compress-tool.ts).
+
+### openai (`/chat/completions`, `messages[]`)
+- `buildRequest`: `coreToOpenai(coreMessages)` (openai.ts:106). systemPrompt → a `{role:"system",content}` message at messages[0].
+- `parseStream`: `data: {choices:[{delta:{content?,tool_calls?}}]}` chunks + `data: [DONE]`. Reference baseline `compress-loop.ts` + `stream-openai.ts`.
+- emit*: `stream-openai.ts` SSE builders (buildFinishSse etc.).
+
+### anthropic (`/v1/messages`, `messages[]` with content blocks)
+- `buildRequest`: `coreToAnthropic(coreMessages)` (anthropic.ts:138). systemPrompt → top-level `system` field.
+- `parseStream`: `content_block_delta` (text_delta/input_json_delta), `content_block_start` (tool_use), `message_delta` (usage), `message_stop`. Reference baseline `compress-loop-anthropic.ts` + `stream-anthropic.ts`.
+- emit*: `stream-anthropic.ts` SSE builders (buildTerminalSse etc.).
+
+## Kernel APIs (all already exported from acp-kernel, version 0.0.17 pinned)
+- `hideConsumedCompressCalls(state, messages)` — hide-consumed.ts (the per-round cleanup)
+- `createCore`, `CompressionCore`, `processTurn` — compress.ts
+- `buildStatusReport`, `estimateTokensFast` — report.ts, tokenize.ts
+- `COMPRESS_PHILOSOPHY`, `HOW_TO_COMPRESS_RULES` — compression-rules.ts (already wrapped by buildCompressSystemPrompt)
+- types: `CoreMessage`, `CompressionState`, `Config`, `ProcessTurnResult` — types.ts
+- `coreToResponses`/`responsesToCore`, `coreToOpenai`/`openaiToCore`, `coreToAnthropic`/`anthropicToCore` — local src/{responses,openai,anthropic}.ts
+
+## Constraints (from AGENTS.md)
+- No `as any`, no `@ts-ignore`.
+- Hex escapes (`\x3c`/`\x3e`) for any `<acp>`/`<acp_compress>` XML in source.
+- Comments only where strictly necessary (priority-3: encodes an invariant). This is an exception — explain WHY transient/dedup matters in 1-2 lines at the core loop's hygiene point.
+- TypeScript strict, ESM (.js extensions in imports).
+
+## Test plan (Phase 3)
+Existing tests: `npm test` → 212 baseline (before PR#90) / 219 (with PR#90). New tests in `tests/loop-*.test.ts`:
+1. **acp_status-only round**: model calls only acp_status → assert (a) marker surfaced to client, (b) NO re-request (readonly), (c) graceful completion present, (d) `realCalls` passthrough. **No 炸锅.**
+2. **search_context-only round**: same shape as #1.
+3. **compress round**: model calls compress → assert re-request happens (mutating), result fed back, hideConsumed ran (consumed compress records hidden in round 2 input).
+4. **decompress round**: re-request happens.
+5. **limit-hit graceful**: force 10 mutating rounds → assert graceful completion (NOT degenerate empty), no crash.
+6. **philosophy transient**: assert philosophy appears exactly ONCE per round in upstream body (not accumulated) — spy on fetch.
+7. **hideConsumed per round**: after a compress in round 1, round 2's upstream body must NOT contain the consumed compress tool-call/result (verify hideConsumedCompressCalls ran).
+8. **real-tool passthrough**: model calls a real tool (e.g. `bash`) → emitted to client, loop ends (no re-request).
+9. **mixed**: compress + real tool in same round → forwarded (no re-request), compress executed, marker shown.
+Run via `node --import tsx --test tests/loop-*.test.ts` (node/npm at /home/dog/.local/bin; npx NOT available, use `npm test`).
+
+## Verification gate (must pass before declaring done)
+- `npm run typecheck` (tsc --noEmit) clean.
+- `npm test` all green (existing + new).
+- Manual smoke: `ACP_LOOP_V2=1` path at least imports + a round-trip works under mocked fetch.
+
+## Out of scope for this delegation
+- Live testing (bili-test-pi/codex/claude) — Phase 4, done by lead.
+- Double-agent review — Phase 5, done by lead.
+- Removing/reverting PR#90's MUTATING/READONLY split in baseline files — leave baseline as-is.

--- a/src/compress-loop-anthropic.ts
+++ b/src/compress-loop-anthropic.ts
@@ -6,7 +6,12 @@ import {
     type CoreMessage,
 } from "acp-kernel";
 import type { Session } from "./session.js";
-import { parseCompressInput, PROXY_TOOL_NAMES } from "./compress-tool.js";
+import {
+    MUTATING_PROXY_TOOLS,
+    parseCompressInput,
+    PROXY_TOOL_NAMES,
+    READONLY_PROXY_TOOLS,
+} from "./compress-tool.js";
 import { applyRanges } from "./stream.js";
 import { resolveDecompress } from "./decompress-shared.js";
 import { buildVisibilityMarker } from "./compress-loop.js";
@@ -264,9 +269,24 @@ export async function* compressLoopAnthropicStream(
             clientIndex = state.clientIndex;
 
             const proxyCalls = [...state.toolBlocks.values()].filter((b) => PROXY_TOOL_NAMES.has(b.name));
-            const hasOnlyProxy = proxyCalls.length > 0 && !hasRealToolUse;
+            const mutatingProxy = proxyCalls.filter((b) => MUTATING_PROXY_TOOLS.has(b.name));
+            const readonlyProxy = proxyCalls.filter((b) => READONLY_PROXY_TOOLS.has(b.name));
+            const hasMutatingOnly = mutatingProxy.length > 0 && !hasRealToolUse;
 
-            if (!hasOnlyProxy) {
+            if (!hasMutatingOnly) {
+                for (const tc of readonlyProxy) {
+                    const args = safeParse(tc.json);
+                    let result: string;
+                    try {
+                        result = executeProxyTool(tc.name, args, ctx);
+                    } catch (e) {
+                        result = `[${tc.name} FAILED: ${e instanceof Error ? e.message : String(e)}]`;
+                    }
+                    const preview = result.length > 120 ? result.slice(0, 120) + "..." : result;
+                    ctx.log(`[acp-proxy: ${tc.name} (${tc.id}) → ${preview.replace(/\n/g, " ")}]`);
+                    yield Buffer.from(buildTextBlockSse(clientIndex, buildVisibilityMarker(tc.name, result)), "utf8");
+                    clientIndex++;
+                }
                 const stop = hasRealToolUse ? "tool_use" : (roundStopReason ?? "end_turn");
                 yield Buffer.from(buildTerminalSse(stop, totalOutputTokens, totalInputTokens, totalCachedTokens, messageId, model), "utf8");
                 return;

--- a/src/compress-loop-responses.ts
+++ b/src/compress-loop-responses.ts
@@ -8,7 +8,7 @@ import {
     type CoreMessage,
 } from "acp-kernel";
 import type { Session } from "./session.js";
-import { parseCompressInput, PROXY_TOOL_NAMES, COMPRESS_TOOL_NAME, ACP_TEXT_OPEN, ACP_TEXT_CLOSE } from "./compress-tool.js";
+import { parseCompressInput, PROXY_TOOL_NAMES, MUTATING_PROXY_TOOLS, READONLY_PROXY_TOOLS, COMPRESS_TOOL_NAME, ACP_TEXT_OPEN, ACP_TEXT_CLOSE } from "./compress-tool.js";
 import { log as loggerLog } from "./logger.js";
 import { applyRanges } from "./stream.js";
 import { resolveDecompress } from "./decompress-shared.js";
@@ -358,6 +358,30 @@ function replaceResponsesJsonText(parts: Array<Record<string, unknown>>, text: s
     });
 }
 
+function surfaceReadonlyJson(
+    current: Record<string, unknown>,
+    proxyCalls: FunctionCallAccumulator[],
+    ctx: CompressLoopResponsesCtx,
+): Record<string, unknown> {
+    const markers: string[] = [];
+    for (const call of proxyCalls) {
+        if (MUTATING_PROXY_TOOLS.has(call.name)) continue;
+        let args: Record<string, unknown> = {};
+        try {
+            args = JSON.parse(call.arguments) as Record<string, unknown>;
+        } catch {
+            args = {};
+        }
+        const result = executeProxyTool(call.name, args, ctx);
+        ctx.log(`[acp-proxy: responses JSON ${call.name} (read-only) → ${result.slice(0, 120).replace(/\n/g, " ")}]`);
+        markers.push(buildVisibilityMarker(call.name, result));
+    }
+    if (markers.length === 0) return current;
+    const out = Array.isArray(current.output) ? [...(current.output as unknown[])] : [];
+    out.push({ type: "message", id: `msg_acp_ro_${Date.now()}`, role: "assistant", content: [{ type: "output_text", text: markers.join("\n") }] });
+    return { ...current, output: out };
+}
+
 export async function compressLoopResponsesJson(
     initialResponse: Record<string, unknown>,
     ctx: CompressLoopResponsesCtx,
@@ -371,8 +395,12 @@ export async function compressLoopResponsesJson(
         const allCalls = [...output.calls, ...extracted.calls].filter((call) => call.name.length > 0);
         const proxyCalls = allCalls.filter((call) => PROXY_TOOL_NAMES.has(call.name));
         const realCalls = allCalls.filter((call) => !PROXY_TOOL_NAMES.has(call.name));
-        if (proxyCalls.length === 0 || realCalls.length > 0) {
-            if (proxyCalls.length > 0) replaceResponsesJsonText(output.textParts, extracted.clean);
+        const mutatingProxy = proxyCalls.filter((call) => MUTATING_PROXY_TOOLS.has(call.name));
+        if (mutatingProxy.length === 0 || realCalls.length > 0) {
+            if (proxyCalls.length > 0) {
+                replaceResponsesJsonText(output.textParts, extracted.clean);
+                if (realCalls.length === 0) current = surfaceReadonlyJson(current, proxyCalls, ctx);
+            }
             return current;
         }
         const inputItems = Array.isArray(requestBody.input) ? [...(requestBody.input as unknown[])] : [];
@@ -549,11 +577,26 @@ export async function* compressLoopResponsesStream(
         const allCalls = [...fcByItemId.values()].filter((c) => c.name.length > 0);
         const proxyCalls = allCalls.filter((c) => PROXY_TOOL_NAMES.has(c.name));
         const realCalls = allCalls.filter((c) => !PROXY_TOOL_NAMES.has(c.name));
+        const readonlyProxy = proxyCalls.filter((c) => READONLY_PROXY_TOOLS.has(c.name));
         // DIAG: log what tools the upstream returned this round.
         loggerLog("debug", `[acp-diag] round ${loopCount} allCalls=[${allCalls.map((c) => c.name).join(",")}] realCalls=[${realCalls.map((c) => c.name).join(",")}] customToolCalls=${customToolCalls} text=${JSON.stringify(contentText.slice(0, 120))}`);
-        const hasOnlyProxy = proxyCalls.length > 0 && realCalls.length === 0;
+        const hasMutatingOnly = proxyCalls.some((c) => MUTATING_PROXY_TOOLS.has(c.name)) && realCalls.length === 0;
 
-        if (!hasOnlyProxy) {
+        if (!hasMutatingOnly) {
+            for (const fc of readonlyProxy) {
+                let args: Record<string, unknown> = {};
+                try {
+                    args = JSON.parse(fc.arguments) as Record<string, unknown>;
+                } catch (e) {
+                    loggerLog("warn", `[acp-compress-args] ${fc.name} JSON.parse failed: ${String(e)}`);
+                    args = {};
+                }
+                const result = executeProxyTool(fc.name, args, ctx);
+                const preview = result.length > 120 ? result.slice(0, 120) + "..." : result;
+                ctx.log(`[acp-proxy: responses ${fc.name} (read-only) (${fc.callId}) → ${preview.replace(/\n/g, " ")}]`);
+                const markerItemId = `msg_acp_ro_${Date.now()}_${nextOutputIndex}`;
+                yield Buffer.from(buildMessageItemSequence(markerItemId, nextOutputIndex++, buildVisibilityMarker(fc.name, result)), "utf8");
+            }
             let oi = nextOutputIndex;
             for (const fc of realCalls) {
                 yield Buffer.from(buildFunctionCallEvents(fc, oi), "utf8");
@@ -570,7 +613,8 @@ export async function* compressLoopResponsesStream(
             // Empty upstream response (no text/tool_call/usage): inject
             // response.failed so the client retries instead of hanging.
             const hasUsage = !!(responseObj as Record<string, unknown> | undefined)?.usage;
-            if (contentText.length === 0 && realCalls.length === 0 && customToolCalls === 0 && !hasUsage) {
+            const emittedReadonly = readonlyProxy.length > 0;
+            if (contentText.length === 0 && realCalls.length === 0 && customToolCalls === 0 && !emittedReadonly && !hasUsage) {
                 ctx.log("[acp-proxy: empty upstream response (no content/usage) — injecting response.failed for client retry]");
                 yield Buffer.from(buildFailed(responseObj), "utf8");
                 return;

--- a/src/compress-loop-responses.ts
+++ b/src/compress-loop-responses.ts
@@ -372,13 +372,19 @@ function surfaceReadonlyJson(
         } catch {
             args = {};
         }
-        const result = executeProxyTool(call.name, args, ctx);
-        ctx.log(`[acp-proxy: responses JSON ${call.name} (read-only) → ${result.slice(0, 120).replace(/\n/g, " ")}]`);
+        let result: string;
+        try {
+            result = executeProxyTool(call.name, args, ctx);
+            ctx.log(`[acp-proxy: responses JSON ${call.name} (read-only) → ${result.slice(0, 120).replace(/\n/g, " ")}]`);
+        } catch (e) {
+            result = `\u274c [ACP] ${call.name} FAILED: ${String(e)}`;
+            ctx.log(`[acp-proxy: responses JSON ${call.name} (read-only) FAILED: ${String(e)}]`);
+        }
         markers.push(buildVisibilityMarker(call.name, result));
     }
     if (markers.length === 0) return current;
     const out = Array.isArray(current.output) ? [...(current.output as unknown[])] : [];
-    out.push({ type: "message", id: `msg_acp_ro_${Date.now()}`, role: "assistant", content: [{ type: "output_text", text: markers.join("\n") }] });
+    out.push({ type: "message", id: `msg_acp_ro_${Date.now()}_${markers.length}`, role: "assistant", content: [{ type: "output_text", text: markers.join("\n") }] });
     return { ...current, output: out };
 }
 
@@ -399,7 +405,7 @@ export async function compressLoopResponsesJson(
         if (mutatingProxy.length === 0 || realCalls.length > 0) {
             if (proxyCalls.length > 0) {
                 replaceResponsesJsonText(output.textParts, extracted.clean);
-                if (realCalls.length === 0) current = surfaceReadonlyJson(current, proxyCalls, ctx);
+                current = surfaceReadonlyJson(current, proxyCalls, ctx);
             }
             return current;
         }
@@ -591,9 +597,15 @@ export async function* compressLoopResponsesStream(
                     loggerLog("warn", `[acp-compress-args] ${fc.name} JSON.parse failed: ${String(e)}`);
                     args = {};
                 }
-                const result = executeProxyTool(fc.name, args, ctx);
-                const preview = result.length > 120 ? result.slice(0, 120) + "..." : result;
-                ctx.log(`[acp-proxy: responses ${fc.name} (read-only) (${fc.callId}) → ${preview.replace(/\n/g, " ")}]`);
+                let result: string;
+                try {
+                    result = executeProxyTool(fc.name, args, ctx);
+                    const preview = result.length > 120 ? result.slice(0, 120) + "..." : result;
+                    ctx.log(`[acp-proxy: responses ${fc.name} (read-only) (${fc.callId}) → ${preview.replace(/\n/g, " ")}]`);
+                } catch (e) {
+                    result = `\u274c [ACP] ${fc.name} FAILED: ${String(e)}`;
+                    ctx.log(`[acp-proxy: responses ${fc.name} (read-only) (${fc.callId}) FAILED: ${String(e)}]`);
+                }
                 const markerItemId = `msg_acp_ro_${Date.now()}_${nextOutputIndex}`;
                 yield Buffer.from(buildMessageItemSequence(markerItemId, nextOutputIndex++, buildVisibilityMarker(fc.name, result)), "utf8");
             }

--- a/src/compress-loop.ts
+++ b/src/compress-loop.ts
@@ -8,7 +8,12 @@ import {
     type CoreMessage,
 } from "acp-kernel";
 import type { Session } from "./session.js";
-import { parseCompressInput, PROXY_TOOL_NAMES } from "./compress-tool.js";
+import {
+    MUTATING_PROXY_TOOLS,
+    parseCompressInput,
+    PROXY_TOOL_NAMES,
+    READONLY_PROXY_TOOLS,
+} from "./compress-tool.js";
 import { applyRanges } from "./stream.js";
 import { resolveDecompress } from "./decompress-shared.js";
 import { fetchWithTimeout } from "./fetch-util.js";
@@ -334,8 +339,9 @@ export async function* compressLoopStream(
 
         const proxyCalls = toolCalls.filter((tc) => PROXY_TOOL_NAMES.has(tc.name));
         const realCalls = toolCalls.filter((tc) => !PROXY_TOOL_NAMES.has(tc.name));
-
-        const hasOnlyProxy = proxyCalls.length > 0 && realCalls.length === 0;
+        const mutatingProxy = proxyCalls.filter((tc) => MUTATING_PROXY_TOOLS.has(tc.name));
+        const readonlyProxy = proxyCalls.filter((tc) => READONLY_PROXY_TOOLS.has(tc.name));
+        const hasMutatingOnly = mutatingProxy.length > 0 && realCalls.length === 0;
 
         // Log cache-hit stats from the upstream usage object so we can measure
         // prefix-cache health on the OpenAI chat-completions path (GLM/zhipu).
@@ -358,7 +364,27 @@ export async function* compressLoopStream(
             }
         }
 
-        if (!hasOnlyProxy) {
+        if (!hasMutatingOnly) {
+            for (const tc of readonlyProxy) {
+                let args: Record<string, unknown> = {};
+                try {
+                    args = JSON.parse(tc.arguments) as Record<string, unknown>;
+                } catch {
+                    args = {};
+                }
+                let result: string;
+                try {
+                    result = executeProxyTool(tc.name, args, ctx);
+                } catch (e) {
+                    result = `[${tc.name} FAILED: ${e instanceof Error ? e.message : String(e)}]`;
+                }
+                const preview = result.length > 120 ? result.slice(0, 120) + "..." : result;
+                ctx.log(`[acp-proxy: ${tc.name} (${tc.id}) → ${preview.replace(/\n/g, " ")}]`);
+                yield Buffer.from(
+                    buildContentSse(responseId, model, buildVisibilityMarker(tc.name, result)),
+                    "utf8",
+                );
+            }
             for (const tc of realCalls) {
                 yield Buffer.from(buildToolCallSse(makeBase(), tc), "utf8");
             }

--- a/src/compress-tool.ts
+++ b/src/compress-tool.ts
@@ -41,24 +41,28 @@ export type ParsedRange = {
     endRef: string;
     summary: string;
     topic?: string;
+    compressCallId?: string;
 };
 
-export function parseCompressInput(input: unknown): ParsedRange[] {
+export function parseCompressInput(input: unknown, callId?: string): ParsedRange[] {
     if (!input || typeof input !== "object") {
         loggerLog("warn", `[acp-compress-input] rejected: not object (${typeof input})`);
         return [];
     }
     const obj = input as Record<string, unknown>;
-    if (Array.isArray(obj.content)) {
-        const out = obj.content
-            .map((r) => toRange(r as Record<string, unknown>))
-            .filter((r): r is ParsedRange => r !== null);
-        if (out.length === 0) loggerLog("warn", `[acp-compress-input] content array but 0 valid ranges. keys per item: ${obj.content.map((c) => Object.keys(c ?? {}).join(",")).join(" | ")}`);
-        return out;
-    }
     const single = toRange(obj);
-    if (!single) loggerLog("warn", `[acp-compress-input] no content array, single-parse failed. top keys: ${Object.keys(obj).join(",")}`);
-    return single ? [single] : [];
+    const ranges = Array.isArray(obj.content)
+        ? obj.content
+              .map((r) => toRange(r as Record<string, unknown>))
+              .filter((r): r is ParsedRange => r !== null)
+        : single
+          ? [single]
+          : [];
+    if (ranges.length === 0) {
+        loggerLog("warn", `[acp-compress-input] parsed 0 valid ranges. top keys: ${Object.keys(obj).join(",")}`);
+    }
+    if (callId) for (const r of ranges) r.compressCallId = callId;
+    return ranges;
 }
 
 function toRange(r: Record<string, unknown>): ParsedRange | null {

--- a/src/compress-tool.ts
+++ b/src/compress-tool.ts
@@ -94,7 +94,7 @@ export const COMPRESS_TOOL_OPENAI = {
                 topic: { type: "string", description: "Optional short title for the compressed range" },
                 content: {
                     type: "array",
-                    description: "One or more ranges to compress into separate summary blocks",
+                    description: "One or more ranges to compress into separate summary blocks. REQUIRED — compress without content is invalid.",
                     items: {
                         type: "object",
                         properties: {
@@ -107,6 +107,7 @@ export const COMPRESS_TOOL_OPENAI = {
                     },
                 },
             },
+            required: ["content"],
         },
     },
 };

--- a/src/compress-tool.ts
+++ b/src/compress-tool.ts
@@ -296,3 +296,17 @@ export const PROXY_TOOL_NAMES: ReadonlySet<string> = new Set([
     SEARCH_CONTEXT_TOOL_NAME,
     ACP_STATUS_TOOL_NAME,
 ]);
+
+/** compress/decompress: mutate history → must drive the compress loop (their
+ *  result is folded into the request before the model continues). */
+export const MUTATING_PROXY_TOOLS: ReadonlySet<string> = new Set([
+    COMPRESS_TOOL_NAME,
+    DECOMPRESS_TOOL_NAME,
+]);
+
+/** acp_status/search_context: read-only → must NOT loop. Looping them made the
+ *  model re-call until the 5× limit and discarded the whole turn. */
+export const READONLY_PROXY_TOOLS: ReadonlySet<string> = new Set([
+    SEARCH_CONTEXT_TOOL_NAME,
+    ACP_STATUS_TOOL_NAME,
+]);

--- a/src/compress-tool.ts
+++ b/src/compress-tool.ts
@@ -13,7 +13,7 @@ export const ACP_TEXT_CLOSE = "\x3c/acp_compress\x3e";
 export const COMPRESS_TOOL = {
     name: COMPRESS_TOOL_NAME,
     description:
-        "Replace a contiguous range of older conversation with a detailed summary you write. Use when content is genuinely consumed. Batch form: content=[{startId,endId,summary,topic?}].",
+        "Replace a contiguous range of older conversation with a detailed summary you write. Use when content is genuinely consumed. Batch form: content=[{startId,endId,summary,topic?}]. REQUIRED — compress without content is invalid.",
     input_schema: {
         type: "object",
         properties: {
@@ -33,6 +33,7 @@ export const COMPRESS_TOOL = {
                 },
             },
         },
+        required: ["content"],
     },
 };
 

--- a/src/loop/adapter-anthropic.ts
+++ b/src/loop/adapter-anthropic.ts
@@ -172,9 +172,6 @@ export function createAnthropicAdapter(requestBody: Record<string, unknown>): Co
                         const name = typeof block.name === "string" ? block.name : "";
                         const id = typeof block.id === "string" ? block.id : `toolu_${upstreamIndex}`;
                         pending.set(upstreamIndex, { id, name, json: "" });
-                        if (round === 1) {
-                            indexMap.set(upstreamIndex, clientIndex++);
-                        }
                     } else if (round === 1) {
                         const ci = clientIndex++;
                         indexMap.set(upstreamIndex, ci);

--- a/src/loop/adapter-anthropic.ts
+++ b/src/loop/adapter-anthropic.ts
@@ -19,17 +19,24 @@ async function* iterSseEvents(stream: ReadableStream<Uint8Array>): AsyncGenerato
     let buf = "";
     try {
         while (true) {
-            const { done, value } = await reader.read();
+            let done: boolean;
+            let value: Uint8Array | undefined;
+            try {
+                ({ done, value } = await reader.read());
+            } catch {
+                break;
+            }
             if (done) break;
             buf += new TextDecoder().decode(value, { stream: true });
+            buf = buf.replace(/\r\n|\r/g, "\n");
             let idx: number;
             while ((idx = buf.indexOf("\n\n")) >= 0) {
                 const raw = buf.slice(0, idx);
                 buf = buf.slice(idx + 2);
-                if (raw.trim().length > 0) yield raw.replace(/\r\n/g, "\n");
+                if (raw.trim().length > 0) yield raw;
             }
         }
-        if (buf.trim().length > 0) yield buf.replace(/\r\n/g, "\n");
+        if (buf.trim().length > 0) yield buf;
     } finally {
         reader.releaseLock();
     }
@@ -51,6 +58,29 @@ function parseAnthropicSse(eventStr: string): { type: string; data: Record<strin
     } catch {
         return { type, data: {} };
     }
+}
+
+function remapIndexInEvent(eventStr: string, newIndex: number): Buffer {
+    const lines = eventStr.split("\n");
+    const rebuilt: string[] = [];
+    let touched = false;
+    for (const l of lines) {
+        if (!touched && l.startsWith("data:")) {
+            const jsonStr = l.slice(5).replace(/^ /, "");
+            try {
+                const obj = JSON.parse(jsonStr) as Record<string, unknown>;
+                if (typeof obj === "object" && obj !== null && typeof obj.index === "number") {
+                    obj.index = newIndex;
+                    rebuilt.push(`data: ${JSON.stringify(obj)}`);
+                    touched = true;
+                    continue;
+                }
+            } catch {
+            }
+        }
+        rebuilt.push(l);
+    }
+    return Buffer.from(rebuilt.join("\n") + "\n\n", "utf8");
 }
 
 export function createAnthropicAdapter(requestBody: Record<string, unknown>): CompressLoopAdapter {
@@ -116,6 +146,7 @@ export function createAnthropicAdapter(requestBody: Record<string, unknown>): Co
             let roundOutput: number | undefined;
             let stopReason: string | undefined;
             let usageYielded = false;
+            const indexMap = new Map<number, number>();
 
             for await (const eventStr of iterSseEvents(upstream)) {
                 const parsed = parseAnthropicSse(eventStr);
@@ -141,9 +172,13 @@ export function createAnthropicAdapter(requestBody: Record<string, unknown>): Co
                         const name = typeof block.name === "string" ? block.name : "";
                         const id = typeof block.id === "string" ? block.id : `toolu_${upstreamIndex}`;
                         pending.set(upstreamIndex, { id, name, json: "" });
+                        if (round === 1) {
+                            indexMap.set(upstreamIndex, clientIndex++);
+                        }
                     } else if (round === 1) {
-                        clientIndex += 1;
-                        yield { kind: "meta", chunk: rawBuf, firstRoundOnly: true } as ParsedStreamEvent;
+                        const ci = clientIndex++;
+                        indexMap.set(upstreamIndex, ci);
+                        yield { kind: "meta", chunk: remapIndexInEvent(eventStr, ci), firstRoundOnly: true } as ParsedStreamEvent;
                     }
                 } else if (type === "content_block_delta") {
                     const upstreamIndex = (data.index as number) ?? 0;
@@ -154,12 +189,14 @@ export function createAnthropicAdapter(requestBody: Record<string, unknown>): Co
                         }
                     } else if (delta.type === "text_delta" && typeof delta.text === "string") {
                         if (round === 1) {
-                            yield { kind: "text", delta: delta.text, raw: rawBuf } as ParsedStreamEvent;
+                            const ci = indexMap.get(upstreamIndex) ?? upstreamIndex;
+                            yield { kind: "text", delta: delta.text, raw: remapIndexInEvent(eventStr, ci) } as ParsedStreamEvent;
                         } else {
                             yield { kind: "text", delta: delta.text } as ParsedStreamEvent;
                         }
                     } else if (round === 1) {
-                        yield { kind: "meta", chunk: rawBuf, firstRoundOnly: true } as ParsedStreamEvent;
+                        const ci = indexMap.get(upstreamIndex) ?? upstreamIndex;
+                        yield { kind: "meta", chunk: remapIndexInEvent(eventStr, ci), firstRoundOnly: true } as ParsedStreamEvent;
                     }
                 } else if (type === "content_block_stop") {
                     const upstreamIndex = (data.index as number) ?? 0;
@@ -173,7 +210,8 @@ export function createAnthropicAdapter(requestBody: Record<string, unknown>): Co
                             arguments: tb.json,
                         } as ParsedStreamEvent;
                     } else if (round === 1) {
-                        yield { kind: "meta", chunk: rawBuf, firstRoundOnly: true } as ParsedStreamEvent;
+                        const ci = indexMap.get(upstreamIndex) ?? upstreamIndex;
+                        yield { kind: "meta", chunk: remapIndexInEvent(eventStr, ci), firstRoundOnly: true } as ParsedStreamEvent;
                     }
                 } else if (type === "message_delta") {
                     const u = (data.usage ?? {}) as Record<string, unknown>;

--- a/src/loop/adapter-anthropic.ts
+++ b/src/loop/adapter-anthropic.ts
@@ -1,0 +1,239 @@
+import type { CoreMessage } from "acp-kernel";
+import { coreToAnthropic } from "../anthropic.js";
+import { buildVisibilityMarker } from "../compress-loop.js";
+import type {
+    CompressLoopAdapter,
+    EmitCompletionOpts,
+    ParsedStreamEvent,
+    ToolCallEmit,
+} from "./core.js";
+
+interface ToolUseBuffer {
+    id: string;
+    name: string;
+    json: string;
+}
+
+async function* iterSseEvents(stream: ReadableStream<Uint8Array>): AsyncGenerator<string> {
+    const reader = stream.getReader();
+    let buf = "";
+    try {
+        while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            buf += new TextDecoder().decode(value, { stream: true });
+            let idx: number;
+            while ((idx = buf.indexOf("\n\n")) >= 0) {
+                const raw = buf.slice(0, idx);
+                buf = buf.slice(idx + 2);
+                if (raw.trim().length > 0) yield raw.replace(/\r\n/g, "\n");
+            }
+        }
+        if (buf.trim().length > 0) yield buf.replace(/\r\n/g, "\n");
+    } finally {
+        reader.releaseLock();
+    }
+}
+
+function parseAnthropicSse(eventStr: string): { type: string; data: Record<string, unknown> } | null {
+    const lines = eventStr.split("\n");
+    let type = "";
+    const dataLines: string[] = [];
+    for (const l of lines) {
+        if (l.startsWith("event:")) type = l.slice(6).trim();
+        else if (l.startsWith("data:")) dataLines.push(l.slice(5).replace(/^ /, ""));
+    }
+    if (!type) return null;
+    const jsonStr = dataLines.join("\n").trim();
+    if (!jsonStr) return { type, data: {} };
+    try {
+        return { type, data: JSON.parse(jsonStr) as Record<string, unknown> };
+    } catch {
+        return { type, data: {} };
+    }
+}
+
+export function createAnthropicAdapter(requestBody: Record<string, unknown>): CompressLoopAdapter {
+    const model = (requestBody.model as string) ?? undefined;
+    let messageId: string | undefined;
+    let clientIndex = 0;
+
+    const buildTextBlock = (index: number, text: string): Buffer =>
+        Buffer.from(
+            `event: content_block_start\n` +
+            `data: ${JSON.stringify({ type: "content_block_start", index, content_block: { type: "text", text: "" } })}\n\n` +
+            `event: content_block_delta\n` +
+            `data: ${JSON.stringify({ type: "content_block_delta", index, delta: { type: "text_delta", text } })}\n\n` +
+            `event: content_block_stop\n` +
+            `data: ${JSON.stringify({ type: "content_block_stop", index })}\n\n`,
+            "utf8",
+        );
+
+    const buildToolUseBlock = (index: number, call: ToolCallEmit): Buffer =>
+        Buffer.from(
+            `event: content_block_start\n` +
+            `data: ${JSON.stringify({ type: "content_block_start", index, content_block: { type: "tool_use", id: call.callId, name: call.name, input: {} } })}\n\n` +
+            `event: content_block_delta\n` +
+            `data: ${JSON.stringify({ type: "content_block_delta", index, delta: { type: "input_json_delta", partial_json: call.arguments } })}\n\n` +
+            `event: content_block_stop\n` +
+            `data: ${JSON.stringify({ type: "content_block_stop", index })}\n\n`,
+            "utf8",
+        );
+
+    const buildTerminal = (
+        stopReason: string,
+        outputTokens: number,
+        inputTokens: number,
+        cachedTokens: number,
+    ): Buffer => {
+        const usage: Record<string, unknown> = {
+            input_tokens: inputTokens,
+            output_tokens: outputTokens,
+            cache_read_input_tokens: cachedTokens,
+        };
+        const extra: Record<string, unknown> = {};
+        if (messageId) extra.id = messageId;
+        if (model) extra.model = model;
+        return Buffer.from(
+            `event: message_delta\n` +
+            `data: ${JSON.stringify({ type: "message_delta", delta: { stop_reason: stopReason, stop_sequence: null }, usage, ...extra })}\n\n` +
+            `event: message_stop\n` +
+            `data: ${JSON.stringify({ type: "message_stop" })}\n\n`,
+            "utf8",
+        );
+    };
+
+    return {
+        buildRequest(coreMessages, systemPrompt, body) {
+            const messages = coreToAnthropic(coreMessages);
+            return { ...body, system: systemPrompt, messages };
+        },
+
+        async *parseStream(upstream, round) {
+            const pending = new Map<number, ToolUseBuffer>();
+            let roundInput: number | undefined;
+            let roundCached: number | undefined;
+            let roundOutput: number | undefined;
+            let stopReason: string | undefined;
+            let usageYielded = false;
+
+            for await (const eventStr of iterSseEvents(upstream)) {
+                const parsed = parseAnthropicSse(eventStr);
+                if (!parsed) continue;
+                const { type, data } = parsed;
+                const rawBuf = Buffer.from(eventStr + "\n\n", "utf8");
+
+                if (type === "message_start") {
+                    const msg = (data.message ?? {}) as Record<string, unknown>;
+                    if (typeof msg.id === "string" && !messageId) messageId = msg.id;
+                    const u = (msg.usage ?? {}) as Record<string, unknown>;
+                    if (typeof u.input_tokens === "number") roundInput = u.input_tokens;
+                    if (typeof u.cache_read_input_tokens === "number") roundCached = u.cache_read_input_tokens;
+                    if (round === 1) {
+                        yield { kind: "meta", chunk: rawBuf, firstRoundOnly: true } as ParsedStreamEvent;
+                    }
+                } else if (type === "ping") {
+                    yield { kind: "meta", chunk: rawBuf } as ParsedStreamEvent;
+                } else if (type === "content_block_start") {
+                    const upstreamIndex = (data.index as number) ?? 0;
+                    const block = (data.content_block ?? {}) as Record<string, unknown>;
+                    if (block.type === "tool_use") {
+                        const name = typeof block.name === "string" ? block.name : "";
+                        const id = typeof block.id === "string" ? block.id : `toolu_${upstreamIndex}`;
+                        pending.set(upstreamIndex, { id, name, json: "" });
+                    } else if (round === 1) {
+                        clientIndex += 1;
+                        yield { kind: "meta", chunk: rawBuf, firstRoundOnly: true } as ParsedStreamEvent;
+                    }
+                } else if (type === "content_block_delta") {
+                    const upstreamIndex = (data.index as number) ?? 0;
+                    const delta = (data.delta ?? {}) as Record<string, unknown>;
+                    if (pending.has(upstreamIndex)) {
+                        if (delta.type === "input_json_delta" && typeof delta.partial_json === "string") {
+                            pending.get(upstreamIndex)!.json += delta.partial_json;
+                        }
+                    } else if (delta.type === "text_delta" && typeof delta.text === "string") {
+                        if (round === 1) {
+                            yield { kind: "text", delta: delta.text, raw: rawBuf } as ParsedStreamEvent;
+                        } else {
+                            yield { kind: "text", delta: delta.text } as ParsedStreamEvent;
+                        }
+                    } else if (round === 1) {
+                        yield { kind: "meta", chunk: rawBuf, firstRoundOnly: true } as ParsedStreamEvent;
+                    }
+                } else if (type === "content_block_stop") {
+                    const upstreamIndex = (data.index as number) ?? 0;
+                    const tb = pending.get(upstreamIndex);
+                    if (tb) {
+                        pending.delete(upstreamIndex);
+                        yield {
+                            kind: "tool_call",
+                            name: tb.name,
+                            callId: tb.id,
+                            arguments: tb.json,
+                        } as ParsedStreamEvent;
+                    } else if (round === 1) {
+                        yield { kind: "meta", chunk: rawBuf, firstRoundOnly: true } as ParsedStreamEvent;
+                    }
+                } else if (type === "message_delta") {
+                    const u = (data.usage ?? {}) as Record<string, unknown>;
+                    if (typeof u.output_tokens === "number") roundOutput = u.output_tokens;
+                    if (typeof u.input_tokens === "number") roundInput = u.input_tokens;
+                    if (typeof u.cache_read_input_tokens === "number") roundCached = u.cache_read_input_tokens;
+                    const d = (data.delta ?? {}) as Record<string, unknown>;
+                    if (typeof d.stop_reason === "string") stopReason = d.stop_reason;
+                    if (!usageYielded) {
+                        usageYielded = true;
+                        yield {
+                            kind: "usage",
+                            inputTokens: roundInput,
+                            outputTokens: roundOutput,
+                            cachedTokens: roundCached,
+                        } as ParsedStreamEvent;
+                    }
+                    yield { kind: "done", finishReason: stopReason } as ParsedStreamEvent;
+                } else if (type === "message_stop") {
+                    if (!usageYielded) {
+                        usageYielded = true;
+                        yield {
+                            kind: "usage",
+                            inputTokens: roundInput,
+                            outputTokens: roundOutput,
+                            cachedTokens: roundCached,
+                        } as ParsedStreamEvent;
+                    }
+                    yield { kind: "done", finishReason: stopReason ?? "end_turn" } as ParsedStreamEvent;
+                } else if (round === 1) {
+                    yield { kind: "meta", chunk: rawBuf, firstRoundOnly: true } as ParsedStreamEvent;
+                }
+            }
+        },
+
+        emitText(delta) {
+            return buildTextBlock(clientIndex++, delta);
+        },
+
+        emitToolCall(call) {
+            return buildToolUseBlock(clientIndex++, call);
+        },
+
+        emitMarker(toolName, result) {
+            return buildTextBlock(clientIndex++, buildVisibilityMarker(toolName, result));
+        },
+
+        emitCompletion(opts?: EmitCompletionOpts) {
+            const stopReason = opts?.finishReason ?? "end_turn";
+            return buildTerminal(
+                stopReason,
+                opts?.usage?.outputTokens ?? 0,
+                opts?.usage?.inputTokens ?? 0,
+                opts?.usage?.cachedTokens ?? 0,
+            );
+        },
+
+        emitError(message) {
+            const errBlock = buildTextBlock(clientIndex++, `\n[acp-proxy: ${message}]\n`);
+            return Buffer.concat([errBlock, buildTerminal("end_turn", 0, 0, 0)]);
+        },
+    };
+}

--- a/src/loop/adapter-openai.ts
+++ b/src/loop/adapter-openai.ts
@@ -20,17 +20,24 @@ async function* iterSseChunks(stream: ReadableStream<Uint8Array>): AsyncGenerato
     let buf = "";
     try {
         while (true) {
-            const { done, value } = await reader.read();
+            let done: boolean;
+            let value: Uint8Array | undefined;
+            try {
+                ({ done, value } = await reader.read());
+            } catch {
+                break;
+            }
             if (done) break;
             buf += new TextDecoder().decode(value, { stream: true });
+            buf = buf.replace(/\r\n|\r/g, "\n");
             let idx: number;
             while ((idx = buf.indexOf("\n\n")) >= 0) {
                 const raw = buf.slice(0, idx);
                 buf = buf.slice(idx + 2);
-                if (raw.trim().length > 0) yield raw.replace(/\r\n/g, "\n");
+                if (raw.trim().length > 0) yield raw;
             }
         }
-        if (buf.trim().length > 0) yield buf.replace(/\r\n/g, "\n");
+        if (buf.trim().length > 0) yield buf;
     } finally {
         reader.releaseLock();
     }

--- a/src/loop/adapter-openai.ts
+++ b/src/loop/adapter-openai.ts
@@ -1,0 +1,227 @@
+import type { CoreMessage } from "acp-kernel";
+import { coreToOpenai, injectOpenaiSystem } from "../openai.js";
+import { buildVisibilityMarker } from "../compress-loop.js";
+import type {
+    CompressLoopAdapter,
+    EmitCompletionOpts,
+    ParsedStreamEvent,
+    ToolCallEmit,
+} from "./core.js";
+
+interface ToolCallBuffer {
+    index: number;
+    id: string;
+    name: string;
+    arguments: string;
+}
+
+async function* iterSseChunks(stream: ReadableStream<Uint8Array>): AsyncGenerator<string> {
+    const reader = stream.getReader();
+    let buf = "";
+    try {
+        while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            buf += new TextDecoder().decode(value, { stream: true });
+            let idx: number;
+            while ((idx = buf.indexOf("\n\n")) >= 0) {
+                const raw = buf.slice(0, idx);
+                buf = buf.slice(idx + 2);
+                if (raw.trim().length > 0) yield raw.replace(/\r\n/g, "\n");
+            }
+        }
+        if (buf.trim().length > 0) yield buf.replace(/\r\n/g, "\n");
+    } finally {
+        reader.releaseLock();
+    }
+}
+
+export function createOpenaiAdapter(requestBody: Record<string, unknown>): CompressLoopAdapter {
+    const model = (requestBody.model as string) ?? "unknown";
+    let responseId = `chatcmpl-proxy-${Date.now()}`;
+    let toolIndex = 0;
+
+    const makeBase = () => ({
+        id: responseId,
+        object: "chat.completion.chunk" as const,
+        created: Date.now(),
+        model,
+    });
+
+    const buildContent = (content: string): Buffer =>
+        Buffer.from(
+            `data: ${JSON.stringify({
+                id: responseId,
+                object: "chat.completion.chunk",
+                created: Date.now(),
+                model,
+                choices: [{ index: 0, delta: { content }, finish_reason: null }],
+            })}\n\n`,
+            "utf8",
+        );
+
+    const buildToolCall = (call: ToolCallEmit): Buffer => {
+        const idx = toolIndex++;
+        return Buffer.from(
+            `data: ${JSON.stringify({
+                ...makeBase(),
+                choices: [{
+                    index: 0,
+                    delta: {
+                        tool_calls: [{
+                            index: idx,
+                            id: call.callId,
+                            type: "function",
+                            function: { name: call.name, arguments: call.arguments },
+                        }],
+                    },
+                    finish_reason: null,
+                }],
+            })}\n\n`,
+            "utf8",
+        );
+    };
+
+    const buildFinish = (finishReason: string, usage: Record<string, unknown> | null): Buffer =>
+        Buffer.from(
+            `data: ${JSON.stringify({
+                ...makeBase(),
+                choices: [{ index: 0, delta: {}, finish_reason: finishReason }],
+                ...(usage ? { usage } : {}),
+            })}\n\n`,
+            "utf8",
+        );
+
+    return {
+        buildRequest(coreMessages, systemPrompt, body) {
+            const messages = coreToOpenai(coreMessages);
+            const withSys = injectOpenaiSystem(messages, [systemPrompt]);
+            return { ...body, messages: withSys };
+        },
+
+        async *parseStream(upstream, _round) {
+            const pending = new Map<number, ToolCallBuffer>();
+            for await (const eventStr of iterSseChunks(upstream)) {
+                const dataLine = eventStr.split("\n").find((l) => l.startsWith("data:"));
+                if (!dataLine) continue;
+                const jsonStr = dataLine.slice(5).trim();
+                if (jsonStr === "[DONE]") {
+                    for (const [, tc] of pending) {
+                        if (tc.name.length > 0 || tc.id.length > 0) {
+                            yield {
+                                kind: "tool_call",
+                                name: tc.name,
+                                callId: tc.id,
+                                arguments: tc.arguments,
+                            } as ParsedStreamEvent;
+                        }
+                    }
+                    pending.clear();
+                    yield { kind: "done", finishReason: "stop" } as ParsedStreamEvent;
+                    continue;
+                }
+                let parsed: Record<string, unknown>;
+                try {
+                    parsed = JSON.parse(jsonStr);
+                } catch {
+                    continue;
+                }
+                const rawBuf = Buffer.from(eventStr + "\n\n", "utf8");
+                const choices = parsed.choices as Array<Record<string, unknown>> | undefined;
+                const choice = choices?.[0];
+                if (!choice) continue;
+                const delta = choice.delta as Record<string, unknown> | undefined;
+                const finishReason = typeof choice.finish_reason === "string" ? choice.finish_reason : undefined;
+
+                if (finishReason) {
+                    for (const [, tc] of pending) {
+                        if (tc.name.length > 0 || tc.id.length > 0) {
+                            yield {
+                                kind: "tool_call",
+                                name: tc.name,
+                                callId: tc.id,
+                                arguments: tc.arguments,
+                            } as ParsedStreamEvent;
+                        }
+                    }
+                    pending.clear();
+                    const u = parsed.usage as Record<string, unknown> | undefined;
+                    const pd = u?.prompt_tokens_details as Record<string, unknown> | undefined;
+                    yield {
+                        kind: "usage",
+                        inputTokens: typeof u?.prompt_tokens === "number" ? u.prompt_tokens : undefined,
+                        outputTokens: typeof u?.completion_tokens === "number" ? u.completion_tokens : undefined,
+                        cachedTokens: typeof pd?.cached_tokens === "number" ? pd.cached_tokens : undefined,
+                    } as ParsedStreamEvent;
+                    yield { kind: "done", finishReason } as ParsedStreamEvent;
+                }
+
+                if (!delta) continue;
+
+                if (delta.tool_calls) {
+                    const tcs = delta.tool_calls as Array<Record<string, unknown>>;
+                    for (const tc of tcs) {
+                        const idx = typeof tc.index === "number" ? tc.index : 0;
+                        const fn = tc.function as Record<string, unknown> | undefined;
+                        const name = typeof fn?.name === "string" ? fn.name : "";
+                        const id = typeof tc.id === "string" ? tc.id : "";
+                        const args = typeof fn?.arguments === "string" ? fn.arguments : "";
+                        let buf = pending.get(idx);
+                        if (!buf) {
+                            buf = { index: idx, id, name, arguments: args };
+                            pending.set(idx, buf);
+                        } else {
+                            if (id) buf.id = id;
+                            if (name) buf.name = name;
+                            buf.arguments += args;
+                        }
+                    }
+                    if (typeof delta.content === "string" && delta.content.length > 0) {
+                        yield { kind: "text", delta: delta.content } as ParsedStreamEvent;
+                    }
+                    continue;
+                }
+
+                if (typeof delta.content === "string" && delta.content.length > 0) {
+                    yield { kind: "text", delta: delta.content, raw: rawBuf } as ParsedStreamEvent;
+                } else if (delta.role || Object.keys(delta).length === 0) {
+                    yield { kind: "meta", chunk: rawBuf, firstRoundOnly: true } as ParsedStreamEvent;
+                }
+            }
+        },
+
+        emitText(delta) {
+            return buildContent(delta);
+        },
+
+        emitToolCall(call) {
+            return buildToolCall(call);
+        },
+
+        emitMarker(toolName, result) {
+            return buildContent(buildVisibilityMarker(toolName, result));
+        },
+
+        emitCompletion(opts?: EmitCompletionOpts) {
+            const finishReason = opts?.finishReason ?? "stop";
+            const usage = opts?.usage
+                ? {
+                      prompt_tokens: opts.usage.inputTokens,
+                      completion_tokens: opts.usage.outputTokens,
+                      ...(typeof opts.usage.cachedTokens === "number"
+                          ? { prompt_tokens_details: { cached_tokens: opts.usage.cachedTokens } }
+                          : {}),
+                  }
+                : null;
+            return Buffer.concat([buildFinish(finishReason, usage), Buffer.from("data: [DONE]\n\n", "utf8")]);
+        },
+
+        emitError(message) {
+            return Buffer.concat([
+                buildContent(`\n[acp-proxy: ${message}]\n`),
+                buildFinish("stop", null),
+                Buffer.from("data: [DONE]\n\n", "utf8"),
+            ]);
+        },
+    };
+}

--- a/src/loop/adapter-openai.ts
+++ b/src/loop/adapter-openai.ts
@@ -184,7 +184,7 @@ export function createOpenaiAdapter(requestBody: Record<string, unknown>): Compr
 
                 if (typeof delta.content === "string" && delta.content.length > 0) {
                     yield { kind: "text", delta: delta.content, raw: rawBuf } as ParsedStreamEvent;
-                } else if (delta.role || Object.keys(delta).length === 0) {
+                } else if (delta.role || (Object.keys(delta).length === 0 && !finishReason)) {
                     yield { kind: "meta", chunk: rawBuf, firstRoundOnly: true } as ParsedStreamEvent;
                 }
             }

--- a/src/loop/adapter-openai.ts
+++ b/src/loop/adapter-openai.ts
@@ -136,7 +136,19 @@ export function createOpenaiAdapter(requestBody: Record<string, unknown>): Compr
                 const rawBuf = Buffer.from(eventStr + "\n\n", "utf8");
                 const choices = parsed.choices as Array<Record<string, unknown>> | undefined;
                 const choice = choices?.[0];
-                if (!choice) continue;
+                if (!choice) {
+                    if (parsed.usage) {
+                        const u = parsed.usage as Record<string, unknown>;
+                        const pd = u.prompt_tokens_details as Record<string, unknown> | undefined;
+                        yield {
+                            kind: "usage",
+                            inputTokens: typeof u.prompt_tokens === "number" ? u.prompt_tokens : undefined,
+                            outputTokens: typeof u.completion_tokens === "number" ? u.completion_tokens : undefined,
+                            cachedTokens: typeof pd?.cached_tokens === "number" ? pd.cached_tokens : undefined,
+                        } as ParsedStreamEvent;
+                    }
+                    continue;
+                }
                 const delta = choice.delta as Record<string, unknown> | undefined;
                 const finishReason = typeof choice.finish_reason === "string" ? choice.finish_reason : undefined;
 

--- a/src/loop/adapter-responses.ts
+++ b/src/loop/adapter-responses.ts
@@ -116,7 +116,8 @@ function buildCompleted(responseObj: Record<string, unknown> | null): Buffer {
     );
 }
 
-export function createResponsesAdapter(): CompressLoopAdapter {
+export function createResponsesAdapter(textProtocol?: boolean): CompressLoopAdapter {
+    const suppressTextLifecycle = !!textProtocol;
     let outputIndex = 0;
     let responseObj: Record<string, unknown> | null = null;
     let terminalRaw: Buffer | null = null;
@@ -178,7 +179,9 @@ export function createResponsesAdapter(): CompressLoopAdapter {
                     type === "response.content_part.done" ||
                     type === "response.output_text.done"
                 ) {
-                    yield { kind: "meta", chunk: rawBuf, firstRoundOnly: true } as ParsedStreamEvent;
+                    if (!suppressTextLifecycle) {
+                        yield { kind: "meta", chunk: rawBuf, firstRoundOnly: true } as ParsedStreamEvent;
+                    }
                 } else if (type === "response.output_text.delta") {
                     const delta = typeof obj.delta === "string" ? obj.delta : "";
                     if (delta.length > 0) {
@@ -216,6 +219,16 @@ export function createResponsesAdapter(): CompressLoopAdapter {
                     responseObj = (obj.response as Record<string, unknown>) ?? null;
                     terminalKind = "completed";
                     terminalRaw = null;
+                    const respUsage = (responseObj as Record<string, unknown> | null)?.usage as
+                        | Record<string, unknown>
+                        | undefined;
+                    const pd = respUsage?.input_tokens_details as Record<string, unknown> | undefined;
+                    yield {
+                        kind: "usage",
+                        inputTokens: typeof respUsage?.input_tokens === "number" ? respUsage.input_tokens : undefined,
+                        outputTokens: typeof respUsage?.output_tokens === "number" ? respUsage.output_tokens : undefined,
+                        cachedTokens: typeof pd?.cached_tokens === "number" ? pd.cached_tokens : undefined,
+                    } as ParsedStreamEvent;
                     yield { kind: "done", finishReason: "completed" } as ParsedStreamEvent;
                 } else if (type === "response.incomplete") {
                     terminalKind = "incomplete";

--- a/src/loop/adapter-responses.ts
+++ b/src/loop/adapter-responses.ts
@@ -1,0 +1,314 @@
+import type { CoreMessage } from "acp-kernel";
+import { coreToResponses, injectResponsesDeveloperMessage } from "../responses.js";
+import { buildVisibilityMarker } from "../compress-loop.js";
+import { ACP_TEXT_OPEN, ACP_TEXT_CLOSE, COMPRESS_TOOL_NAME } from "../compress-tool.js";
+import type { BiliMessage } from "../bili-message.js";
+import type {
+    CompressLoopAdapter,
+    EmitCompletionOpts,
+    ExtractedTextTriggers,
+    ParsedStreamEvent,
+    ToolCallEmit,
+} from "./core.js";
+
+interface FunctionCallBuffer {
+    itemId: string;
+    callId: string;
+    name: string;
+    arguments: string;
+}
+
+async function* iterSseEvents(stream: ReadableStream<Uint8Array>): AsyncGenerator<string> {
+    const reader = stream.getReader();
+    let buf = "";
+    try {
+        while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            buf += new TextDecoder().decode(value, { stream: true });
+            let idx: number;
+            while ((idx = buf.indexOf("\n\n")) >= 0) {
+                const raw = buf.slice(0, idx);
+                buf = buf.slice(idx + 2);
+                if (raw.trim().length > 0) yield raw.replace(/\r\n/g, "\n");
+            }
+        }
+        if (buf.trim().length > 0) yield buf.replace(/\r\n/g, "\n");
+    } finally {
+        reader.releaseLock();
+    }
+}
+
+function extractEventType(rawEvent: string): string | null {
+    for (const l of rawEvent.split("\n")) {
+        if (l.startsWith("event:")) return l.slice(6).trim();
+    }
+    return null;
+}
+
+function extractDataLine(rawEvent: string): string | null {
+    const parts: string[] = [];
+    for (const l of rawEvent.split("\n")) {
+        if (l.startsWith("data:")) {
+            let v = l.slice(5);
+            if (v.startsWith(" ")) v = v.slice(1);
+            parts.push(v);
+        }
+    }
+    return parts.length ? parts.join("\n") : null;
+}
+
+function buildMessageItemSequence(itemId: string, outputIndex: number, text: string): Buffer {
+    const item = { type: "message", id: itemId, role: "assistant", content: [] as unknown[] };
+    const part = { type: "output_text", text: "" };
+    const doneItem = {
+        type: "message",
+        id: itemId,
+        role: "assistant",
+        content: [{ type: "output_text", text }],
+    };
+    return Buffer.from(
+        [
+            `event: response.output_item.added\ndata: ${JSON.stringify({ type: "response.output_item.added", output_index: outputIndex, item })}\n\n`,
+            `event: response.content_part.added\ndata: ${JSON.stringify({ type: "response.content_part.added", item_id: itemId, output_index: outputIndex, part })}\n\n`,
+            `event: response.output_text.delta\ndata: ${JSON.stringify({ type: "response.output_text.delta", item_id: itemId, output_index: outputIndex, delta: text })}\n\n`,
+            `event: response.output_text.done\ndata: ${JSON.stringify({ type: "response.output_text.done", item_id: itemId, output_index: outputIndex, text })}\n\n`,
+            `event: response.content_part.done\ndata: ${JSON.stringify({ type: "response.content_part.done", item_id: itemId, output_index: outputIndex, part: { type: "output_text", text } })}\n\n`,
+            `event: response.output_item.done\ndata: ${JSON.stringify({ type: "response.output_item.done", output_index: outputIndex, item: doneItem })}\n\n`,
+        ].join(""),
+        "utf8",
+    );
+}
+
+function buildFunctionCallEvents(fc: ToolCallEmit, itemId: string, outputIndex: number): Buffer {
+    return Buffer.from(
+        [
+            `event: response.output_item.added\ndata: ${JSON.stringify({
+                type: "response.output_item.added",
+                output_index: outputIndex,
+                item: { type: "function_call", id: itemId, call_id: fc.callId, name: fc.name, arguments: "" },
+            })}\n\n`,
+            `event: response.function_call_arguments.delta\ndata: ${JSON.stringify({
+                type: "response.function_call_arguments.delta",
+                item_id: itemId,
+                delta: fc.arguments,
+            })}\n\n`,
+            `event: response.function_call_arguments.done\ndata: ${JSON.stringify({
+                type: "response.function_call_arguments.done",
+                item_id: itemId,
+                arguments: fc.arguments,
+            })}\n\n`,
+            `event: response.output_item.done\ndata: ${JSON.stringify({
+                type: "response.output_item.done",
+                output_index: outputIndex,
+                item: { type: "function_call", id: itemId, call_id: fc.callId, name: fc.name, arguments: fc.arguments },
+            })}\n\n`,
+        ].join(""),
+        "utf8",
+    );
+}
+
+function buildCompleted(responseObj: Record<string, unknown> | null): Buffer {
+    const resp = responseObj ?? { id: `resp-proxy-${Date.now()}`, status: "completed", output: [] };
+    return Buffer.from(
+        `event: response.completed\ndata: ${JSON.stringify({ type: "response.completed", response: resp })}\n\n`,
+        "utf8",
+    );
+}
+
+export function createResponsesAdapter(): CompressLoopAdapter {
+    let outputIndex = 0;
+    let responseObj: Record<string, unknown> | null = null;
+    let terminalRaw: Buffer | null = null;
+    let terminalKind: string | null = null;
+
+    return {
+        buildRequest(coreMessages, systemPrompt, requestBody) {
+            const customToolCallIds = new Set<string>();
+            for (const m of coreMessages) {
+                const bm = m as BiliMessage;
+                const raw = bm?.rawResponsesItem as Record<string, unknown> | undefined;
+                if (raw && (raw.type === "custom_tool_call" || raw.type === "custom_tool_call_output")) {
+                    const id = typeof raw.call_id === "string" ? raw.call_id : (typeof raw.id === "string" ? raw.id : "");
+                    if (id) customToolCallIds.add(id);
+                }
+            }
+            const inputItems = coreToResponses(coreMessages, customToolCallIds);
+            const withDev = injectResponsesDeveloperMessage(inputItems, systemPrompt);
+            const rebuilt: Record<string, unknown> = { ...requestBody, input: withDev };
+            delete rebuilt.previous_response_id;
+            delete rebuilt.instructions;
+            return rebuilt;
+        },
+
+        async *parseStream(upstream, round) {
+            const pending = new Map<string, FunctionCallBuffer>();
+            for await (const eventStr of iterSseEvents(upstream)) {
+                const type = extractEventType(eventStr);
+                const dataLine = extractDataLine(eventStr);
+                if (!type || !dataLine) continue;
+                let obj: Record<string, unknown>;
+                try {
+                    obj = JSON.parse(dataLine);
+                } catch {
+                    continue;
+                }
+                const rawBuf = Buffer.from(eventStr + "\n\n", "utf8");
+                if (round === 1 && typeof obj.output_index === "number") {
+                    outputIndex = Math.max(outputIndex, obj.output_index + 1);
+                }
+
+                if (type === "response.created" || type === "response.in_progress") {
+                    yield { kind: "meta", chunk: rawBuf, firstRoundOnly: true } as ParsedStreamEvent;
+                } else if (type === "response.output_item.added") {
+                    const item = obj.item as Record<string, unknown> | undefined;
+                    if (item?.type === "function_call") {
+                        const itemId = typeof item.id === "string" ? item.id : "";
+                        pending.set(itemId, {
+                            itemId,
+                            callId: typeof item.call_id === "string" ? item.call_id : "",
+                            name: typeof item.name === "string" ? item.name : "",
+                            arguments: "",
+                        });
+                    } else {
+                        yield { kind: "meta", chunk: rawBuf, firstRoundOnly: true } as ParsedStreamEvent;
+                    }
+                } else if (
+                    type === "response.content_part.added" ||
+                    type === "response.content_part.done" ||
+                    type === "response.output_text.done"
+                ) {
+                    yield { kind: "meta", chunk: rawBuf, firstRoundOnly: true } as ParsedStreamEvent;
+                } else if (type === "response.output_text.delta") {
+                    const delta = typeof obj.delta === "string" ? obj.delta : "";
+                    if (delta.length > 0) {
+                        yield { kind: "text", delta, raw: rawBuf } as ParsedStreamEvent;
+                    }
+                } else if (type === "response.function_call_arguments.delta") {
+                    const itemId = typeof obj.item_id === "string" ? obj.item_id : "";
+                    const delta = typeof obj.delta === "string" ? obj.delta : "";
+                    const fc = pending.get(itemId);
+                    if (fc) fc.arguments += delta;
+                } else if (type === "response.function_call_arguments.done") {
+                    const itemId = typeof obj.item_id === "string" ? obj.item_id : "";
+                    const args = typeof obj.arguments === "string" ? obj.arguments : "";
+                    const fc = pending.get(itemId);
+                    if (fc && args) fc.arguments = args;
+                } else if (type === "response.output_item.done") {
+                    const item = obj.item as Record<string, unknown> | undefined;
+                    if (item?.type === "function_call") {
+                        const itemId = typeof item.id === "string" ? item.id : "";
+                        const fc = pending.get(itemId);
+                        if (fc) {
+                            if (typeof item.arguments === "string" && item.arguments) fc.arguments = item.arguments;
+                            pending.delete(itemId);
+                            yield {
+                                kind: "tool_call",
+                                name: fc.name,
+                                callId: fc.callId,
+                                arguments: fc.arguments,
+                            } as ParsedStreamEvent;
+                        }
+                    } else {
+                        yield { kind: "meta", chunk: rawBuf, firstRoundOnly: true } as ParsedStreamEvent;
+                    }
+                } else if (type === "response.completed") {
+                    responseObj = (obj.response as Record<string, unknown>) ?? null;
+                    terminalKind = "completed";
+                    terminalRaw = null;
+                    yield { kind: "done", finishReason: "completed" } as ParsedStreamEvent;
+                } else if (type === "response.incomplete") {
+                    terminalKind = "incomplete";
+                    terminalRaw = rawBuf;
+                    yield { kind: "done", finishReason: "incomplete" } as ParsedStreamEvent;
+                } else if (type === "response.failed" || type === "response.error") {
+                    terminalKind = "failed";
+                    terminalRaw = rawBuf;
+                    yield { kind: "done", finishReason: "failed" } as ParsedStreamEvent;
+                } else {
+                    yield { kind: "meta", chunk: rawBuf, firstRoundOnly: true } as ParsedStreamEvent;
+                }
+            }
+        },
+
+        emitText(delta) {
+            return buildMessageItemSequence(`msg-proxy-${Date.now()}-${outputIndex}`, outputIndex++, delta);
+        },
+
+        emitToolCall(call) {
+            const buf = buildFunctionCallEvents(call, `fc-proxy-${Date.now()}-${outputIndex}`, outputIndex);
+            outputIndex += 1;
+            return buf;
+        },
+
+        emitMarker(toolName, result) {
+            return buildMessageItemSequence(
+                `marker-${Date.now()}-${outputIndex}`,
+                outputIndex++,
+                buildVisibilityMarker(toolName, result),
+            );
+        },
+
+        emitCompletion(opts?: EmitCompletionOpts) {
+            if (terminalRaw && (terminalKind === "failed" || terminalKind === "incomplete")) {
+                return terminalRaw;
+            }
+            let resp = responseObj
+                ? ({ ...responseObj } as Record<string, unknown>)
+                : { id: `resp-proxy-${Date.now()}`, status: "completed", output: [] };
+            if (opts?.usage) {
+                const usage: Record<string, unknown> = {
+                    ...(typeof (resp as Record<string, unknown>).usage === "object"
+                        ? ((resp as Record<string, unknown>).usage as Record<string, unknown>)
+                        : {}),
+                };
+                if (typeof opts.usage.inputTokens === "number") usage.input_tokens = opts.usage.inputTokens;
+                if (typeof opts.usage.outputTokens === "number") usage.output_tokens = opts.usage.outputTokens;
+                if (typeof opts.usage.cachedTokens === "number") {
+                    usage.input_tokens_details = {
+                        ...((usage.input_tokens_details as Record<string, unknown>) ?? {}),
+                        cached_tokens: opts.usage.cachedTokens,
+                    };
+                }
+                resp = { ...resp, usage };
+            }
+            return buildCompleted(resp);
+        },
+
+        emitError(message) {
+            const resp = {
+                id: `resp-error-${Date.now()}`,
+                status: "failed",
+                error: { code: "server_error", message },
+            };
+            return Buffer.from(
+                `event: response.failed\ndata: ${JSON.stringify({ type: "response.failed", response: resp })}\n\n`,
+                "utf8",
+            );
+        },
+
+        extractTextTriggers(text) {
+            const calls: ToolCallEmit[] = [];
+            let clean = text;
+            let hadTrigger = false;
+            let start = clean.indexOf(ACP_TEXT_OPEN);
+            while (start >= 0) {
+                const end = clean.indexOf(ACP_TEXT_CLOSE, start + ACP_TEXT_OPEN.length);
+                if (end < 0) break;
+                hadTrigger = true;
+                const payload = clean.slice(start + ACP_TEXT_OPEN.length, end).trim();
+                if (payload.length > 0) {
+                    const stamp = `${Date.now()}-${calls.length}`;
+                    calls.push({
+                        name: COMPRESS_TOOL_NAME,
+                        callId: `call_text_${stamp}`,
+                        arguments: payload,
+                    });
+                }
+                clean = clean.slice(0, start) + clean.slice(end + ACP_TEXT_CLOSE.length);
+                start = clean.indexOf(ACP_TEXT_OPEN);
+            }
+            return { clean: hadTrigger ? clean : text, calls } as ExtractedTextTriggers;
+        },
+    };
+}

--- a/src/loop/adapter-responses.ts
+++ b/src/loop/adapter-responses.ts
@@ -23,17 +23,24 @@ async function* iterSseEvents(stream: ReadableStream<Uint8Array>): AsyncGenerato
     let buf = "";
     try {
         while (true) {
-            const { done, value } = await reader.read();
+            let done: boolean;
+            let value: Uint8Array | undefined;
+            try {
+                ({ done, value } = await reader.read());
+            } catch {
+                break;
+            }
             if (done) break;
             buf += new TextDecoder().decode(value, { stream: true });
+            buf = buf.replace(/\r\n|\r/g, "\n");
             let idx: number;
             while ((idx = buf.indexOf("\n\n")) >= 0) {
                 const raw = buf.slice(0, idx);
                 buf = buf.slice(idx + 2);
-                if (raw.trim().length > 0) yield raw.replace(/\r\n/g, "\n");
+                if (raw.trim().length > 0) yield raw;
             }
         }
-        if (buf.trim().length > 0) yield buf.replace(/\r\n/g, "\n");
+        if (buf.trim().length > 0) yield buf;
     } finally {
         reader.releaseLock();
     }
@@ -171,6 +178,8 @@ export function createResponsesAdapter(textProtocol?: boolean): CompressLoopAdap
                             name: typeof item.name === "string" ? item.name : "",
                             arguments: "",
                         });
+                    } else if (item?.type === "custom_tool_call") {
+                        yield { kind: "meta", chunk: rawBuf, firstRoundOnly: false } as ParsedStreamEvent;
                     } else {
                         yield { kind: "meta", chunk: rawBuf, firstRoundOnly: true } as ParsedStreamEvent;
                     }
@@ -212,6 +221,8 @@ export function createResponsesAdapter(textProtocol?: boolean): CompressLoopAdap
                                 arguments: fc.arguments,
                             } as ParsedStreamEvent;
                         }
+                    } else if (item?.type === "custom_tool_call") {
+                        yield { kind: "meta", chunk: rawBuf, firstRoundOnly: false } as ParsedStreamEvent;
                     } else {
                         yield { kind: "meta", chunk: rawBuf, firstRoundOnly: true } as ParsedStreamEvent;
                     }
@@ -242,6 +253,9 @@ export function createResponsesAdapter(textProtocol?: boolean): CompressLoopAdap
                     yield { kind: "meta", chunk: rawBuf, firstRoundOnly: true } as ParsedStreamEvent;
                 }
             }
+            if (!terminalKind) {
+                yield { kind: "done", finishReason: "failed" } as ParsedStreamEvent;
+            }
         },
 
         emitText(delta) {
@@ -265,6 +279,17 @@ export function createResponsesAdapter(textProtocol?: boolean): CompressLoopAdap
         emitCompletion(opts?: EmitCompletionOpts) {
             if (terminalRaw && (terminalKind === "failed" || terminalKind === "incomplete")) {
                 return terminalRaw;
+            }
+            if (!responseObj && opts?.finishReason === "failed") {
+                const failed = {
+                    id: `resp-error-${Date.now()}`,
+                    status: "failed",
+                    error: { code: "server_error", message: "upstream returned no response" },
+                };
+                return Buffer.from(
+                    `event: response.failed\ndata: ${JSON.stringify({ type: "response.failed", response: failed })}\n\n`,
+                    "utf8",
+                );
             }
             let resp = responseObj
                 ? ({ ...responseObj } as Record<string, unknown>)

--- a/src/loop/core.ts
+++ b/src/loop/core.ts
@@ -284,6 +284,15 @@ export async function* runCompressLoop(
             ctx.log(`[acp-loop] round ${round} saw mutating proxy tool; re-requesting`);
 
             const newBody = adapter.buildRequest(coreMessages, systemPrompt, requestBody);
+            if (process.env.ACP_DUMP_REQ !== "0" && ctx.debug) {
+                try {
+                    const fs = await import("node:fs");
+                    const dumpDir = process.env.ACP_DUMP_DIR || `${process.env.HOME}/.local/state/billion-context/dumps`;
+                    fs.mkdirSync(dumpDir, { recursive: true });
+                    const sid = ctx.session.id ?? "unknown";
+                    fs.writeFileSync(`${dumpDir}/req-${Date.now()}-${sid}-REREQUEST.json`, JSON.stringify(newBody, null, 2));
+                } catch { /* best-effort */ }
+            }
             const { response: resp, clearTimer } = await fetchWithTimeout(requestOptions.url, {
                 method: "POST",
                 headers: requestOptions.headers,

--- a/src/loop/core.ts
+++ b/src/loop/core.ts
@@ -213,6 +213,19 @@ export async function* runCompressLoop(
                 }
             }
 
+            if (ctx.debug) {
+                const callSummary = allCalls.map(c => {
+                    const argSnippet = c.arguments.length > 200 ? c.arguments.slice(0, 200) + "..." : c.arguments;
+                    return `${c.name}(${argSnippet})`;
+                }).join(" | ");
+                ctx.log(`[acp-loop] round ${round}: ${allCalls.length} call(s): ${callSummary || "(none)"}`);
+                for (const pr of proxyResults) {
+                    const resSnippet = pr.result.length > 300 ? pr.result.slice(0, 300) + "..." : pr.result;
+                    ctx.log(`[acp-loop]   → ${pr.name} result: ${resSnippet}`);
+                }
+                if (realCalls > 0) ctx.log(`[acp-loop] round ${round}: ${realCalls} real tool call(s) forwarded to client`);
+            }
+
             // Per-round hygiene (fixes the injection-persistence 炸锅): the
             // philosophy systemPrompt is transient (passed fresh to buildRequest,
             // never in coreMessages), and hideConsumedCompressCalls runs each

--- a/src/loop/core.ts
+++ b/src/loop/core.ts
@@ -8,7 +8,6 @@ import {
 } from "acp-kernel";
 import type { Session } from "../session.js";
 import {
-    MUTATING_PROXY_TOOLS,
     parseCompressInput,
     PROXY_TOOL_NAMES,
 } from "../compress-tool.js";
@@ -193,7 +192,6 @@ export async function* runCompressLoop(
                 yield adapter.emitText(resolvedText);
             }
 
-            let sawMutating = false;
             let realCalls = 0;
             const realToolCalls: ToolCallEmit[] = [];
             const proxyResults: { name: string; callId: string; result: string; arguments: string }[] = [];
@@ -209,7 +207,6 @@ export async function* runCompressLoop(
                     const result = executeProxyTool(call.name, parsedArgs, ctx, call.callId);
                     proxyResults.push({ name: call.name, callId: call.callId, result, arguments: call.arguments });
                     yield adapter.emitMarker(call.name, result);
-                    if (MUTATING_PROXY_TOOLS.has(call.name)) sawMutating = true;
                 } else {
                     realToolCalls.push(call);
                     realCalls += 1;
@@ -269,7 +266,7 @@ export async function* runCompressLoop(
                 yield adapter.emitToolCall(tc);
             }
 
-            const reRequest = sawMutating && realCalls === 0;
+            const reRequest = proxyResults.length > 0 && realCalls === 0;
             if (!reRequest) {
                 yield adapter.emitCompletion({ finishReason, usage });
                 return;

--- a/src/loop/core.ts
+++ b/src/loop/core.ts
@@ -14,6 +14,7 @@ import {
 } from "../compress-tool.js";
 import { applyRanges } from "../stream.js";
 import { resolveDecompress } from "../decompress-shared.js";
+import { buildVisibilityMarker } from "../compress-loop.js";
 import { fetchWithTimeout } from "../fetch-util.js";
 import { proxyDispatcher } from "../upstream-proxy.js";
 import { log as loggerLog } from "../logger.js";
@@ -78,9 +79,10 @@ export function executeProxyTool(
     toolName: string,
     args: Record<string, unknown>,
     ctx: LoopCtx,
+    callId?: string,
 ): string {
     if (toolName === "compress") {
-        return applyRanges(parseCompressInput(args), ctx);
+        return applyRanges(parseCompressInput(args, callId), ctx);
     }
     if (toolName === "decompress") {
         return resolveDecompress(args, ctx);
@@ -194,7 +196,7 @@ export async function* runCompressLoop(
             let sawMutating = false;
             let realCalls = 0;
             const realToolCalls: ToolCallEmit[] = [];
-            const proxyResults: { name: string; callId: string; result: string }[] = [];
+            const proxyResults: { name: string; callId: string; result: string; arguments: string }[] = [];
 
             for (const call of allCalls) {
                 if (PROXY_TOOL_NAMES.has(call.name)) {
@@ -204,8 +206,8 @@ export async function* runCompressLoop(
                     } catch {
                         parsedArgs = {};
                     }
-                    const result = executeProxyTool(call.name, parsedArgs, ctx);
-                    proxyResults.push({ name: call.name, callId: call.callId, result });
+                    const result = executeProxyTool(call.name, parsedArgs, ctx, call.callId);
+                    proxyResults.push({ name: call.name, callId: call.callId, result, arguments: call.arguments });
                     yield adapter.emitMarker(call.name, result);
                     if (MUTATING_PROXY_TOOLS.has(call.name)) sawMutating = true;
                 } else {
@@ -228,26 +230,38 @@ export async function* runCompressLoop(
                     });
                 }
                 for (const pr of proxyResults) {
-                    coreMessages.push({
-                        id: `acp_loop_r${round}_asst_tc_${pr.callId}`,
-                        role: "assistant",
-                        contentType: "tool-call",
-                        toolName: pr.name,
-                        toolCallId: pr.callId,
-                    });
-                    coreMessages.push({
-                        id: `acp_loop_r${round}_tool_${pr.callId}`,
-                        role: "tool",
-                        contentType: "tool-result",
-                        toolCallId: pr.callId,
-                        text: pr.result,
-                    });
+                    if (ctx.textProtocol) {
+                        coreMessages.push({
+                            id: `acp_loop_r${round}_marker_${pr.callId}`,
+                            role: "user",
+                            contentType: "text",
+                            text: buildVisibilityMarker(pr.name, pr.result),
+                        });
+                    } else {
+                        coreMessages.push({
+                            id: `acp_loop_r${round}_asst_tc_${pr.callId}`,
+                            role: "assistant",
+                            contentType: "tool-call",
+                            toolName: pr.name,
+                            toolCallId: pr.callId,
+                            text: pr.arguments,
+                        });
+                        coreMessages.push({
+                            id: `acp_loop_r${round}_tool_${pr.callId}`,
+                            role: "tool",
+                            contentType: "tool-result",
+                            toolCallId: pr.callId,
+                            text: pr.result,
+                        });
+                    }
                 }
-                const hidden = hideConsumedCompressCalls(ctx.session.state, coreMessages);
-                if (hidden.hidden > 0) {
-                    ctx.log(`[acp-loop] round ${round} hideConsumed hid ${hidden.hidden} compress record(s)`);
-                    coreMessages.length = 0;
-                    coreMessages.push(...hidden.messages);
+                if (!ctx.textProtocol) {
+                    const hidden = hideConsumedCompressCalls(ctx.session.state, coreMessages);
+                    if (hidden.hidden > 0) {
+                        ctx.log(`[acp-loop] round ${round} hideConsumed hid ${hidden.hidden} compress record(s)`);
+                        coreMessages.length = 0;
+                        coreMessages.push(...hidden.messages);
+                    }
                 }
             }
 
@@ -281,6 +295,7 @@ export async function* runCompressLoop(
             });
 
             if (!resp.ok || !resp.body) {
+                clearTimer();
                 const errText = await resp.text().catch(() => "upstream error");
                 ctx.log(`[acp-proxy: compress loop upstream error ${resp.status}: ${errText.slice(0, 200)}]`);
                 loggerLog("error", `[acp-loop] upstream error ${resp.status}: ${errText.slice(0, 200)}`);

--- a/src/loop/core.ts
+++ b/src/loop/core.ts
@@ -1,0 +1,301 @@
+import {
+    buildStatusReport,
+    estimateTokensFast,
+    hideConsumedCompressCalls,
+    type CompressionCore,
+    type Config,
+    type CoreMessage,
+} from "acp-kernel";
+import type { Session } from "../session.js";
+import {
+    MUTATING_PROXY_TOOLS,
+    parseCompressInput,
+    PROXY_TOOL_NAMES,
+} from "../compress-tool.js";
+import { applyRanges } from "../stream.js";
+import { resolveDecompress } from "../decompress-shared.js";
+import { fetchWithTimeout } from "../fetch-util.js";
+import { proxyDispatcher } from "../upstream-proxy.js";
+import { log as loggerLog } from "../logger.js";
+
+export const MAX_LOOP_ROUNDS = 10;
+
+export interface LoopCtx {
+    core: CompressionCore;
+    config: Config;
+    messages: CoreMessage[];
+    session: Session;
+    log: (msg: string) => void;
+    proxyUrl?: string;
+    textProtocol?: boolean;
+    debug?: boolean;
+}
+
+export interface RequestOptions {
+    url: string;
+    headers: Record<string, string>;
+}
+
+export type ParsedStreamEvent =
+    | { kind: "text"; delta: string; raw?: Buffer }
+    | { kind: "tool_call"; name: string; callId: string; arguments: string }
+    | { kind: "usage"; inputTokens?: number; outputTokens?: number; cachedTokens?: number }
+    | { kind: "done"; finishReason?: string }
+    | { kind: "meta"; chunk: Buffer; firstRoundOnly?: boolean };
+
+export interface EmitCompletionOpts {
+    finishReason?: string;
+    usage?: { inputTokens?: number; outputTokens?: number; cachedTokens?: number };
+}
+
+export interface ToolCallEmit {
+    name: string;
+    callId: string;
+    arguments: string;
+}
+
+export interface ExtractedTextTriggers {
+    clean: string;
+    calls: ToolCallEmit[];
+}
+
+export interface CompressLoopAdapter {
+    buildRequest(
+        coreMessages: CoreMessage[],
+        systemPrompt: string,
+        requestBody: Record<string, unknown>,
+    ): Record<string, unknown>;
+    parseStream(upstream: ReadableStream<Uint8Array>, round: number): AsyncGenerator<ParsedStreamEvent>;
+    emitText(delta: string): Buffer;
+    emitToolCall(call: ToolCallEmit): Buffer;
+    emitMarker(toolName: string, result: string): Buffer;
+    emitCompletion(opts?: EmitCompletionOpts): Buffer;
+    emitError(message: string): Buffer;
+    extractTextTriggers?(text: string): ExtractedTextTriggers;
+}
+
+export function executeProxyTool(
+    toolName: string,
+    args: Record<string, unknown>,
+    ctx: LoopCtx,
+): string {
+    if (toolName === "compress") {
+        return applyRanges(parseCompressInput(args), ctx);
+    }
+    if (toolName === "decompress") {
+        return resolveDecompress(args, ctx);
+    }
+    if (toolName === "search_context") {
+        const query = typeof args.query === "string" ? args.query : "";
+        if (query.length === 0) return "[search_context FAILED: query is required]";
+        const limit = typeof args.limit === "number" && args.limit > 0 ? Math.floor(args.limit) : 5;
+        const blocks = ctx.core.search(query, ctx.session.state).slice(0, limit);
+        if (blocks.length === 0) return `[No blocks matched "${query}"]`;
+        const lines = blocks.map((b) => {
+            const topic = b.topic ?? "(no topic)";
+            const preview = b.summary.length > 200 ? b.summary.slice(0, 200) + "..." : b.summary;
+            return `${b.blockId} (T${b.tier}) "${topic}"\n  ${preview}`;
+        });
+        return `Found ${blocks.length} block(s) for "${query}":\n\n${lines.join("\n\n")}`;
+    }
+    if (toolName === "acp_status") {
+        return buildStatusReport(ctx.session.state, ctx.messages, estimateTokensFast);
+    }
+    return `[Unknown proxy tool: ${toolName}]`;
+}
+
+function recordUsage(
+    ctx: LoopCtx,
+    usage: { inputTokens?: number; outputTokens?: number; cachedTokens?: number },
+    round: number,
+): void {
+    const prompt = usage.inputTokens;
+    const cached = usage.cachedTokens;
+    const out = usage.outputTokens;
+    if (typeof prompt === "number") ctx.session.stats.inputTokens += prompt;
+    ctx.session.stats.lastInputTokens =
+        (typeof prompt === "number" ? prompt : 0) + (typeof cached === "number" ? cached : 0);
+    if (typeof cached === "number") ctx.session.stats.cachedTokens += cached;
+    if (typeof out === "number") ctx.session.stats.outputTokens += out;
+    ctx.session.stats.cacheSamples += 1;
+    const hitPct =
+        typeof prompt === "number" && typeof cached === "number" && prompt + cached > 0
+            ? Math.round((cached / (prompt + cached)) * 100)
+            : 0;
+    ctx.log(
+        `[acp-usage] round ${round} input=${ctx.session.stats.lastInputTokens} cached=${cached ?? 0} (cache hit ${hitPct}%)`,
+    );
+}
+
+export async function* runCompressLoop(
+    upstream: ReadableStream<Uint8Array>,
+    ctx: LoopCtx,
+    requestBody: Record<string, unknown>,
+    requestOptions: RequestOptions,
+    adapter: CompressLoopAdapter,
+    systemPrompt: string,
+): AsyncGenerator<Buffer> {
+    let activeClearTimer: (() => void) | null = null;
+    let currentUpstream = upstream;
+    const coreMessages: CoreMessage[] = [...ctx.messages];
+
+    try {
+        for (let round = 1; round <= MAX_LOOP_ROUNDS; round++) {
+            let assistantText = "";
+            const calls: ToolCallEmit[] = [];
+            let usage: { inputTokens?: number; outputTokens?: number; cachedTokens?: number } = {};
+            let finishReason: string | undefined;
+
+            for await (const ev of adapter.parseStream(currentUpstream, round)) {
+                if (ev.kind === "text") {
+                    assistantText += ev.delta;
+                    if (!ctx.textProtocol && round === 1 && ev.raw) {
+                        yield ev.raw;
+                    }
+                } else if (ev.kind === "tool_call") {
+                    calls.push({ name: ev.name, callId: ev.callId, arguments: ev.arguments });
+                } else if (ev.kind === "usage") {
+                    usage = {
+                        inputTokens: ev.inputTokens,
+                        outputTokens: ev.outputTokens,
+                        cachedTokens: ev.cachedTokens,
+                    };
+                } else if (ev.kind === "done") {
+                    finishReason = ev.finishReason;
+                } else if (ev.kind === "meta") {
+                    if (round === 1 || !ev.firstRoundOnly) {
+                        yield ev.chunk;
+                    }
+                }
+            }
+
+            if (
+                usage.inputTokens !== undefined ||
+                usage.outputTokens !== undefined ||
+                usage.cachedTokens !== undefined
+            ) {
+                recordUsage(ctx, usage, round);
+            }
+
+            let resolvedText = assistantText;
+            let allCalls = calls;
+            if (ctx.textProtocol && assistantText.length > 0 && adapter.extractTextTriggers) {
+                const extracted = adapter.extractTextTriggers(assistantText);
+                resolvedText = extracted.clean;
+                allCalls = [...calls, ...extracted.calls];
+            }
+
+            if (ctx.textProtocol && resolvedText.length > 0) {
+                yield adapter.emitText(resolvedText);
+            } else if (!ctx.textProtocol && round > 1 && resolvedText.length > 0) {
+                yield adapter.emitText(resolvedText);
+            }
+
+            let sawMutating = false;
+            let realCalls = 0;
+            const realToolCalls: ToolCallEmit[] = [];
+            const proxyResults: { name: string; callId: string; result: string }[] = [];
+
+            for (const call of allCalls) {
+                if (PROXY_TOOL_NAMES.has(call.name)) {
+                    let parsedArgs: Record<string, unknown>;
+                    try {
+                        parsedArgs = call.arguments.length > 0 ? JSON.parse(call.arguments) : {};
+                    } catch {
+                        parsedArgs = {};
+                    }
+                    const result = executeProxyTool(call.name, parsedArgs, ctx);
+                    proxyResults.push({ name: call.name, callId: call.callId, result });
+                    yield adapter.emitMarker(call.name, result);
+                    if (MUTATING_PROXY_TOOLS.has(call.name)) sawMutating = true;
+                } else {
+                    realToolCalls.push(call);
+                    realCalls += 1;
+                }
+            }
+
+            // Per-round hygiene (fixes the injection-persistence 炸锅): the
+            // philosophy systemPrompt is transient (passed fresh to buildRequest,
+            // never in coreMessages), and hideConsumedCompressCalls runs each
+            // round so consumed compress records cannot re-prime the model.
+            if (proxyResults.length > 0) {
+                if (resolvedText.length > 0) {
+                    coreMessages.push({
+                        id: `acp_loop_r${round}_asst`,
+                        role: "assistant",
+                        contentType: "text",
+                        text: resolvedText,
+                    });
+                }
+                for (const pr of proxyResults) {
+                    coreMessages.push({
+                        id: `acp_loop_r${round}_asst_tc_${pr.callId}`,
+                        role: "assistant",
+                        contentType: "tool-call",
+                        toolName: pr.name,
+                        toolCallId: pr.callId,
+                    });
+                    coreMessages.push({
+                        id: `acp_loop_r${round}_tool_${pr.callId}`,
+                        role: "tool",
+                        contentType: "tool-result",
+                        toolCallId: pr.callId,
+                        text: pr.result,
+                    });
+                }
+                const hidden = hideConsumedCompressCalls(ctx.session.state, coreMessages);
+                if (hidden.hidden > 0) {
+                    ctx.log(`[acp-loop] round ${round} hideConsumed hid ${hidden.hidden} compress record(s)`);
+                    coreMessages.length = 0;
+                    coreMessages.push(...hidden.messages);
+                }
+            }
+
+            for (const tc of realToolCalls) {
+                yield adapter.emitToolCall(tc);
+            }
+
+            const reRequest = sawMutating && realCalls === 0;
+            if (!reRequest) {
+                yield adapter.emitCompletion({ finishReason, usage });
+                return;
+            }
+
+            // Graceful termination at the loop limit — NEVER a degenerate empty
+            // completion; surface whatever text/markers were produced this round.
+            if (round >= MAX_LOOP_ROUNDS) {
+                ctx.log(`[acp-loop] round ${round} hit MAX_LOOP_ROUNDS; completing gracefully`);
+                loggerLog("warn", `[acp-loop] loop limit (${MAX_LOOP_ROUNDS}) reached; completing gracefully`);
+                yield adapter.emitCompletion({ finishReason: "length", usage });
+                return;
+            }
+
+            ctx.log(`[acp-loop] round ${round} saw mutating proxy tool; re-requesting`);
+
+            const newBody = adapter.buildRequest(coreMessages, systemPrompt, requestBody);
+            const { response: resp, clearTimer } = await fetchWithTimeout(requestOptions.url, {
+                method: "POST",
+                headers: requestOptions.headers,
+                body: JSON.stringify(newBody),
+                ...(ctx.proxyUrl ? { dispatcher: proxyDispatcher(ctx.proxyUrl) } : {}),
+            });
+
+            if (!resp.ok || !resp.body) {
+                const errText = await resp.text().catch(() => "upstream error");
+                ctx.log(`[acp-proxy: compress loop upstream error ${resp.status}: ${errText.slice(0, 200)}]`);
+                loggerLog("error", `[acp-loop] upstream error ${resp.status}: ${errText.slice(0, 200)}`);
+                yield adapter.emitError(`upstream error ${resp.status}: ${errText.slice(0, 200)}`);
+                return;
+            }
+
+            currentUpstream = resp.body as ReadableStream<Uint8Array>;
+            if (activeClearTimer) activeClearTimer();
+            activeClearTimer = clearTimer;
+        }
+    } finally {
+        if (activeClearTimer) {
+            activeClearTimer();
+            activeClearTimer = null;
+        }
+    }
+}

--- a/src/loop/index.ts
+++ b/src/loop/index.ts
@@ -1,0 +1,26 @@
+export { runCompressLoop, executeProxyTool, MAX_LOOP_ROUNDS } from "./core.js";
+export type {
+    LoopCtx,
+    RequestOptions,
+    ParsedStreamEvent,
+    CompressLoopAdapter,
+    EmitCompletionOpts,
+    ToolCallEmit,
+    ExtractedTextTriggers,
+} from "./core.js";
+export { createResponsesAdapter } from "./adapter-responses.js";
+export { createOpenaiAdapter } from "./adapter-openai.js";
+export { createAnthropicAdapter } from "./adapter-anthropic.js";
+import { createResponsesAdapter } from "./adapter-responses.js";
+import { createOpenaiAdapter } from "./adapter-openai.js";
+import { createAnthropicAdapter } from "./adapter-anthropic.js";
+import type { CompressLoopAdapter } from "./core.js";
+
+export function pickAdapter(
+    protocol: "responses" | "openai" | "anthropic",
+    requestBody: Record<string, unknown>,
+): CompressLoopAdapter {
+    if (protocol === "responses") return createResponsesAdapter();
+    if (protocol === "openai") return createOpenaiAdapter(requestBody);
+    return createAnthropicAdapter(requestBody);
+}

--- a/src/loop/index.ts
+++ b/src/loop/index.ts
@@ -19,8 +19,10 @@ import type { CompressLoopAdapter } from "./core.js";
 export function pickAdapter(
     protocol: "responses" | "openai" | "anthropic",
     requestBody: Record<string, unknown>,
+    textProtocol?: boolean,
 ): CompressLoopAdapter {
-    if (protocol === "responses") return createResponsesAdapter();
+    if (protocol === "responses") return createResponsesAdapter(textProtocol);
     if (protocol === "openai") return createOpenaiAdapter(requestBody);
-    return createAnthropicAdapter(requestBody);
+    if (protocol === "anthropic") return createAnthropicAdapter(requestBody);
+    throw new Error(`[acp-loop] unknown protocol: ${protocol}`);
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,5 @@
 import http from "node:http";
 import fs from "node:fs";
-import { tmpdir } from "node:os";
 import { createCore, type CompressionCore, type Config, type CoreMessage, type NudgeDecision, estimateTokensFast, renderNudgeText, deactivateBlock } from "acp-kernel";
 import type { ProxyOptions } from "./config.js";
 import { loadOptions, loadRoutes } from "./config.js";
@@ -44,7 +43,7 @@ import { getStore } from "./persist.js";
 import { compressLoopStream } from "./compress-loop.js";
 import { compressLoopAnthropicStream } from "./compress-loop-anthropic.js";
 import { log as loggerLog, configureLogger, getLogPath, closeLogger } from "./logger.js";
-import { defaultLogFile } from "./paths.js";
+import { defaultLogFile, stateDir } from "./paths.js";
 import { compressLoopResponsesJson, compressLoopResponsesStream } from "./compress-loop-responses.js";
 import { runCompressLoop, pickAdapter } from "./loop/index.js";
 import { rewriteOpenaiJsonResponse } from "./stream-openai.js";
@@ -1026,9 +1025,17 @@ async function forward(
                 return fn?.name ?? (t.name as string | undefined) ?? "?";
             });
             log("info", `[debug] tools=[${toolNames.join(",")}] msgs=${parsed.messages?.length ?? 0} stream=${parsed.stream ?? false} system_len=${JSON.stringify(parsed.messages?.find((m: Record<string, string>) => m.role === "system")?.content ?? "").length}`);
-            if (process.env.ACP_DUMP_REQ === "1") {
-                const out = `${tmpdir()}/acp-proxy-debug-req-${Date.now()}.json`;
-                fs.writeFileSync(out, body.slice(0, 50000));
+            if (process.env.ACP_DUMP_REQ !== "0") {
+                const dumpDir = process.env.ACP_DUMP_DIR || `${stateDir()}/dumps`;
+                try { fs.mkdirSync(dumpDir, { recursive: true }); } catch { /* best-effort */ }
+                const sid = prepared?.session.id ?? "unknown";
+                const out = `${dumpDir}/req-${Date.now()}-${sid}.json`;
+                try {
+                    const pretty = JSON.stringify(JSON.parse(body), null, 2);
+                    fs.writeFileSync(out, pretty);
+                } catch {
+                    fs.writeFileSync(out, body);
+                }
                 log("info", `[debug] forwarded body written to ${out}`);
             }
         } catch { /* best-effort */ }

--- a/src/server.ts
+++ b/src/server.ts
@@ -46,6 +46,7 @@ import { compressLoopAnthropicStream } from "./compress-loop-anthropic.js";
 import { log as loggerLog, configureLogger, getLogPath, closeLogger } from "./logger.js";
 import { defaultLogFile } from "./paths.js";
 import { compressLoopResponsesJson, compressLoopResponsesStream } from "./compress-loop-responses.js";
+import { runCompressLoop, pickAdapter } from "./loop/index.js";
 import { rewriteOpenaiJsonResponse } from "./stream-openai.js";
 import { rewriteResponsesSseStream, rewriteResponsesJsonResponse } from "./stream-responses.js";
 import { emitStreamError } from "./stream-error.js";
@@ -1128,7 +1129,37 @@ async function forward(
         // emitStreamError sends a protocol-appropriate error + finish so the
         // client ends cleanly instead of seeing a bare truncated stream.
         try {
-        if (prepared.protocol === "openai") {
+        if (process.env.ACP_LOOP_V2 === "1") {
+            const parsedReq = JSON.parse(typeof body === "string" ? body : body.toString("utf8"));
+            const reqHeaders: Record<string, string> = {};
+            for (const [k, v] of Object.entries(headers)) {
+                if (k.toLowerCase() === "content-length" || k.toLowerCase() === "host") continue;
+                reqHeaders[k] = v;
+            }
+            reqHeaders["content-type"] = "application/json";
+            const textProtocol = prepared.protocol === "responses" && !!prepared.responsesTextProtocol;
+            const systemPrompt = textProtocol ? buildCompressTextSystemPrompt() : buildCompressSystemPrompt();
+            const adapter = pickAdapter(prepared.protocol, parsedReq);
+            const loop = runCompressLoop(
+                streamToRead,
+                { core, config, messages: prepared.originalMessages, session: prepared.session, log: ctx.log, proxyUrl, textProtocol, debug: opts.debug },
+                parsedReq,
+                { url: upstreamUrl, headers: reqHeaders },
+                adapter,
+                systemPrompt,
+            );
+            for await (const chunk of loop) {
+                {
+                    const s = chunk.toString("utf8");
+                    if (s.includes("\x3cacp ") || s.includes("\x3c/acp")) {
+                        log("warn", `[${prepared.session.id}] tag echo: ${prepared.protocol} response stream contains \x3cacp tag`);
+                    }
+                }
+                res.write(chunk);
+                if (res.writableNeedDrain) await new Promise<void>((r) => res.once("drain", () => r()));
+            }
+            res.end();
+        } else if (prepared.protocol === "openai") {
             const parsedReq = JSON.parse(typeof body === "string" ? body : body.toString("utf8"));
             const reqHeaders: Record<string, string> = {};
             for (const [k, v] of Object.entries(headers)) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1149,7 +1149,7 @@ async function forward(
             const adapter = pickAdapter(prepared.protocol, parsedReq, textProtocol);
             const loop = runCompressLoop(
                 streamToRead,
-                { core, config, messages: prepared.originalMessages, session: prepared.session, log: ctx.log, proxyUrl, textProtocol, debug: opts.debug },
+                { core, config, messages: prepared.processedMessages.length > 0 ? prepared.processedMessages : prepared.originalMessages, session: prepared.session, log: ctx.log, proxyUrl, textProtocol, debug: opts.debug },
                 parsedReq,
                 { url: upstreamUrl, headers: reqHeaders },
                 adapter,

--- a/src/server.ts
+++ b/src/server.ts
@@ -1136,7 +1136,7 @@ async function forward(
         // emitStreamError sends a protocol-appropriate error + finish so the
         // client ends cleanly instead of seeing a bare truncated stream.
         try {
-        if (process.env.ACP_LOOP_V2 === "1") {
+        if (process.env.ACP_LOOP_V2 !== "0") {
             const parsedReq = JSON.parse(typeof body === "string" ? body : body.toString("utf8"));
             const reqHeaders: Record<string, string> = {};
             for (const [k, v] of Object.entries(headers)) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1139,7 +1139,7 @@ async function forward(
             reqHeaders["content-type"] = "application/json";
             const textProtocol = prepared.protocol === "responses" && !!prepared.responsesTextProtocol;
             const systemPrompt = textProtocol ? buildCompressTextSystemPrompt() : buildCompressSystemPrompt();
-            const adapter = pickAdapter(prepared.protocol, parsedReq);
+            const adapter = pickAdapter(prepared.protocol, parsedReq, textProtocol);
             const loop = runCompressLoop(
                 streamToRead,
                 { core, config, messages: prepared.originalMessages, session: prepared.session, log: ctx.log, proxyUrl, textProtocol, debug: opts.debug },

--- a/tests/loop-adapters.test.ts
+++ b/tests/loop-adapters.test.ts
@@ -3,7 +3,8 @@ import assert from "node:assert/strict";
 import type { Config, CoreMessage } from "acp-kernel";
 import { createCore, createInitialState } from "acp-kernel";
 import type { Session } from "../src/session.ts";
-import { runCompressLoop, createOpenaiAdapter, createAnthropicAdapter } from "../src/loop/index.ts";
+import { runCompressLoop, createOpenaiAdapter, createAnthropicAdapter, createResponsesAdapter } from "../src/loop/index.ts";
+import type { ParsedStreamEvent } from "../src/loop/index.ts";
 import { buildCompressSystemPrompt } from "../src/compress-tool.ts";
 
 function makeCtx(id: string, messages: CoreMessage[] = []): {
@@ -164,4 +165,244 @@ test("ACP_LOOP_V2 smoke: import + runCompressLoop round-trips (responses) withou
     assert.equal(typeof openaiA.emitCompletion, "function", "openai adapter has emitCompletion");
     const anthA = mod.pickAdapter("anthropic", { model: "claude" });
     assert.equal(typeof anthA.emitText, "function", "anthropic adapter has emitText");
+});
+
+function mockStream(...chunks: string[]): ReadableStream<Uint8Array> {
+    return new ReadableStream<Uint8Array>({
+        start(controller) {
+            const enc = new TextEncoder();
+            for (const c of chunks) controller.enqueue(enc.encode(c));
+            controller.close();
+        },
+    });
+}
+
+function erroringStream(firstChunk: string): ReadableStream<Uint8Array> {
+    let calls = 0;
+    return new ReadableStream<Uint8Array>({
+        async pull(controller) {
+            calls++;
+            if (calls === 1) {
+                controller.enqueue(new TextEncoder().encode(firstChunk));
+                return;
+            }
+            throw new Error("simulated network drop on second read");
+        },
+    });
+}
+
+function sseLf(type: string, data: unknown): string {
+    return `event: ${type}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+function sseCrlf(type: string, data: unknown): string {
+    return `event: ${type}\r\ndata: ${JSON.stringify(data)}\r\n\r\n`;
+}
+
+async function collectParseEvents(
+    adapter: ReturnType<typeof createResponsesAdapter> | ReturnType<typeof createOpenaiAdapter> | ReturnType<typeof createAnthropicAdapter>,
+    stream: ReadableStream<Uint8Array>,
+    round: number,
+): Promise<ParsedStreamEvent[]> {
+    const events: ParsedStreamEvent[] = [];
+    for await (const ev of adapter.parseStream(stream, round)) events.push(ev);
+    return events;
+}
+
+test("F1 (CRLF): responses adapter yields text delta from \\r\\n-separated SSE (not silently swallowed)", async () => {
+    const crlf = sseCrlf("response.output_text.delta", {
+        type: "response.output_text.delta",
+        item_id: "m1",
+        output_index: 0,
+        delta: "HiCRLF",
+    });
+    const events = await collectParseEvents(createResponsesAdapter(), mockStream(crlf), 1);
+    const textEv = events.find((e) => e.kind === "text");
+    assert.ok(textEv, "text delta yielded — CRLF (0D0A0D0A) normalized so indexOf(\\n\\n) matches");
+    if (textEv && textEv.kind === "text") {
+        assert.equal(textEv.delta, "HiCRLF", "delta content intact");
+    }
+});
+
+test("F1 (CRLF): openai adapter yields text delta from \\r\\n-separated SSE (not silently swallowed)", async () => {
+    const crlf = `data: ${JSON.stringify({
+        id: "c1",
+        object: "chat.completion.chunk",
+        created: 1,
+        model: "gpt",
+        choices: [{ index: 0, delta: { content: "HiCRLF" }, finish_reason: null }],
+    })}\r\n\r\n`;
+    const events = await collectParseEvents(createOpenaiAdapter({ model: "gpt" }), mockStream(crlf), 1);
+    const textEv = events.find((e) => e.kind === "text");
+    assert.ok(textEv, "text delta yielded — CRLF (0D0A0D0A) normalized so indexOf(\\n\\n) matches");
+    if (textEv && textEv.kind === "text") {
+        assert.equal(textEv.delta, "HiCRLF", "delta content intact");
+    }
+});
+
+test("F1 (CRLF): anthropic adapter yields text delta from \\r\\n-separated SSE (not silently swallowed)", async () => {
+    const crlf = sseCrlf("content_block_delta", {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text: "HiCRLF" },
+    });
+    const events = await collectParseEvents(createAnthropicAdapter({ model: "claude" }), mockStream(crlf), 1);
+    const textEv = events.find((e) => e.kind === "text");
+    assert.ok(textEv, "text delta yielded — CRLF (0D0A0D0A) normalized so indexOf(\\n\\n) matches");
+    if (textEv && textEv.kind === "text") {
+        assert.equal(textEv.delta, "HiCRLF", "delta content intact");
+    }
+});
+
+test("F2: responses custom_tool_call meta events have firstRoundOnly=false (passthrough survives round 2+)", async () => {
+    const stream = mockStream(
+        sseLf("response.output_item.added", {
+            type: "response.output_item.added",
+            output_index: 0,
+            item: { type: "custom_tool_call", id: "ctc_1", call_id: "call_x", name: "code_mode_tool", arguments: "" },
+        }),
+        sseLf("response.output_item.done", {
+            type: "response.output_item.done",
+            output_index: 0,
+            item: { type: "custom_tool_call", id: "ctc_1", call_id: "call_x", name: "code_mode_tool", arguments: "{}" },
+        }),
+    );
+    const events = await collectParseEvents(createResponsesAdapter(), stream, 2);
+    const metas = events.filter((e) => e.kind === "meta");
+    assert.ok(metas.length >= 2, "both custom_tool_call events (added+done) yielded in round 2");
+    for (const m of metas) {
+        if (m.kind === "meta") {
+            assert.equal(
+                m.firstRoundOnly,
+                false,
+                "custom_tool_call passthrough has firstRoundOnly=false (not the generic else branch firstRoundOnly:true)",
+            );
+        }
+    }
+});
+
+test("F3: anthropic remaps forwarded block indices to be strictly sequential when tool_use is suppressed", async () => {
+    const stream = mockStream(
+        sseLf("message_start", { type: "message_start", message: { id: "msg_1", usage: { input_tokens: 3 } } }),
+        sseLf("content_block_start", { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } }),
+        sseLf("content_block_delta", { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "Hello" } }),
+        sseLf("content_block_stop", { type: "content_block_stop", index: 0 }),
+        sseLf("content_block_start", {
+            type: "content_block_start",
+            index: 1,
+            content_block: { type: "tool_use", id: "toolu_1", name: "get_weather", input: {} },
+        }),
+        sseLf("content_block_delta", {
+            type: "content_block_delta",
+            index: 1,
+            delta: { type: "input_json_delta", partial_json: '{"city":"SF"}' },
+        }),
+        sseLf("content_block_stop", { type: "content_block_stop", index: 1 }),
+        sseLf("content_block_start", { type: "content_block_start", index: 2, content_block: { type: "text", text: "" } }),
+        sseLf("content_block_delta", { type: "content_block_delta", index: 2, delta: { type: "text_delta", text: "World" } }),
+        sseLf("content_block_stop", { type: "content_block_stop", index: 2 }),
+        sseLf("message_delta", { type: "message_delta", delta: { stop_reason: "tool_use" }, usage: { output_tokens: 5 } }),
+        sseLf("message_stop", { type: "message_stop" }),
+    );
+    const adapter = createAnthropicAdapter({ model: "claude" });
+    const forwardedBlockIndices: number[] = [];
+    const toolCallEvents: ParsedStreamEvent[] = [];
+    for await (const ev of adapter.parseStream(stream, 1)) {
+        if (ev.kind === "tool_call") {
+            toolCallEvents.push(ev);
+            continue;
+        }
+        const buf = ev.kind === "text" ? ev.raw : ev.kind === "meta" ? ev.chunk : undefined;
+        if (!buf) continue;
+        for (const line of buf.toString("utf8").split("\n")) {
+            if (!line.startsWith("data:")) continue;
+            try {
+                const obj = JSON.parse(line.slice(5).trim()) as Record<string, unknown>;
+                if (
+                    typeof obj.index === "number" &&
+                    typeof obj.type === "string" &&
+                    obj.type.startsWith("content_block_")
+                ) {
+                    forwardedBlockIndices.push(obj.index);
+                }
+            } catch {
+            }
+        }
+    }
+
+    assert.equal(toolCallEvents.length, 1, "suppressed tool_use@1 emitted as a tool_call event");
+    const tc = toolCallEvents[0];
+    if (tc && tc.kind === "tool_call") {
+        assert.equal(tc.name, "get_weather", "tool_call name from content_block_start");
+        assert.equal(tc.callId, "toolu_1", "tool_call id from content_block_start");
+        assert.ok(
+            tc.arguments.includes('"city":"SF"'),
+            "tool_call arguments accumulated from input_json_delta",
+        );
+    }
+
+    const distinct = [...new Set(forwardedBlockIndices)].sort((a, b) => a - b);
+    const expected = Array.from({ length: distinct.length }, (_, i) => i);
+    assert.deepEqual(
+        distinct,
+        expected,
+        `forwarded content_block indices STRICTLY SEQUENTIAL (0,1,...) with no gaps/dupes; got ${JSON.stringify(distinct)}`,
+    );
+    assert.ok(
+        distinct.includes(1),
+        "text@2 (upstream) remapped to client index 1 because tool_use@1 was suppressed (fills the gap)",
+    );
+});
+
+test("F4 (network drop): responses parseStream completes normally when upstream read() throws", async () => {
+    const firstChunk = sseLf("response.output_text.delta", {
+        type: "response.output_text.delta",
+        item_id: "m1",
+        output_index: 0,
+        delta: "before-drop",
+    });
+    const events = await collectParseEvents(createResponsesAdapter(), erroringStream(firstChunk), 1);
+    const textEv = events.find((e) => e.kind === "text");
+    assert.ok(textEv, "pre-drop text yielded; iterator completed normally without rethrowing the read() error");
+});
+
+test("F4 (network drop): openai parseStream completes normally when upstream read() throws", async () => {
+    const firstChunk = `data: ${JSON.stringify({
+        id: "c1",
+        object: "chat.completion.chunk",
+        created: 1,
+        model: "gpt",
+        choices: [{ index: 0, delta: { content: "before-drop" }, finish_reason: null }],
+    })}\n\n`;
+    const events = await collectParseEvents(createOpenaiAdapter({ model: "gpt" }), erroringStream(firstChunk), 1);
+    const textEv = events.find((e) => e.kind === "text");
+    assert.ok(textEv, "pre-drop text yielded; iterator completed normally without rethrowing the read() error");
+});
+
+test("F4 (network drop): anthropic parseStream completes normally when upstream read() throws", async () => {
+    const firstChunk = sseLf("content_block_delta", {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text: "before-drop" },
+    });
+    const events = await collectParseEvents(createAnthropicAdapter({ model: "claude" }), erroringStream(firstChunk), 1);
+    const textEv = events.find((e) => e.kind === "text");
+    assert.ok(textEv, "pre-drop text yielded; iterator completed normally without rethrowing the read() error");
+});
+
+test("F5: responses empty upstream → emitCompletion produces response.failed (not fabricated completed)", async () => {
+    const adapter = createResponsesAdapter();
+    let doneFinishReason: string | undefined;
+    for await (const ev of adapter.parseStream(mockStream(), 1)) {
+        if (ev.kind === "done") doneFinishReason = ev.finishReason;
+    }
+    assert.equal(doneFinishReason, "failed", "empty upstream yields done.finishReason=failed (not undefined)");
+
+    const out = adapter.emitCompletion({ finishReason: doneFinishReason }).toString("utf8");
+    assert.ok(out.includes("event: response.failed"), "emitCompletion emits response.failed event");
+    assert.ok(out.includes('"status":"failed"'), "response object carries status:failed");
+    assert.ok(
+        !out.includes("event: response.completed"),
+        "emitCompletion does NOT fabricate response.completed on empty upstream",
+    );
 });

--- a/tests/loop-adapters.test.ts
+++ b/tests/loop-adapters.test.ts
@@ -1,0 +1,151 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { Config, CoreMessage } from "acp-kernel";
+import { createCore, createInitialState } from "acp-kernel";
+import type { Session } from "../src/session.ts";
+import { runCompressLoop, createOpenaiAdapter, createAnthropicAdapter } from "../src/loop/index.ts";
+import { buildCompressSystemPrompt } from "../src/compress-tool.ts";
+
+function makeCtx(id: string, messages: CoreMessage[] = []): {
+    core: ReturnType<typeof createCore>;
+    config: Config;
+    messages: CoreMessage[];
+    session: Session;
+    log: (m: string) => void;
+    proxyUrl?: string;
+    textProtocol?: boolean;
+} {
+    return {
+        core: createCore(),
+        config: { modelContextLimit: 200000 } as Config,
+        messages,
+        session: {
+            id,
+            meta: {},
+            stats: { requests: 0, tokensSaved: 0, inputTokens: 0, cachedTokens: 0, outputTokens: 0, cacheSamples: 0, lastInputTokens: 0, contextTokens: 0 },
+            metadata: {},
+            state: createInitialState(),
+            createdAt: Date.now(),
+            lastSeen: Date.now(),
+            blockContents: new Map(),
+            inFlight: 0,
+            persisted: false,
+        },
+        log: () => {},
+    };
+}
+
+async function drain(
+    stream: ReadableStream<Uint8Array>,
+    ctx: ReturnType<typeof makeCtx>,
+    adapter: ReturnType<typeof createOpenaiAdapter> | ReturnType<typeof createAnthropicAdapter>,
+    requestBody: Record<string, unknown>,
+): Promise<string> {
+    const chunks: Buffer[] = [];
+    for await (const chunk of runCompressLoop(stream, ctx, requestBody, { url: "http://mock", headers: {} }, adapter, buildCompressSystemPrompt())) {
+        chunks.push(chunk);
+    }
+    return Buffer.concat(chunks).toString("utf8");
+}
+
+test("openai adapter: plain text round-trips live + [DONE] termination", async () => {
+    const round1 = [
+        `data: ${JSON.stringify({ id: "c1", object: "chat.completion.chunk", created: 1, model: "gpt", choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }] })}\n\n`,
+        `data: ${JSON.stringify({ id: "c1", object: "chat.completion.chunk", created: 1, model: "gpt", choices: [{ index: 0, delta: { content: "Hello" }, finish_reason: null }] })}\n\n`,
+        `data: ${JSON.stringify({ id: "c1", object: "chat.completion.chunk", created: 1, model: "gpt", choices: [{ index: 0, delta: {}, finish_reason: "stop" }], usage: { prompt_tokens: 5, completion_tokens: 1 } })}\n\n`,
+        `data: [DONE]\n\n`,
+    ].join("");
+    const out = await drain(
+        new Response(round1, { status: 200 }).body!,
+        makeCtx("openai-text"),
+        createOpenaiAdapter({ model: "gpt" }),
+        { model: "gpt", messages: [], stream: true },
+    );
+    assert.ok(out.includes("Hello"), "round-1 text streamed live");
+    assert.ok(out.includes("[DONE]"), "[DONE] terminator present");
+    assert.ok(/finish_reason/.test(out), "finish chunk present");
+});
+
+test("openai adapter: acp_status-only round → marker + graceful completion, no re-request, no crash", async () => {
+    const round1 = [
+        `data: ${JSON.stringify({ id: "c1", object: "chat.completion.chunk", created: 1, model: "gpt", choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }] })}\n\n`,
+        `data: ${JSON.stringify({ id: "c1", object: "chat.completion.chunk", created: 1, model: "gpt", choices: [{ index: 0, delta: { tool_calls: [{ index: 0, id: "call_s", type: "function", function: { name: "acp_status", arguments: "{}" } }] }, finish_reason: null }] })}\n\n`,
+        `data: ${JSON.stringify({ id: "c1", object: "chat.completion.chunk", created: 1, model: "gpt", choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }] })}\n\n`,
+        `data: [DONE]\n\n`,
+    ].join("");
+    let fetchCalls = 0;
+    const orig = globalThis.fetch;
+    globalThis.fetch = (async () => { fetchCalls++; return new Response(round1, { status: 200 }); }) as typeof fetch;
+    try {
+        const out = await drain(
+            new Response(round1, { status: 200 }).body!,
+            makeCtx("openai-status"),
+            createOpenaiAdapter({ model: "gpt" }),
+            { model: "gpt", messages: [], stream: true },
+        );
+        assert.ok(out.includes("[ACP]"), "acp_status marker surfaced");
+        assert.ok(out.includes("[DONE]"), "graceful completion ([DONE])");
+        assert.equal(fetchCalls, 0, "no re-request for read-only acp_status");
+    } finally {
+        globalThis.fetch = orig;
+    }
+});
+
+test("anthropic adapter: plain text round-trips live + message_delta/message_stop termination", async () => {
+    const round1 = [
+        `event: message_start\ndata: ${JSON.stringify({ type: "message_start", message: { id: "msg_1", usage: { input_tokens: 3 } } })}\n\n`,
+        `event: content_block_start\ndata: ${JSON.stringify({ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } })}\n\n`,
+        `event: content_block_delta\ndata: ${JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "Hello" } })}\n\n`,
+        `event: content_block_stop\ndata: ${JSON.stringify({ type: "content_block_stop", index: 0 })}\n\n`,
+        `event: message_delta\ndata: ${JSON.stringify({ type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 1 } })}\n\n`,
+        `event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`,
+    ].join("");
+    const out = await drain(
+        new Response(round1, { status: 200 }).body!,
+        makeCtx("anthropic-text"),
+        createAnthropicAdapter({ model: "claude" }),
+        { model: "claude", messages: [], stream: true, max_tokens: 10 },
+    );
+    assert.ok(out.includes("Hello"), "round-1 text streamed live");
+    assert.ok(out.includes("message_delta"), "message_delta terminal present");
+    assert.ok(out.includes("message_stop"), "message_stop terminal present");
+});
+
+test("anthropic adapter: acp_status-only round → marker + graceful completion, no re-request, no crash", async () => {
+    const round1 = [
+        `event: message_start\ndata: ${JSON.stringify({ type: "message_start", message: { id: "msg_1", usage: { input_tokens: 3 } } })}\n\n`,
+        `event: content_block_start\ndata: ${JSON.stringify({ type: "content_block_start", index: 0, content_block: { type: "tool_use", id: "toolu_s", name: "acp_status", input: {} } })}\n\n`,
+        `event: content_block_delta\ndata: ${JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "input_json_delta", partial_json: "{}" } })}\n\n`,
+        `event: content_block_stop\ndata: ${JSON.stringify({ type: "content_block_stop", index: 0 })}\n\n`,
+        `event: message_delta\ndata: ${JSON.stringify({ type: "message_delta", delta: { stop_reason: "tool_use" }, usage: { output_tokens: 1 } })}\n\n`,
+        `event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`,
+    ].join("");
+    let fetchCalls = 0;
+    const orig = globalThis.fetch;
+    globalThis.fetch = (async () => { fetchCalls++; return new Response(round1, { status: 200 }); }) as typeof fetch;
+    try {
+        const out = await drain(
+            new Response(round1, { status: 200 }).body!,
+            makeCtx("anthropic-status"),
+            createAnthropicAdapter({ model: "claude" }),
+            { model: "claude", messages: [], stream: true, max_tokens: 10 },
+        );
+        assert.ok(out.includes("[ACP]"), "acp_status marker surfaced");
+        assert.ok(out.includes("message_stop"), "graceful completion (message_stop)");
+        assert.equal(fetchCalls, 0, "no re-request for read-only acp_status");
+    } finally {
+        globalThis.fetch = orig;
+    }
+});
+
+test("ACP_LOOP_V2 smoke: import + runCompressLoop round-trips (responses) without crashing", async () => {
+    const mod = await import("../src/loop/index.ts");
+    assert.equal(typeof mod.runCompressLoop, "function", "runCompressLoop exported");
+    assert.equal(typeof mod.pickAdapter, "function", "pickAdapter exported");
+    const adapter = mod.pickAdapter("responses", { model: "gpt" });
+    assert.equal(typeof adapter.parseStream, "function", "responses adapter has parseStream");
+    const openaiA = mod.pickAdapter("openai", { model: "gpt" });
+    assert.equal(typeof openaiA.emitCompletion, "function", "openai adapter has emitCompletion");
+    const anthA = mod.pickAdapter("anthropic", { model: "claude" });
+    assert.equal(typeof anthA.emitText, "function", "anthropic adapter has emitText");
+});

--- a/tests/loop-adapters.test.ts
+++ b/tests/loop-adapters.test.ts
@@ -67,6 +67,23 @@ test("openai adapter: plain text round-trips live + [DONE] termination", async (
     assert.ok(/finish_reason/.test(out), "finish chunk present");
 });
 
+test("openai adapter: separated usage chunk (choices:[] + usage) captured → lastInputTokens set", async () => {
+    const round1 = [
+        `data: ${JSON.stringify({ id: "c1", object: "chat.completion.chunk", created: 1, model: "gpt", choices: [{ index: 0, delta: { content: "Hi" }, finish_reason: null }] })}\n\n`,
+        `data: ${JSON.stringify({ id: "c1", object: "chat.completion.chunk", created: 1, model: "gpt", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] })}\n\n`,
+        `data: ${JSON.stringify({ id: "c1", object: "chat.completion.chunk", created: 1, model: "gpt", choices: [], usage: { prompt_tokens: 42, completion_tokens: 7, prompt_tokens_details: { cached_tokens: 30 } } })}\n\n`,
+        `data: [DONE]\n\n`,
+    ].join("");
+    const ctx = makeCtx("openai-usage-sep");
+    await drain(
+        new Response(round1, { status: 200 }).body!,
+        ctx,
+        createOpenaiAdapter({ model: "gpt" }),
+        { model: "gpt", messages: [], stream: true },
+    );
+    assert.ok((ctx.session.stats.lastInputTokens ?? 0) > 0, "usage from choices:[] chunk captured (lastInputTokens > 0)");
+});
+
 test("openai adapter: acp_status-only round → marker + re-request, no crash", async () => {
     const round1 = [
         `data: ${JSON.stringify({ id: "c1", object: "chat.completion.chunk", created: 1, model: "gpt", choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }] })}\n\n`,

--- a/tests/loop-adapters.test.ts
+++ b/tests/loop-adapters.test.ts
@@ -138,6 +138,22 @@ test("anthropic adapter: acp_status-only round → marker + graceful completion,
     }
 });
 
+test("openai adapter (S1): a single finish_reason chunk is forwarded exactly once (not double-emitted)", async () => {
+    const round1 = [
+        `data: ${JSON.stringify({ id: "c1", object: "chat.completion.chunk", created: 1, model: "gpt", choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }] })}\n\n`,
+        `data: ${JSON.stringify({ id: "c1", object: "chat.completion.chunk", created: 1, model: "gpt", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] })}\n\n`,
+        `data: [DONE]\n\n`,
+    ].join("");
+    const out = await drain(
+        new Response(round1, { status: 200 }).body!,
+        makeCtx("openai-single-finish"),
+        createOpenaiAdapter({ model: "gpt" }),
+        { model: "gpt", messages: [], stream: true },
+    );
+    const finishCount = (out.match(/"finish_reason":"stop"/g) || []).length;
+    assert.equal(finishCount, 1, "finish_reason:\"stop\" emitted exactly once (S1: original finish chunk not passthrough'd + emitCompletion)");
+});
+
 test("ACP_LOOP_V2 smoke: import + runCompressLoop round-trips (responses) without crashing", async () => {
     const mod = await import("../src/loop/index.ts");
     assert.equal(typeof mod.runCompressLoop, "function", "runCompressLoop exported");

--- a/tests/loop-adapters.test.ts
+++ b/tests/loop-adapters.test.ts
@@ -67,16 +67,20 @@ test("openai adapter: plain text round-trips live + [DONE] termination", async (
     assert.ok(/finish_reason/.test(out), "finish chunk present");
 });
 
-test("openai adapter: acp_status-only round → marker + graceful completion, no re-request, no crash", async () => {
+test("openai adapter: acp_status-only round → marker + re-request, no crash", async () => {
     const round1 = [
         `data: ${JSON.stringify({ id: "c1", object: "chat.completion.chunk", created: 1, model: "gpt", choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }] })}\n\n`,
         `data: ${JSON.stringify({ id: "c1", object: "chat.completion.chunk", created: 1, model: "gpt", choices: [{ index: 0, delta: { tool_calls: [{ index: 0, id: "call_s", type: "function", function: { name: "acp_status", arguments: "{}" } }] }, finish_reason: null }] })}\n\n`,
         `data: ${JSON.stringify({ id: "c1", object: "chat.completion.chunk", created: 1, model: "gpt", choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }] })}\n\n`,
         `data: [DONE]\n\n`,
     ].join("");
+    const round2 = [
+        `data: ${JSON.stringify({ id: "c2", object: "chat.completion.chunk", created: 2, model: "gpt", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] })}\n\n`,
+        `data: [DONE]\n\n`,
+    ].join("");
     let fetchCalls = 0;
     const orig = globalThis.fetch;
-    globalThis.fetch = (async () => { fetchCalls++; return new Response(round1, { status: 200 }); }) as typeof fetch;
+    globalThis.fetch = (async () => { fetchCalls++; return new Response(round2, { status: 200 }); }) as typeof fetch;
     try {
         const out = await drain(
             new Response(round1, { status: 200 }).body!,
@@ -86,7 +90,7 @@ test("openai adapter: acp_status-only round → marker + graceful completion, no
         );
         assert.ok(out.includes("[ACP]"), "acp_status marker surfaced");
         assert.ok(out.includes("[DONE]"), "graceful completion ([DONE])");
-        assert.equal(fetchCalls, 0, "no re-request for read-only acp_status");
+        assert.equal(fetchCalls, 1, "re-request after acp_status (avoids tool_calls-no-body hang)");
     } finally {
         globalThis.fetch = orig;
     }
@@ -112,7 +116,7 @@ test("anthropic adapter: plain text round-trips live + message_delta/message_sto
     assert.ok(out.includes("message_stop"), "message_stop terminal present");
 });
 
-test("anthropic adapter: acp_status-only round → marker + graceful completion, no re-request, no crash", async () => {
+test("anthropic adapter: acp_status-only round → marker + re-request, no crash", async () => {
     const round1 = [
         `event: message_start\ndata: ${JSON.stringify({ type: "message_start", message: { id: "msg_1", usage: { input_tokens: 3 } } })}\n\n`,
         `event: content_block_start\ndata: ${JSON.stringify({ type: "content_block_start", index: 0, content_block: { type: "tool_use", id: "toolu_s", name: "acp_status", input: {} } })}\n\n`,
@@ -121,9 +125,14 @@ test("anthropic adapter: acp_status-only round → marker + graceful completion,
         `event: message_delta\ndata: ${JSON.stringify({ type: "message_delta", delta: { stop_reason: "tool_use" }, usage: { output_tokens: 1 } })}\n\n`,
         `event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`,
     ].join("");
+    const round2 = [
+        `event: message_start\ndata: ${JSON.stringify({ type: "message_start", message: { id: "msg_2", usage: { input_tokens: 3 } } })}\n\n`,
+        `event: message_delta\ndata: ${JSON.stringify({ type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 1 } })}\n\n`,
+        `event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`,
+    ].join("");
     let fetchCalls = 0;
     const orig = globalThis.fetch;
-    globalThis.fetch = (async () => { fetchCalls++; return new Response(round1, { status: 200 }); }) as typeof fetch;
+    globalThis.fetch = (async () => { fetchCalls++; return new Response(round2, { status: 200 }); }) as typeof fetch;
     try {
         const out = await drain(
             new Response(round1, { status: 200 }).body!,
@@ -133,7 +142,7 @@ test("anthropic adapter: acp_status-only round → marker + graceful completion,
         );
         assert.ok(out.includes("[ACP]"), "acp_status marker surfaced");
         assert.ok(out.includes("message_stop"), "graceful completion (message_stop)");
-        assert.equal(fetchCalls, 0, "no re-request for read-only acp_status");
+        assert.equal(fetchCalls, 1, "re-request after acp_status (avoids tool_use-no-body hang)");
     } finally {
         globalThis.fetch = orig;
     }

--- a/tests/loop-compress.test.ts
+++ b/tests/loop-compress.test.ts
@@ -1,0 +1,201 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { Config, CoreMessage } from "acp-kernel";
+import { createCore, createInitialState } from "acp-kernel";
+import type { Session } from "../src/session.ts";
+import { runCompressLoop, createResponsesAdapter } from "../src/loop/index.ts";
+import { buildCompressSystemPrompt } from "../src/compress-tool.ts";
+
+function makeCtx(messages: CoreMessage[] = []): {
+    core: ReturnType<typeof createCore>;
+    config: Config;
+    messages: CoreMessage[];
+    session: Session;
+    log: (m: string) => void;
+    proxyUrl?: string;
+    textProtocol?: boolean;
+} {
+    return {
+        core: createCore(),
+        config: { modelContextLimit: 200000 } as Config,
+        messages,
+        session: {
+            id: "loop-compress-test",
+            meta: {},
+            stats: { requests: 0, tokensSaved: 0, inputTokens: 0, cachedTokens: 0, outputTokens: 0, cacheSamples: 0, lastInputTokens: 0, contextTokens: 0 },
+            metadata: {},
+            state: createInitialState(),
+            createdAt: Date.now(),
+            lastSeen: Date.now(),
+            blockContents: new Map(),
+            inFlight: 0,
+            persisted: false,
+        },
+        log: () => {},
+    };
+}
+
+function sse(type: string, data: unknown): string {
+    return `event: ${type}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+function fcEvents(outputIndex: number, callId: string, name: string, args: string): string {
+    return [
+        sse("response.output_item.added", { item: { type: "function_call", id: `fc_${callId}`, call_id: callId, name }, output_index: outputIndex }),
+        sse("response.function_call_arguments.delta", { item_id: `fc_${callId}`, delta: args }),
+        sse("response.output_item.done", { item: { type: "function_call", id: `fc_${callId}`, call_id: callId, name, arguments: args }, output_index: outputIndex }),
+    ].join("");
+}
+
+const COMPLETED = sse("response.completed", { response: { id: "resp_done", status: "completed", output: [] } });
+
+const SYS_PROMPT = buildCompressSystemPrompt();
+const PROMPT_NEEDLE = "COMPRESSION";
+
+async function drain(
+    stream: ReadableStream<Uint8Array>,
+    ctx: ReturnType<typeof makeCtx>,
+    requestBody: Record<string, unknown>,
+    requestOptions: { url: string; headers: Record<string, string> },
+): Promise<string> {
+    const chunks: Buffer[] = [];
+    for await (const chunk of runCompressLoop(stream, ctx, requestBody, requestOptions, createResponsesAdapter(), SYS_PROMPT)) {
+        chunks.push(chunk);
+    }
+    return Buffer.concat(chunks).toString("utf8");
+}
+
+test("loop #3: compress round → re-request happens, result fed back, marker shown", async () => {
+    const round1 = [
+        sse("response.created", { response: { id: "resp_1", status: "in_progress" } }),
+        fcEvents(0, "call_c", "compress", JSON.stringify({ content: [{ startId: "m00001", endId: "m00002", summary: "s" }] })),
+        COMPLETED,
+    ].join("");
+    const round2 = [
+        sse("response.created", { response: { id: "resp_2", status: "in_progress" } }),
+        sse("response.output_text.delta", { item_id: "msg_2", output_index: 0, delta: "Compressed." }),
+        COMPLETED,
+    ].join("");
+    let fetchCalls = 0;
+    const orig = globalThis.fetch;
+    globalThis.fetch = (async () => {
+        fetchCalls++;
+        return new Response(round2, { status: 200 });
+    }) as typeof fetch;
+    try {
+        const out = await drain(
+            new Response(round1, { status: 200 }).body!,
+            makeCtx(),
+            { model: "gpt-4o", input: [], stream: true },
+            { url: "http://mock", headers: {} },
+        );
+        assert.equal(fetchCalls, 1, "exactly one re-request after mutating compress");
+        assert.ok(out.includes("[ACP]"), "compress marker shown");
+        assert.ok(out.includes("Compressed."), "round 2 content (result fed back) reached client");
+        assert.ok(/event: response\.completed/.test(out), "graceful completion");
+    } finally {
+        globalThis.fetch = orig;
+    }
+});
+
+test("loop #4: decompress round → re-request happens", async () => {
+    const round1 = [
+        sse("response.created", { response: { id: "resp_1", status: "in_progress" } }),
+        fcEvents(0, "call_d", "decompress", JSON.stringify({ blockId: "b0" })),
+        COMPLETED,
+    ].join("");
+    const round2 = [
+        sse("response.output_text.delta", { item_id: "msg_2", output_index: 0, delta: "Done." }),
+        COMPLETED,
+    ].join("");
+    let fetchCalls = 0;
+    const orig = globalThis.fetch;
+    globalThis.fetch = (async () => {
+        fetchCalls++;
+        return new Response(round2, { status: 200 });
+    }) as typeof fetch;
+    try {
+        const out = await drain(
+            new Response(round1, { status: 200 }).body!,
+            makeCtx(),
+            { model: "gpt-4o", input: [], stream: true },
+            { url: "http://mock", headers: {} },
+        );
+        assert.equal(fetchCalls, 1, "exactly one re-request after mutating decompress");
+        assert.ok(out.includes("[ACP]"), "decompress marker shown");
+        assert.ok(/event: response\.completed/.test(out), "graceful completion");
+    } finally {
+        globalThis.fetch = orig;
+    }
+});
+
+test("loop #6: philosophy systemPrompt is transient — appears exactly once per round body (not accumulated)", async () => {
+    const round1 = [
+        sse("response.created", { response: { id: "resp_1", status: "in_progress" } }),
+        fcEvents(0, "call_c", "compress", JSON.stringify({ content: [{ startId: "m00001", endId: "m00002", summary: "s" }] })),
+        COMPLETED,
+    ].join("");
+    const round2 = [
+        sse("response.output_text.delta", { item_id: "msg_2", output_index: 0, delta: "Done." }),
+        COMPLETED,
+    ].join("");
+    const forwardedBodies: string[] = [];
+    const orig = globalThis.fetch;
+    globalThis.fetch = (async (_u: unknown, init?: RequestInit) => {
+        forwardedBodies.push(String(init?.body));
+        return new Response(round2, { status: 200 });
+    }) as typeof fetch;
+    try {
+        await drain(
+            new Response(round1, { status: 200 }).body!,
+            makeCtx(),
+            { model: "gpt-4o", input: [], stream: true },
+            { url: "http://mock", headers: {} },
+        );
+        assert.equal(forwardedBodies.length, 1, "one re-request body captured");
+        const body = forwardedBodies[0];
+        const occurrences = (body.match(new RegExp(PROMPT_NEEDLE, "g")) || []).length;
+        const promptOcc = (body.match(/COMPRESSION PHILOSOPHY|context management serves/gi) || []).length;
+        assert.ok(promptOcc >= 1 || occurrences >= 1, "philosophy prompt present in round-2 body");
+        const needleCount = (body.match(/PRIORITY/g) || []).length;
+        const sysMarkerCount = (body.match(/"role":"developer"/g) || []).length;
+        assert.equal(sysMarkerCount, 1, "philosophy injected as exactly ONE developer message (transient, not accumulated)");
+        assert.ok(needleCount < 50, "philosophy not duplicated excessively");
+    } finally {
+        globalThis.fetch = orig;
+    }
+});
+
+test("loop #7: hideConsumed per round — consumed compress records not re-forwarded verbatim in round 2", async () => {
+    const compressArgs = JSON.stringify({ content: [{ startId: "m00001", endId: "m00002", summary: "SECRET-SUMMARY-PAYLOAD" }] });
+    const round1 = [
+        sse("response.created", { response: { id: "resp_1", status: "in_progress" } }),
+        fcEvents(0, "call_c", "compress", compressArgs),
+        COMPLETED,
+    ].join("");
+    const round2 = [
+        sse("response.output_text.delta", { item_id: "msg_2", output_index: 0, delta: "Done." }),
+        COMPLETED,
+    ].join("");
+    let forwardedBody: string | undefined;
+    const orig = globalThis.fetch;
+    globalThis.fetch = (async (_u: unknown, init?: RequestInit) => {
+        forwardedBody = String(init?.body);
+        return new Response(round2, { status: 200 });
+    }) as typeof fetch;
+    try {
+        await drain(
+            new Response(round1, { status: 200 }).body!,
+            makeCtx(),
+            { model: "gpt-4o", input: [], stream: true },
+            { url: "http://mock", headers: {} },
+        );
+        assert.ok(forwardedBody, "round-2 body captured");
+        assert.ok(
+            !forwardedBody!.includes("SECRET-SUMMARY-PAYLOAD"),
+            "consumed compress summary payload not re-forwarded verbatim (hideConsumed ran and rewrote/hid it)",
+        );
+    } finally {
+        globalThis.fetch = orig;
+    }
+});

--- a/tests/loop-compress.test.ts
+++ b/tests/loop-compress.test.ts
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import type { Config, CoreMessage } from "acp-kernel";
-import { createCore, createInitialState } from "acp-kernel";
+import { createCore, createInitialState, assignRefs, emptyRefMap, defaultConfig } from "acp-kernel";
 import type { Session } from "../src/session.ts";
 import { runCompressLoop, createResponsesAdapter } from "../src/loop/index.ts";
 import { buildCompressSystemPrompt } from "../src/compress-tool.ts";
@@ -17,7 +17,7 @@ function makeCtx(messages: CoreMessage[] = []): {
 } {
     return {
         core: createCore(),
-        config: { modelContextLimit: 200000 } as Config,
+        config: defaultConfig(200000),
         messages,
         session: {
             id: "loop-compress-test",
@@ -57,13 +57,39 @@ async function drain(
     ctx: ReturnType<typeof makeCtx>,
     requestBody: Record<string, unknown>,
     requestOptions: { url: string; headers: Record<string, string> },
+    adapter: ReturnType<typeof createResponsesAdapter> = createResponsesAdapter(),
 ): Promise<string> {
     const chunks: Buffer[] = [];
-    for await (const chunk of runCompressLoop(stream, ctx, requestBody, requestOptions, createResponsesAdapter(), SYS_PROMPT)) {
+    for await (const chunk of runCompressLoop(stream, ctx, requestBody, requestOptions, adapter, SYS_PROMPT)) {
         chunks.push(chunk);
     }
     return Buffer.concat(chunks).toString("utf8");
 }
+
+function textMsg(id: string, role: "user" | "assistant", text: string): CoreMessage {
+    return { id, role, contentType: "text", text };
+}
+
+// Kernel default compress.minCompressRange is 5000 chars; ranges below that are
+// rejected with "content too small" and create NO block. Use big text so a real
+// active block is created and hideConsumed has something to keep.
+function bigText(n: number): string {
+    return "x".repeat(n);
+}
+
+// The compress loop does not run the kernel's ref-assignment pipeline (the proxy
+// runs processTurn once per client turn, BEFORE the loop). To create a REAL block
+// (so hideConsumed has an active compressCallId to keep), the ref map must be
+// pre-populated — otherwise resolveBoundaries finds nothing and no block is created.
+function withRefs(ctx: ReturnType<typeof makeCtx>): ReturnType<typeof makeCtx> {
+    const res = assignRefs(ctx.messages, { existing: emptyRefMap(), nextIndex: 0 });
+    ctx.session.state.messageRefs = res.map;
+    return ctx;
+}
+
+const COMPLETED_USAGE = sse("response.completed", {
+    response: { id: "resp_done", status: "completed", output: [], usage: { input_tokens: 42, output_tokens: 7, input_tokens_details: { cached_tokens: 3 } } },
+});
 
 test("loop #3: compress round → re-request happens, result fed back, marker shown", async () => {
     const round1 = [
@@ -166,8 +192,23 @@ test("loop #6: philosophy systemPrompt is transient — appears exactly once per
     }
 });
 
-test("loop #7: hideConsumed per round — consumed compress records not re-forwarded verbatim in round 2", async () => {
-    const compressArgs = JSON.stringify({ content: [{ startId: "m00001", endId: "m00002", summary: "SECRET-SUMMARY-PAYLOAD" }] });
+test("loop #7: successful compress KEEPS the active record in round 2 (B2: compressCallId threading prevents re-compress loop)", async () => {
+    // Real messages with IDs => applyCompression creates an ACTIVE block whose
+    // compressCallId matches the live call => hideConsumed keeps the record.
+    // Without B2 the block's compressCallId is undefined, the record is hidden,
+    // and the model re-compresses (the 炸锅 loop class).
+    // 7 messages: kernel protects the last 5, so m00001/m00002 (the oldest pair)
+    // are compressible; a 2-message corpus would be entirely protected.
+    const ctx = withRefs(makeCtx([
+        textMsg("raw_1", "user", bigText(5000)),
+        textMsg("raw_2", "assistant", bigText(5000)),
+        textMsg("raw_3", "user", bigText(5000)),
+        textMsg("raw_4", "assistant", bigText(5000)),
+        textMsg("raw_5", "user", bigText(5000)),
+        textMsg("raw_6", "assistant", bigText(5000)),
+        textMsg("raw_7", "user", bigText(5000)),
+    ]));
+    const compressArgs = JSON.stringify({ content: [{ startId: "m00001", endId: "m00002", summary: "PAIR-SUMMARY-PAYLOAD-THAT-IS-LONG-ENOUGH-FOR-THE-KERNEL-MIN-LENGTH-CHECK" }] });
     const round1 = [
         sse("response.created", { response: { id: "resp_1", status: "in_progress" } }),
         fcEvents(0, "call_c", "compress", compressArgs),
@@ -186,15 +227,119 @@ test("loop #7: hideConsumed per round — consumed compress records not re-forwa
     try {
         await drain(
             new Response(round1, { status: 200 }).body!,
-            makeCtx(),
+            ctx,
             { model: "gpt-4o", input: [], stream: true },
             { url: "http://mock", headers: {} },
         );
         assert.ok(forwardedBody, "round-2 body captured");
         assert.ok(
-            !forwardedBody!.includes("SECRET-SUMMARY-PAYLOAD"),
-            "consumed compress summary payload not re-forwarded verbatim (hideConsumed ran and rewrote/hid it)",
+            /"name"\s*:\s*"compress"/.test(forwardedBody!),
+            "active compress function_call KEPT in round-2 body (B2: compressCallId threading)",
         );
+        assert.ok(
+            forwardedBody!.includes("PAIR-SUMMARY-PAYLOAD"),
+            "compress arguments preserved in round-2 body (B1: tool-call args not dropped)",
+        );
+    } finally {
+        globalThis.fetch = orig;
+    }
+});
+
+test("loop #8 (B3): textProtocol compress round → round-2 body has NO function_call items (marker user message instead)", async () => {
+    const ctx = makeCtx([
+        textMsg("m00001", "user", "hello"),
+        textMsg("m00002", "assistant", "hi"),
+    ]);
+    ctx.textProtocol = true;
+    const compressArgs = JSON.stringify({ content: [{ startId: "m00001", endId: "m00002", summary: "s" }] });
+    const round1 = [
+        sse("response.created", { response: { id: "resp_1", status: "in_progress" } }),
+        fcEvents(0, "call_c", "compress", compressArgs),
+        COMPLETED,
+    ].join("");
+    const round2 = [
+        sse("response.output_text.delta", { item_id: "msg_2", output_index: 0, delta: "Done." }),
+        COMPLETED,
+    ].join("");
+    let forwardedBody: string | undefined;
+    const orig = globalThis.fetch;
+    globalThis.fetch = (async (_u: unknown, init?: RequestInit) => {
+        forwardedBody = String(init?.body);
+        return new Response(round2, { status: 200 });
+    }) as typeof fetch;
+    try {
+        await drain(
+            new Response(round1, { status: 200 }).body!,
+            ctx,
+            { model: "gpt-4o", input: [], stream: true },
+            { url: "http://mock", headers: {} },
+            createResponsesAdapter(true),
+        );
+        assert.ok(forwardedBody, "round-2 body captured");
+        assert.ok(
+            !/"type"\s*:\s*"function_call"/.test(forwardedBody!),
+            "NO function_call items in textProtocol round-2 body (B3: code_mode compatibility)",
+        );
+        assert.ok(forwardedBody!.includes("[ACP]"), "visibility marker present as user-role text");
+    } finally {
+        globalThis.fetch = orig;
+    }
+});
+
+test("loop #9 (S2): responses round yields usage → session.stats populated (nudge/stat tracking)", async () => {
+    const ctx = makeCtx([
+        textMsg("m00001", "user", "hello"),
+        textMsg("m00002", "assistant", "hi"),
+    ]);
+    const compressArgs = JSON.stringify({ content: [{ startId: "m00001", endId: "m00002", summary: "s" }] });
+    const round1 = [
+        sse("response.created", { response: { id: "resp_1", status: "in_progress" } }),
+        fcEvents(0, "call_c", "compress", compressArgs),
+        COMPLETED_USAGE,
+    ].join("");
+    const round2 = [
+        sse("response.output_text.delta", { item_id: "msg_2", output_index: 0, delta: "Done." }),
+        COMPLETED_USAGE,
+    ].join("");
+    const orig = globalThis.fetch;
+    globalThis.fetch = (async () => new Response(round2, { status: 200 })) as typeof fetch;
+    try {
+        await drain(
+            new Response(round1, { status: 200 }).body!,
+            ctx,
+            { model: "gpt-4o", input: [], stream: true },
+            { url: "http://mock", headers: {} },
+        );
+        assert.ok(ctx.session.stats.lastInputTokens > 0, "lastInputTokens populated from response.completed usage (S2)");
+    } finally {
+        globalThis.fetch = orig;
+    }
+});
+
+test("loop #10 (S3): upstream 500 mid-loop terminates cleanly (timer cleared, no hang)", async () => {
+    const ctx = makeCtx([
+        textMsg("m00001", "user", "hello"),
+        textMsg("m00002", "assistant", "hi"),
+    ]);
+    const compressArgs = JSON.stringify({ content: [{ startId: "m00001", endId: "m00002", summary: "s" }] });
+    const round1 = [
+        sse("response.created", { response: { id: "resp_1", status: "in_progress" } }),
+        fcEvents(0, "call_c", "compress", compressArgs),
+        COMPLETED,
+    ].join("");
+    const orig = globalThis.fetch;
+    globalThis.fetch = (async () => new Response("upstream error", { status: 500 })) as typeof fetch;
+    try {
+        const out = await Promise.race([
+            drain(
+                new Response(round1, { status: 200 }).body!,
+                ctx,
+                { model: "gpt-4o", input: [], stream: true },
+                { url: "http://mock", headers: {} },
+            ),
+            new Promise<string>((_, reject) => setTimeout(() => reject(new Error("loop hung (timer not cleared)")), 3000)),
+        ]);
+        assert.ok(typeof out === "string", "loop terminated cleanly on upstream 500 (S3: timer cleared)");
     } finally {
         globalThis.fetch = orig;
     }

--- a/tests/loop-core.test.ts
+++ b/tests/loop-core.test.ts
@@ -1,0 +1,190 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { Config, CoreMessage } from "acp-kernel";
+import { createCore, createInitialState } from "acp-kernel";
+import type { Session } from "../src/session.ts";
+import { runCompressLoop, createResponsesAdapter } from "../src/loop/index.ts";
+import { buildCompressSystemPrompt } from "../src/compress-tool.ts";
+
+function makeCtx(messages: CoreMessage[] = []): {
+    core: ReturnType<typeof createCore>;
+    config: Config;
+    messages: CoreMessage[];
+    session: Session;
+    log: (m: string) => void;
+    proxyUrl?: string;
+    textProtocol?: boolean;
+} {
+    return {
+        core: createCore(),
+        config: { modelContextLimit: 200000 } as Config,
+        messages,
+        session: {
+            id: "loop-core-test",
+            meta: {},
+            stats: { requests: 0, tokensSaved: 0, inputTokens: 0, cachedTokens: 0, outputTokens: 0, cacheSamples: 0, lastInputTokens: 0, contextTokens: 0 },
+            metadata: {},
+            state: createInitialState(),
+            createdAt: Date.now(),
+            lastSeen: Date.now(),
+            blockContents: new Map(),
+            inFlight: 0,
+            persisted: false,
+        },
+        log: () => {},
+    };
+}
+
+function sse(type: string, data: unknown): string {
+    return `event: ${type}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+async function drain(
+    stream: ReadableStream<Uint8Array>,
+    ctx: ReturnType<typeof makeCtx>,
+    requestBody: Record<string, unknown>,
+    requestOptions: { url: string; headers: Record<string, string> },
+    systemPrompt = buildCompressSystemPrompt(),
+): Promise<string> {
+    const chunks: Buffer[] = [];
+    for await (const chunk of runCompressLoop(stream, ctx, requestBody, requestOptions, createResponsesAdapter(), systemPrompt)) {
+        chunks.push(chunk);
+    }
+    return Buffer.concat(chunks).toString("utf8");
+}
+
+function fcEvents(outputIndex: number, callId: string, name: string, args: string): string {
+    return [
+        sse("response.output_item.added", { item: { type: "function_call", id: `fc_${callId}`, call_id: callId, name }, output_index: outputIndex }),
+        sse("response.function_call_arguments.delta", { item_id: `fc_${callId}`, delta: args }),
+        sse("response.output_item.done", { item: { type: "function_call", id: `fc_${callId}`, call_id: callId, name, arguments: args }, output_index: outputIndex }),
+    ].join("");
+}
+
+const COMPLETED = sse("response.completed", { response: { id: "resp_done", status: "completed", output: [] } });
+
+test("loop #1: acp_status-only round → marker surfaced, NO re-request, graceful completion", async () => {
+    const round1 = [
+        sse("response.created", { response: { id: "resp_1", status: "in_progress" } }),
+        fcEvents(0, "call_status", "acp_status", "{}"),
+        COMPLETED,
+    ].join("");
+    let fetchCalls = 0;
+    const orig = globalThis.fetch;
+    globalThis.fetch = (async () => { fetchCalls++; return new Response(round1, { status: 200 }); }) as typeof fetch;
+    try {
+        const out = await drain(
+            new Response(round1, { status: 200 }).body!,
+            makeCtx(),
+            { model: "gpt-4o", input: [], stream: true },
+            { url: "http://mock", headers: {} },
+        );
+        assert.ok(out.includes("[ACP]"), "acp_status visibility marker surfaced to client");
+        assert.ok(/response\.completed/.test(out), "graceful completion present (no 炸锅)");
+        assert.equal(fetchCalls, 0, "NO re-request: acp_status is read-only, turn ends");
+    } finally {
+        globalThis.fetch = orig;
+    }
+});
+
+test("loop #2: search_context-only round → marker surfaced, NO re-request, graceful completion", async () => {
+    const round1 = [
+        sse("response.created", { response: { id: "resp_1", status: "in_progress" } }),
+        fcEvents(0, "call_search", "search_context", JSON.stringify({ query: "auth", limit: 3 })),
+        COMPLETED,
+    ].join("");
+    let fetchCalls = 0;
+    const orig = globalThis.fetch;
+    globalThis.fetch = (async () => { fetchCalls++; return new Response(round1, { status: 200 }); }) as typeof fetch;
+    try {
+        const out = await drain(
+            new Response(round1, { status: 200 }).body!,
+            makeCtx(),
+            { model: "gpt-4o", input: [], stream: true },
+            { url: "http://mock", headers: {} },
+        );
+        assert.ok(out.includes("[ACP]"), "search_context marker surfaced");
+        assert.ok(/response\.completed/.test(out), "graceful completion present");
+        assert.equal(fetchCalls, 0, "NO re-request: search_context is read-only");
+    } finally {
+        globalThis.fetch = orig;
+    }
+});
+
+test("loop #8: real-tool passthrough → emitted to client, loop ends (no re-request)", async () => {
+    const round1 = [
+        sse("response.created", { response: { id: "resp_1", status: "in_progress" } }),
+        fcEvents(0, "call_bash", "bash", JSON.stringify({ command: "ls" })),
+        COMPLETED,
+    ].join("");
+    let fetchCalls = 0;
+    const orig = globalThis.fetch;
+    globalThis.fetch = (async () => { fetchCalls++; return new Response(round1, { status: 200 }); }) as typeof fetch;
+    try {
+        const out = await drain(
+            new Response(round1, { status: 200 }).body!,
+            makeCtx(),
+            { model: "gpt-4o", input: [], stream: true },
+            { url: "http://mock", headers: {} },
+        );
+        assert.ok(out.includes("\"name\":\"bash\""), "real tool call emitted to client");
+        assert.ok(/response\.completed/.test(out), "completion present (loop ended)");
+        assert.equal(fetchCalls, 0, "NO re-request: real tool ends the loop");
+    } finally {
+        globalThis.fetch = orig;
+    }
+});
+
+test("loop #9: mixed compress + real tool → forwarded (no re-request), compress executed, marker shown", async () => {
+    const round1 = [
+        sse("response.created", { response: { id: "resp_1", status: "in_progress" } }),
+        fcEvents(0, "call_compress", "compress", JSON.stringify({ content: [{ startId: "m00001", endId: "m00002", summary: "s" }] })),
+        fcEvents(1, "call_bash", "bash", JSON.stringify({ command: "echo hi" })),
+        COMPLETED,
+    ].join("");
+    let fetchCalls = 0;
+    const orig = globalThis.fetch;
+    globalThis.fetch = (async () => { fetchCalls++; return new Response(round1, { status: 200 }); }) as typeof fetch;
+    try {
+        const out = await drain(
+            new Response(round1, { status: 200 }).body!,
+            makeCtx(),
+            { model: "gpt-4o", input: [], stream: true },
+            { url: "http://mock", headers: {} },
+        );
+        assert.ok(out.includes("[ACP]"), "compress marker shown");
+        assert.ok(out.includes("\"name\":\"bash\""), "real tool forwarded to client");
+        assert.equal(fetchCalls, 0, "NO re-request: real tool present alongside mutating proxy tool");
+        assert.ok(/response\.completed/.test(out), "completion present");
+    } finally {
+        globalThis.fetch = orig;
+    }
+});
+
+test("loop #5: limit-hit graceful — 10 mutating rounds never degenerate empty, no crash", async () => {
+    const mutatingRound = [
+        sse("response.created", { response: { id: "resp_m", status: "in_progress" } }),
+        fcEvents(0, "call_c", "compress", JSON.stringify({ content: [{ startId: "m00001", endId: "m00002", summary: "s" }] })),
+        COMPLETED,
+    ].join("");
+    let fetchCalls = 0;
+    const orig = globalThis.fetch;
+    globalThis.fetch = (async () => {
+        fetchCalls++;
+        return new Response(mutatingRound, { status: 200 });
+    }) as typeof fetch;
+    try {
+        const out = await drain(
+            new Response(mutatingRound, { status: 200 }).body!,
+            makeCtx(),
+            { model: "gpt-4o", input: [], stream: true },
+            { url: "http://mock", headers: {} },
+        );
+        assert.ok(/response\.completed/.test(out), "graceful completion at limit (NOT degenerate empty)");
+        assert.ok(!/^data: \[\]\n\n$/.test(out), "no degenerate empty payload");
+        const completedCount = (out.match(/event: response\.completed/g) || []).length;
+        assert.equal(completedCount, 1, "exactly one completion event (one SSE event line)");
+    } finally {
+        globalThis.fetch = orig;
+    }
+});

--- a/tests/loop-core.test.ts
+++ b/tests/loop-core.test.ts
@@ -63,15 +63,16 @@ function fcEvents(outputIndex: number, callId: string, name: string, args: strin
 
 const COMPLETED = sse("response.completed", { response: { id: "resp_done", status: "completed", output: [] } });
 
-test("loop #1: acp_status-only round → marker surfaced, NO re-request, graceful completion", async () => {
+test("loop #1: acp_status-only round → marker surfaced + re-request (avoids tool_calls-no-body hang)", async () => {
     const round1 = [
         sse("response.created", { response: { id: "resp_1", status: "in_progress" } }),
         fcEvents(0, "call_status", "acp_status", "{}"),
         COMPLETED,
     ].join("");
+    const round2 = COMPLETED;
     let fetchCalls = 0;
     const orig = globalThis.fetch;
-    globalThis.fetch = (async () => { fetchCalls++; return new Response(round1, { status: 200 }); }) as typeof fetch;
+    globalThis.fetch = (async () => { fetchCalls++; return new Response(round2, { status: 200 }); }) as typeof fetch;
     try {
         const out = await drain(
             new Response(round1, { status: 200 }).body!,
@@ -81,21 +82,22 @@ test("loop #1: acp_status-only round → marker surfaced, NO re-request, gracefu
         );
         assert.ok(out.includes("[ACP]"), "acp_status visibility marker surfaced to client");
         assert.ok(/response\.completed/.test(out), "graceful completion present (no 炸锅)");
-        assert.equal(fetchCalls, 0, "NO re-request: acp_status is read-only, turn ends");
+        assert.equal(fetchCalls, 1, "re-request after acp_status so model can continue (not finish_reason=tool_calls with no body)");
     } finally {
         globalThis.fetch = orig;
     }
 });
 
-test("loop #2: search_context-only round → marker surfaced, NO re-request, graceful completion", async () => {
+test("loop #2: search_context-only round → marker surfaced + re-request", async () => {
     const round1 = [
         sse("response.created", { response: { id: "resp_1", status: "in_progress" } }),
         fcEvents(0, "call_search", "search_context", JSON.stringify({ query: "auth", limit: 3 })),
         COMPLETED,
     ].join("");
+    const round2 = COMPLETED;
     let fetchCalls = 0;
     const orig = globalThis.fetch;
-    globalThis.fetch = (async () => { fetchCalls++; return new Response(round1, { status: 200 }); }) as typeof fetch;
+    globalThis.fetch = (async () => { fetchCalls++; return new Response(round2, { status: 200 }); }) as typeof fetch;
     try {
         const out = await drain(
             new Response(round1, { status: 200 }).body!,
@@ -105,7 +107,7 @@ test("loop #2: search_context-only round → marker surfaced, NO re-request, gra
         );
         assert.ok(out.includes("[ACP]"), "search_context marker surfaced");
         assert.ok(/response\.completed/.test(out), "graceful completion present");
-        assert.equal(fetchCalls, 0, "NO re-request: search_context is read-only");
+        assert.equal(fetchCalls, 1, "re-request after search_context so model can use results");
     } finally {
         globalThis.fetch = orig;
     }

--- a/tests/proxy-responses-review.test.ts
+++ b/tests/proxy-responses-review.test.ts
@@ -197,3 +197,70 @@ test("compressLoopResponsesJson: Codex text trigger is intercepted and re-reques
         globalThis.fetch = previousFetch;
     }
 });
+
+test("compressLoopResponsesJson: read-only acp_status executes once, surfaces marker, NO upstream re-request (炸锅 regression, JSON path)", async () => {
+    let fetchCalls = 0;
+    const previousFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+        fetchCalls++;
+        return new Response(JSON.stringify({ id: "resp_never", status: "completed", output: [] }), {
+            status: 200, headers: { "content-type": "application/json" },
+        });
+    }) as typeof fetch;
+    try {
+        const initial = {
+            id: "resp_st_json",
+            status: "completed",
+            output: [{
+                type: "function_call",
+                id: "fc_st",
+                call_id: "call_st",
+                name: "acp_status",
+                arguments: "{}",
+            }],
+        };
+        const out = await compressLoopResponsesJson(initial, makeCtx(() => {}), {
+            model: "gpt-4o",
+            input: [{ type: "message", role: "user", content: "status?" }],
+        }, { url: "https://unused.example/responses", headers: { "content-type": "application/json" } });
+        assert.equal(fetchCalls, 0, "read-only acp_status must NOT trigger an upstream re-request (JSON path)");
+        const outputs = out.output as Array<Record<string, unknown>>;
+        const joined = JSON.stringify(outputs);
+        assert.ok(joined.includes("📊"), "acp_status marker (📊) appended to JSON output");
+        assert.ok(joined.includes("[ACP]"), "[ACP] visibility tag present in marker");
+    } finally {
+        globalThis.fetch = previousFetch;
+    }
+});
+
+test("compressLoopResponsesJson: real tool + read-only acp_status surfaces marker AND preserves real call (Q2 stream/JSON parity)", async () => {
+    let fetchCalls = 0;
+    const previousFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+        fetchCalls++;
+        return new Response(JSON.stringify({ id: "resp_never", status: "completed", output: [] }), {
+            status: 200, headers: { "content-type": "application/json" },
+        });
+    }) as typeof fetch;
+    try {
+        const initial = {
+            id: "resp_rmx_json",
+            status: "completed",
+            output: [
+                { type: "function_call", id: "fc_shell", call_id: "call_shell", name: "shell", arguments: '{"cmd":"ls"}' },
+                { type: "function_call", id: "fc_st", call_id: "call_st", name: "acp_status", arguments: "{}" },
+            ],
+        };
+        const out = await compressLoopResponsesJson(initial, makeCtx(() => {}), {
+            model: "gpt-4o",
+            input: [{ type: "message", role: "user", content: "run + status" }],
+        }, { url: "https://unused.example/responses", headers: { "content-type": "application/json" } });
+        assert.equal(fetchCalls, 0, "no MUTATING tool present → must NOT re-request");
+        const outputs = out.output as Array<Record<string, unknown>>;
+        const joined = JSON.stringify(outputs);
+        assert.ok(joined.includes("📊"), "acp_status marker surfaced even when a real tool accompanies it (regression: JSON used to drop it)");
+        assert.ok(joined.includes('"shell"'), "the real tool call is preserved in output so the client can execute it");
+    } finally {
+        globalThis.fetch = previousFetch;
+    }
+});

--- a/tests/proxy-responses-stream.test.ts
+++ b/tests/proxy-responses-stream.test.ts
@@ -279,9 +279,134 @@ test("compressLoopResponsesStream: mixed mutating + read-only round still re-req
             { url: "http://mock", headers: {} },
         );
         assert.equal(fetchCalls, 1, "a round containing a MUTATING tool (compress) must re-request exactly once");
-        assert.ok(out.includes("[ACP]"), "visibility markers emitted");
+        // Count [ACP] tags, not icons: the empty session makes both tools return
+        // "not found", flipping their icons to ❌. ≥2 markers proves both ran.
+        const markerCount = (out.match(/\[ACP\]/g) || []).length;
+        assert.ok(markerCount >= 2, `both compress + acp_status must produce markers (got ${markerCount})`);
         assert.ok(out.includes("Done."), "round 2 real content emitted");
         assert.ok(out.includes("response.completed"), "final completion emitted");
+    } finally {
+        globalThis.fetch = originalFetch;
+    }
+});
+
+test("compressLoopResponsesStream: read-only search_context executes once and completes WITHOUT upstream re-request", async () => {
+    const round1 = [
+        sse("response.created", { response: { id: "resp_sc_1", status: "in_progress" } }),
+        sse("response.output_item.added", {
+            item: { type: "function_call", id: "fc_sc", call_id: "call_sc", name: "search_context" },
+            output_index: 0,
+        }),
+        sse("response.function_call_arguments.delta", { item_id: "fc_sc", delta: JSON.stringify({ query: "kv cache" }) }),
+        sse("response.output_item.done", {
+            item: { type: "function_call", id: "fc_sc", call_id: "call_sc", name: "search_context", arguments: JSON.stringify({ query: "kv cache" }) },
+            output_index: 0,
+        }),
+        sse("response.completed", { response: { id: "resp_sc_1", status: "completed", output: [] } }),
+    ].join("");
+    let fetchCalls = 0;
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+        fetchCalls++;
+        return new Response(round1, { status: 200, headers: { "content-type": "text/event-stream" } });
+    }) as typeof fetch;
+    try {
+        const out = await drain(
+            new Response(round1, { status: 200, headers: { "content-type": "text/event-stream" } }).body!,
+            makeCtx(() => {}),
+            { model: "gpt-4o", input: [{ type: "message", role: "user", content: "search" }], stream: true },
+            { url: "http://mock", headers: {} },
+        );
+        assert.equal(fetchCalls, 0, "read-only search_context must NOT trigger an upstream re-request");
+        assert.ok(out.includes("[ACP]"), "search_context visibility marker emitted to client");
+        assert.ok(out.includes("response.completed"), "turn completes instead of looping or being discarded");
+        assert.ok(!out.includes("compress loop limit"), "loop limit must not be hit for a read-only tool");
+    } finally {
+        globalThis.fetch = originalFetch;
+    }
+});
+
+test("compressLoopResponsesStream: MUTATING decompress-only round STILL drives the re-request loop (locks no-behavior-change)", async () => {
+    const round1 = [
+        sse("response.created", { response: { id: "resp_dc_1", status: "in_progress" } }),
+        sse("response.output_item.added", {
+            item: { type: "function_call", id: "fc_dc", call_id: "call_dc", name: "decompress" },
+            output_index: 0,
+        }),
+        sse("response.function_call_arguments.delta", { item_id: "fc_dc", delta: JSON.stringify({ blockId: "b0" }) }),
+        sse("response.output_item.done", {
+            item: { type: "function_call", id: "fc_dc", call_id: "call_dc", name: "decompress", arguments: JSON.stringify({ blockId: "b0" }) },
+            output_index: 0,
+        }),
+        sse("response.completed", { response: { id: "resp_dc_1", status: "completed", output: [] } }),
+    ].join("");
+    const round2 = [
+        sse("response.created", { response: { id: "resp_dc_2", status: "in_progress" } }),
+        sse("response.output_text.delta", { item_id: "msg_dc", output_index: 0, delta: "Restored." }),
+        sse("response.completed", { response: { id: "resp_dc_2", status: "completed", output: [] } }),
+    ].join("");
+    let fetchCalls = 0;
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+        fetchCalls++;
+        return new Response(fetchCalls === 1 ? round2 : round1, { status: 200, headers: { "content-type": "text/event-stream" } });
+    }) as typeof fetch;
+    try {
+        const out = await drain(
+            new Response(round1, { status: 200, headers: { "content-type": "text/event-stream" } }).body!,
+            makeCtx(() => {}),
+            { model: "gpt-4o", input: [{ type: "message", role: "user", content: "restore" }], stream: true },
+            { url: "http://mock", headers: {} },
+        );
+        assert.equal(fetchCalls, 1, "decompress (MUTATING) must re-request exactly once — behavior unchanged from pre-fix");
+        assert.ok(out.includes("[ACP]"), "decompress visibility marker emitted");
+        assert.ok(out.includes("Restored."), "round 2 real content emitted");
+        assert.ok(out.includes("response.completed"), "final completion emitted");
+    } finally {
+        globalThis.fetch = originalFetch;
+    }
+});
+
+test("compressLoopResponsesStream: real tool + read-only acp_status surfaces marker, forwards real call, NO re-request", async () => {
+    const round1 = [
+        sse("response.created", { response: { id: "resp_rmx_1", status: "in_progress" } }),
+        sse("response.output_item.added", {
+            item: { type: "function_call", id: "fc_shell", call_id: "call_shell", name: "shell" },
+            output_index: 0,
+        }),
+        sse("response.function_call_arguments.delta", { item_id: "fc_shell", delta: '{"cmd":"ls"}' }),
+        sse("response.output_item.done", {
+            item: { type: "function_call", id: "fc_shell", call_id: "call_shell", name: "shell", arguments: '{"cmd":"ls"}' },
+            output_index: 0,
+        }),
+        sse("response.output_item.added", {
+            item: { type: "function_call", id: "fc_st", call_id: "call_st", name: "acp_status" },
+            output_index: 1,
+        }),
+        sse("response.function_call_arguments.delta", { item_id: "fc_st", delta: "{}" }),
+        sse("response.output_item.done", {
+            item: { type: "function_call", id: "fc_st", call_id: "call_st", name: "acp_status", arguments: "{}" },
+            output_index: 1,
+        }),
+        sse("response.completed", { response: { id: "resp_rmx_1", status: "completed", output: [] } }),
+    ].join("");
+    let fetchCalls = 0;
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+        fetchCalls++;
+        return new Response(round1, { status: 200, headers: { "content-type": "text/event-stream" } });
+    }) as typeof fetch;
+    try {
+        const out = await drain(
+            new Response(round1, { status: 200, headers: { "content-type": "text/event-stream" } }).body!,
+            makeCtx(() => {}),
+            { model: "gpt-4o", input: [{ type: "message", role: "user", content: "run + status" }], stream: true },
+            { url: "http://mock", headers: {} },
+        );
+        assert.equal(fetchCalls, 0, "a (real tool + read-only) round must NOT re-request — no MUTATING tool present");
+        assert.ok(out.includes("📊"), "acp_status marker emitted even though a real tool accompanies it");
+        assert.ok(out.includes('"shell"'), "the real tool call is forwarded to the client");
+        assert.ok(out.includes("response.completed"), "turn completes");
     } finally {
         globalThis.fetch = originalFetch;
     }

--- a/tests/proxy-responses-stream.test.ts
+++ b/tests/proxy-responses-stream.test.ts
@@ -196,3 +196,93 @@ test("compressLoopResponsesStream: empty upstream response (no content/usage) yi
     assert.ok(!out.includes("response.completed"), "no fake completion for empty response");
     assert.ok(out.includes("empty response"), "error message included");
 });
+
+test("compressLoopResponsesStream: read-only acp_status executes once and completes WITHOUT upstream re-request (regression for 炸锅 loop)", async () => {
+    const round1 = [
+        sse("response.created", { response: { id: "resp_st_1", status: "in_progress" } }),
+        sse("response.output_item.added", {
+            item: { type: "function_call", id: "fc_st", call_id: "call_st", name: "acp_status" },
+            output_index: 0,
+        }),
+        sse("response.function_call_arguments.delta", { item_id: "fc_st", delta: "{}" }),
+        sse("response.output_item.done", {
+            item: { type: "function_call", id: "fc_st", call_id: "call_st", name: "acp_status", arguments: "{}" },
+            output_index: 0,
+        }),
+        sse("response.completed", { response: { id: "resp_st_1", status: "completed", output: [] } }),
+    ].join("");
+    let fetchCalls = 0;
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+        fetchCalls++;
+        return new Response(round1, { status: 200, headers: { "content-type": "text/event-stream" } });
+    }) as typeof fetch;
+    const logs: string[] = [];
+    try {
+        const out = await drain(
+            new Response(round1, { status: 200, headers: { "content-type": "text/event-stream" } }).body!,
+            makeCtx((m) => logs.push(m)),
+            { model: "gpt-4o", input: [{ type: "message", role: "user", content: "status?" }], stream: true },
+            { url: "http://mock", headers: {} },
+        );
+        assert.equal(fetchCalls, 0, "read-only acp_status must NOT trigger an upstream re-request");
+        assert.ok(out.includes("[ACP]"), "acp_status visibility marker emitted to client");
+        assert.ok(out.includes("response.completed"), "turn completes instead of looping or being discarded");
+        assert.ok(!out.includes("compress loop limit"), "loop limit must not be hit for a read-only tool");
+    } finally {
+        globalThis.fetch = originalFetch;
+    }
+});
+
+test("compressLoopResponsesStream: mixed mutating + read-only round still re-requests (only MUTATING tools drive the loop)", async () => {
+    const round1 = [
+        sse("response.created", { response: { id: "resp_mx_1", status: "in_progress" } }),
+        sse("response.output_item.added", {
+            item: { type: "function_call", id: "fc_c", call_id: "call_c", name: "compress" },
+            output_index: 0,
+        }),
+        sse("response.function_call_arguments.delta", {
+            item_id: "fc_c",
+            delta: JSON.stringify({ content: [{ startId: "m00001", endId: "m00002", summary: "sum" }] }),
+        }),
+        sse("response.output_item.done", {
+            item: { type: "function_call", id: "fc_c", call_id: "call_c", name: "compress", arguments: JSON.stringify({ content: [{ startId: "m00001", endId: "m00002", summary: "sum" }] }) },
+            output_index: 0,
+        }),
+        sse("response.output_item.added", {
+            item: { type: "function_call", id: "fc_s", call_id: "call_s", name: "acp_status" },
+            output_index: 1,
+        }),
+        sse("response.function_call_arguments.delta", { item_id: "fc_s", delta: "{}" }),
+        sse("response.output_item.done", {
+            item: { type: "function_call", id: "fc_s", call_id: "call_s", name: "acp_status", arguments: "{}" },
+            output_index: 1,
+        }),
+        sse("response.completed", { response: { id: "resp_mx_1", status: "completed", output: [] } }),
+    ].join("");
+    const round2 = [
+        sse("response.created", { response: { id: "resp_mx_2", status: "in_progress" } }),
+        sse("response.output_text.delta", { item_id: "msg_mx", output_index: 0, delta: "Done." }),
+        sse("response.completed", { response: { id: "resp_mx_2", status: "completed", output: [] } }),
+    ].join("");
+    let fetchCalls = 0;
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+        fetchCalls++;
+        return new Response(fetchCalls === 1 ? round2 : round1, { status: 200, headers: { "content-type": "text/event-stream" } });
+    }) as typeof fetch;
+    try {
+        const out = await drain(
+            new Response(round1, { status: 200, headers: { "content-type": "text/event-stream" } }).body!,
+            makeCtx(() => {}),
+            { model: "gpt-4o", input: [{ type: "message", role: "user", content: "go" }], stream: true },
+            { url: "http://mock", headers: {} },
+        );
+        assert.equal(fetchCalls, 1, "a round containing a MUTATING tool (compress) must re-request exactly once");
+        assert.ok(out.includes("[ACP]"), "visibility markers emitted");
+        assert.ok(out.includes("Done."), "round 2 real content emitted");
+        assert.ok(out.includes("response.completed"), "final completion emitted");
+    } finally {
+        globalThis.fetch = originalFetch;
+    }
+});

--- a/tools/analyze-dumps.mjs
+++ b/tools/analyze-dumps.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+// Analyze request-dump prefix overlap for cache-hit diagnosis.
+//
+// Usage:
+//   node tools/analyze-dumps.mjs [dump-dir] [session-id?]
+//   node tools/analyze-dumps.mjs              # all sessions in default dir
+//   node tools/analyze-dumps.mjs -- sid       # filter by session id
+//
+// Default dump dir: ~/.local/state/billion-context/dumps
+//
+// For each consecutive pair of dumps (A → B), computes how much of A's
+// serialized messages array survives as a PREFIX of B. Without compression
+// the ratio is ~100% (B = A + appended messages). Compression, tag
+// re-estimation, or message rewrites cause the ratio to drop — pinpointing
+// the cache-breaker.
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+const args = process.argv.slice(2);
+const dir = args[0] || join(homedir(), ".local", "state", "billion-context", "dumps");
+const sid = args[1];
+
+let files;
+try {
+    files = readdirSync(dir)
+        .filter((f) => f.endsWith(".json") && (!sid || f.includes(sid)))
+        .sort();
+} catch {
+    console.error(`dump dir not found: ${dir}`);
+    process.exit(1);
+}
+
+if (files.length === 0) {
+    console.error(`No dump files in ${dir}${sid ? ` matching "${sid}"` : ""}`);
+    process.exit(1);
+}
+
+const sessions = new Map();
+for (const f of files) {
+    const m = f.match(/req-\d+-(.+)\.json$/);
+    const s = m ? m[1] : "?";
+    if (!sessions.has(s)) sessions.set(s, []);
+    sessions.get(s).push(f);
+}
+
+function load(f) {
+    return JSON.parse(readFileSync(join(dir, f), "utf8"));
+}
+
+function msgKey(body) {
+    return JSON.stringify(body.messages ?? []);
+}
+
+function prefixLen(a, b) {
+    const min = Math.min(a.length, b.length);
+    let i = 0;
+    while (i < min && a.charCodeAt(i) === b.charCodeAt(i)) i++;
+    return i;
+}
+
+function firstDivergentMsg(a, b) {
+    const n = Math.min(a.length, b.length);
+    for (let i = 0; i < n; i++) {
+        if (JSON.stringify(a[i]) !== JSON.stringify(b[i])) return i;
+    }
+    return n < a.length ? n : -1;
+}
+
+function fmtPct(n) {
+    return n >= 99.95 ? "100%" : n.toFixed(1) + "%";
+}
+
+for (const [session, sfiles] of sessions) {
+    console.log(`\n=== session ${session} (${sfiles.length} dumps) ===`);
+    console.log("#  msgs  Δmsgs  prefix_overlap  first_diff  verdict");
+    console.log("-".repeat(72));
+
+    let prevBody = null;
+    let prevKey = null;
+    sfiles.forEach((f, idx) => {
+        const body = load(f);
+        const key = msgKey(body);
+        const msgs = body.messages?.length ?? 0;
+        const short = f.replace(/req-\d+-/, "").replace(/\.json$/, "").slice(0, 8);
+
+        if (prevKey === null) {
+            console.log(`${String(idx).padStart(2)}  ${String(msgs).padStart(4)}     -              -          ${short}`);
+        } else {
+            const plen = prefixLen(prevKey, key);
+            const overlap = prevKey.length === 0 ? 100 : (plen / prevKey.length) * 100;
+            const diff = firstDivergentMsg(prevBody.messages ?? [], body.messages ?? []);
+            const verdict =
+                overlap >= 99.5 ? "stable" :
+                overlap >= 80 ? "partial" :
+                "PREFIX CHANGED";
+            console.log(
+                `${String(idx).padStart(2)}  ${String(msgs).padStart(4)}  ${String(msgs - (prevBody.messages?.length ?? 0)).padStart(5)}  ${fmtPct(overlap).padStart(13)}  ${
+                    diff < 0 ? "none" : "msg[" + diff + "]"
+                }`.padEnd(58) + verdict,
+            );
+        }
+        prevBody = body;
+        prevKey = key;
+    });
+}
+
+console.log(
+    `\nLegend: prefix_overlap = how much of the previous dump's messages survive` +
+    `\n  as a prefix of this dump. ~100% = no compression/prefix change (good).` +
+    `\n  first_diff = index of the first message that changed (or "none").\n`,
+);


### PR DESCRIPTION
## 概述

修复 issue dog/billion-context-pi#22「billion context 通用版本炸锅」——当模型调用 `acp_status` / `search_context` 等只读代理工具时，代理陷入无限重试循环直到达到轮次上限，导致整个对话被丢弃。

在此基础上，构建了**统一的协议无关压缩循环（V2）**，默认启用，解决了原始 `compress-loop-*.ts` 三套基线循环中的注入持久化炸锅根因。

---

## 问题根因

### 炸锅（循环爆炸）

原始代码将 `acp_status` 和 `search_context` 当作**可变工具**（与 `compress`/`decompress` 一样）处理——每次调用都触发一次重新请求（re-request），把结果喂回模型。但这两个工具是**只读**的：执行一次、把结果展示给客户端即可。把它们当可变工具处理，导致模型反复调用 `acp_status` → 代理反复重发请求 → 达到 5 轮上限 → 整个对话被丢弃。

### V2 发现的深层问题

深入审查后发现原始三套循环（`compress-loop.ts` / `compress-loop-responses.ts` / `compress-loop-anthropic.ts`）存在一个共同的注入持久化缺陷：

- **压缩哲学 system prompt 被持久化**到请求体中，每轮累积，导致 system prompt 不断膨胀
- **hideConsumedCompressCalls** 没有在循环内每轮运行，已消费的 compress 记录会重新激发模型重复压缩
- 三个协议的 executeProxyTool 各自重复实现，逻辑分散

---

## 修复内容

### 1. 只读代理工具不再驱动循环
`acp_status` / `search_context` 执行一次，将结果以 `[ACP]` 可见性标记展示给客户端，然后正常结束本轮。只有 `compress` / `decompress`（可变工具）驱动重新请求。

### 2. V2 统一协议无关压缩循环（`src/loop/`）

新增 `src/loop/` 子系统：

| 文件 | 职责 |
|------|------|
| `core.ts` | 协议无关的 `runCompressLoop`——调度代理工具、hideConsumed、重新请求、终止 |
| `adapter-responses.ts` | Responses API SSE 适配器（Codex） |
| `adapter-openai.ts` | OpenAI Chat Completions SSE 适配器（pi/opencode） |
| `adapter-anthropic.ts` | Anthropic Messages SSE 适配器（Claude Code） |
| `index.ts` | `pickAdapter` 协议选择 + 工具分类 |

**核心设计决策：**

- ✅ **哲学 system prompt 是瞬态的**——每轮通过 `buildRequest` 传入，绝不累积在 coreMessages 中（镜像 bili-pi 的瞬态 system-prompt 模型）
- ✅ **hideConsumedCompressCalls 每轮运行**——已消费的 compress 记录不会重新激发模型
- ✅ **共享 executeProxyTool**——去重了基线的 ×3 重复实现
- ✅ **循环上限优雅终止**——`MAX_LOOP_ROUNDS=10`，达到上限时输出 `finish_reason:"length"`，而非退化的空响应
- ✅ **textProtocol 支持**——Codex code_mode 使用纯文本格式（无 function_call），注入 `[ACP]` 用户角色标记
- ✅ **prefix cache 保护**——重新请求使用 `processedMessages`（已打 tag），与 round-1 转发体前缀一致

### 3. 双 Oracle Review 修复

两轮独立 Oracle 审查（核心逻辑 + 协议适配器）发现并修复的问题：

**核心逻辑（已验证安全）：**
- B1 代理工具调用参数丢失（`arguments` 字段）
- B2 `compressCallId` 线程化防止已消费 compress 记录被隐藏（炸锅循环类的根因）
- B3 textProtocol 注入 `function_call` 到无工具请求

**协议适配器：**
- F1 **CRLF 兼容**：所有 3 个适配器在 split 前规范化 `\r\n` → `\n`（否则 CRLF 上游的 SSE 被静默吞没）
- F2 **custom_tool_call 透传**：Codex code_mode 的宿主工具调用在 round 2+ 不再被抑制
- F3 **Anthropic index 碰撞**：端口基线 `indexMap`，防止 text-after-tool_use 导致的重复索引 SDK 崩溃
- F4 **网络断开恢复**：`reader.read()` 抛出时 try/catch → 正常结束流（而非客户端挂起）
- F5 **空上游处理**：输出 `response.failed`（而非伪造空 `response.completed`）

### 4. 调试工具

- **请求 dump 默认开启**（`--debug` 模式下），持久化到 `~/.local/state/billion-context/dumps/`
- **V2 循环日志**：每轮记录工具调用（名称+参数）、代理工具结果（snippet）、真实工具调用数
- **prefix-overlap 分析器**：`tools/analyze-dumps.mjs` 计算连续 dump 的前缀重叠率

---

## 测试

- **247/247 测试通过**（基线 219 + 新增 28）
- typecheck clean
- build clean（2.02MB）
- **三协议 live test 全过**：OpenAI（pi）、Anthropic（Claude Code）、Responses（Codex）
- **cache-drop 验证**：重新请求 cache hit 从 2-3% → 49%（prefix 100% 匹配）
- **Anthropic 协议 cache**：~92%（智谱直连）

---

## Commit 列表

| Commit | 描述 |
|--------|------|
| `839f8ec` | readonly proxy tools 不再驱动循环（炸锅主因） |
| `eccf34c` | review: JSON/stream readonly parity |
| `6fee03c` | OpenAI + Anthropic 路径同样修复 |
| `d674d69` | V2 统一 compress-loop（核心） |
| `56296d6` | oracle review 修复 (B1/B2/B3 + S1/S2/S3/S5 + N3) |
| `968d9fc` | 5 个 oracle review 回归测试 |
| `cb783fa` | 双 oracle review 修复 (F1-F5) |
| `6f4273f` | F3 index gap 修复 + 9 个回归测试 |
| `bf6690b` | debug dump + prefix-overlap 分析器 |
| `d8a1e0d` | acp_status/search_context hang 修复 |
| `6e99592` | OpenAI usage chunk 丢失修复 |
| `7ce4c2a` | cache-drop 修复（processedMessages tagged prefix） |
| `2c98369` | compress schema required:content + V2 loop 日志 |
| `9f82078` | Anthropic schema required:content 对齐 |
| `3b7dcfe` | V2 默认开启 |

---

## 关闭 issue

Fixes dog/billion-context-pi#22