### PR TITLE
fix(#99): skip body decode for non-protocol passthrough requests

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -393,9 +393,6 @@ async function handle(
     let bodyBuffer: Buffer;
     try {
         bodyBuffer = await readBody(req);
-        const decoded = await decodeRequestBody(headerValue(req, "content-encoding"), bodyBuffer, MAX_REQUEST_BYTES);
-        bodyBuffer = decoded.body;
-        if (decoded.decoded) delete req.headers["content-encoding"];
     } catch (err) {
         if (err instanceof BodyTooLargeError) {
             log("warn", `413: request body exceeds ${err.limit} bytes`);
@@ -403,7 +400,7 @@ async function handle(
             res.end(JSON.stringify({ error: { type: "request_too_large", message: err.message } }));
             return;
         }
-        log("warn", `read/decode body failed: ${String(err)}`);
+        log("warn", `read body failed: ${String(err)}`);
         res.writeHead(400, { "content-type": "application/json" });
         res.end(JSON.stringify({ error: { type: "invalid_request", message: String(err) } }));
         return;
@@ -413,7 +410,6 @@ async function handle(
     // `/v1/responses?foo=1` must still be detected as the responses protocol.
     const urlPath = url.split("?", 2)[0];
     const responsesCompact = urlPath.endsWith("/responses/compact");
-    const countTokens = isCountTokensRequest(req.method ?? "GET", urlPath, bodyBuffer.length > 0);
     const route = resolveUpstream(opts, req.url ?? "", req);
     const upstreamOrigin = route ? route.upstream : opts.upstream;
     const protocol: "anthropic" | "openai" | "responses" | null =
@@ -427,6 +423,27 @@ async function handle(
                     ? "responses"
                     : null
             : null);
+    // Issue #99: decode body only for known protocols — passthrough requests
+    // (e.g. GET /models) must forward raw bytes without content-encoding decode.
+    if (protocol !== null && bodyBuffer.length > 0) {
+        try {
+            const decoded = await decodeRequestBody(headerValue(req, "content-encoding"), bodyBuffer, MAX_REQUEST_BYTES);
+            bodyBuffer = decoded.body;
+            if (decoded.decoded) delete req.headers["content-encoding"];
+        } catch (err) {
+            if (err instanceof BodyTooLargeError) {
+                log("warn", `413: decoded body exceeds ${err.limit} bytes`);
+                res.writeHead(413, { "content-type": "application/json" });
+                res.end(JSON.stringify({ error: { type: "request_too_large", message: err.message } }));
+                return;
+            }
+            log("warn", `decode body failed: ${String(err)}`);
+            res.writeHead(400, { "content-type": "application/json" });
+            res.end(JSON.stringify({ error: { type: "invalid_request", message: String(err) } }));
+            return;
+        }
+    }
+    const countTokens = isCountTokensRequest(req.method ?? "GET", urlPath, bodyBuffer.length > 0);
     // Per-request context limit: look up body.model against the per-route model
     // declaration in providers.json first (same model can have different
     // windows behind different relays), then the built-in table. Falls back to

--- a/src/server.ts
+++ b/src/server.ts
@@ -391,8 +391,36 @@ async function handle(
         return;
     }
     let bodyBuffer: Buffer;
+    let urlPath: string;
+    let responsesCompact: boolean;
+    let route: ReturnType<typeof resolveUpstream>;
+    let upstreamOrigin: string;
+    let protocol: "anthropic" | "openai" | "responses" | null;
     try {
         bodyBuffer = await readBody(req);
+        const url = req.url ?? "";
+        urlPath = url.split("?", 2)[0];
+        responsesCompact = urlPath.endsWith("/responses/compact");
+        route = resolveUpstream(opts, req.url ?? "", req);
+        upstreamOrigin = route ? route.upstream : opts.upstream;
+        protocol =
+            route?.explicitProtocol
+            ?? (req.method === "POST" && bodyBuffer.length > 0
+                ? urlPath.endsWith("/chat/completions")
+                    ? "openai"
+                    : urlPath.endsWith("/v1/messages") || urlPath.endsWith("/messages")
+                      ? "anthropic"
+                      : urlPath.endsWith("/responses") || responsesCompact
+                        ? "responses"
+                        : null
+                : null);
+        // Issue #99: decode body only for known protocols — passthrough requests
+        // (e.g. GET /models) must forward raw bytes without content-encoding decode.
+        if (protocol !== null && bodyBuffer.length > 0) {
+            const decoded = await decodeRequestBody(headerValue(req, "content-encoding"), bodyBuffer, MAX_REQUEST_BYTES);
+            bodyBuffer = decoded.body;
+            if (decoded.decoded) delete req.headers["content-encoding"];
+        }
     } catch (err) {
         if (err instanceof BodyTooLargeError) {
             log("warn", `413: request body exceeds ${err.limit} bytes`);
@@ -400,48 +428,10 @@ async function handle(
             res.end(JSON.stringify({ error: { type: "request_too_large", message: err.message } }));
             return;
         }
-        log("warn", `read body failed: ${String(err)}`);
+        log("warn", `read/decode body failed: ${String(err)}`);
         res.writeHead(400, { "content-type": "application/json" });
         res.end(JSON.stringify({ error: { type: "invalid_request", message: String(err) } }));
         return;
-    }
-    const url = req.url ?? "";
-    // Strip query string before matching path suffixes: a request like
-    // `/v1/responses?foo=1` must still be detected as the responses protocol.
-    const urlPath = url.split("?", 2)[0];
-    const responsesCompact = urlPath.endsWith("/responses/compact");
-    const route = resolveUpstream(opts, req.url ?? "", req);
-    const upstreamOrigin = route ? route.upstream : opts.upstream;
-    const protocol: "anthropic" | "openai" | "responses" | null =
-        route?.explicitProtocol
-        ?? (req.method === "POST" && bodyBuffer.length > 0
-            ? urlPath.endsWith("/chat/completions")
-                ? "openai"
-                : urlPath.endsWith("/v1/messages") || urlPath.endsWith("/messages")
-                  ? "anthropic"
-                  : urlPath.endsWith("/responses") || responsesCompact
-                    ? "responses"
-                    : null
-            : null);
-    // Issue #99: decode body only for known protocols — passthrough requests
-    // (e.g. GET /models) must forward raw bytes without content-encoding decode.
-    if (protocol !== null && bodyBuffer.length > 0) {
-        try {
-            const decoded = await decodeRequestBody(headerValue(req, "content-encoding"), bodyBuffer, MAX_REQUEST_BYTES);
-            bodyBuffer = decoded.body;
-            if (decoded.decoded) delete req.headers["content-encoding"];
-        } catch (err) {
-            if (err instanceof BodyTooLargeError) {
-                log("warn", `413: decoded body exceeds ${err.limit} bytes`);
-                res.writeHead(413, { "content-type": "application/json" });
-                res.end(JSON.stringify({ error: { type: "request_too_large", message: err.message } }));
-                return;
-            }
-            log("warn", `decode body failed: ${String(err)}`);
-            res.writeHead(400, { "content-type": "application/json" });
-            res.end(JSON.stringify({ error: { type: "invalid_request", message: String(err) } }));
-            return;
-        }
     }
     const countTokens = isCountTokensRequest(req.method ?? "GET", urlPath, bodyBuffer.length > 0);
     // Per-request context limit: look up body.model against the per-route model
@@ -539,7 +529,7 @@ async function handle(
     }
     if (!prepared) {
         if (protocol === null && !opts.passthrough) {
-            log("warn", `unrecognized path ${url} — not a known protocol (/chat/completions, /v1/messages, /responses, /responses/compact); forwarding unchanged`);
+            log("warn", `unrecognized path ${req.url ?? ""} — not a known protocol (/chat/completions, /v1/messages, /responses, /responses/compact); forwarding unchanged`);
         }
         await forward(req, res, opts, bodyBuffer, null, core, reqConfig, log, route, undefined);
     }


### PR DESCRIPTION
## Problem (issue #99)

On Windows 11, Codex CLI using ChatGPT OAuth through billion-context v0.1.32 hits `invalid zstd data` on `/models`:

```
[warn] unrecognized path /bili/.../models — forwarding unchanged
[info] forward GET → https://chatgpt.com/backend-api/codex/models
[warn] read/decode body failed: Error: invalid zstd data
```

## Root Cause

The request body decode (`decodeRequestBody`) ran **unconditionally** for ALL requests — including GET /models and other non-protocol passthrough requests — **before** protocol detection.

When the client sends a `content-encoding: zstd` header on a request whose body is empty or not ours to decode, the zstd decoder (`fzstd`) throws `invalid zstd data`.

## Fix

Restructured the body handling in `server.ts`:

1. **Read raw body** — always (needed for protocol detection)
2. **Detect protocol** — from URL path (unchanged logic)
3. **Decode body** — **only** for known protocol requests (`protocol !== null && bodyBuffer.length > 0`)

Non-protocol passthrough requests (GET /models, POST to unknown paths, etc.) now forward the raw body **verbatim** without any content-encoding decompression.

## Verification

- 249/249 tests pass ✅
- typecheck clean ✅
- build clean (75ms) ✅

## Response-side note

Tested undici behavior on Node v25.9.0: both gzip and zstd responses are **auto-decompressed** by fetch, but the `content-encoding` header is **kept**. The existing `UPSTREAM_HOP_HEADERS` strip (line 68) correctly removes it so clients don't double-decompress. On Node ≥ 22.15 (which has zstd in zlib), this works for all encodings. Users on older Node versions may need to upgrade.