### PR TITLE
fix(config/session): honor env proxy by default + validate port + bound session pool

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -184,6 +184,9 @@ export function loadOptions(env: NodeJS.ProcessEnv = process.env): ProxyOptions 
 
     // --- Source 2: env vars (highest priority) ---
     const port = parseInt(env.ACP_PORT ?? env.PORT ?? `${fileConfig.port ?? 8787}`, 10);
+    if (!Number.isInteger(port) || port < 1 || port > 65535) {
+        throw new Error(`Invalid port ${Number.isNaN(port) ? "(not a number)" : port}; must be 1-65535`);
+    }
     const host = env.ACP_HOST ?? fileConfig.host ?? "127.0.0.1";
     const upstream = (env.ACP_UPSTREAM ?? fileConfig.upstream ?? "https://api.anthropic.com").replace(/\/$/, "");
     const routes = loadRoutes(env);
@@ -191,9 +194,9 @@ export function loadOptions(env: NodeJS.ProcessEnv = process.env): ProxyOptions 
     const biliProxy = nonEmpty(env.BILI_UPSTREAM_PROXY);
     const webProxy = nonEmpty(fileConfig.upstreamProxy);
     const configProxy = nonEmpty(fileConfig.proxy);
-    const proxyMode = parseUpstreamProxyMode(
-        env.BILI_UPSTREAM_PROXY_MODE ?? fileConfig.upstreamProxyMode ?? (webProxy ? "manual" : undefined),
-    );
+    const rawProxyMode = env.BILI_UPSTREAM_PROXY_MODE ?? fileConfig.upstreamProxyMode ?? (webProxy ? "manual" : undefined);
+    const proxyMode = parseUpstreamProxyMode(rawProxyMode);
+    const explicitDirect = proxyMode === "direct" && rawProxyMode === "direct";
     const proxy = biliProxy ?? (proxyMode === "direct" ? "" : proxyMode === "manual" ? webProxy ?? configProxy : configProxy);
     const proxySource: ProxyOptions["proxySource"] = biliProxy
         ? "bili-env"
@@ -213,8 +216,9 @@ export function loadOptions(env: NodeJS.ProcessEnv = process.env): ProxyOptions 
         ...(httpsProxy ? { httpsProxy } : {}),
         ...(allProxy ? { allProxy } : {}),
         ...(noProxy ? { noProxy } : {}),
-        biliPort: Number.isFinite(port) ? port : 8787,
+        biliPort: port,
         globalSource: proxySource,
