### PR TITLE
fix(responses): add mutatedThisTurn guard + use MAX_LOOP_ROUNDS in non-stream loop

### DIFF
--- a/src/compress-loop-responses.ts
+++ b/src/compress-loop-responses.ts
@@ -11,6 +11,7 @@ import { log as loggerLog } from "./logger.js";
 import { applyRanges } from "./stream.js";
 import { resolveDecompress } from "./decompress-shared.js";
 import { buildVisibilityMarker } from "./compress-loop.js";
+import { MAX_LOOP_ROUNDS } from "./loop/index.js";
 import { fetchWithTimeout } from "./fetch-util.js";
 import { proxyDispatcher } from "./upstream-proxy.js";
 
@@ -180,7 +181,7 @@ export async function compressLoopResponsesJson(
     requestOptions: RequestOptions,
 ): Promise<Record<string, unknown>> {
     let current = initialResponse;
-    for (let loopCount = 1; loopCount <= 5; loopCount++) {
+    for (let loopCount = 1; loopCount <= MAX_LOOP_ROUNDS; loopCount++) {
         const output = responsesJsonOutput(current);
         const extracted = extractTextTriggers(output.text);
         const allCalls = [...output.calls, ...extracted.calls].filter((call) => call.name.length > 0);
@@ -198,6 +199,7 @@ export async function compressLoopResponsesJson(
         if (extracted.clean.trim()) {
             inputItems.push({ type: "message", role: "assistant", content: [{ type: "output_text", text: extracted.clean }] });
         }
+        let mutatedThisTurn = false;
         for (const call of proxyCalls) {
             let args: Record<string, unknown> = {};
             try {
@@ -205,8 +207,15 @@ export async function compressLoopResponsesJson(
             } catch (error) {
                 loggerLog("warn", `[acp-compress-args] ${call.name} JSON.parse failed: ${String(error)}`);
             }
-            const result = executeProxyTool(call.name, args, ctx);
-            ctx.log(`[acp-proxy: responses JSON ${call.name} → ${result.slice(0, 120).replace(/\n/g, " ")}]`);
+            let result: string;
+            if (MUTATING_PROXY_TOOLS.has(call.name) && mutatedThisTurn) {
+                result = `Already ${call.name}ed once this turn. Do not ${call.name} again; generate your normal response now.`;
+                ctx.log(`[acp-proxy: responses JSON ${call.name} skipped (state already mutated this turn)]`);
+            } else {
+                result = executeProxyTool(call.name, args, ctx);
+                if (MUTATING_PROXY_TOOLS.has(call.name)) mutatedThisTurn = true;
+                ctx.log(`[acp-proxy: responses JSON ${call.name} → ${result.slice(0, 120).replace(/\n/g, " ")}]`);
+            }
             inputItems.push({ type: "message", role: "developer", content: buildVisibilityMarker(call.name, result) });
         }
         requestBody.input = inputItems;
@@ -226,6 +235,6 @@ export async function compressLoopResponsesJson(
             clearTimer();
         }
     }
-    ctx.log("[acp-proxy: responses JSON compress loop limit (5) reached]");
+    ctx.log(`[acp-proxy: responses JSON compress loop limit (${MAX_LOOP_ROUNDS}) reached]`);
     return current;
 }

--- a/tests/fix-responses-guard.test.ts
+++ b/tests/fix-responses-guard.test.ts
@@ -1,0 +1,106 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { compressLoopResponsesJson } from "../src/compress-loop-responses.ts";
+import type {
+    ApplyCompressionInput,
+    ApplyCompressionResult,
+    CompressionCore,
+    Config,
+    CoreMessage,
+} from "acp-kernel";
+import { createCore } from "acp-kernel";
+import type { Session } from "../src/session.ts";
+import { getSession } from "../src/session.ts";
+
+test("compressLoopResponsesJson: mutatedThisTurn guard — second mutating call in a turn is a no-op", async () => {
+    let applyCalls = 0;
+    const baseCore = createCore();
+    const applyCompression = (input: ApplyCompressionInput): ApplyCompressionResult => {
+        applyCalls += 1;
+        return {
+            state: input.state,
+            result: { blocksCreated: 0, tokensCompressed: 0, errors: [], warnings: [] },
+        };
+    };
+    const core: CompressionCore = { ...baseCore, applyCompression };
+    const session = getSession("test-guard");
+    const ctx = {
+        core,
+        config: { modelContextLimit: 200000 } as Config,
+        messages: [] as CoreMessage[],
+        session,
+        log: () => {},
+    };
+
+    let forwarded: Record<string, unknown> | undefined;
+    const previousFetch = globalThis.fetch;
+    globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+        forwarded = JSON.parse(String(init?.body)) as Record<string, unknown>;
+        return new Response(
+            JSON.stringify({
+                id: "resp_final",
+                status: "completed",
+                output: [{ type: "message", role: "assistant", content: [{ type: "output_text", text: "done" }] }],
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+        );
+    }) as typeof fetch;
+
+    try {
+        const initial = {
+            id: "resp_two_compress",
+            status: "completed",
+            output: [
+                {
+                    type: "function_call",
+                    id: "fc_c1",
+                    call_id: "call_c1",
+                    name: "compress",
+                    arguments: JSON.stringify({ content: [{ startId: "m1", endId: "m1", summary: "first" }] }),
+                },
+                {
+                    type: "function_call",
+                    id: "fc_c2",
+                    call_id: "call_c2",
+                    name: "compress",
+                    arguments: JSON.stringify({ content: [{ startId: "m2", endId: "m2", summary: "second" }] }),
+                },
+            ],
+        };
+        const out = await compressLoopResponsesJson(
+            initial,
+            ctx,
+            { model: "gpt-5", input: [{ type: "message", role: "user", content: "go" }] },
+            { url: "https://unused.example/responses", headers: { "content-type": "application/json" } },
+        );
+
+        assert.equal(
+            applyCalls,
+            1,
+            "applyCompression must run exactly once — second compress is a no-op (mutatedThisTurn guard)",
+        );
+
+        assert.ok(forwarded, "upstream was re-requested with both compress markers folded in");
+        const input = forwarded.input as Array<Record<string, unknown>>;
+        const devMessages = input.filter((item) => item.role === "developer");
+        assert.equal(devMessages.length, 2, "two developer markers (one per compress call)");
+
+        const NO_OP = /Already compressed once this turn\. Do not compress again; generate your normal response now\./;
+        assert.match(
+            JSON.stringify(devMessages[1]),
+            NO_OP,
+            "second compress returns the no-op 'Already compressed...' message",
+        );
+        assert.doesNotMatch(
+            JSON.stringify(devMessages[0]),
+            NO_OP,
+            "first compress executed for real, not the no-op",
+        );
+
+        const finalMsg = (out.output as Array<Record<string, unknown>>)[0]!;
+        const part = (finalMsg.content as Array<Record<string, unknown>>)[0]!;
+        assert.equal(part.text, "done");
+    } finally {
+        globalThis.fetch = previousFetch;
+    }
+});


### PR DESCRIPTION
Fixes 2 review bugs in the non-streaming Responses compress path.

- **r4 [MED]** compressLoopResponsesJson executed every compress/decompress call unconditionally — ported the runCompressLoop `mutatedThisTurn` guard (second mutating call in a turn is a no-op).
- **r5 [MED]** loop cap hardcoded 5 — now uses the shared MAX_LOOP_ROUNDS constant (10).

Files: src/compress-loop-responses.ts + tests/fix-responses-guard.test.ts. typecheck clean, 237/237 pass, build OK.