### PR TITLE
fix(session-id): recognize x-claude-code-session-id from Claude Code CLI

### DIFF
--- a/src/session-id.ts
+++ b/src/session-id.ts
@@ -47,7 +47,11 @@ function extractKey(headers: Record<string, string | string[] | undefined>): str
 
 /** Pull a client-provided conversation signal from headers, if any. */
 export function clientConversationHeader(headers: Record<string, string | string[] | undefined>): string | undefined {
-    const names = ["x-session-affinity", "x-acp-session", "x-session-id", "x-opencode-session", "session-id", "session_id"];
+    // x-claude-code-session-id first: the CLI's true per-session UUID — the
+    // strongest signal. The name is client-specific, so no other agent
+    // (opencode/codex/zcode/curl) ever hits it; their own headers are
+    // unchanged below.
+    const names = ["x-claude-code-session-id", "x-session-affinity", "x-acp-session", "x-session-id", "x-opencode-session", "session-id", "session_id"];
     for (const name of names) {
         const v = headers[name];
         if (typeof v === "string" && v.trim().length > 0) return v.trim();

--- a/tests/proxy-session-id.test.ts
+++ b/tests/proxy-session-id.test.ts
@@ -88,6 +88,10 @@ test("affinityToken: generated identities are never forwarded upstream", () => {
 });
 
 test("clientConversationHeader: reads known session header names in priority order", () => {
+    // Claude Code's true per-session UUID is the strongest signal and wins
+    // over any other session header (only claude-code-family clients send it).
+    assert.equal(clientConversationHeader({ "x-claude-code-session-id": "S", "x-session-affinity": "A" }), "S");
+    assert.equal(clientConversationHeader({ "x-claude-code-session-id": "S" }), "S");
     assert.equal(clientConversationHeader({ "x-session-affinity": "A", "x-acp-session": "B" }), "A");
     assert.equal(clientConversationHeader({ "x-acp-session": "B" }), "B");
     assert.equal(clientConversationHeader({ "x-session-id": "C" }), "C");


### PR DESCRIPTION
## 问题

同一项目(相同 CLAUDE.md)下所有 Claude Code 会话共享同一个代理会话 ID,导致上下文无限累计,最终上游超时、Claude Code 完全无输出。

## 根因

会话 ID 的 conversation 维度在客户端没有会话 header 时,退化为首条 user 消息前 200 字符的哈希。Claude Code 把 CLAUDE.md 以 `<system-reminder>` 注入每条请求的首条 user 消息,前 200 字符固定 → 同项目所有会话 conversation 相同 → 会话 ID 碰撞。

此前实测结论"Claude Code 不发送任何会话 header"基于更早版本,已不成立:Claude Code 自 v2.1.86 起每次请求都发送 `x-claude-code-session-id`(每会话 UUID,官方 llm-gateway-protocol 文档明载)。

## 修复

`clientConversationHeader`(`src/session-id.ts`)识别名单首位追加 `x-claude-code-session-id`。header 名带 `claude-code` 前缀,其他客户端(opencode/codex/zcode/curl)不会发送,各自识别路径与内容指纹 fallback 完全不变。

## 验证

- 单测 212/212 全绿(含新增断言:新 header 识别、优先于 x-session-affinity)
- e2e(Claude Code 2.1.211 实测):同项目两个独立会话 → 两个不同会话 ID;同一会话 --continue 两轮 → 同一会话 ID;curl 无 header 请求与旧版(0.1.31)产生逐字节一致的会话 ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)