### PR TITLE
release v0.1.32

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.31",
+      "version": "0.1.32",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Release v0.1.32

Version bump only (no code changes). Triggers CI auto-publish on merge.

### Changes since v0.1.31 (PR #89)

**Features**
- **#96** feat: text triggers for `acp_status`/`search_context`/`decompress` in textProtocol mode (Codex) — these read-only tools can now be invoked via text triggers, not just function calls.

**Bug fixes**
- **#95** fix(loop): preserve system/preamble prefix in V2 loop re-request — **Responses (Codex) + Anthropic**. Round-2 of the compress loop dropped `systemParts` (instructions) and the `additional_tools`/system side-channels, causing a full prompt-cache miss on every compress re-request and losing the client system / tool declarations. OpenAI Chat was unaffected (system rides in `coreMessages`).
- **#93** fix: suppress upstream message-item events in textProtocol mode — Codex textProtocol output duplication.
- **#92** fix(session-id): recognize `x-claude-code-session-id` from Claude Code CLI for session isolation.
- **#90** fix(responses): read-only proxy tools (`acp_status`/`search_context`) no longer drive the compress loop re-request — fixes the hang/炸锅 after a read-only tool call.

### Pre-flight (local, matches CI)
- `npm run typecheck` ✅
- `npm test` — 249/249 pass ✅
- `npm run build` ✅

### Notes
- No changes to `src/update.ts`, so no no-op staging release is required (per AGENTS.md §5).
- `acp-kernel` dependency version unchanged.
- Per AGENTS.md, I will **not** merge this PR — human merge triggers CI publish (`release.yml` detects `*_release-v*` branch + `release v0.1.32` commit → `npm publish --tag latest` + git tag + GitHub Release).
- After merge, verify: `npm view billion-context version` → `0.1.32`.