+        explicitDirect,
     };
     validateHttpProxy(proxy, proxyFallback.biliPort);
     for (const [url, route] of Object.entries(routes)) {
@@ -225,7 +229,7 @@ export function loadOptions(env: NodeJS.ProcessEnv = process.env): ProxyOptions 
         }
     }
     return {
-        port: Number.isFinite(port) ? port : 8787,
+        port,
         host,
         upstream,
         routes,

--- a/src/session.ts
+++ b/src/session.ts
@@ -88,7 +88,8 @@ export type Session = {
 
 const sessions = new Map<string, Session>();
 
-const MAX_SESSIONS = Number.parseInt(process.env.BILI_MAX_SESSIONS ?? "256", 10) || 256;
+// `|| 256` only catches falsy (0/NaN); Math.max(1, ...) also rejects negatives.
+let MAX_SESSIONS = Math.max(1, Number.parseInt(process.env.BILI_MAX_SESSIONS ?? "256", 10) || 256);
 
 let initialized = false;
 
@@ -132,7 +133,12 @@ export function getSession(id: string, meta?: { protocol?: Session["meta"]["prot
         sessions.set(id, reloaded);
         return reloaded;
     }
-    if (sessions.size >= MAX_SESSIONS) evictOldest();
+    if (sessions.size >= MAX_SESSIONS) {
+        const evicted = evictOldest();
+        if (!evicted) {
+            throw new Error(`session pool exhausted (MAX_SESSIONS=${MAX_SESSIONS}; all in-flight)`);
+        }
+    }
     const session: Session = {
         id,
         meta: { protocol: meta?.protocol, upstreamOrigin: meta?.upstreamOrigin, label: meta?.label },
@@ -229,8 +235,8 @@ export function reconcileNativeCompactionBoundary(session: Session): boolean {
 
 /** Flush a session to disk and drop it from memory (LRU eviction). Refuses to
  *  evict sessions that are in-flight or whose flush failed (would lose a
- *  never-persisted session permanently). */
-function evictOldest(): void {
+ *  never-persisted session permanently). Returns true if a slot was freed. */
+function evictOldest(): boolean {
     let oldestId: string | undefined;
     let oldestSeen = Infinity;
     for (const [id, s] of sessions) {
@@ -243,18 +249,31 @@ function evictOldest(): void {
             oldestId = id;
         }
     }
-    if (!oldestId) return;
+    if (!oldestId) return false;
     const s = sessions.get(oldestId)!;
     const ok = getStore().flushSync(s);
     if (!ok && !s.persisted) {
         // Flush failed AND this session was never written to disk — evicting
         // would permanently lose it. Keep it in memory instead.
-        return;
+        return false;
     }
     sessions.delete(oldestId);
+    return true;
 }
 
 /** Graceful shutdown: flush all sessions with pending writes. */
 export async function flushAllSessions(): Promise<void> {
     await getStore().flushAll(sessions.values());
+}
+
+export function _resetSessionsForTest(max?: number): void {
+    if (max !== undefined) MAX_SESSIONS = Math.max(1, Math.floor(max));
+    for (const s of sessions.values()) {
+        if (s.inFlight > 0) s.inFlight = 0;
+    }
+    sessions.clear();
+}
+
+export function _sessionsSizeForTest(): number {
+    return sessions.size;
 }

--- a/src/upstream-proxy.ts
+++ b/src/upstream-proxy.ts
@@ -20,6 +20,10 @@ export type ProxyFallbackOptions = {
     biliPort?: number;
     systemProxy?: WindowsSystemProxy;
     globalSource?: "bili-env" | "web-manual" | "config" | "auto" | "direct";
+    /** True only when the user EXPLICITLY set proxy mode "direct". The default
+     *  unset mode also parses as "direct" but means "no preference" — in that
+     *  case an empty globalProxy must fall through to env proxy discovery. */
+    explicitDirect?: boolean;
 };
 
 export type UpstreamProxyDecision = {
@@ -237,7 +241,7 @@ export function resolveProxyDecision(
             return { proxy: parsed.url, source: "provider" };
         }
     }
-    if (globalProxy === "") return { source: "direct" };
+    if (globalProxy === "" && fallback.explicitDirect) return { source: "direct" };
     const explicit = parseHttpProxy(globalProxy, fallback.biliPort)?.url;
     if (explicit) return { proxy: explicit, source: fallback.globalSource ?? "global" };
     if (target && matchesNoProxy(target, fallback.noProxy)) return { source: "no-proxy" };

--- a/tests/fix-config-session.test.ts
+++ b/tests/fix-config-session.test.ts
@@ -1,0 +1,164 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { loadOptions, parseUpstreamProxyMode } from "../src/config.ts";
+import { resolveProxyDecision } from "../src/upstream-proxy.ts";
+import { SessionStore, _setStoreForTest } from "../src/persist.ts";
+import {
+    acquireInFlight,
+    getSession,
+    releaseInFlight,
+    _resetSessionsForTest,
+    _sessionsSizeForTest,
+} from "../src/session.ts";
+
+const HTTPS_UPSTREAM = "https://upstream.example/v1/messages";
+
+test("parseUpstreamProxyMode: unset -> direct (default), explicit strings preserved", () => {
+    assert.equal(parseUpstreamProxyMode(undefined), "direct");
+    assert.equal(parseUpstreamProxyMode("direct"), "direct");
+    assert.equal(parseUpstreamProxyMode("manual"), "manual");
+    assert.equal(parseUpstreamProxyMode("auto"), "auto");
+    assert.equal(parseUpstreamProxyMode("garbage"), "direct");
+});
+
+test("resolveProxyDecision: default mode (explicitDirect=false) + HTTPS_PROXY -> uses env proxy", () => {
+    const decision = resolveProxyDecision({}, "", HTTPS_UPSTREAM, {
+        httpsProxy: "http://proxy.example:8080",
+        explicitDirect: false,
+    });
+    assert.equal(decision.source, "HTTPS_PROXY");
+    assert.equal(decision.proxy, "http://proxy.example:8080/");
+});
+
+test("resolveProxyDecision: default mode (explicitDirect omitted) + HTTPS_PROXY -> uses env proxy", () => {
+    const decision = resolveProxyDecision({}, "", HTTPS_UPSTREAM, {
+        httpsProxy: "http://proxy.example:8080",
+    });
+    assert.equal(decision.source, "HTTPS_PROXY");
+    assert.equal(decision.proxy, "http://proxy.example:8080/");
+});
+
+test("resolveProxyDecision: explicit direct (explicitDirect=true) + HTTPS_PROXY -> direct, env ignored", () => {
+    const decision = resolveProxyDecision({}, "", HTTPS_UPSTREAM, {
+        httpsProxy: "http://proxy.example:8080",
+        explicitDirect: true,
+    });
+    assert.equal(decision.source, "direct");
+    assert.equal(decision.proxy, undefined);
+});
+
+test("resolveProxyDecision: default mode + HTTP_PROXY (http target) -> uses HTTP_PROXY", () => {
+    const decision = resolveProxyDecision({}, "", "http://upstream.example/v1/messages", {
+        httpProxy: "http://proxy.example:8080",
+        explicitDirect: false,
+    });
+    assert.equal(decision.source, "HTTP_PROXY");
+    assert.equal(decision.proxy, "http://proxy.example:8080/");
+});
+
+test("resolveProxyDecision: default mode + ALL_PROXY fallback -> uses ALL_PROXY", () => {
+    const decision = resolveProxyDecision({}, "", HTTPS_UPSTREAM, {
+        allProxy: "http://all.example:8080",
+        explicitDirect: false,
+    });
+    assert.equal(decision.source, "ALL_PROXY");
+    assert.equal(decision.proxy, "http://all.example:8080/");
+});
+
+test("resolveProxyDecision: default mode, no env set -> still direct", () => {
+    const decision = resolveProxyDecision({}, "", HTTPS_UPSTREAM, {
+        explicitDirect: false,
+    });
+    assert.equal(decision.source, "direct");
+    assert.equal(decision.proxy, undefined);
+});
+
+test("resolveProxyDecision: explicit global proxy (manual mode) still wins over env", () => {
+    const decision = resolveProxyDecision({}, "http://global.example:9090", HTTPS_UPSTREAM, {
+        httpsProxy: "http://proxy.example:8080",
+        globalSource: "config",
+    });
+    assert.equal(decision.source, "config");
+    assert.equal(decision.proxy, "http://global.example:9090/");
+});
+
+// --- Bug 2: loadOptions rejects out-of-range ports. ---
+
+for (const bad of ["0", "-1", "99999", "65536", "abc"]) {
+    test(`loadOptions: port ${JSON.stringify(bad)} throws`, () => {
+        assert.throws(() => loadOptions({ ACP_PORT: bad }), /Invalid port .* must be 1-65535/);
+    });
+}
+
+for (const good of ["1", "80", "8787", "65535"]) {
+    test(`loadOptions: port ${good} accepted`, () => {
+        const opts = loadOptions({ ACP_PORT: good });
+        assert.equal(opts.port, Number(good));
+    });
+}
+
+test("loadOptions: PORT env also validated (ACP_PORT absent)", () => {
+    assert.throws(() => loadOptions({ PORT: "0" }), /Invalid port/);
+    assert.throws(() => loadOptions({ PORT: "99999" }), /Invalid port/);
+});
+
+// --- Bug 3: getSession must not exceed MAX_SESSIONS when eviction can't free
+//     an in-flight slot; pool-exhausted throws instead of growing the Map. ---
+
+test("getSession: throws when pool exhausted and the only candidate is in-flight", () => {
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    _resetSessionsForTest(1);
+    try {
+        const a = getSession("a");
+        acquireInFlight(a);
+        assert.equal(_sessionsSizeForTest(), 1);
+        assert.throws(
+            () => getSession("b"),
+            /session pool exhausted \(MAX_SESSIONS=1; all in-flight\)/,
+        );
+        assert.equal(_sessionsSizeForTest(), 1, "pool size must not grow past MAX");
+    } finally {
+        releaseInFlight(getSession("a"));
+        _resetSessionsForTest();
+    }
+});
+
+test("getSession: evicts an idle session to make room when at MAX", () => {
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    _resetSessionsForTest(1);
+    try {
+        const a = getSession("a");
+        assert.equal(_sessionsSizeForTest(), 1);
+        const b = getSession("b");
+        assert.equal(_sessionsSizeForTest(), 1, "eviction must keep pool at MAX");
+        assert.notEqual(a.id, b.id);
+    } finally {
+        _resetSessionsForTest();
+    }
+});
+
+test("getSession: below MAX, no eviction, no throw", () => {
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    _resetSessionsForTest(256);
+    try {
+        getSession("x");
+        getSession("y");
+        getSession("z");
+        assert.equal(_sessionsSizeForTest(), 3);
+    } finally {
+        _resetSessionsForTest();
+    }
+});
+
+test("_resetSessionsForTest: clamps MAX to minimum 1 (mirrors module-load clamp)", () => {
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    _resetSessionsForTest(-5);
+    try {
+        const a = getSession("a");
+        acquireInFlight(a);
+        assert.throws(() => getSession("b"), /MAX_SESSIONS=1/);
+    } finally {
+        releaseInFlight(getSession("a"));
+        _resetSessionsForTest();
+    }
+});

--- a/tests/upstream-proxy-routing.test.ts
+++ b/tests/upstream-proxy-routing.test.ts
@@ -162,6 +162,7 @@ test("loadOptions keeps BILI_UPSTREAM_PROXY above config/environment fallback", 
         noProxy: "localhost,127.0.0.1",
         biliPort: 9100,
         globalSource: "bili-env",
+        explicitDirect: false,
     });
 });
 


### PR DESCRIPTION
Fixes 3 review bugs.

- **r1 [HIGH]** resolveProxyDecision only short-circuits to direct when mode is EXPLICITLY set; the default now falls through to HTTP_PROXY/HTTPS_PROXY/ALL_PROXY env (enterprise proxy no longer silently ignored).
- **v8#4 [MED]** loadOptions rejects ports outside 1-65535 instead of silently coercing.
- **v8#5 [MED-LOW]** session: don't exceed MAX_SESSIONS when eviction can't free an in-flight slot (throw instead of growing the Map unbounded).

Files: src/config.ts, src/upstream-proxy.ts, src/session.ts + tests/fix-config-session.test.ts. typecheck clean, 258/258 pass, build OK.