### PR TITLE
fix: textProtocol compress interrupt + visibility marker role

### DIFF
--- a/src/compress-loop-responses.ts
+++ b/src/compress-loop-responses.ts
@@ -422,7 +422,7 @@ export async function compressLoopResponsesJson(
             }
             const result = executeProxyTool(call.name, args, ctx);
             ctx.log(`[acp-proxy: responses JSON ${call.name} → ${result.slice(0, 120).replace(/\n/g, " ")}]`);
-            inputItems.push({ type: "message", role: "user", content: buildVisibilityMarker(call.name, result) });
+            inputItems.push({ type: "message", role: "developer", content: buildVisibilityMarker(call.name, result) });
         }
         requestBody.input = inputItems;
         const { response, clearTimer } = await fetchWithTimeout(requestOptions.url, {
@@ -680,7 +680,7 @@ export async function* compressLoopResponsesStream(
                 "utf8",
             );
             inputItems.push(textProtocol
-                ? { type: "message", role: "user", content: buildVisibilityMarker(fc.name, result) }
+                ? { type: "message", role: "developer", content: buildVisibilityMarker(fc.name, result) }
                 : { type: "function_call_output", call_id: fc.callId || `call_${Date.now()}`, output: result });
         }
 

--- a/src/compress-tool.ts
+++ b/src/compress-tool.ts
@@ -167,9 +167,9 @@ You manage context by emitting a special trigger in your text output. When you d
 ${ACP_TEXT_OPEN}{"content":[{"startId":"m00150","endId":"m00220","summary":"...","topic":"optional"}]}${ACP_TEXT_CLOSE}
 
 Rules for the trigger:
-- Output the marker on its own, with NO surrounding prose. Just the raw marker.
+- Append the marker at the END of your response, AFTER completing your task. Complete your work first, then compress.
 - JSON shape matches the compress tool: {"content":[{startId,endId,summary,topic?}]}. Batch multiple ranges in one trigger.
-- After emitting the marker, STOP your turn. Do not continue with other text — the proxy will execute the compression and return the result, then you continue fresh.
+- The proxy applies the compression silently — your response is delivered as-is. You do not need to wait for a result.
 - Do NOT wrap the marker in code fences, quotes, or commentary.
 - NEVER compress on short conversations or when context is small (well below the window limit). Only compress when context is genuinely large.
 
@@ -190,9 +190,9 @@ Since host tools cannot coexist with a declared tools field, ALL ACP tools use t
    Optional: {"blockId":"b5","toFile":"/tmp/b5.txt"} to write to file instead.
    Optional: {"blockId":"b5","full":true} to restore all the way to original messages.
 
-Rules for ALL triggers:
+Rules for acp_status, search_context, decompress triggers:
 - Output on its own, NO surrounding prose. Just the raw marker.
-- After emitting, STOP your turn. The proxy executes and returns the result.
+- After emitting, STOP your turn. The proxy executes and returns the result in a new round.
 - Do NOT wrap in code fences, quotes, or commentary.`;
 }
 

--- a/src/loop/core.ts
+++ b/src/loop/core.ts
@@ -243,7 +243,7 @@ export async function* runCompressLoop(
                     if (ctx.textProtocol) {
                         coreMessages.push({
                             id: `acp_loop_r${round}_marker_${pr.callId}`,
-                            role: "user",
+                            role: "system",
                             contentType: "text",
                             text: buildVisibilityMarker(pr.name, pr.result),
                         });

--- a/src/loop/core.ts
+++ b/src/loop/core.ts
@@ -279,7 +279,12 @@ export async function* runCompressLoop(
                 yield adapter.emitToolCall(tc);
             }
 
-            const reRequest = proxyResults.length > 0 && realCalls === 0;
+            const compressOnly = proxyResults.length > 0 && proxyResults.every((p) => p.name === "compress");
+            const silentCompress = ctx.textProtocol && compressOnly && resolvedText.length > 0;
+            if (silentCompress) {
+                ctx.log(`[acp-loop] round ${round}: textProtocol compress applied silently (no re-request)`);
+            }
+            const reRequest = proxyResults.length > 0 && realCalls === 0 && !silentCompress;
             if (!reRequest) {
                 yield adapter.emitCompletion({ finishReason, usage });
                 return;

--- a/tests/loop-compress.test.ts
+++ b/tests/loop-compress.test.ts
@@ -344,3 +344,38 @@ test("loop #10 (S3): upstream 500 mid-loop terminates cleanly (timer cleared, no
         globalThis.fetch = orig;
     }
 });
+
+test("loop #11: textProtocol compress WITH text → no re-request (silent compress, prevents task interruption)", async () => {
+    const ctx = makeCtx([
+        textMsg("m00001", "user", "hello"),
+        textMsg("m00002", "assistant", "hi"),
+    ]);
+    ctx.textProtocol = true;
+    const compressArgs = JSON.stringify({ content: [{ startId: "m00001", endId: "m00002", summary: "s" }] });
+    const trigger = `\x3cacp_compress\x3e${compressArgs}\x3c/acp_compress\x3e`;
+    const round1 = [
+        sse("response.created", { response: { id: "resp_1", status: "in_progress" } }),
+        sse("response.output_text.delta", { item_id: "msg_1", output_index: 0, delta: "Here is your result." }),
+        sse("response.output_text.delta", { item_id: "msg_1", output_index: 0, delta: trigger }),
+        COMPLETED,
+    ].join("");
+    let fetchCalls = 0;
+    const orig = globalThis.fetch;
+    globalThis.fetch = (async () => {
+        fetchCalls++;
+        return new Response(COMPLETED, { status: 200 });
+    }) as typeof fetch;
+    try {
+        const out = await drain(
+            new Response(round1, { status: 200 }).body!,
+            ctx,
+            { model: "gpt-4o", input: [], stream: true },
+            { url: "http://mock", headers: {} },
+            createResponsesAdapter(true),
+        );
+        assert.equal(fetchCalls, 0, "NO upstream re-request for textProtocol compress-with-text");
+        assert.ok(out.includes("Here is your result."), "model text delivered to client (trigger stripped)");
+    } finally {
+        globalThis.fetch = orig;
+    }
+});


### PR DESCRIPTION
## Problem

textProtocol 压缩后任务中断 + 降智：
1. 压缩结果标记注入为 `role: "user"` → 模型理解为"用户要状态报告" → 输出结论 → 任务中断
2. textProtocol 压缩有文本内容时仍然 re-request → 打断模型正在输出的任务

## Fix

### 1. 可见性标记 role: user → developer (5280c2a)

压缩结果标记（"📦 Compressed m00001-m00044"）的 role 从 `user` 改为 `developer`（系统注释）。模型理解为上下文信息，不理解为用户指令。

3 处修改：
- `loop/core.ts:246`: BiliMessage `role: "system"`（coreToResponses 转为 `developer`）
- `compress-loop-responses.ts:683` (SSE): `role: "developer"`
- `compress-loop-responses.ts:425` (JSON): `role: "developer"`

标记**不删除**——模型仍然能看到压缩结果，避免重复压缩。

### 2. textProtocol silent compress (1bdb6ee)

textProtocol 压缩 + 有文本内容 → 不 re-request（silentCompress）。压缩结果静默写入 session state，下次请求自动生效。系统提示更新：在回复末尾追加标记。

## Testing
- 250/250 tests pass
- typecheck clean
- build clean