### PR TITLE
release v0.1.36

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to **billion-context** are documented here.
 Versions follow the merge of a `*_release-v*` branch; CI publishes to npm on tag.
 
+## [0.1.36] — 2026-08-12
+
+### Fixes
+
+- **Round-2+ streaming after a tool call** (#122): `runCompressLoop` forwarded round-1 text to the client in real-time but **buffered** round-2+ text (the re-request round, emitted after the model calls `compress`/`acp_status`/…) and flushed it all at once when the stream completed — so the first token after a compress tool call appeared to hang. Round-2+ non-text-protocol text now streams per-delta (`yield adapter.emitText(ev.delta)`). The text-protocol path still buffers (marker extraction needs the whole text).
+
+### Tests
+
+- **L2 end-to-end proxy smoke test** (#122): `tests/e2e-proxy-smoke.test.ts` spins up the real `startServer` + a stub upstream. Round 1 returns a `compress` tool_call (bili intercepts → re-request); round 2 returns text deltas 40 ms apart. Asserts the upstream saw ≥2 requests (re-request happened), the client received the full text, and round-2 chunks span ≥50 ms (real-time streaming, not buffered). Model-free, deterministic, CI-friendly — would have caught the round-2 buffering bug.
+
 ## [0.1.35] — 2026-08-12
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## release v0.1.36

Small release: ships the round-2 streaming fix + the L2 e2e proxy smoke test (both from #122, already merged to master).

### Changes since v0.1.35
- **fix(loop): round-2+ streaming after a tool call** (#122, 5bd12b3) — `runCompressLoop` buffered round-2+ text (the re-request round after `compress`/`acp_status`/…) and flushed it all at once at stream-end, so the first token after a tool call appeared to hang. Now streams per-delta (`yield adapter.emitText(ev.delta)`). text-protocol still buffers (marker extraction).
- **test(e2e): proxy smoke** (#122, 977cae1) — model-free `startServer` + stub upstream; asserts compress→re-request fires + round-2 text streams in real-time (≥50 ms span). Would have caught the buffering bug.

### Release-only changes
- `package.json` 0.1.35 → 0.1.36
- `CHANGELOG.md` entry

### Verification
- typecheck clean
- 323/323 tests pass
- build OK

Merge → CI publishes `billion-context@0.1.36` + tag + Release.
