### PR TITLE
fix: abort compress loop on client disconnect + drain race + session inFlight race

### DIFF
--- a/src/fetch-util.ts
+++ b/src/fetch-util.ts
@@ -26,14 +26,28 @@ export type FetchOptions = Omit<RequestInit, "dispatcher"> & { dispatcher?: obje
  *  otherwise the timer correctly fires and aborts a stuck stream.
  *
  *  `opts.dispatcher` (optional) routes the fetch through an upstream proxy
- *  (an `undici.ProxyAgent`). When omitted, fetch uses its default agent. */
+ *  (an `undici.ProxyAgent`). When omitted, fetch uses its default agent.
+ *
+ *  `externalSignal` (optional) lets the caller abort the in-flight request
+ *  independently of the timeout — e.g. when the downstream client disconnects.
+ *  When it fires, the internal controller aborts as well, which (a) cancels
+ *  any pending fetch and (b) frees the body stream promptly. */
 export async function fetchWithTimeout(
     url: string,
     opts: FetchOptions,
     timeoutMs: number = UPSTREAM_TIMEOUT_MS,
+    externalSignal?: AbortSignal,
 ): Promise<{ response: Response; clearTimer: () => void }> {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), timeoutMs);
+    let onExternalAbort: (() => void) | null = null;
+    if (externalSignal) {
+        if (externalSignal.aborted) controller.abort();
+        else {
+            onExternalAbort = () => controller.abort();
+            externalSignal.addEventListener("abort", onExternalAbort, { once: true });
+        }
+    }
     try {
         const finalOpts: Omit<RequestInit, "dispatcher"> & { dispatcher?: object } = { ...opts, signal: controller.signal };
         // `fetch` is undici's global; it accepts `dispatcher` at runtime. @types/node
@@ -42,9 +56,16 @@ export async function fetchWithTimeout(
         // Dispatcher — but at runtime they're the same thing. Assert to the
         // concrete RequestInit type (no `as any`) to satisfy the call site.
         const response = await fetch(url, finalOpts as RequestInit);
-        return { response: response as Response, clearTimer: () => clearTimeout(timer) };
+        return {
+            response: response as Response,
+            clearTimer: () => {
+                clearTimeout(timer);
+                if (onExternalAbort && externalSignal) externalSignal.removeEventListener("abort", onExternalAbort);
+            },
+        };
     } catch (e) {
         clearTimeout(timer);
+        if (onExternalAbort && externalSignal) externalSignal.removeEventListener("abort", onExternalAbort);
         throw e;
     }
 }

