### PR TITLE
fix(loop): preserve system/preamble prefix in V2 loop re-request (Responses + Anthropic)

### DIFF
--- a/src/loop/adapter-anthropic.ts
+++ b/src/loop/adapter-anthropic.ts
@@ -1,5 +1,5 @@
 import type { CoreMessage } from "acp-kernel";
-import { coreToAnthropic } from "../anthropic.js";
+import { coreToAnthropic, extractSystem, buildSystem, type AnthropicRequestBody } from "../anthropic.js";
 import { buildVisibilityMarker } from "../compress-loop.js";
 import type {
     CompressLoopAdapter,
@@ -83,7 +83,7 @@ function remapIndexInEvent(eventStr: string, newIndex: number): Buffer {
     return Buffer.from(rebuilt.join("\n") + "\n\n", "utf8");
 }
 
-export function createAnthropicAdapter(requestBody: Record<string, unknown>): CompressLoopAdapter {
+export function createAnthropicAdapter(requestBody: Record<string, unknown>, originalSystem?: AnthropicRequestBody["system"]): CompressLoopAdapter {
     const model = (requestBody.model as string) ?? undefined;
     let messageId: string | undefined;
     let clientIndex = 0;
@@ -136,7 +136,10 @@ export function createAnthropicAdapter(requestBody: Record<string, unknown>): Co
     return {
         buildRequest(coreMessages, systemPrompt, body) {
             const messages = coreToAnthropic(coreMessages);
-            return { ...body, system: systemPrompt, messages };
+            const baseText = originalSystem !== undefined ? extractSystem(originalSystem) : "";
+            const full = baseText ? `${baseText}\n\n---\n\n${systemPrompt}` : systemPrompt;
+            const system = originalSystem !== undefined ? buildSystem(full, originalSystem) : full;
+            return { ...body, system, messages };
         },
 
         async *parseStream(upstream, round) {

--- a/src/loop/adapter-responses.ts
+++ b/src/loop/adapter-responses.ts
@@ -1,5 +1,5 @@
 import type { CoreMessage } from "acp-kernel";
-import { coreToResponses, injectResponsesDeveloperMessage } from "../responses.js";
+import { coreToResponses, injectResponsesDeveloperMessage, patchResponsesInput, type ResponseInputItem, type ResponsesProjection } from "../responses.js";
 import { buildVisibilityMarker } from "../compress-loop.js";
 import { ACP_TEXT_OPEN, ACP_TEXT_CLOSE, COMPRESS_TOOL_NAME } from "../compress-tool.js";
 import type { BiliMessage } from "../bili-message.js";
@@ -123,7 +123,7 @@ function buildCompleted(responseObj: Record<string, unknown> | null): Buffer {
     );
 }
 
-export function createResponsesAdapter(textProtocol?: boolean): CompressLoopAdapter {
+export function createResponsesAdapter(textProtocol?: boolean, projection?: ResponsesProjection): CompressLoopAdapter {
     const suppressTextLifecycle = !!textProtocol;
     let outputIndex = 0;
     let responseObj: Record<string, unknown> | null = null;
@@ -141,8 +141,19 @@ export function createResponsesAdapter(textProtocol?: boolean): CompressLoopAdap
                     if (id) customToolCallIds.add(id);
                 }
             }
-            const inputItems = coreToResponses(coreMessages, customToolCallIds);
-            const withDev = injectResponsesDeveloperMessage(inputItems, systemPrompt);
+            let inputItems: ResponseInputItem[];
+            if (projection) {
+                const rebuiltInput = patchResponsesInput(projection, coreMessages);
+                inputItems = typeof rebuiltInput === "string"
+                    ? [{ type: "message", role: "user", content: rebuiltInput }]
+                    : rebuiltInput;
+            } else {
+                inputItems = coreToResponses(coreMessages, customToolCallIds);
+            }
+            const devParts = projection && projection.systemParts.length > 0
+                ? [...projection.systemParts, systemPrompt]
+                : [systemPrompt];
+            const withDev = injectResponsesDeveloperMessage(inputItems, devParts.join("\n\n---\n\n"));
             const rebuilt: Record<string, unknown> = { ...requestBody, input: withDev };
             delete rebuilt.previous_response_id;
             delete rebuilt.instructions;

--- a/src/loop/index.ts
+++ b/src/loop/index.ts
@@ -15,13 +15,15 @@ import { createResponsesAdapter } from "./adapter-responses.js";
 import { createOpenaiAdapter } from "./adapter-openai.js";
 import { createAnthropicAdapter } from "./adapter-anthropic.js";
 import type { CompressLoopAdapter } from "./core.js";
+import type { ResponsesProjection } from "../responses.js";
 
 export function pickAdapter(
     protocol: "responses" | "openai" | "anthropic",
     requestBody: Record<string, unknown>,
     textProtocol?: boolean,
+    responsesProjection?: ResponsesProjection,
 ): CompressLoopAdapter {
-    if (protocol === "responses") return createResponsesAdapter(textProtocol);
+    if (protocol === "responses") return createResponsesAdapter(textProtocol, responsesProjection);
     if (protocol === "openai") return createOpenaiAdapter(requestBody);
     if (protocol === "anthropic") return createAnthropicAdapter(requestBody);
     throw new Error(`[acp-loop] unknown protocol: ${protocol}`);

--- a/src/loop/index.ts
+++ b/src/loop/index.ts
@@ -16,15 +16,17 @@ import { createOpenaiAdapter } from "./adapter-openai.js";
 import { createAnthropicAdapter } from "./adapter-anthropic.js";
 import type { CompressLoopAdapter } from "./core.js";
 import type { ResponsesProjection } from "../responses.js";
+import type { AnthropicRequestBody } from "../anthropic.js";
 
 export function pickAdapter(
     protocol: "responses" | "openai" | "anthropic",
     requestBody: Record<string, unknown>,
     textProtocol?: boolean,
     responsesProjection?: ResponsesProjection,
+    anthropicSystem?: AnthropicRequestBody["system"],
 ): CompressLoopAdapter {
     if (protocol === "responses") return createResponsesAdapter(textProtocol, responsesProjection);
     if (protocol === "openai") return createOpenaiAdapter(requestBody);
-    if (protocol === "anthropic") return createAnthropicAdapter(requestBody);
+    if (protocol === "anthropic") return createAnthropicAdapter(requestBody, anthropicSystem);
     throw new Error(`[acp-loop] unknown protocol: ${protocol}`);
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -27,6 +27,7 @@ import {
 import {
     type ResponsesRequestBody,
     type ResponseInputItem,
+    type ResponsesProjection,
     responsesToCore,
     patchResponsesInput,
     injectResponsesDeveloperMessage,
@@ -249,6 +250,7 @@ type Prepared = {
     compressInjected: boolean;
     responsesTextProtocol?: boolean;
     resetAfterSuccess?: boolean;
+    responsesProjection?: ResponsesProjection;
 };
 
 /** True if `addr` is a loopback (IPv4 127.x or IPv6 ::1 / ::ffff:127.0.0.1).
@@ -730,6 +732,7 @@ function prepareResponses(
 
     let processedMessages: CoreMessage[] = [];
     let originalMessages: CoreMessage[] = [];
+    let responsesProjection: ResponsesProjection | undefined;
     let rebuiltInput: ResponseInputItem[] | string = parsed.input;
     let toolsOut = parsed.tools;
 
@@ -740,6 +743,7 @@ function prepareResponses(
 
     try {
         const projection = responsesToCore(parsed);
+        responsesProjection = projection;
         const { msgs } = projection;
         originalMessages = msgs;
         if (process.env.ACP_DEBUG) {
@@ -819,6 +823,7 @@ function prepareResponses(
         session,
         processedMessages,
         originalMessages,
+        responsesProjection,
         protocol: "responses",
         stream,
         compressInjected: shouldInject,
@@ -1146,7 +1151,7 @@ async function forward(
             reqHeaders["content-type"] = "application/json";
             const textProtocol = prepared.protocol === "responses" && !!prepared.responsesTextProtocol;
             const systemPrompt = textProtocol ? buildCompressTextSystemPrompt() : buildCompressSystemPrompt();
-            const adapter = pickAdapter(prepared.protocol, parsedReq, textProtocol);
+            const adapter = pickAdapter(prepared.protocol, parsedReq, textProtocol, prepared.responsesProjection);
             const loop = runCompressLoop(
                 streamToRead,
                 { core, config, messages: prepared.processedMessages.length > 0 ? prepared.processedMessages : prepared.originalMessages, session: prepared.session, log: ctx.log, proxyUrl, textProtocol, debug: opts.debug },

--- a/src/server.ts
+++ b/src/server.ts
@@ -251,6 +251,7 @@ type Prepared = {
     responsesTextProtocol?: boolean;
     resetAfterSuccess?: boolean;
     responsesProjection?: ResponsesProjection;
+    anthropicSystem?: AnthropicRequestBody["system"];
 };
 
 /** True if `addr` is a loopback (IPv4 127.x or IPv6 ::1 / ::ffff:127.0.0.1).
@@ -622,7 +623,7 @@ function prepareAnthropic(
 
     const rebuilt: AnthropicRequestBody = { ...parsed, messages: rebuiltMessages, system: systemOut, tools: toolsOut };
     markDirty(session);
-    return { body: JSON.stringify(rebuilt), session, processedMessages, originalMessages, protocol: "anthropic", stream, compressInjected: opts.compress.injectTool } as Prepared;
+    return { body: JSON.stringify(rebuilt), session, processedMessages, originalMessages, anthropicSystem: parsed.system, protocol: "anthropic", stream, compressInjected: opts.compress.injectTool } as Prepared;
 }
 
 function prepareOpenai(
@@ -1151,7 +1152,7 @@ async function forward(
             reqHeaders["content-type"] = "application/json";
             const textProtocol = prepared.protocol === "responses" && !!prepared.responsesTextProtocol;
             const systemPrompt = textProtocol ? buildCompressTextSystemPrompt() : buildCompressSystemPrompt();
-            const adapter = pickAdapter(prepared.protocol, parsedReq, textProtocol, prepared.responsesProjection);
+            const adapter = pickAdapter(prepared.protocol, parsedReq, textProtocol, prepared.responsesProjection, prepared.anthropicSystem);
             const loop = runCompressLoop(
                 streamToRead,
                 { core, config, messages: prepared.processedMessages.length > 0 ? prepared.processedMessages : prepared.originalMessages, session: prepared.session, log: ctx.log, proxyUrl, textProtocol, debug: opts.debug },

--- a/tests/loop-adapters.test.ts
+++ b/tests/loop-adapters.test.ts
@@ -462,3 +462,19 @@ test("F6: responses buildRequest preserves instructions + additional_tools prefi
     assert.ok(typeof dev?.content === "string" && dev.content.includes("AGENTS_MD_RULES"), "developer includes original instructions (systemParts) — matches round-1 prefix");
     assert.ok(typeof dev?.content === "string" && dev.content.includes(systemPrompt), "developer includes compress prompt");
 });
+
+test("F7: anthropic buildRequest preserves client system + cache_control + merges compress prompt (prefix-cache fix)", () => {
+    const clientSystem = [{ type: "text", text: "YOU_ARE_CLAUDE", cache_control: { type: "ephemeral" } }];
+    const systemPrompt = buildCompressSystemPrompt();
+    const adapter = createAnthropicAdapter({ model: "claude" }, clientSystem);
+    const rebuilt = adapter.buildRequest([], systemPrompt, { model: "claude", messages: [] }) as Record<string, unknown>;
+    const system = rebuilt.system;
+    assert.ok(Array.isArray(system), "system preserved as structured array (buildSystem keeps array form when original was array)");
+    const text = Array.isArray(system)
+        ? (system as Array<Record<string, unknown>>).map((b) => b.text as string).join("\n\n")
+        : (system as string);
+    assert.ok(text.includes("YOU_ARE_CLAUDE"), "client system text preserved (not lost in round-2) — matches round-1 prefix");
+    assert.ok(text.includes(systemPrompt), "compress prompt merged into system");
+    const hasCc = Array.isArray(system) && (system as Array<Record<string, unknown>>).some((b) => b.cache_control);
+    assert.ok(hasCc, "cache_control marker preserved on system block (Anthropic prefix-cache anchor)");
+});

--- a/tests/loop-adapters.test.ts
+++ b/tests/loop-adapters.test.ts
@@ -6,6 +6,8 @@ import type { Session } from "../src/session.ts";
 import { runCompressLoop, createOpenaiAdapter, createAnthropicAdapter, createResponsesAdapter } from "../src/loop/index.ts";
 import type { ParsedStreamEvent } from "../src/loop/index.ts";
 import { buildCompressSystemPrompt } from "../src/compress-tool.ts";
+import { responsesToCore } from "../src/responses.ts";
+import type { ResponsesRequestBody } from "../src/responses.ts";
 
 function makeCtx(id: string, messages: CoreMessage[] = []): {
     core: ReturnType<typeof createCore>;
@@ -431,4 +433,32 @@ test("F5: responses empty upstream → emitCompletion produces response.failed (
         !out.includes("event: response.completed"),
         "emitCompletion does NOT fabricate response.completed on empty upstream",
     );
+});
+
+test("F6: responses buildRequest preserves instructions + additional_tools prefix (codex prefix-cache fix)", () => {
+    const body = {
+        instructions: "AGENTS_MD_RULES",
+        input: [
+            { type: "additional_tools", name: "shell", tools: [{ type: "function", name: "shell", parameters: {} }] },
+            { type: "message", role: "user", content: "hello codex" },
+        ],
+        stream: true,
+    } as unknown as ResponsesRequestBody;
+    const projection = responsesToCore(body);
+    assert.ok(projection.systemParts.includes("AGENTS_MD_RULES"), "instructions lifted into systemParts");
+    assert.ok(projection.preamble.some((i) => i.type === "additional_tools"), "additional_tools captured as preamble");
+
+    const systemPrompt = buildCompressSystemPrompt();
+    const adapter = createResponsesAdapter(false, projection);
+    const rebuilt = adapter.buildRequest(projection.msgs, systemPrompt, body) as Record<string, unknown>;
+    const input = rebuilt.input as Array<Record<string, unknown>>;
+
+    assert.equal(!("instructions" in rebuilt), true, "top-level instructions stripped (responses_lite contract)");
+    assert.equal(!("previous_response_id" in rebuilt), true, "previous_response_id stripped");
+
+    assert.equal(input[0]?.type, "additional_tools", "additional_tools stays at input[0] (preamble preserved)");
+    const dev = input.find((i) => i.role === "developer");
+    assert.ok(dev, "developer message present");
+    assert.ok(typeof dev?.content === "string" && dev.content.includes("AGENTS_MD_RULES"), "developer includes original instructions (systemParts) — matches round-1 prefix");
+    assert.ok(typeof dev?.content === "string" && dev.content.includes(systemPrompt), "developer includes compress prompt");
 });


### PR DESCRIPTION
## Problem

The V2 compress loop rebuilds the upstream request body each round via the protocol adapter's `buildRequest`. For **Responses (Codex)** and **Anthropic**, round-2 dropped content that round-1 had preserved in a side-channel (NOT in `coreMessages`), so the round-1→round-2 input prefix diverged → **full prompt-cache miss on every compress re-request**, and round-2+ silently lost the client system / tool declarations.

This is the residual cache miss that `7ce4c2a` (V2 re-request uses tagged processedMessages) did **not** fix — it only aligned the message-body prefix.

## Affected protocols

### 1. Responses (Codex) — fixed in commit 87e67ad
`responsesToCore` lifts `instructions` → `projection.systemParts` and `additional_tools`/`mcp_list_tools` → `projection.preamble` (neither in `msgs`). Round-1 used both (`patchResponsesInput` + developer msg `[...systemParts, prompt]`); round-2 used neither (`coreToResponses` + dev msg = prompt only).

**Fix:** thread `ResponsesProjection` from `prepareResponses` → `pickAdapter` → responses adapter. `buildRequest` now calls `patchResponsesInput(projection, coreMessages)` (the same fn round-1 uses → prefix identical by construction) and injects dev = `[...systemParts, prompt]`.

### 2. Anthropic — fixed in commit 43a0cc9
`anthropicToCore` does NOT put system into `msgs` (only user/assistant/tool/reasoning), so the client system is unrecoverable from `coreMessages`. Round-1 `systemOut = injectSystem(parsed, opts)` = `[client system] + [compress prompt]` via `buildSystem` (preserves `cache_control`); round-2 overwrote `system: systemPrompt` (compress prompt only).

**Fix:** thread original `parsed.system` from `prepareAnthropic` → `pickAdapter` → anthropic adapter. `buildRequest` now reconstructs `system = buildSystem(extractSystem(original) + "---" + systemPrompt, original)` — the same merge `injectSystem` uses — so client system text + `cache_control` marker survive and the prefix matches byte-for-byte.

## NOT affected
**OpenAI Chat** ✅ — its system is a `role:"system"` message that rides **inside** `coreMessages`. `coreToOpenai` re-emits it and `injectOpenaiSystem` merges the compress prompt identically in both rounds. No side-channel, no divergence. (Verified, no change needed.)

## Changes (8 files across 2 commits)
**Responses:** `src/loop/adapter-responses.ts`, `src/loop/index.ts`, `src/server.ts`, `tests/loop-adapters.test.ts` (F6)
**Anthropic:** `src/loop/adapter-anthropic.ts`, `src/loop/index.ts`, `src/server.ts`, `tests/loop-adapters.test.ts` (F7)

## Verification
- `npm run typecheck` ✅
- `npm test` — 249/249 pass (incl. new F6 Responses + F7 Anthropic regressions) ✅
- `npm run build` ✅

## Notes
- Discovered during issue review: dog/billion-context-pi#24.
- Built on top of master (post PR #92 merge). Independent of PR #92.
- Headers (`prompt_cache_key` / Anthropic `cache_control`) are already preserved by `runCompressLoop`; only the rebuilt body was the problem.
- Per AGENTS.md, I will **not** merge this PR.