### PR TITLE
release v0.1.34 — bump acp-kernel to 0.0.19 (fixed 50K nudge growth)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@types/node": "^22.0.0",
         "@types/node-forge": "^1.3.14",
-        "acp-kernel": "0.0.18",
+        "acp-kernel": "0.0.19",
         "fzstd": "0.1.1",
         "node-forge": "^1.4.0",
         "tar": "^7.5.22",
@@ -972,9 +972,9 @@
       }
     },
     "node_modules/acp-kernel": {
-      "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.18.tgz",
-      "integrity": "sha512-V9QLaUvutOr3eSYuDMPfjkK3jUKexueiLsU2kEFpXUu6jeALjHACPZbYSYDxxpE1OkRDaD1XXxcjV+Q/t6v4NQ==",
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.19.tgz",
+      "integrity": "sha512-Ul13wjjP9bWYPBaUPyap4jeD4GpUJ1/sofWyJA/PxaEIOV9QmRDOvAJRAV436dojodgCpBv9UygyaJ7eiq4LuA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.33",
+      "version": "0.1.34",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/node-forge": "^1.3.14",
-    "acp-kernel": "0.0.18",
+    "acp-kernel": "0.0.19",
     "fzstd": "0.1.1",
     "node-forge": "^1.4.0",
     "tar": "^7.5.22",


### PR DESCRIPTION
# release v0.1.34 — bump acp-kernel to 0.0.19 (fixed 50K nudge growth)

## Summary

Bumps `acp-kernel` from `0.0.18` to **`0.0.19`**. No source changes — billion-context
inherits the kernel's nudge config and bundles it inline.

## What 0.0.19 brings

acp-kernel [v0.0.19](https://github.com/ranxianglei/acp-kernel/pull/61) pins the nudge
growth threshold to a **fixed 50,000 tokens**. Previously `resolveAdaptiveGrowth`
returned `5% of context (clamped 20K–50K)`, so sub-1M-context models got smaller
thresholds and nudges fired too eagerly, driving over-compression. Now every model
uses the same 50K growth threshold.

The change in the kernel (`src/config.ts`):

```diff
- growthFloor: Math.max(20000, Math.round(modelContextLimit * 0.05)),
+ growthFloor: 50000,
```

(`growthCap` is already 50000, so `resolveAdaptiveGrowth` now always returns 50000.)

## Changes in this PR (per AGENTS.md §4 — two-commit release pattern)

1. `deps: bump acp-kernel to exact 0.0.19` — package.json + package-lock.json
2. `release v0.1.34` — version 0.1.33 → 0.1.34 + lockfile version sync

No source changes.

## Verification

- typecheck (`tsc --noEmit --project tsconfig.build.json`): clean
- tests (`node --import tsx --test tests/*.test.ts`): 266 pass / 0 fail
- build (`tsup`): success, 1.99 MB

## Merge → auto-publish

Merging this PR triggers `release.yml`, which detects the `2026-08-12_release-v*`
branch, tags `v0.1.34`, and publishes to npm `latest`. PR merge is human-only.
