### PR TITLE
feat: text triggers for all ACP tools in textProtocol mode

### DIFF
--- a/src/compress-tool.ts
+++ b/src/compress-tool.ts
@@ -9,6 +9,12 @@ export const COMPRESS_TOOL_NAME = "compress";
  *  `<acp tokens=...>` history tags so they never collide. */
 export const ACP_TEXT_OPEN = "\x3cacp_compress\x3e";
 export const ACP_TEXT_CLOSE = "\x3c/acp_compress\x3e";
+export const ACP_STATUS_OPEN = "\x3cacp_status\x3e";
+export const ACP_STATUS_CLOSE = "\x3c/acp_status\x3e";
+export const ACP_SEARCH_OPEN = "\x3cacp_search\x3e";
+export const ACP_SEARCH_CLOSE = "\x3c/acp_search\x3e";
+export const ACP_DECOMPRESS_OPEN = "\x3cacp_decompress\x3e";
+export const ACP_DECOMPRESS_CLOSE = "\x3c/acp_decompress\x3e";
 
 export const COMPRESS_TOOL = {
     name: COMPRESS_TOOL_NAME,
@@ -165,7 +171,29 @@ Rules for the trigger:
 - JSON shape matches the compress tool: {"content":[{startId,endId,summary,topic?}]}. Batch multiple ranges in one trigger.
 - After emitting the marker, STOP your turn. Do not continue with other text — the proxy will execute the compression and return the result, then you continue fresh.
 - Do NOT wrap the marker in code fences, quotes, or commentary.
-- NEVER compress on short conversations or when context is small (well below the window limit). Only compress when context is genuinely large.`;
+- NEVER compress on short conversations or when context is small (well below the window limit). Only compress when context is genuinely large.
+
+ACP TOOLS (TEXT TRIGGERS)
+
+Since host tools cannot coexist with a declared tools field, ALL ACP tools use text triggers. Emit the marker; the proxy intercepts and executes it; the marker is stripped from what the user sees.
+
+1. acp_status — view context usage, compression state, and compressible ranges:
+   ${ACP_STATUS_OPEN}${ACP_STATUS_CLOSE}
+   No payload needed. Use this FIRST when unsure about context state.
+
+2. search_context — search compressed block summaries by keyword:
+   ${ACP_SEARCH_OPEN}{"query":"auth token refresh"}${ACP_SEARCH_CLOSE}
+   Use when you need details that may have been compressed away.
+
+3. decompress — restore compressed content for exact details:
+   ${ACP_DECOMPRESS_OPEN}{"blockId":"b5"}${ACP_DECOMPRESS_CLOSE}
+   Optional: {"blockId":"b5","toFile":"/tmp/b5.txt"} to write to file instead.
+   Optional: {"blockId":"b5","full":true} to restore all the way to original messages.
+
+Rules for ALL triggers:
+- Output on its own, NO surrounding prose. Just the raw marker.
+- After emitting, STOP your turn. The proxy executes and returns the result.
+- Do NOT wrap in code fences, quotes, or commentary.`;
 }
 
 export const DECOMPRESS_TOOL_NAME = "decompress";

--- a/src/loop/adapter-responses.ts
+++ b/src/loop/adapter-responses.ts
@@ -1,7 +1,7 @@
 import type { CoreMessage } from "acp-kernel";
 import { coreToResponses, injectResponsesDeveloperMessage } from "../responses.js";
 import { buildVisibilityMarker } from "../compress-loop.js";