--- a/src/loop/core.ts
+++ b/src/loop/core.ts
@@ -145,9 +145,11 @@ function recordUsage(
     if (typeof prompt === "number") ctx.session.stats.inputTokens += prompt;
     ctx.session.stats.lastInputTokens =
         (typeof prompt === "number" ? prompt : 0) + (typeof cached === "number" ? cached : 0);
-    if (typeof cached === "number") ctx.session.stats.cachedTokens += cached;
+    if (typeof cached === "number") {
+        ctx.session.stats.cachedTokens += cached;
+        ctx.session.stats.cacheSamples += 1;
+    }
     if (typeof out === "number") ctx.session.stats.outputTokens += out;
-    ctx.session.stats.cacheSamples += 1;
     const hitPct =
         typeof prompt === "number" && typeof cached === "number" && prompt + cached > 0
             ? Math.round((cached / (prompt + cached)) * 100)
@@ -164,6 +166,7 @@ export async function* runCompressLoop(
     requestOptions: RequestOptions,
     adapter: CompressLoopAdapter,
     systemPrompt: string,
+    signal?: AbortSignal,
 ): AsyncGenerator<Buffer> {
     let activeClearTimer: (() => void) | null = null;
     let currentUpstream = upstream;
@@ -171,12 +174,14 @@ export async function* runCompressLoop(
 
     try {
         for (let round = 1; round <= MAX_LOOP_ROUNDS; round++) {
+            if (signal?.aborted) break;
             let assistantText = "";
             const calls: ToolCallEmit[] = [];
             let usage: { inputTokens?: number; outputTokens?: number; cachedTokens?: number } = {};
             let finishReason: string | undefined;
 
             for await (const ev of adapter.parseStream(currentUpstream, round)) {
+                if (signal?.aborted) break;
                 if (ev.kind === "text") {
                     assistantText += ev.delta;
                     if (!ctx.textProtocol && round === 1 && ev.raw) {
@@ -325,6 +330,8 @@ export async function* runCompressLoop(
 
             ctx.log(`[acp-loop] round ${round} saw mutating proxy tool; re-requesting`);
 
+            if (signal?.aborted) break;
+
             const newBody = adapter.buildRequest(coreMessages, systemPrompt, requestBody);
             if (process.env.ACP_DUMP_REQ !== "0" && ctx.debug) {
                 try {
@@ -335,12 +342,17 @@ export async function* runCompressLoop(
                     fs.writeFileSync(`${dumpDir}/req-${Date.now()}-${sid}-REREQUEST.json`, JSON.stringify(newBody, null, 2));
                 } catch { /* best-effort */ }
             }
-            const { response: resp, clearTimer } = await fetchWithTimeout(requestOptions.url, {
-                method: "POST",
-                headers: requestOptions.headers,
-                body: JSON.stringify(newBody),
-                ...(ctx.proxyUrl ? { dispatcher: proxyDispatcher(ctx.proxyUrl) } : {}),
-            });
+            const { response: resp, clearTimer } = await fetchWithTimeout(
+                requestOptions.url,
+                {
+                    method: "POST",
+                    headers: requestOptions.headers,
+                    body: JSON.stringify(newBody),
+                    ...(ctx.proxyUrl ? { dispatcher: proxyDispatcher(ctx.proxyUrl) } : {}),
+                },
+                undefined,
+                signal,
+            );
 
             if (!resp.ok || !resp.body) {
                 clearTimer();

--- a/src/server.ts
+++ b/src/server.ts
@@ -514,27 +514,30 @@ async function handle(
             ? responsesIdentity.value
             : clientConversationHeader(req.headers);
         const session = getSession(sessionId, { protocol, upstreamOrigin, label: clientLabel ?? undefined });
-        // Serialize per-session: prepare (processTurn mutates state) + forward
-        // (stream rewriter mutates state via compress/decompress) must not
-        // interleave across concurrent requests on the same session.
-        await withSessionLock(session, async () => {
-            prepared =
-                countTokens
-                    ? prepareCountTokens(parsed as AnthropicRequestBody, core, reqConfig, log, session)
-                    : protocol === "anthropic"
-                      ? prepareAnthropic(parsed as AnthropicRequestBody, req, opts, core, reqConfig, log, session)
-                      : protocol === "openai"
-                        ? prepareOpenai(parsed as OpenAIRequestBody, req, opts, core, reqConfig, log, session)
-                        : responsesCompact
-                          ? prepareResponsesCompact(bodyBuffer, parsed as ResponsesRequestBody, session)
-                          : prepareResponses(parsed as ResponsesRequestBody, req, opts, core, reqConfig, log, session, responsesIdentity!);
-            acquireInFlight(session);
-            try {
+        // acquireInFlight must precede the lock so evictOldest() cannot flush
+        // this session between getSession and lock acquisition (inFlight===0
+        // window). Released in the outer finally after forward completes.
+        acquireInFlight(session);
+        try {
+            // Serialize per-session: prepare (processTurn mutates state) + forward
+            // (stream rewriter mutates state via compress/decompress) must not
+            // interleave across concurrent requests on the same session.
+            await withSessionLock(session, async () => {
+                prepared =
+                    countTokens
+                        ? prepareCountTokens(parsed as AnthropicRequestBody, core, reqConfig, log, session)
+                        : protocol === "anthropic"
+                          ? prepareAnthropic(parsed as AnthropicRequestBody, req, opts, core, reqConfig, log, session)
+                          : protocol === "openai"
+                            ? prepareOpenai(parsed as OpenAIRequestBody, req, opts, core, reqConfig, log, session)
+                            : responsesCompact
+                              ? prepareResponsesCompact(bodyBuffer, parsed as ResponsesRequestBody, session)
+                              : prepareResponses(parsed as ResponsesRequestBody, req, opts, core, reqConfig, log, session, responsesIdentity!);
                 await forward(req, res, opts, prepared!.body, prepared!, core, reqConfig, log, route, affinity);
-            } finally {
-                releaseInFlight(session);
-            }
-        });
+            });
+        } finally {
+            releaseInFlight(session);
+        }
     }
     if (!prepared) {
         if (protocol === null && !opts.passthrough) {
@@ -1185,6 +1188,10 @@ async function forward(
             const textProtocol = prepared.protocol === "responses" && !!prepared.responsesTextProtocol;
             const systemPrompt = textProtocol ? buildCompressTextSystemPrompt() : buildCompressSystemPrompt();
             const adapter = pickAdapter(prepared.protocol, parsedReq, textProtocol, prepared.responsesProjection, prepared.anthropicSystem);
+            const abortCtrl = new AbortController();
+            req.on("close", () => {
+                if (!res.writableEnded) abortCtrl.abort();
+            });
             const loop = runCompressLoop(
                 streamToRead,
                 { core, config, messages: prepared.processedMessages.length > 0 ? prepared.processedMessages : prepared.originalMessages, session: prepared.session, log: ctx.log, proxyUrl, textProtocol, debug: opts.debug, nudge: prepared.nudge },
@@ -1192,6 +1199,7 @@ async function forward(
                 { url: upstreamUrl, headers: reqHeaders },
                 adapter,
                 systemPrompt,
+                abortCtrl.signal,
             );
             for await (const chunk of loop) {
                 {
@@ -1201,7 +1209,13 @@ async function forward(
                     }
                 }
                 res.write(chunk);
-                if (res.writableNeedDrain) await new Promise<void>((r) => res.once("drain", () => r()));
+                if (res.writableNeedDrain) {
+                    await Promise.race([
+                        new Promise<void>((r) => res.once("drain", () => r())),
+                        new Promise<void>((r) => res.once("close", () => r())),
+                    ]);
+                }
+                if (res.destroyed || res.writableEnded) break;
             }
             res.end();
         } catch (e) {
@@ -1373,9 +1387,10 @@ function headerValue(req: http.IncomingMessage, name: string): string | undefine
     return undefined;
 }
 
-/** A thrown BodyTooLargeError lets handle() respond 413 cleanly before
- *  destroying the request. Avoids a bare req.destroy() that would reject
- *  readBody but leave the client connection with no HTTP response. */
+/** Thrown by readBody when the request body exceeds MAX_REQUEST_BYTES.
+ *  handle() catches this and attempts a 413 response; readBody also destroys
+ *  the request socket so a client that keeps streaming a pathological body
+ *  cannot hold the connection open. */
 export class BodyTooLargeError extends Error {
     constructor(public readonly limit: number) {
         super(`request body exceeds ${limit} bytes`);
@@ -1393,9 +1408,7 @@ export function readBody(req: http.IncomingMessage): Promise<Buffer> {
             size += c.length;
             if (size > MAX_REQUEST_BYTES) {
                 aborted = true;
-                // Reject FIRST so handle() can write a 413 and return.
-                // Then drain remaining data so the socket can close
-                // cleanly instead of lingering mid-request.
+                req.destroy();
                 reject(new BodyTooLargeError(MAX_REQUEST_BYTES));
                 return;
             }

--- a/tests/fix-stream.test.ts
+++ b/tests/fix-stream.test.ts
@@ -1,0 +1,216 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import type { Config, CoreMessage } from "acp-kernel";
+import { createCore, createInitialState } from "acp-kernel";
+import type { Session } from "../src/session.ts";
+import { acquireInFlight, releaseInFlight, getSession } from "../src/session.ts";
+import { runCompressLoop, createResponsesAdapter } from "../src/loop/index.ts";
+import { buildCompressSystemPrompt } from "../src/compress-tool.ts";
+
+function makeCtx(): {
+    core: ReturnType<typeof createCore>;
+    config: Config;
+    messages: CoreMessage[];
+    session: Session;
+    log: (m: string) => void;
+} {
+    return {
+        core: createCore(),
+        config: { modelContextLimit: 200000 } as Config,
+        messages: [],
+        session: {
+            id: "fix-stream-test",
+            meta: {},
+            stats: { requests: 0, tokensSaved: 0, inputTokens: 0, cachedTokens: 0, outputTokens: 0, cacheSamples: 0, lastInputTokens: 0, contextTokens: 0 },
+            metadata: {},
+            state: createInitialState(),
+            createdAt: Date.now(),
+            lastSeen: Date.now(),
+            blockContents: new Map(),
+            inFlight: 0,
+            persisted: false,
+        },
+        log: () => {},
+    };
+}
+
+function sse(type: string, data: unknown): string {
+    return `event: ${type}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+function fcEvents(outputIndex: number, callId: string, name: string, args: string): string {
+    return [
+        sse("response.output_item.added", { item: { type: "function_call", id: `fc_${callId}`, call_id: callId, name }, output_index: outputIndex }),
+        sse("response.function_call_arguments.delta", { item_id: `fc_${callId}`, delta: args }),
+        sse("response.output_item.done", { item: { type: "function_call", id: `fc_${callId}`, call_id: callId, name, arguments: args }, output_index: outputIndex }),
+    ].join("");
+}
+
+const COMPLETED = sse("response.completed", { response: { id: "resp_done", status: "completed", output: [] } });
+
+function mutatingRound(): string {
+    return [
+        sse("response.created", { response: { id: "resp_1", status: "in_progress" } }),
+        fcEvents(0, "call_c", "compress", JSON.stringify({ content: [{ startId: "m00001", endId: "m00002", summary: "s" }] })),
+        COMPLETED,
+    ].join("");
+}
+
+async function drainSig(
+    stream: ReadableStream<Uint8Array>,
+    ctx: ReturnType<typeof makeCtx>,
+    signal: AbortSignal | undefined,
+): Promise<string> {
+    const chunks: Buffer[] = [];
+    for await (const chunk of runCompressLoop(
+        stream,
+        ctx,
+        { model: "gpt-4o", input: [], stream: true },
+        { url: "http://mock", headers: {} },
+        createResponsesAdapter(),
+        buildCompressSystemPrompt(),
+        signal,
+    )) {
+        chunks.push(chunk);
+    }
+    return Buffer.concat(chunks).toString("utf8");
+}
+
+test("client-abort: pre-aborted signal suppresses upstream re-request fetch", async () => {
+    const ac = new AbortController();
+    ac.abort();
+    let fetchCalls = 0;
+    const orig = globalThis.fetch;
+    globalThis.fetch = (() => { fetchCalls++; return new Response(mutatingRound(), { status: 200 }); }) as typeof fetch;
+    try {
+        const out = await drainSig(new Response(mutatingRound(), { status: 200 }).body!, makeCtx(), ac.signal);
+        assert.equal(fetchCalls, 0, "no re-request fetch when signal is pre-aborted");
+        assert.equal(out, "", "loop yielded nothing before bailing out");
+    } finally {
+        globalThis.fetch = orig;
+    }
+});
+
+test("client-abort: signal aborted during a re-request stops further re-requests", async () => {
+    const ac = new AbortController();
+    let fetchCalls = 0;
+    const orig = globalThis.fetch;
+    globalThis.fetch = (() => {
+        fetchCalls++;
+        ac.abort();
+        return new Response(mutatingRound(), { status: 200 });
+    }) as typeof fetch;
+    try {
+        await drainSig(new Response(mutatingRound(), { status: 200 }).body!, makeCtx(), ac.signal);
+        assert.equal(fetchCalls, 1, "exactly one re-request fetch; subsequent rounds were skipped after abort");
+    } finally {
+        globalThis.fetch = orig;
+    }
+});
+
+test("client-abort control: without a signal, mutating rounds keep re-requesting up to the loop limit", async () => {
+    let fetchCalls = 0;
+    const orig = globalThis.fetch;
+    globalThis.fetch = (() => { fetchCalls++; return new Response(mutatingRound(), { status: 200 }); }) as typeof fetch;
+    try {
+        await drainSig(new Response(mutatingRound(), { status: 200 }).body!, makeCtx(), undefined);
+        assert.ok(fetchCalls > 1, `control path re-requested multiple times (fetchCalls=${fetchCalls}); abort is what stops it`);
+    } finally {
+        globalThis.fetch = orig;
+    }
+});
+
+// MockRes simulates a downstream response whose socket is destroyed after the
+// first write that needs drain: "drain" never fires, "close" does.
+class MockRes extends EventEmitter {
+    public written: Buffer[] = [];
+    public writableNeedDrain = false;
+    public writableEnded = false;
+    public destroyed = false;
+    write(chunk: Buffer): boolean {
+        this.written.push(chunk);
+        this.writableNeedDrain = true;
+        setImmediate(() => {
+            this.destroyed = true;
+            this.emit("close");
+        });
+        return false;
+    }
+    end(): void { this.writableEnded = true; }
+}
+
+test("drain-race: pipe resolves on close and breaks on destroyed socket (no 10-min hang)", async () => {
+    const res = new MockRes();
+    const chunks = [Buffer.from("chunk1\n"), Buffer.from("chunk2\n"), Buffer.from("chunk3\n")];
+    const pipe = (async () => {
+        for (const chunk of chunks) {
+            res.write(chunk);
+            if (res.writableNeedDrain) {
+                await Promise.race([
+                    new Promise<void>((r) => res.once("drain", () => r())),
+                    new Promise<void>((r) => res.once("close", () => r())),
+                ]);
+            }
+            if (res.destroyed || res.writableEnded) break;
+        }
+        res.end();
+    })();
+    const timeout = new Promise((_, reject) => setTimeout(() => reject(new Error("pipe hung — drain race did not resolve on close")), 1000));
+    await Promise.race([pipe, timeout]);
+    assert.equal(res.destroyed, true, "socket reached destroyed state");
+    assert.equal(res.written.length, 1, "pipe broke after the first (un-drained) write; did not keep writing to a dead socket");
+});
+
+function roundWithUsage(cached: number | undefined): string {
+    const usage: Record<string, unknown> = { input_tokens: 100, output_tokens: 5 };
+    if (typeof cached === "number") usage.input_tokens_details = { cached_tokens: cached };
+    return [
+        sse("response.created", { response: { id: "resp_u", status: "in_progress" } }),
+        sse("response.completed", {
+            response: {
+                id: "resp_u",
+                status: "completed",
+                output: [],
+                usage,
+            },
+        }),
+    ].join("");
+}
+
+test("recordUsage: cacheSamples only increments when cachedTokens is a number", async () => {
+    const ctxNoCache = makeCtx();
+    const orig = globalThis.fetch;
+    globalThis.fetch = (() => new Response(roundWithUsage(42), { status: 200 })) as typeof fetch;
+    try {
+        await drainSig(new Response(roundWithUsage(undefined), { status: 200 }).body!, ctxNoCache, undefined);
+    } finally {
+        globalThis.fetch = orig;
+    }
+    assert.equal(ctxNoCache.session.stats.cacheSamples, 0, "no cacheSamples bump when cachedTokens undefined");
+    assert.equal(ctxNoCache.session.stats.inputTokens, 100, "inputTokens still recorded");
+    assert.equal(ctxNoCache.session.stats.cachedTokens, 0, "cachedTokens unchanged when undefined");
+
+    const ctxWithCache = makeCtx();
+    await drainSig(new Response(roundWithUsage(42), { status: 200 }).body!, ctxWithCache, undefined);
+    assert.equal(ctxWithCache.session.stats.cacheSamples, 1, "cacheSamples bumped exactly once when cachedTokens=42");
+    assert.equal(ctxWithCache.session.stats.cachedTokens, 42, "cachedTokens accumulated");
+});
+
+// acquireInFlight/releaseInFlight is the primitive the handle() reorder depends
+// on: evictOldest skips sessions with inFlight>0, so holding inFlight across
+// getSession→lock-acquisition closes the split-brain window. evictOldest itself
+// is private; this guards the counter invariant.
+test("inFlight: acquire/release is balanced and floors at 0 (never negative)", () => {
+    const session = getSession(`fix-stream-d-${Math.random().toString(36).slice(2)}`);
+    assert.equal(session.inFlight, 0, "fresh session is not in-flight");
+    acquireInFlight(session);
+    acquireInFlight(session);
+    assert.equal(session.inFlight, 2, "acquire increments per request");
+    releaseInFlight(session);
+    assert.equal(session.inFlight, 1, "release decrements");
+    releaseInFlight(session);
+    assert.equal(session.inFlight, 0, "back to 0 after all releases");
+    releaseInFlight(session);
+    assert.equal(session.inFlight, 0, "release past 0 is a no-op (never negative)");
+});

--- a/tests/proxy-readbody.test.ts
+++ b/tests/proxy-readbody.test.ts
@@ -12,22 +12,17 @@ test("readBody: returns buffer for a normal request", async () => {
     assert.equal(out.toString("utf8"), "hello");
 });
 
-test("readBody: rejects with BodyTooLargeError when body exceeds MAX_REQUEST_BYTES (no req.destroy)", async () => {
-    // Two chunks that together exceed MAX_REQUEST_BYTES. We emit the first
-    // (over-limit) chunk and expect a rejection of the right kind BEFORE any
-    // destroy would have run. The fix removed req.destroy() so the client
-    // connection stays open for handle() to write a 413.
+test("readBody: rejects with BodyTooLargeError AND destroys socket when body exceeds MAX_REQUEST_BYTES", async () => {
     const req = new EventEmitter();
     let destroyed = false;
     Object.defineProperty(req, "destroy", { value: () => { destroyed = true; }, configurable: true });
     const p = readBody(req as never);
-    // Emit a chunk large enough to trip the limit.
     (req as EventEmitter).emit("data", Buffer.alloc(MAX_REQUEST_BYTES + 1));
     await assert.rejects(p, (e: unknown) => {
         assert.ok(e instanceof BodyTooLargeError, `expected BodyTooLargeError, got ${(e as Error)?.constructor?.name}`);
         return true;
     });
-    assert.equal(destroyed, false, "req.destroy() must NOT be called (it cuts off the 413 response)");
+    assert.equal(destroyed, true, "req.destroy() must be called on over-limit (Bug C)");
 });
 
 test("readBody: BodyTooLargeError carries the limit", async () => {


### PR DESCRIPTION
Fixes 5 review bugs (from /tmp/v8.txt + regress-review.txt). Pure fixes, behavior-preserving.

- **v8#1 [HIGH]** forward() streaming: abort runCompressLoop (AbortSignal into loop + upstream fetch) when client closes — a dead connection no longer burns API on re-requests.
- **v8#3 [MED]** pipe: race drain vs close + break on destroyed — a destroyed socket no longer hangs the request for UPSTREAM_TIMEOUT_MS.
- **r7 [LOW-MED]** readBody: destroy the socket when body exceeds MAX_REQUEST_BYTES.
- **r3 [MED]** handle(): acquireInFlight immediately after getSession (outside the lock), release in an outer finally — closes the LRU-eviction split-brain window.
- **r8 [LOW]** recordUsage: only bump cacheSamples when a real cached-tokens sample exists.

Files: src/server.ts, src/loop/core.ts, src/fetch-util.ts + tests/fix-stream.test.ts. typecheck clean, 242/242 pass, build OK.