### PR TITLE
fix: visibility marker role user→developer

### DIFF
--- a/src/compress-loop-responses.ts
+++ b/src/compress-loop-responses.ts
@@ -422,7 +422,7 @@ export async function compressLoopResponsesJson(
             }
             const result = executeProxyTool(call.name, args, ctx);
             ctx.log(`[acp-proxy: responses JSON ${call.name} → ${result.slice(0, 120).replace(/\n/g, " ")}]`);
-            inputItems.push({ type: "message", role: "user", content: buildVisibilityMarker(call.name, result) });
+            inputItems.push({ type: "message", role: "developer", content: buildVisibilityMarker(call.name, result) });
         }
         requestBody.input = inputItems;
         const { response, clearTimer } = await fetchWithTimeout(requestOptions.url, {
@@ -680,7 +680,7 @@ export async function* compressLoopResponsesStream(
                 "utf8",
             );
             inputItems.push(textProtocol
-                ? { type: "message", role: "user", content: buildVisibilityMarker(fc.name, result) }
+                ? { type: "message", role: "developer", content: buildVisibilityMarker(fc.name, result) }
                 : { type: "function_call_output", call_id: fc.callId || `call_${Date.now()}`, output: result });
         }
 

--- a/src/loop/core.ts
+++ b/src/loop/core.ts
@@ -243,7 +243,7 @@ export async function* runCompressLoop(
                     if (ctx.textProtocol) {
                         coreMessages.push({
                             id: `acp_loop_r${round}_marker_${pr.callId}`,
-                            role: "user",
+                            role: "system",
                             contentType: "text",
                             text: buildVisibilityMarker(pr.name, pr.result),
                         });


### PR DESCRIPTION
## Problem

textProtocol 压缩结果标记注入为 `role: "user"` → 模型理解为"用户要状态报告" → 输出结论 → 任务中断。

## Fix

role: `user` → `developer`（系统注释），3 处修改，共 3 行：

| 文件 | 位置 | 旧 | 新 |
|------|------|-----|-----|
| `loop/core.ts` | :246 | `"user"` | `"system"`（coreToResponses 转为 developer） |
| `compress-loop-responses.ts` | :425 (JSON) | `"user"` | `"developer"` |
| `compress-loop-responses.ts` | :683 (SSE) | `"user"` | `"developer"` |

标记**不删除**——模型仍然能看到压缩结果，避免重复压缩。仅 role 变了。

## Diff
```diff
- role: "user",
+ role: "system",
```
```diff
- role: "user", content: buildVisibilityMarker(...)
+ role: "developer", content: buildVisibilityMarker(...)
```

249/249 tests pass. typecheck clean.

> 新 worktree 从 master `d40bfa9` 创建，仅 3 行改动。