### PR TITLE
release v0.1.35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to **billion-context** are documented here.
+Versions follow the merge of a `*_release-v*` branch; CI publishes to npm on tag.
+
+## [0.1.35] — 2026-08-12
+
+### Features
+
+- **Cert-MITM launcher (`bili pi` / `bili codex` / `bili claude` / `bili test pi`)** (#98): one command auto-spawns a local bili proxy with MITM root-CA, redirects the client through it, and tears it down on exit. Discoveries are read from each client's config (Claude `~/.claude/settings.json`, Codex `~/.codex/config.toml`, Pi `~/.pi/agent/models.json`); HTTPS providers go through cert-MITM, HTTP providers through `/bili/` rewrite. `bili pi-test` runs an extension-free Pi (no double-compression with the billion-context-pi adapter).
+- **Codex Responses: read-only ACP tools as real function tools** (#120): `acp_status`, `search_context`, `decompress` are now injected as Responses `tools` (codex's `additional_tools` preserved). `compress` is also a function tool. Per-URL `compressProtocol: "tools" | "marker"` in the `providers` route config (default `tools` for all upstreams; set `"marker"` to force text markers).
+
+### Fixes
+
+- **Compress death-loop (definitive)** (#120): `hideConsumedCompressCalls` was hiding failed compress *attempt records* (call + result), blinding the model — it reset to "attempt 1" every round and looped to `MAX_LOOP_ROUNDS`. Now failed compress/decompress records stay visible so the model can count attempts, adapt, and stop with a report. Proxy-tool results (success or failure) are fed back as standard `function_call_output` (Responses) / tool-result (other protocols).
+- **Removed wrong guards & directives** (#120): the `mutatedThisTurn` (compress) / `readOnlyCalled` (acp_status) one-call guards and the proxy's `"Do not retry the same range."` directive were removed — they blocked legitimate multi-range compress and sent the model into retry spirals. The kernel's correct `"Combine more messages"` guidance is kept.
+- **Strip redundant in-place `acp_summary`** (#102): the host now strips the kernel's generic in-place summary markers (it relies on the compress tool-call as the record), preventing mid-stream insertion that broke prompt-cache prefixes.
+- **Code-review bug batch** (#113): `registry.ts` ESM `statSync` import (24 h TTL was never honored), `logger.ts` rotation writing to an ended stream, `persist.ts` `flushAll` missing in-flight write chains (shutdown data loss), `server.ts` dump WriteStream with no error listener, `update.ts` unbounded tarball buffer (OOM) — now streamed with a 100 MB cap.
+
+## [0.1.34] — 2026-08-11
+
+- Bump `acp-kernel` to **0.0.19** (fixed 50 K nudge growth).
+- Aborted-loop / drain-race / session-inFlight-race fixes (#109), Responses non-stream guard + `MAX_LOOP_ROUNDS` (#110), env-proxy-by-default + port validation + bounded session pool (#111), decompress temp-file reaper (#112), `acp_status` compressible-ranges in default overview (#103), visibility-marker role `developer` (#106), V1 streaming loops removed + forward-header/route dedup (#108).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.34",
+      "version": "0.1.35",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Release **v0.1.35**. Version bump `0.1.34 → 0.1.35` + new `CHANGELOG.md`.

## What's in v0.1.35 (since v0.1.34 / #114)

4 PRs merged:

### Features
- **#98** Cert-MITM launcher: `bili pi` / `bili codex` / `bili claude` / `bili test pi`. Auto-spawns a local proxy with MITM root-CA, routes the client through it, tears down on exit. Per-client config discovery (HTTPS→cert, HTTP→`/bili/` rewrite). `bili pi-test` = extension-free Pi.
- **#120** Codex Responses: read-only ACP tools (`acp_status`/`search_context`/`decompress`) + `compress` injected as real Responses function tools. Per-URL `compressProtocol` in `providers` route (default `tools`).

### Fixes
- **#120** Compress death-loop (definitive): `hideConsumedCompressCalls` hid *failed* attempt records → model reset to "attempt 1" every round → loop. Now failed records stay visible; model counts, adapts, stops, reports. Results fed back as standard `function_call_output` / tool-result.
- **#120** Removed wrong guards (`mutatedThisTurn`/`readOnlyCalled`) + the `"Do not retry"` directive; kept the kernel's correct `"Combine more messages"` guidance.
- **#102** Strip redundant in-place `acp_summary` markers (host relies on the compress tool-call record) — prevents mid-stream insertion that broke prompt-cache prefixes.
- **#113** Review-bug batch: registry ESM `statSync` (24h TTL), logger rotation ended-stream, persist `flushAll` in-flight drain, dump WriteStream error listener, update tarball OOM (→ 100MB stream cap).

See `CHANGELOG.md` for the full entry.

## Pre-flight
- `npm run typecheck` ✅
- `npm test` → **322/322** ✅
- `npm run build` ✅
- Only `package.json` + `package-lock.json` + `CHANGELOG.md` touched (release commit, no source changes).

Merge → CI publishes `billion-context@0.1.35`.
