### PR TITLE
fix: novel review bugs (registry ESM, logger rotation, persist drain, dump error, tarball cap)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-node_modules/
+node_modules
 dist/
 *.log
 .env

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/home/dog/projects/billion-context-fix-stream/node_modules

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -93,7 +93,7 @@ export const log: Logger = (level, msg) => {
         // best-effort: stderr is gone (EPIPE), nothing we can do
     }
     // file — durable record.
-    const s = getStream();
+    let s = getStream();
     if (s) {
         // Runtime rotation: if we've crossed the threshold since last check,
         // reopen the file (rotates the old one out). This keeps a long-running
@@ -103,6 +103,7 @@ export const log: Logger = (level, msg) => {
                 s.end();
             } catch { /* best-effort */ }
             stream = openStream(logPath!);
+            s = stream;
         }
         try {
             s.write(line);

--- a/src/persist.ts
+++ b/src/persist.ts
@@ -405,6 +405,8 @@ export class SessionStore {
             );
         }
         await Promise.all(pending);
+        // Drain writes whose timer fired (absent from `dirty`) but are still mid-flight.
+        await Promise.allSettled([...this.writeChains.values()]);
     }
 
     /** Whether a write is currently pending (debounce timer armed) for a id. */

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,5 +1,5 @@
 import { readFile, writeFile, mkdir } from "node:fs/promises";
-import { existsSync } from "node:fs";
+import { existsSync, statSync } from "node:fs";
 import path from "node:path";
 import { cacheDir } from "./paths.js";
 import { log as loggerLog } from "./logger.js";
@@ -47,7 +47,7 @@ async function writeDiskCache(data: RegistryShape): Promise<void> {
 function diskCacheFresh(): boolean {
     if (!existsSync(CACHE_FILE)) return false;
     try {
-        const { mtimeMs } = require("node:fs").statSync(CACHE_FILE);
+        const { mtimeMs } = statSync(CACHE_FILE);
         return Date.now() - mtimeMs < TTL_MS;
     } catch {
         return false;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1312,6 +1312,7 @@ async function dumpStreamToFile(stream: ReadableStream<Uint8Array>, dir: string,
     try {
         mkdirSync(dir, { recursive: true });
         const ws = createWriteStream(join(dir, name));
+        ws.on("error", (e) => { loggerLog("debug", `[dump] write stream error: ${(e as Error).message ?? e}`); });
         const reader = stream.getReader();
         try {
             for (;;) {

--- a/src/update.ts
+++ b/src/update.ts
@@ -306,14 +306,35 @@ async function installViaTarball(
         return { ok: false, error: `install dir not writable: ${installDir}` };
     }
 
-    // Download tarball
+    // Download tarball. Stream into memory with a hard size cap so a corrupt
+    // or malicious tarball cannot exhaust memory.
+    const MAX_TARBALL_BYTES = 100 * 1024 * 1024;
     let tgzBuffer: Buffer;
     try {
         const tgzRes = await fetch(tarballUrl, { signal: AbortSignal.timeout(60_000) });
         if (!tgzRes.ok) {
             return { ok: false, error: `tarball download failed: HTTP ${tgzRes.status} ${tgzRes.statusText}` };
         }
-        tgzBuffer = Buffer.from(await tgzRes.arrayBuffer());
+        if (!tgzRes.body) {
+            return { ok: false, error: "tarball download failed: empty response body" };
+        }
+        const reader = tgzRes.body.getReader();
+        const chunks: Uint8Array[] = [];
+        let total = 0;
+        try {
+            for (;;) {
+                const { done, value } = await reader.read();
+                if (done) break;
+                total += value.byteLength;
+                if (total > MAX_TARBALL_BYTES) {
+                    return { ok: false, error: `tarball exceeds ${MAX_TARBALL_BYTES} byte cap` };
+                }
+                chunks.push(value);
+            }
+        } finally {
+            reader.releaseLock();
+        }
+        tgzBuffer = Buffer.concat(chunks);
     } catch (e) {
         return { ok: false, error: `tarball download failed: ${String(e)}` };
     }


### PR DESCRIPTION
## Novel bugs found by 3-client regression review (pi + codex)

All 5 confirmed real, minimal fixes (no `as any`, no `@ts-ignore`, no scope creep).

| # | File:line | Bug | Fix |
|---|---|---|---|
| 1 | `src/registry.ts:50` | `require("node:fs").statSync` undefined in ESM → ReferenceError caught by try/catch → **24h disk-cache TTL always missed** (network fetch every cold start) | added `statSync` to existing ESM import, used directly |
| 2 | `src/logger.ts:96-108` | post-rotation write targeted the const-captured **old (ended)** stream, not the newly-opened one → **post-rotation log lines lost** | `const s`→`let s` + `s = stream;` after reopen |
| 3 | `src/persist.ts:393-408` `flushAll` | only awaited sessions with a live debounce timer; an **in-flight** `writeNow` (timer fired, in `writeChains`) was not awaited → `process.exit(0)` could kill a mid-flight `fs.rename` → **lose last session state on shutdown** | `await Promise.allSettled([...this.writeChains.values()])` |
| 4 | `src/server.ts` `dumpStreamToFile` | `createWriteStream(...)` with **no `.on("error")`** → async stream error escapes try/catch → crashes process | added best-effort debug-log error listener |
| 5 | `src/update.ts:316` | `Buffer.from(await res.arrayBuffer())` buffered **entire tarball unbounded** → OOM on corrupt/malicious tarball | stream via `getReader()` with 100 MB `MAX_TARBALL_BYTES` cap |

### Also: untrack `node_modules`
`node_modules` was tracked as a symlink blob (mode 120000, committed by accident). Untracked it (`git rm --cached`). `.gitignore` had `node_modules/` (trailing slash = dir-only) which does NOT ignore a symlink — changed to `node_modules` so future `git add` won't re-add it.

### Verification
- typecheck: clean
- tests: **266 pass / 0 fail**
- build: ok (`dist/index.js` 2.00 MB)

### Diff
```
 .gitignore      |  2 +-
 node_modules    |  1 -
 src/logger.ts   |  3 ++-
 src/persist.ts  |  2 ++
 src/registry.ts |  4 ++--
 src/server.ts   |  1 +
 src/update.ts   | 25 +++++++++++++++++++++++--
 7 files changed, 31 insertions(+), 7 deletions(-)
```

Deferred (per directive — security/non-critical): mitm open-proxy (r2/v8#2, security), update.ts:146 lock-steal + update.ts:316 are in auto-update path (disabled via `autoUpdate:false`).