-import { ACP_TEXT_OPEN, ACP_TEXT_CLOSE, COMPRESS_TOOL_NAME } from "../compress-tool.js";
+import { ACP_TEXT_OPEN, ACP_TEXT_CLOSE, ACP_STATUS_OPEN, ACP_STATUS_CLOSE, ACP_SEARCH_OPEN, ACP_SEARCH_CLOSE, ACP_DECOMPRESS_OPEN, ACP_DECOMPRESS_CLOSE, COMPRESS_TOOL_NAME } from "../compress-tool.js";
 import type { BiliMessage } from "../bili-message.js";
 import type {
     CompressLoopAdapter,
@@ -329,22 +329,30 @@ export function createResponsesAdapter(textProtocol?: boolean): CompressLoopAdap
             const calls: ToolCallEmit[] = [];
             let clean = text;
             let hadTrigger = false;
-            let start = clean.indexOf(ACP_TEXT_OPEN);
-            while (start >= 0) {
-                const end = clean.indexOf(ACP_TEXT_CLOSE, start + ACP_TEXT_OPEN.length);
-                if (end < 0) break;
-                hadTrigger = true;
-                const payload = clean.slice(start + ACP_TEXT_OPEN.length, end).trim();
-                if (payload.length > 0) {
-                    const stamp = `${Date.now()}-${calls.length}`;
-                    calls.push({
-                        name: COMPRESS_TOOL_NAME,
-                        callId: `call_text_${stamp}`,
-                        arguments: payload,
-                    });
+            const triggers = [
+                { name: "compress", open: ACP_TEXT_OPEN, close: ACP_TEXT_CLOSE, requirePayload: true },
+                { name: "acp_status", open: ACP_STATUS_OPEN, close: ACP_STATUS_CLOSE, requirePayload: false },
+                { name: "search_context", open: ACP_SEARCH_OPEN, close: ACP_SEARCH_CLOSE, requirePayload: true },
+                { name: "decompress", open: ACP_DECOMPRESS_OPEN, close: ACP_DECOMPRESS_CLOSE, requirePayload: true },
+            ];
+            for (const t of triggers) {
+                let start = clean.indexOf(t.open);
+                while (start >= 0) {
+                    const end = clean.indexOf(t.close, start + t.open.length);
+                    if (end < 0) break;
+                    hadTrigger = true;
+                    const payload = clean.slice(start + t.open.length, end).trim();
+                    if (payload.length > 0 || !t.requirePayload) {
+                        const stamp = `${Date.now()}-${calls.length}`;
+                        calls.push({
+                            name: t.name,
+                            callId: `call_text_${stamp}`,
+                            arguments: payload.length > 0 ? payload : "{}",
+                        });
+                    }
+                    clean = clean.slice(0, start) + clean.slice(end + t.close.length);
+                    start = clean.indexOf(t.open);
                 }
-                clean = clean.slice(0, start) + clean.slice(end + ACP_TEXT_CLOSE.length);
-                start = clean.indexOf(ACP_TEXT_OPEN);
             }
             return { clean: hadTrigger ? clean : text, calls } as ExtractedTextTriggers;
         },

--- a/src/server.ts
+++ b/src/server.ts
@@ -1052,6 +1052,13 @@ async function forward(
         headers["x-session-id"] = affinity;
     }
     const proxyUrl = resolveProxy(opts.routes, opts.proxy, route?.rewrittenUrl ?? upstreamUrl, opts.proxyFallback);
+    if (opts.debug) {
+        const hdrLog: Record<string, string> = {};
+        for (const [hk, hv] of Object.entries(headers)) {
+            if (typeof hv === "string") hdrLog[hk] = hv.length > 200 ? hv.slice(0, 200) + "..." : hv;
+        }
+        log("info", `[${prepared?.session.id ?? "unknown"}] → upstream headers: ${JSON.stringify(hdrLog)}`);
+    }
     const dispatcher = proxyDispatcher(proxyUrl);
     const init: Omit<RequestInit, "dispatcher"> & { dispatcher?: object } = {
         method: req.method ?? "GET",
@@ -1073,6 +1080,14 @@ async function forward(
         if (UPSTREAM_HOP_HEADERS.has(k.toLowerCase())) return;
         respHeaders[k] = v;
     });
+    if (opts.debug) {
+        const respLog: Record<string, string> = {};
+        upstream.headers.forEach((v, k) => {
+            if (UPSTREAM_HOP_HEADERS.has(k.toLowerCase())) return;
+            respLog[k] = v.length > 300 ? v.slice(0, 300) + "..." : v;
+        });
+        log("info", `[${prepared?.session.id ?? "unknown"}] ← upstream response headers: ${JSON.stringify(respLog)}`);
+    }
     // P1.2: if the upstream returned a non-2xx (auth, rate-limit, context too
     // long, ...), do NOT route the error body through the SSE rewriter — it has
     // no SSE events and would be silently swallowed, leaving the client with


### PR DESCRIPTION
## Problem

textProtocol mode (Codex code_mode) cannot use function-call tools — declaring any `tools` field disables server-side tools. Previously only `compress` had a text trigger; `acp_status`, `search_context`, and `decompress` were completely inaccessible to the model.

The model would say "acp_status 工具不可用" when asked to check context status.

## Fix

Add text triggers for all 4 ACP tools:

| Tool | Trigger | Payload |
|------|---------|---------|
| compress | `<acp_compress>{...}</acp_compress>` | JSON content array |
| acp_status | `<acp_status></acp_status>` | none needed |
| search_context | `<acp_search>{"query":"..."}</acp_search>` | query string |
| decompress | `<acp_decompress>{"blockId":"b5"}</acp_decompress>` | blockId + options |

### Changes

- `compress-tool.ts`: added `ACP_STATUS`, `ACP_SEARCH`, `ACP_DECOMPRESS` open/close markers
- `adapter-responses.ts`: `extractTextTriggers` rewritten as generic loop over all 4 trigger types
- `compress-tool.ts`: `buildCompressTextSystemPrompt` updated with "ACP TOOLS (TEXT TRIGGERS)" section documenting all 4 triggers with examples
- `server.ts`: upstream request/response header debug logging

### Verification

- 247/247 tests pass
- typecheck clean
- build clean (78ms)
- Deployed and verified with Codex textProtocol harness

### Commit
`30e45cb`