### PR TITLE
release v0.1.33

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.32",
+      "version": "0.1.33",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@types/node": "^22.0.0",
         "@types/node-forge": "^1.3.14",
-        "acp-kernel": "0.0.17",
+        "acp-kernel": "0.0.18",
         "fzstd": "0.1.1",
         "node-forge": "^1.4.0",
         "tar": "^7.5.22",
@@ -972,9 +972,9 @@
       }
     },
     "node_modules/acp-kernel": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.17.tgz",
-      "integrity": "sha512-Mu7CIU1jo79cqHV6tZ8OgZe9ed4HBctVUsoSLKK3SStpkExZw7O3lcUTJLXNqyViuYA83gVH4Z8t43hn89qDDg==",
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.18.tgz",
+      "integrity": "sha512-V9QLaUvutOr3eSYuDMPfjkK3jUKexueiLsU2kEFpXUu6jeALjHACPZbYSYDxxpE1OkRDaD1XXxcjV+Q/t6v4NQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/node-forge": "^1.3.14",
-    "acp-kernel": "0.0.17",
+    "acp-kernel": "0.0.18",
     "fzstd": "0.1.1",
     "node-forge": "^1.4.0",
     "tar": "^7.5.22",


### PR DESCRIPTION
Release `billion-context` **v0.1.33** — bumps bundled `acp-kernel` 0.0.17 → **0.0.18**.

## Commits (matches repo conventions: deps + version-only release)

- `deps: bump acp-kernel to exact 0.0.18` — acp-kernel dep line + lockfile resolution (matches `a297054` precedent)
- `release v0.1.33` — version-only (matches `29cb447` precedent; respects AGENTS.md §4)

## What's in acp-kernel 0.0.18

Bug-fix release bundling 4 merged PRs (no API changes, zero adapter code changes needed):

| acp-kernel PR | Type | Summary |
|---------------|------|---------|
| #52 | fix | `hide-consumed` per-block — stops summary leak in batched compress calls |
| #54 | fix | T2/T3 distillation nudge warns that span raw messages are absorbed |
| #55 | fix | overlap → warn+skip instead of aborting the whole batch (ISSUE-42) |
| #56 | fix | `recommend` uses `ctx.countTokens` instead of hardcoded chars/4 |

**Not included**: acp-kernel #57 (nudge overhaul) remains open and intentionally excluded; will ship in a later version.

## Cross-repo prerequisite (satisfied)

Per AGENTS.md §5 "Cross-repo dependency": acp-kernel ships first, then billion-context.
- `npm view acp-kernel version` → `0.0.18` ✅ (published)
- Lockfile resolves `https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.18.tgz` ✅

## Pre-flight (local, on final state v0.1.33 + kernel 0.0.18)

- `npm run typecheck` ✅ clean
- `npm test` ✅ 249 pass / 0 fail
- `npm run build` ✅ 2.03 MB (kernel inlined, self-contained)

Zero source changes — proxy fully compatible with acp-kernel 0.0.18.

---

Worktree: `/home/dog/projects/billion-context-kernel-upgrade`. After merge, CI will tag `v0.1.33` and publish to npm. Verify with:
```
npm view billion-context version   # expect 0.1.33
```
