### PR TITLE
feat(config): three-level ACP/compression tuning (global > provider > model)

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -1,0 +1,330 @@
+# billion-context Configuration Reference
+
+[English](./CONFIGURATION.md) | [中文](./CONFIGURATION.zh-CN.md)
+
+`billion-context` is an HTTP proxy that injects [ACP](https://github.com/ranxianglei/acp-kernel) (Active Context Pruning) context compression into LLM API streams. Every option below lives in a single JSON config file (or an equivalent environment variable / CLI flag).
+
+---
+
+## Config File Locations
+
+| Scope | Path | Notes |
+|-------|------|-------|
+| **Config file (Linux)** | `~/.config/billion-context/billion-context.json` | XDG Base Directory — the canonical, user-editable config |
+| **Config file (override)** | value of `XDG_CONFIG_HOME` | relocates the whole config dir |
+| **Config file (explicit)** | value of `BILI_CONFIG_FILE` | points directly at any JSON file |
+| **CLI flag** | `--config <FILE>` | same as `BILI_CONFIG_FILE`; highest precedence for the file path |
+| **Session data** | `~/.local/share/billion-context/sessions/` | persisted compression state, grows over time |
+
+On first run, `billion-context` seeds an empty template (`{ "providers": {} }`) at the config path so you have something to edit. It never overwrites an existing file.
+
+The config file is a pure override layer — every field is optional. Anything unset falls through to the built-in default.
+
+---
+
+## Quick Start
+
+```jsonc
+// ~/.config/billion-context/billion-context.json
+{
+  // Server
+  "port": 8787,
+  "host": "127.0.0.1",
+
+  // Route two providers
+  "providers": {
+    "https://api.anthropic.com": {
+      "models": {
+        "claude-sonnet-4-5": { "context": 200000, "output": 8192 }
+      }
+    },
+    "https://generativelanguage.googleapis.com": {
+      "models": {
+        "gemini-2.5-pro": { "context": 1000000 }
+      }
+    }
+  },
+
+  // Global compression tuning (applies to every request)
+  "compress": {
+    "maxContextLimit": "75%",
+    "emergencyThresholdPercent": "95%"
+  }
+}
+```
+
+---
+
+## Parameter Reference
+
+Status legend: **ACTIVE** = currently used | **DEPRECATED** = accepted but no effect | **EXPERIMENTAL** = may change
+
+---
+
+## Server Settings
+
+Top-level keys that control how the proxy listens and behaves globally.
+
+### `port`
+
+- **Type:** `number`
+- **Default:** `8787`
+- **Status:** ACTIVE
+- **Description:** TCP port the proxy listens on. Must be an integer between 1 and 65535. Overridden by the `ACP_PORT` (or `PORT`) environment variable, or the `--port` CLI flag. An invalid value aborts startup.
+
+### `host`
+
+- **Type:** `string`
+- **Default:** `127.0.0.1`
+- **Status:** ACTIVE
+- **Description:** Network interface the proxy binds to. `127.0.0.1` (default) listens only on localhost — safe for a local sidecar. Use `::` for IPv4 + IPv6 dual-stack. Use `0.0.0.0` inside a container to expose the proxy on all interfaces (ensure the surrounding network is trusted). Overridden by `ACP_HOST` / `--host`.
+
+### `sessionHeader`
+
+- **Type:** `string`
+- **Default:** `x-acp-session`
+- **Status:** ACTIVE
+- **Description:** Name of the HTTP request header clients may send to identify a conversation. Requests carrying the same value share compression state across calls. Overridden by `ACP_SESSION_HEADER`.
+
+### `log`
+
+- **Type:** `boolean`
+- **Default:** `true`
+- **Status:** ACTIVE
+- **Description:** Enable per-request logging. Set `false` (or `ACP_LOG=0`) to silence the standard request log.
+
+### `debug`
+
+- **Type:** `boolean`
+- **Default:** `false`
+- **Status:** ACTIVE
+- **Description:** Verbose logging — equivalent to setting `ACP_DEBUG=1`. Useful for diagnosing routing or compression behaviour.
+
+### `passthrough`
+
+- **Type:** `boolean`
+- **Default:** `false`
+- **Status:** ACTIVE
+- **Description:** Forward every request to the upstream **without** compression, tool injection, or nudging. Equivalent to `ACP_PASSTHROUGH=1`. Handy for A/B comparison against the uncompressed baseline.
+
+### `proxy`
+
+- **Type:** `string`
+- **Default:** *(none — no upstream proxy)*
+- **Status:** ACTIVE
+- **Description:** Upstream HTTP proxy (`http://host:port`) used for the proxy's **own** outbound connections to model providers. SOCKS5 is not supported. A per-URL `proxy` set inside a `providers` entry overrides this for that provider. An empty string means "explicitly direct" — it disables any environment/system proxy fallback for all providers.
+
+---
+
+## Providers
+
+The `providers` block maps **upstream URLs** to per-provider configuration. Each key is a URL prefix; each value can declare model context windows, a per-provider proxy, a compression protocol, and compression overrides.
+
+```jsonc
+{
+  "providers": {
+    "https://api.anthropic.com": {
+      "models": {
+        "claude-sonnet-4-5": { "context": 200000, "output": 8192 }
+      },
+      "proxy": "http://10.0.0.1:7890",
+      "compressProtocol": "tools",
+      "compress": { "maxContextLimit": "70%" }
+    }
+  }
+}
+```
+
+### URL key matching
+
+Keys are matched against the request's upstream URL by **longest-prefix wins**. A key matches if the request URL equals the key, or starts with `key + "/"`. This makes matching boundary-safe: a key `https://api.example.com` matches `https://api.example.com/v1/chat` but does **not** match `https://api.example.com.evil` (an attacker-controlled lookalike host).
+
+A shallow key (`https://open.bigmodel.cn`) matches every path on that host. A deep key (`https://open.bigmodel.cn/api/anthropic`) matches only that endpoint. When two keys both match, the longest (most specific) one wins. Trailing slashes on keys are stripped automatically.
+
+### `models`
+
+- **Type:** `Record<string, { context?: number; output?: number; compress?: CompressSettings }>`
+- **Default:** *(none)*
+- **Status:** ACTIVE
+- **Description:** Maps a model name to its context-window declaration. The LLM `/models` endpoint does **not** return context windows (verified across OpenAI, Anthropic, zhipu, comfly), so the proxy cannot discover them at runtime — you must declare them here. `context` is the model's context window in tokens; `output` is the max output size. When a model is not declared, the proxy falls back to its built-in context table or the models.dev registry. Each model entry may also carry a per-model `compress` block (see [Compression Tuning](#compression-tuning)).
+
+### `proxy`
+
+- **Type:** `string`
+- **Default:** *(inherits top-level `proxy`)*
+- **Status:** ACTIVE
+- **Description:** Per-provider upstream HTTP proxy (`http://host:port`). Overrides the top-level `proxy` for this provider only. An empty string means "explicitly direct" — override the global proxy with no proxy for this one provider.
+
+### `compressProtocol`
+
+- **Type:** `"tools" | "marker"`
+- **Default:** `"tools"`
+- **Status:** ACTIVE
+- **Description:** How compression tools are injected into the request. `"tools"` (default) injects them as native function-call tools. `"marker"` uses a text-trigger protocol instead — use this for upstreams that cannot coexist with a declared `tools` field.
+
+### `compress`
+
+- **Type:** `CompressSettings`
+- **Default:** *(inherits global `compress`)*
+- **Status:** ACTIVE
+- **Description:** Per-provider compression overrides. This is **level 2 of 3** in the merge hierarchy — see [Compression Tuning](#compression-tuning).
+
+---
+
+## Compression Tuning
+
+Compression behaviour is controlled by the `compress` block, which can appear at three levels. They merge **per-field, deepest wins**: a field set at a deeper level overrides the same field higher up, but an *unset* field at a deeper level never clears a value set higher up. In other words, the child covers the parent field-by-field — it never replaces the whole object.
+
+The three levels, from broadest to most specific:
+
+1. **Global** — a top-level `"compress": { … }` key. Applies to every request. This is the only level where the `injectTool` / `injectNudge` toggles are honoured.
+2. **Per-provider** — a `"compress": { … }` block inside a `providers[url]` entry.
+3. **Per-model** — a `"compress": { … }` block inside a `providers[url].models[model]` entry.
+
+For each request, the proxy resolves the settings by longest-URL-prefix match (to find the provider) and the request's model name (to find the model entry), then merges global → provider → model.
+
+### CompressSettings fields
+
+#### `modelContextLimit`
+
+- **Type:** `number | string`
+- **Default:** *(the model's native window)*
+- **Status:** ACTIVE
+- **Description:** The context window size, in tokens. This is the **denominator** the engine uses for its usage ratio (`usage = tokens / modelContextLimit`) — it is **not** a truncation cap. Accepts an absolute number (`200000`) or a percent string (`"80%"` = 80% of the model's native window, resolved from the built-in table or models.dev registry). When omitted at every level, the native window is used. This is the highest-priority source for the model limit; it overrides the built-in table, the legacy per-model `context` field, and the top-level `modelContextLimit`.
+
+#### `maxContextLimit`
+
+- **Type:** `number | string`
+- **Default:** `"75%"`
+- **Status:** ACTIVE
+- **Description:** Context-usage threshold that triggers **forced compression** nudges. Once usage crosses this ratio, the engine fires a nudge that bypasses the growth-gate and cadence checks. Accepts a ratio (`0.75`) or a percent string (`"75%"`). Lower values compress earlier. Maps to the kernel field `nudge.maxContextLimitPct`.
+
+#### `emergencyThresholdPercent`
+
+- **Type:** `number | string`
+- **Default:** `"95%"`
+- **Status:** ACTIVE
+- **Description:** Context-usage threshold that triggers **emergency truncation** of large tool outputs. Accepts a ratio or a percent string. Must be greater than or equal to `maxContextLimit`. Maps to the kernel fields `nudge.emergencyThresholdPct` and `truncate.threshold`.
+
+#### `nudgeGrowthTokens`
+
+- **Type:** `number`
+- **Default:** `50000`
+- **Status:** ACTIVE
+- **Description:** Token-growth step for soft compression nudges. A nudge fires roughly every time this many tokens become compressible. Lower values produce more frequent nudges. Maps to the kernel fields `nudge.growthFloor` and `nudge.growthCap` (it flattens the engine's adaptive band to this fixed step).
+
+#### `preserveRecentMessages`
+
+- **Type:** `number`
+- **Default:** *(kernel default, typically `5`)*
+- **Status:** ACTIVE
+- **Description:** Number of most-recent messages that are never offered for compression. Protects the active working set so the model retains the latest turns verbatim. Maps to the kernel field `preserveRecentMessages`.
+
+#### `preserveRecentTokens`
+
+- **Type:** `number`
+- **Default:** *(kernel default, typically `5000`)*
+- **Status:** ACTIVE
+- **Description:** Token budget reserved for recent-message protection. Maps to the kernel field `preserveRecentTokens`.
+
+#### `minCompressRange`
+
+- **Type:** `number`
+- **Default:** *(kernel default, typically `5000`)*
+- **Status:** ACTIVE
+- **Description:** Minimum token count for a message range to be eligible for compression; smaller ranges are skipped. Maps to the kernel field `compress.minCompressRange`.
+
+#### `tiers`
+
+- **Type:** `boolean`
+- **Default:** `true`
+- **Status:** ACTIVE
+- **Description:** Enable multi-tier compression — tier-2 distillation of old summaries and tier-3 condensation. Set `false` to run in tier-1-only mode (every summary is a flat tier-1 summary). Maps to the kernel field `tiers.enabled`.
+
+### Injection toggles (global only)
+
+These two toggles are honoured only at the **global** level. Setting them inside a per-provider or per-model `compress` block has no effect.
+
+#### `injectTool`
+
+- **Type:** `boolean`
+- **Default:** `true`
+- **Status:** ACTIVE
+- **Description:** Inject the `compress` / `decompress` / `search_context` tools and the compression system prompt into each request. Set `false` (or `ACP_COMPRESS_TOOL=0`) to disable tool injection entirely.
+
+#### `injectNudge`
+
+- **Type:** `boolean`
+- **Default:** `true`
+- **Status:** ACTIVE
+- **Description:** Inject automatic compression-nudge messages when usage thresholds are crossed. Set `false` (or `ACP_COMPRESS_NUDGE=0`) to disable nudge injection. Disabling both `injectTool` and `injectNudge` is functionally similar to `passthrough`, except the proxy still tracks token usage.
+
+### Three-level merge example
+
+This example shows global defaults, a per-provider override, and a per-model override all stacking per-field:
+
+```jsonc
+{
+  // Level 1 — global: applies to every request
+  "compress": {
+    "maxContextLimit": "75%",
+    "emergencyThresholdPercent": "95%",
+    "nudgeGrowthTokens": 50000,
+    "tiers": true,
+    "injectTool": true,
+    "injectNudge": true
+  },
+
+  "providers": {
+    "https://api.anthropic.com": {
+      // Level 2 — per-provider: overrides global fields for this provider
+      "compress": {
+        "maxContextLimit": "70%",          // compress a bit earlier here
+        "preserveRecentMessages": 8        // keep more recent turns
+      },
+      "models": {
+        "claude-sonnet-4-5": {
+          "context": 200000,
+          // Level 3 — per-model: the deepest, highest priority
+          "compress": {
+            "modelContextLimit": 180000,   // treat window as 180k (leaves headroom)
+            "emergencyThresholdPercent": "90%"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+For a request to `https://api.anthropic.com/v1/messages` with model `claude-sonnet-4-5`, the resolved settings are:
+
+| Field | Resolved from | Value |
+|-------|---------------|-------|
+| `maxContextLimit` | provider (level 2) | `"70%"` |
+| `emergencyThresholdPercent` | model (level 3) | `"90%"` |
+| `nudgeGrowthTokens` | global (level 1) | `50000` |
+| `preserveRecentMessages` | provider (level 2) | `8` |
+| `modelContextLimit` | model (level 3) | `180000` |
+| `tiers` | global (level 1) | `true` |
+
+---
+
+## Environment Variables
+
+Environment variables take precedence over the config file. They are useful for environment-specific overrides (CI, containers) without editing the file.
+
+| Variable | Effect |
+|----------|--------|
+| `ACP_DEBUG` | Set to `1` for verbose logging (same as `"debug": true`). |
+| `ACP_PASSTHROUGH` | Set to `1` to forward without compression (same as `"passthrough": true`). |
+| `ACP_COMPRESS_TOOL` | Set to `0` to disable tool injection (same as `"compress.injectTool": false`). |
+| `ACP_COMPRESS_NUDGE` | Set to `0` to disable nudge injection (same as `"compress.injectNudge": false`). |
+| `ACP_MODEL_CONTEXT_LIMIT` | Override the context limit globally (absolute token count). |
+| `BILI_CONFIG_FILE` | Override the config file path (point at any JSON file). |
+| `ACP_PORT` / `PORT` | Override the listen port. |
+| `ACP_HOST` | Override the listen host. |
+| `ACP_UPSTREAM` | Override the default upstream base URL. |
+| `ACP_LOG` | Set to `0` to disable request logging. |
+| `ACP_AUTO_UPDATE` | Set to `0` to disable auto-update checks. |
+| `ACP_PROVIDERS` | Path to an external `providers.json` (legacy / shared file). |

--- a/CONFIGURATION.zh-CN.md
+++ b/CONFIGURATION.zh-CN.md
@@ -1,0 +1,330 @@
+# billion-context 配置参考
+
+[English](./CONFIGURATION.md) | [中文](./CONFIGURATION.zh-CN.md)
+
+`billion-context` 是一个 HTTP 代理，用于将 [ACP](https://github.com/ranxianglei/acp-kernel)（Active Context Pruning，主动上下文剪枝）的上下文压缩注入到 LLM API 流中。下文所有选项都位于同一个 JSON 配置文件中（也可通过等价的环境变量 / CLI 参数设置）。
+
+---
+
+## 配置文件位置
+
+| 范围 | 路径 | 说明 |
+|------|------|------|
+| **配置文件（Linux）** | `~/.config/billion-context/billion-context.json` | XDG 基础目录规范 —— 标准、用户可编辑的配置 |
+| **配置文件（覆盖目录）** | `XDG_CONFIG_HOME` 的值 | 重定位整个配置目录 |
+| **配置文件（显式指定）** | `BILI_CONFIG_FILE` 的值 | 直接指向任意 JSON 文件 |
+| **CLI 参数** | `--config <FILE>` | 与 `BILI_CONFIG_FILE` 等价，文件路径优先级最高 |
+| **会话数据** | `~/.local/share/billion-context/sessions/` | 持久化的压缩状态，会随时间增长 |
+
+首次运行时，`billion-context` 会在配置路径下生成一个空模板（`{ "providers": {} }`），方便你直接编辑。它**不会**覆盖已存在的文件。
+
+配置文件是一个纯粹的覆盖层 —— 每个字段都是可选的。任何未设置的字段都会回退到内置默认值。
+
+---
+
+## 快速开始
+
+```jsonc
+// ~/.config/billion-context/billion-context.json
+{
+  // 服务端
+  "port": 8787,
+  "host": "127.0.0.1",
+
+  // 路由两个 provider
+  "providers": {
+    "https://api.anthropic.com": {
+      "models": {
+        "claude-sonnet-4-5": { "context": 200000, "output": 8192 }
+      }
+    },
+    "https://generativelanguage.googleapis.com": {
+      "models": {
+        "gemini-2.5-pro": { "context": 1000000 }
+      }
+    }
+  },
+
+  // 全局压缩调优（应用于每个请求）
+  "compress": {
+    "maxContextLimit": "75%",
+    "emergencyThresholdPercent": "95%"
+  }
+}
+```
+
+---
+
+## 参数参考
+
+状态说明：**ACTIVE（启用）** = 当前生效 | **DEPRECATED（已弃用）** = 接受但无效果 | **EXPERIMENTAL（实验性）** = 可能变更
+
+---
+
+## 服务端设置
+
+这些顶层键控制代理的监听方式与全局行为。
+
+### `port`
+
+- **类型：** `number`
+- **默认值：** `8787`
+- **状态：** ACTIVE
+- **说明：** 代理监听的 TCP 端口。必须是 1 到 65535 之间的整数。可由 `ACP_PORT`（或 `PORT`）环境变量或 `--port` CLI 参数覆盖。非法值会导致启动中止。
+
+### `host`
+
+- **类型：** `string`
+- **默认值：** `127.0.0.1`
+- **状态：** ACTIVE
+- **说明：** 代理绑定的网络接口。`127.0.0.1`（默认）仅监听本机 —— 适合本地 sidecar。使用 `::` 可同时监听 IPv4 + IPv6 双栈。在容器中使用 `0.0.0.0` 可将代理暴露到所有接口（请确保所在网络是可信的）。可由 `ACP_HOST` / `--host` 覆盖。
+
+### `sessionHeader`
+
+- **类型：** `string`
+- **默认值：** `x-acp-session`
+- **状态：** ACTIVE
+- **说明：** 客户端可发送的、用于标识一次会话的 HTTP 请求头名称。携带相同值的请求会在多次调用间共享压缩状态。可由 `ACP_SESSION_HEADER` 覆盖。
+
+### `log`
+
+- **类型：** `boolean`
+- **默认值：** `true`
+- **状态：** ACTIVE
+- **说明：** 启用逐请求日志。设为 `false`（或 `ACP_LOG=0`）可关闭标准请求日志。
+
+### `debug`
+
+- **类型：** `boolean`
+- **默认值：** `false`
+- **状态：** ACTIVE
+- **说明：** 详细日志 —— 等价于设置 `ACP_DEBUG=1`。在排查路由或压缩行为时很有用。
+
+### `passthrough`
+
+- **类型：** `boolean`
+- **默认值：** `false`
+- **状态：** ACTIVE
+- **说明：** 将每个请求**不经过**压缩、工具注入或 nudge，直接转发到上游。等价于 `ACP_PASSTHROUGH=1`。便于与未压缩基线做 A/B 对比。
+
+### `proxy`
+
+- **类型：** `string`
+- **默认值：** *（无 —— 不使用上游代理）*
+- **状态：** ACTIVE
+- **说明：** 用于代理**自身**到模型 provider 的出站连接的上游 HTTP 代理（`http://host:port`）。不支持 SOCKS5。在 `providers` 条目内设置的按 URL 的 `proxy` 会针对该 provider 覆盖此项。空字符串表示"显式直连" —— 为所有 provider 禁用任何环境/系统代理回退。
+
+---
+
+## Providers
+
+`providers` 块将**上游 URL** 映射到按 provider 的配置。每个键是一个 URL 前缀；每个值可以声明模型上下文窗口、按 provider 的代理、压缩协议以及压缩覆盖项。
+
+```jsonc
+{
+  "providers": {
+    "https://api.anthropic.com": {
+      "models": {
+        "claude-sonnet-4-5": { "context": 200000, "output": 8192 }
+      },
+      "proxy": "http://10.0.0.1:7890",
+      "compressProtocol": "tools",
+      "compress": { "maxContextLimit": "70%" }
+    }
+  }
+}
+```
+
+### URL 键匹配
+
+键通过**最长前缀胜出**的方式与请求的上游 URL 匹配。当请求 URL 等于该键，或以 `键 + "/"` 开头时，匹配成立。这使得匹配在边界上是安全的：键 `https://api.example.com` 能匹配 `https://api.example.com/v1/chat`，但**不会**匹配 `https://api.example.com.evil`（一个攻击者控制的相似域名）。
+
+浅层键（`https://open.bigmodel.cn`）匹配该主机上的所有路径。深层键（`https://open.bigmodel.cn/api/anthropic`）仅匹配该端点。当两个键都匹配时，最长（最具体）的那个胜出。键末尾的斜杠会被自动去除。
+
+### `models`
+
+- **类型：** `Record<string, { context?: number; output?: number; compress?: CompressSettings }>`
+- **默认值：** *（无）*
+- **状态：** ACTIVE
+- **说明：** 将模型名映射到其上下文窗口声明。LLM 的 `/models` 端点**不会**返回上下文窗口大小（已在 OpenAI、Anthropic、zhipu、comfly 上验证），因此代理无法在运行时发现它们 —— 你必须在此声明。`context` 是模型的上下文窗口（以 token 为单位）；`output` 是最大输出大小。当模型未声明时，代理回退到内置上下文表或 models.dev 注册表。每个模型条目还可以携带按模型的 `compress` 块（见[压缩调优](#压缩调优)）。
+
+### `proxy`
+
+- **类型：** `string`
+- **默认值：** *（继承顶层 `proxy`）*
+- **状态：** ACTIVE
+- **说明：** 按 provider 的上游 HTTP 代理（`http://host:port`）。仅针对该 provider 覆盖顶层 `proxy`。空字符串表示"显式直连" —— 在这一个 provider 上覆盖全局代理且不使用任何代理。
+
+### `compressProtocol`
+
+- **类型：** `"tools" | "marker"`
+- **默认值：** `"tools"`
+- **状态：** ACTIVE
+- **说明：** 压缩工具注入请求的方式。`"tools"`（默认）将它们作为原生函数调用工具注入。`"marker"` 改用文本触发协议 —— 用于那些无法与已声明的 `tools` 字段共存的下游上游。
+
+### `compress`
+
+- **类型：** `CompressSettings`
+- **默认值：** *（继承全局 `compress`）*
+- **状态：** ACTIVE
+- **说明：** 按 provider 的压缩覆盖项。这是三层合并中的**第 2 层** —— 见[压缩调优](#压缩调优)。
+
+---
+
+## 压缩调优
+
+压缩行为由 `compress` 块控制，它可以出现在三个层级。它们按**逐字段、最深层胜出**的方式合并：在更深层设置的字段会覆盖上层同名字段，但更深层*未设置*的字段**永远不会**清除上层已设置的值。换言之，子级按字段覆盖父级 —— 它绝不是整体替换对象。
+
+三个层级，从最宽泛到最具体：
+
+1. **全局（Global）** —— 顶层 `"compress": { … }` 键。应用于每个请求。这是唯一会生效 `injectTool` / `injectNudge` 开关的层级。
+2. **按 provider（Per-provider）** —— `providers[url]` 条目内的 `"compress": { … }` 块。
+3. **按模型（Per-model）** —— `providers[url].models[model]` 条目内的 `"compress": { … }` 块。
+
+对于每个请求，代理通过最长 URL 前缀匹配（找到 provider）和请求的模型名（找到模型条目）来解析设置，随后按 全局 → provider → 模型 合并。
+
+### CompressSettings 字段
+
+#### `modelContextLimit`
+
+- **类型：** `number | string`
+- **默认值：** *（模型的原始窗口）*
+- **状态：** ACTIVE
+- **说明：** 上下文窗口大小，以 token 为单位。它是引擎用于计算使用率比例的**分母**（`usage = tokens / modelContextLimit`）—— 它**不是**截断上限。接受绝对数值（`200000`）或百分比字符串（`"80%"` = 模型原始窗口的 80%，从内置表或 models.dev 注册表解析）。在每个层级都省略时，使用原始窗口。这是模型上限的最高优先级来源；它会覆盖内置表、旧版按模型的 `context` 字段以及顶层的 `modelContextLimit`。
+
+#### `maxContextLimit`
+
+- **类型：** `number | string`
+- **默认值：** `"75%"`
+- **状态：** ACTIVE
+- **说明：** 触发**强制压缩** nudge 的上下文使用率阈值。一旦使用率越过该比例，引擎就会触发一个绕过 growth-gate 与节奏检查的 nudge。接受比例值（`0.75`）或百分比字符串（`"75%"`）。值越小，压缩越早。映射到内核字段 `nudge.maxContextLimitPct`。
+
+#### `emergencyThresholdPercent`
+
+- **类型：** `number | string`
+- **默认值：** `"95%"`
+- **状态：** ACTIVE
+- **说明：** 触发大型工具输出**紧急截断**的上下文使用率阈值。接受比例值或百分比字符串。必须大于或等于 `maxContextLimit`。映射到内核字段 `nudge.emergencyThresholdPct` 和 `truncate.threshold`。
+
+#### `nudgeGrowthTokens`
+
+- **类型：** `number`
+- **默认值：** `50000`
+- **状态：** ACTIVE
+- **说明：** 软压缩 nudge 的 token 增长步长。每当有这么多 token 变为可压缩时，大约就会触发一次 nudge。值越小，nudge 越频繁。映射到内核字段 `nudge.growthFloor` 和 `nudge.growthCap`（它将引擎的自适应区间扁平化为这个固定步长）。
+
+#### `preserveRecentMessages`
+
+- **类型：** `number`
+- **默认值：** *（内核默认值，通常为 `5`）*
+- **状态：** ACTIVE
+- **说明：** 永远不会被纳入压缩的最新消息条数。用于保护活跃工作集，使模型逐字保留最近的几轮对话。映射到内核字段 `preserveRecentMessages`。
+
+#### `preserveRecentTokens`
+
+- **类型：** `number`
+- **默认值：** *（内核默认值，通常为 `5000`）*
+- **状态：** ACTIVE
+- **说明：** 为最近消息保护预留的 token 预算。映射到内核字段 `preserveRecentTokens`。
+
+#### `minCompressRange`
+
+- **类型：** `number`
+- **默认值：** *（内核默认值，通常为 `5000`）*
+- **状态：** ACTIVE
+- **说明：** 一个消息范围可被纳入压缩的最小 token 数；更小的范围会被跳过。映射到内核字段 `compress.minCompressRange`。
+
+#### `tiers`
+
+- **类型：** `boolean`
+- **默认值：** `true`
+- **状态：** ACTIVE
+- **说明：** 启用多层压缩 —— 对旧摘要进行 tier-2 蒸馏，以及 tier-3 凝缩。设为 `false` 可运行在仅 tier-1 模式（每个摘要都是扁平的 tier-1 摘要）。映射到内核字段 `tiers.enabled`。
+
+### 注入开关（仅全局生效）
+
+这两个开关只在**全局**层级生效。在按 provider 或按模型的 `compress` 块中设置它们无效。
+
+#### `injectTool`
+
+- **类型：** `boolean`
+- **默认值：** `true`
+- **状态：** ACTIVE
+- **说明：** 将 `compress` / `decompress` / `search_context` 工具与压缩系统提示注入每个请求。设为 `false`（或 `ACP_COMPRESS_TOOL=0`）可完全禁用工具注入。
+
+#### `injectNudge`
+
+- **类型：** `boolean`
+- **默认值：** `true`
+- **状态：** ACTIVE
+- **说明：** 当使用率越过阈值时注入自动压缩 nudge 消息。设为 `false`（或 `ACP_COMPRESS_NUDGE=0`）可禁用 nudge 注入。同时禁用 `injectTool` 和 `injectNudge` 在功能上类似 `passthrough`，区别在于代理仍会跟踪 token 使用量。
+
+### 三层合并示例
+
+本示例展示了全局默认值、按 provider 覆盖与按模型覆盖如何逐字段叠加：
+
+```jsonc
+{
+  // 第 1 层 —— 全局：应用于每个请求
+  "compress": {
+    "maxContextLimit": "75%",
+    "emergencyThresholdPercent": "95%",
+    "nudgeGrowthTokens": 50000,
+    "tiers": true,
+    "injectTool": true,
+    "injectNudge": true
+  },
+
+  "providers": {
+    "https://api.anthropic.com": {
+      // 第 2 层 —— 按 provider：为该 provider 覆盖全局字段
+      "compress": {
+        "maxContextLimit": "70%",          // 在此稍微提前压缩
+        "preserveRecentMessages": 8        // 保留更多最近轮次
+      },
+      "models": {
+        "claude-sonnet-4-5": {
+          "context": 200000,
+          // 第 3 层 —— 按模型：最深层，优先级最高
+          "compress": {
+            "modelContextLimit": 180000,   // 将窗口视为 18 万（留出余量）
+            "emergencyThresholdPercent": "90%"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+对于发往 `https://api.anthropic.com/v1/messages`、模型为 `claude-sonnet-4-5` 的请求，解析出的设置为：
+
+| 字段 | 来源 | 值 |
+|------|------|-----|
+| `maxContextLimit` | provider（第 2 层） | `"70%"` |
+| `emergencyThresholdPercent` | 模型（第 3 层） | `"90%"` |
+| `nudgeGrowthTokens` | 全局（第 1 层） | `50000` |
+| `preserveRecentMessages` | provider（第 2 层） | `8` |
+| `modelContextLimit` | 模型（第 3 层） | `180000` |
+| `tiers` | 全局（第 1 层） | `true` |
+
+---
+
+## 环境变量
+
+环境变量优先于配置文件。在不修改文件的情况下，它们适用于环境特定的覆盖（CI、容器）。
+
+| 变量 | 效果 |
+|------|------|
+| `ACP_DEBUG` | 设为 `1` 开启详细日志（等同 `"debug": true`）。 |
+| `ACP_PASSTHROUGH` | 设为 `1` 不经压缩直接转发（等同 `"passthrough": true`）。 |
+| `ACP_COMPRESS_TOOL` | 设为 `0` 禁用工具注入（等同 `"compress.injectTool": false`）。 |
+| `ACP_COMPRESS_NUDGE` | 设为 `0` 禁用 nudge 注入（等同 `"compress.injectNudge": false`）。 |
+| `ACP_MODEL_CONTEXT_LIMIT` | 全局覆盖上下文上限（绝对 token 数）。 |
+| `BILI_CONFIG_FILE` | 覆盖配置文件路径（指向任意 JSON 文件）。 |
+| `ACP_PORT` / `PORT` | 覆盖监听端口。 |
+| `ACP_HOST` | 覆盖监听主机。 |
+| `ACP_UPSTREAM` | 覆盖默认上游 base URL。 |
+| `ACP_LOG` | 设为 `0` 关闭请求日志。 |
+| `ACP_AUTO_UPDATE` | 设为 `0` 禁用自动更新检查。 |
+| `ACP_PROVIDERS` | 指向外部 `providers.json` 的路径（旧版 / 共享文件）。 |

--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ The config file is a single JSON object. Example:
 | `debug` | `false` | Verbose logging (same as `ACP_DEBUG=1`) |
 | `passthrough` | `false` | Forward without compression (same as `ACP_PASSTHROUGH=1`) |
 | `providers` | *(none)* | Per-URL context overrides — see below |
-| `compress` | *(see defaults)* | `{ injectTool, injectNudge }` |
+| `compress` | *(see defaults)* | Global compression block: `{ injectTool, injectNudge }` injection toggles **plus** engine tuning (`nudgeGrowthTokens`, `modelContextLimit`, …) — see [Compression tuning](#compression-tuning-the-compress-block) |
 | `proxy` | *(none)* | Upstream HTTP proxy for the proxy's OWN outbound connections to model providers (`http://host:port`). Per-URL `proxy` overrides this. See [Upstream proxy](#upstream-proxy-firewall--gfw). |
 
 > **Choosing a `host`** (IPv6 / containers): the default `127.0.0.1` is
@@ -474,6 +474,61 @@ registry, then the built-in prefix table.
 > document-level information. A wrong value (e.g. GLM-5.2 guessed as 128K
 > instead of 1M) causes spurious frequent compression. Declaring it per
 > URL + model makes the proxy match the registry the client itself uses.
+
+### Compression tuning (the `compress` block)
+
+The `compress` object tunes the compression engine itself — when to nudge, how much
+to compress per step, how many recent messages to protect. It is configurable
+at **three levels** that merge **per field, deepest wins** (child covers
+parent; an unset field at a deeper level never clears a value set higher up):
+
+1. **Global** — top-level `"compress": { … }` (applies to every request). This is
+   also where the `injectTool` / `injectNudge` toggles live (honored globally).
+2. **Per-provider** — `"compress": { … }` inside a `providers[url]` entry.
+3. **Per-model** — `"compress": { … }` inside a `providers[url].models[model]` entry.
+
+```jsonc
+{
+  // Level 1: global default for all providers/models
+  "compress": { "nudgeGrowthTokens": 50000, "maxContextLimit": "70%" },
+  "providers": {
+    "https://api.anthropic.com": {
+      // Level 2: override for this provider only
+      "compress": { "nudgeGrowthTokens": 30000, "preserveRecentMessages": 6 },
+      "models": {
+        "claude-opus-4": {
+          // Level 3: override for this one model (wins per-field)
+          "compress": { "nudgeGrowthTokens": 20000, "tiers": false }
+        }
+      }
+    }
+  }
+}
+```
+
+Fields (all optional; unset fields inherit the kernel default):
+
+| Field | Description |
+|-------|-------------|
+| `modelContextLimit` | The model's context **window size** — the denominator the kernel uses for its usage ratio (`usage = tokens / contextLimit`). **Not** a truncation cap. Accepts an absolute number (`200000`) or a percentage of the native window (`"70%"` → 140000 on a 200K model). When unset, defaults to the native window (built-in table / models.dev registry). ⚠️ Shrinking it pulls *every* ratio threshold (`emergencyThresholdPercent`, truncate) down with it — to leave headroom, set `emergencyThresholdPercent` instead. Highest-priority source for the model limit — overrides the built-in table, the models.dev registry, the legacy `modelContextLimit`, and per-model `context`. |
+| `maxContextLimit` | Usage ratio `0`–`1` at which compression is **forced** (nudge injected regardless of growth). Defaults to `0.75` (75% of the context window). Accepts a number (`0.75`) or percentage string (`"75%"`). Lower = compress earlier / more aggressively. |
+| `nudgeGrowthTokens` | Nudge growth step in tokens. A compression nudge fires roughly every time this many tokens become compressible. Flattens the adaptive band to a fixed step (default 50000 at 1M context). |
+| `emergencyThresholdPercent` | Usage ratio `0`–`1` at which compression becomes an **emergency** and tool outputs are hard-truncated to keep the session alive (default `0.95`). Accepts a number (`0.95`) or percentage string (`"95%"`). Must be ≥ `maxContextLimit`. |
+| `preserveRecentMessages` | Number of trailing messages never offered for compression. |
+| `preserveRecentTokens` | Token budget reserved for recent messages. |
+| `minCompressRange` | Minimum compressible range size in tokens; smaller ranges are skipped. |
+| `tiers` | Enable multi-tier (T2/T3) distillation (`true`/`false`). Promotion across tiers is driven by `nudgeGrowthTokens` (token accumulation), not a separate block-count knob. |
+
+The most common knobs are **`nudgeGrowthTokens`** (raise it to compress less often /
+delay compression) and **`modelContextLimit`** (pin an exact window the registry
+doesn't know). Everything else is for advanced tuning.
+
+**Injection toggles** (`injectTool`, `injectNudge` — global only, not per-level):
+
+| Toggle | Default | Effect |
+|--------|---------|--------|
+| `injectTool` | `true` | Injects the compress/decompress/search **tools** + the compress system prompt, so the model can trigger compression via a tool call. Disable to make compression fully automatic (no manual tool). Env `ACP_COMPRESS_TOOL=0`. |
+| `injectNudge` | `true` | Injects automatic **nudge** messages that prompt the model to compress when the context grows. Disable for tool-only / silent operation. Env `ACP_COMPRESS_NUDGE=0`. |
 
 ### URL key matching rules
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -310,7 +310,7 @@ bili --no-auto-update        # 本次启动禁用自动更新
 | `debug` | `false` | 详细日志(等同 `ACP_DEBUG=1`) |
 | `passthrough` | `false` | 不压缩直接转发(等同 `ACP_PASSTHROUGH=1`) |
 | `providers` | *(无)* | 按 URL 的 context 覆盖 —— 见下文 |
-| `compress` | *(见默认值)* | `{ injectTool, injectNudge }` |
+| `compress` | *(见默认值)* | 全局压缩块:`{ injectTool, injectNudge }` 注入开关 **外加** 引擎调参(`nudgeGrowthTokens`、`modelContextLimit` …)—— 见[压缩调参](#压缩调参compress-块) |
 | `proxy` | *(无)* | 代理自身访问模型提供商时走的上游 HTTP 代理(`http://host:port`)。按 URL 的 `proxy` 会覆盖它。见[上游代理](#上游代理防火墙gfw)。 |
 
 > **选择 `host`**(IPv6 / 容器):默认 `127.0.0.1` 只听 IPv4 且仅
@@ -344,6 +344,55 @@ key 就是客户端写在 `/bili/` 后面的那个字符串:
 同一个模型在不同上游后面可以有不同 context 窗口(例如 relay 把模型包成更大窗口)。`context` 是**输入 context 上限**(压缩器用它判断何时 nudge)。可选;缺失值回退到 [models.dev](https://models.dev) registry,再回退到内置前缀表。
 
 > **为什么要声明 context?** LLM 的 `/models` API **不返回** context 窗口(已跨 OpenAI、Anthropic、智谱、comfly 验证)。它们是文档级信息。值错了(例如把 GLM-5.2 猜成 128K 而非 1M)会导致频繁误触发压缩。按 URL + 模型声明能让代理匹配客户端自己用的注册表。
+
+### 压缩调参(`compress` 块)
+
+`compress` 对象调的是压缩引擎本身 —— 何时 nudge、每步压多少、保护多少条最近消息。可在**三个层级**配置,**按字段深度优先合并**(子覆盖父;深层未设的字段不会清掉高层设的值):
+
+1. **全局** —— 顶层 `"compress": { … }`(对每个请求生效)。`injectTool` / `injectNudge` 开关也放这里(仅全局生效)。
+2. **按 provider** —— `providers[url]` 里的 `"compress": { … }`。
+3. **按模型** —— `providers[url].models[model]` 里的 `"compress": { … }`。
+
+```jsonc
+{
+  // 层级 1:所有 provider/模型的全局默认
+  "compress": { "nudgeGrowthTokens": 50000, "maxContextLimit": "70%" },
+  "providers": {
+    "https://api.anthropic.com": {
+      // 层级 2:仅此 provider 覆盖
+      "compress": { "nudgeGrowthTokens": 30000, "preserveRecentMessages": 6 },
+      "models": {
+        "claude-opus-4": {
+          // 层级 3:仅此模型覆盖(按字段胜出)
+          "compress": { "nudgeGrowthTokens": 20000, "tiers": false }
+        }
+      }
+    }
+  }
+}
+```
+
+字段(均可选;未设的字段继承内核默认值):
+
+| 字段 | 说明 |
+|-------|-------------|
+| `modelContextLimit` | 模型的 context **窗口大小** —— 内核算使用率时的分母(`usage = tokens / contextLimit`)。**不是**截断阈值。支持绝对值(`200000`)或相对原生窗口的百分比(`"70%"` → 200K 模型上 = 140000)。未设置时默认取原生窗口(内置表 / models.dev registry)。⚠️ 调小它会把**所有**按比例的阈值(`emergencyThresholdPercent`、截断)一起拉低 —— 想留余量请调 `emergencyThresholdPercent`。模型上限的最高优先级来源 —— 覆盖内置表、models.dev registry、旧版 `modelContextLimit` 以及按模型的 `context`。 |
+| `maxContextLimit` | 使用率 `0`–`1`,达到则**强制**压缩(无视增长,直接注入 nudge)。默认 `0.75`(窗口的 75%)。支持数字(`0.75`)或百分比字符串(`"75%"`)。调小 → 更早/更激进压缩。 |
+| `nudgeGrowthTokens` | nudge 增长步长(token)。大约每积累这么多可压缩 token 就触发一次压缩 nudge。把自适应区间拍平成固定步长(1M context 默认 50000)。 |
+| `emergencyThresholdPercent` | 使用率 `0`–`1`,达到则进入**紧急**模式,工具输出被硬截断以保住会话(默认 `0.95`)。支持数字(`0.95`)或百分比字符串(`"95%"`)。必须 ≥ `maxContextLimit`。 |
+| `preserveRecentMessages` | 永不纳入压缩的尾部消息条数。 |
+| `preserveRecentTokens` | 为最近消息预留的 token 预算。 |
+| `minCompressRange` | 可压缩范围的最小 token 数;更小的范围会被跳过。 |
+| `tiers` | 是否启用多层(T2/T3)蒸馏(`true`/`false`)。分层晋级由 `nudgeGrowthTokens`(token 累积)驱动,没有单独的块数门槛。 |
+
+最常用的两个旋钮是 **`nudgeGrowthTokens`**(调大 → 压得更少/更晚)和 **`modelContextLimit`**(钉死 registry 不认识的精确窗口)。其余皆为高级调参。
+
+**注入开关**(`injectTool`、`injectNudge` —— 仅全局,不分级):
+
+| 开关 | 默认 | 作用 |
+|--------|---------|--------|
+| `injectTool` | `true` | 注入 compress/decompress/search **工具** + 压缩系统提示,让模型能通过工具调用主动触发压缩。关闭后压缩完全自动化(无手动工具)。环境变量 `ACP_COMPRESS_TOOL=0`。 |
+| `injectNudge` | `true` | 注入自动 **nudge** 提示消息,在 context 增长时提醒模型压缩。关闭后只靠工具/静默运行。环境变量 `ACP_COMPRESS_NUDGE=0`。 |
 
 ### URL key 匹配规则
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@types/node": "^22.0.0",
         "@types/node-forge": "^1.3.14",
-        "acp-kernel": "0.0.19",
+        "acp-kernel": "0.0.21",
         "fzstd": "0.1.1",
         "node-forge": "^1.4.0",
         "tar": "^7.5.22",
@@ -972,9 +972,9 @@
       }
     },
     "node_modules/acp-kernel": {
-      "version": "0.0.19",
-      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.19.tgz",
-      "integrity": "sha512-Ul13wjjP9bWYPBaUPyap4jeD4GpUJ1/sofWyJA/PxaEIOV9QmRDOvAJRAV436dojodgCpBv9UygyaJ7eiq4LuA==",
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.21.tgz",
+      "integrity": "sha512-BSBQzBle5LdiRseXXcDIah6QmdrE4JgrKvz1Y33yOaxIGFkLgaztoOC4QqPYSBxg4yTJLSvEcHWzvVhuc6AseQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/node-forge": "^1.3.14",
-    "acp-kernel": "0.0.19",
+    "acp-kernel": "0.0.21",
     "fzstd": "0.1.1",
     "node-forge": "^1.4.0",
     "tar": "^7.5.22",

--- a/src/compress-settings.ts
+++ b/src/compress-settings.ts
@@ -1,0 +1,117 @@
+import type { Config } from "acp-kernel";
+import { findRoute, type CompressSettings, type ProviderRoutes } from "./config.js";
+
+/** Resolve a raw `contextLimit` value to an absolute token count.
+ *  - `number` → used as-is (absolute window).
+ *  - `string` ending in `%` (e.g. `"70%"`) → that fraction of `nativeLimit`.
+ *  - any other `string` → parsed as a number (absolute window).
+ *  - `undefined` → `nativeLimit` (the model's full window).
+ *
+ *  `contextLimit` is the **window size** the kernel uses as the denominator for
+ *  its usage ratio (`usage = tokens / contextLimit`) — it is NOT a truncation
+ *  cap. All ratio-based thresholds (`emergencyThreshold`, truncate) scale off
+ *  it, so shrinking it pulls every threshold down proportionally. To leave
+ *  headroom, raise/lower `emergencyThreshold` instead. Always returns int ≥ 1. */
+export function resolveContextLimitValue(raw: number | string | undefined, nativeLimit: number): number {
+    if (typeof raw === "number" && Number.isFinite(raw) && raw > 0) return Math.max(1, Math.floor(raw));
+    if (typeof raw === "string") {
+        const pct = /^(\d+(?:\.\d+)?)\s*%$/.exec(raw.trim());
+        if (pct) return Math.max(1, Math.floor((nativeLimit * Number(pct[1])) / 100));
+        const n = Number(raw);
+        if (Number.isFinite(n) && n > 0) return Math.floor(n);
+    }
+    return Math.max(1, Math.floor(nativeLimit));
+}
+
+/** Per-field deepest-wins merge of the three compression config levels. An
+ *  `undefined` field at a deeper level does NOT clear a value set at a shallower
+ *  level — only a defined value overrides. This is what "child covers parent"
+ *  means: the merge is per-field, never a whole-object replace. */
+export function mergeCompress(
+    global?: CompressSettings,
+    provider?: CompressSettings,
+    model?: CompressSettings,
+): CompressSettings {
+    const pick = <K extends keyof CompressSettings>(k: K): CompressSettings[K] =>
+        model?.[k] ?? provider?.[k] ?? global?.[k];
+    return {
+        modelContextLimit: pick("modelContextLimit"),
+        maxContextLimit: pick("maxContextLimit"),
+        emergencyThresholdPercent: pick("emergencyThresholdPercent"),
+        nudgeGrowthTokens: pick("nudgeGrowthTokens"),
+        preserveRecentMessages: pick("preserveRecentMessages"),
+        preserveRecentTokens: pick("preserveRecentTokens"),
+        minCompressRange: pick("minCompressRange"),
+        tiers: pick("tiers"),
+    };
+}
+
+/** Resolve the merged compression settings for one request: global → provider
+ *  (matched by longest-URL-prefix, identical to the context-limit lookup) →
+ *  model. Returns a CompressSettings where every field is `undefined` when
+ *  nothing is configured at any of the three levels. */
+export function resolveCompress(
+    routes: ProviderRoutes,
+    upstreamUrl: string | undefined,
+    model: string | undefined,
+    global?: CompressSettings,
+): CompressSettings {
+    const route = findRoute(routes, upstreamUrl);
+    return mergeCompress(global, route?.compress, model ? route?.models?.[model]?.compress : undefined);
+}
+
+/** True when a CompressSettings carries at least one configured field (i.e. it
+ *  actually overrides something at some level). */
+export function hasCompressSettings(s: CompressSettings): boolean {
+    return Object.values(s).some((v) => v !== undefined);
+}
+
+/** Apply merged compression settings onto a base kernel Config, returning a NEW
+ *  Config (the input is not mutated). `limit` is always written to
+ *  `modelContextLimit` (the caller resolves the final limit, including the
+ *  compress.modelContextLimit override). Unset fields inherit the base value
+ *  untouched. Field mapping:
+ *  - `maxContextLimit` → `nudge.maxContextLimitPct` (force-nudge trigger).
+ *  - `emergencyThresholdPercent` → `nudge.emergencyThresholdPct` +
+ *    `truncate.threshold` (emergency + hard-truncate).
+ *  - `nudgeGrowthTokens` → flattens the adaptive band to a fixed step
+ *    (sets both `nudge.growthFloor` and `nudge.growthCap`).
+ *  - `preserveRecentMessages` / `preserveRecentTokens` → top-level Config.
+ *  - `minCompressRange` → `compress.minCompressRange`.
+ *  - `tiers` → `tiers.enabled`. */
+export function applyCompressSettings(base: Config, limit: number, s: CompressSettings): Config {
+    const nudge = { ...base.nudge };
+    const truncate = { ...base.truncate };
+    if (s.maxContextLimit !== undefined) nudge.maxContextLimitPct = parsePercent(s.maxContextLimit);
+    if (s.emergencyThresholdPercent !== undefined) {
+        const pct = parsePercent(s.emergencyThresholdPercent);
+        nudge.emergencyThresholdPct = pct;
+        truncate.threshold = pct;
+    }
+    if (s.nudgeGrowthTokens !== undefined && s.nudgeGrowthTokens > 0) {
+        nudge.growthFloor = s.nudgeGrowthTokens;
+        nudge.growthCap = s.nudgeGrowthTokens;
+    }
+    const tiers = { ...base.tiers };
+    if (s.tiers !== undefined) tiers.enabled = s.tiers;
+    return {
+        ...base,
+        modelContextLimit: limit,
+        nudge,
+        truncate,
+        tiers,
+        preserveRecentMessages: s.preserveRecentMessages ?? base.preserveRecentMessages,
+        preserveRecentTokens: s.preserveRecentTokens ?? base.preserveRecentTokens,
+        compress: {
+            ...base.compress,
+            minCompressRange: s.minCompressRange ?? base.compress.minCompressRange,
+        },
+    };
+}
+
+function parsePercent(v: number | string): number {
+    if (typeof v === "number") return v;
+    const s = v.trim();
+    if (s.endsWith("%")) return Number(s.slice(0, -1)) / 100;
+    return Number(s);
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,7 +30,7 @@ export function safeReadJson(path: string): unknown {
  *  so the proxy cannot discover them at runtime — the user must declare them.
  */
 export type ProviderRoute = {
-    models?: Record<string, { context?: number; output?: number }>;
+    models?: Record<string, ModelEntry>;
     /** Per-URL upstream HTTP proxy. Overrides the global `proxy`. Empty string
      *  means "explicitly direct" (override global with no proxy). Format:
      *  `http://host:port`. SOCKS5 is not supported yet. */
@@ -39,8 +39,64 @@ export type ProviderRoute = {
      *  (for upstreams that cannot coexist with a declared tools field).
      *  Default / "tools" = native function tools. */
     compressProtocol?: "tools" | "marker";
+    /** Per-provider compression overrides (level 2 of 3). See CompressSettings. */
+    compress?: CompressSettings;
 };
 export type ProviderRoutes = Record<string, ProviderRoute>; // key = upstream URL prefix (the /bili/<this> string)
+
+/** Per-model declaration under a provider route. `context` / `output` are the
+ *  legacy fields; `compress` is the level-3 override (deepest, highest priority). */
+export type ModelEntry = {
+    context?: number;
+    output?: number;
+    /** Per-model compression overrides (level 3 of 3, wins over provider
+     *  and global). See CompressSettings. */
+    compress?: CompressSettings;
+};
+
+/** User-facing compression tuning. Configurable at three levels — global
+ *  (config root `compress`), per-provider (`providers[url].compress`), per-model
+ *  (`providers[url].models[model].compress`) — merged deepest-field-wins by
+ *  {@link mergeCompress} (child covers parent, per field, not whole-object). Every
+ *  field is optional; unset fields fall through to the kernel default. */
+export type CompressSettings = {
+    /** Effective context window used by the compression engine — this is the
+     *  model's context size. It is the **denominator** the kernel uses for its
+     *  usage ratio (`usage = tokens / modelContextLimit`); it is NOT a
+     *  truncation cap. Accepts two forms:
+     *  - **absolute** (`number`): exact token budget, e.g. `200000`.
+     *  - **percentage** (`string` like `"70%"`): a fraction of the model's
+     *    native window (from the built-in table / models.dev registry).
+     *  When unset at every level, the default is the model's **native window**.
+     *  Highest-priority source for the model limit; overrides the built-in
+     *  table / registry and the legacy `modelContextLimit` / per-model
+     *  `context`. See {@link resolveContextLimitValue}. */
+    modelContextLimit?: number | string;
+    /** Context usage percentage that triggers forced compression nudges
+     *  (bypasses growth-gate + cadence). Accepts a ratio (0.75) or percent
+     *  string ("75%"). Maps to kernel `nudge.maxContextLimitPct`. */
+    maxContextLimit?: number | string;
+    /** Context usage percentage that triggers emergency truncation of large
+     *  tool outputs. Accepts a ratio (0.95) or percent string ("95%"). Must
+     *  be >= maxContextLimit. Maps to kernel `nudge.emergencyThresholdPct` +
+     *  `truncate.threshold`. */
+    emergencyThresholdPercent?: number | string;
+    /** Nudge growth magnitude in tokens — a compression nudge fires roughly
+     *  every time this many tokens become compressible. Flattens the kernel's
+     *  adaptive band to a fixed step (sets both `nudge.growthFloor` and
+     *  `nudge.growthCap`). */
+    nudgeGrowthTokens?: number;
+    /** Trailing messages never offered for compression
+     *  (kernel `preserveRecentMessages`). */
+    preserveRecentMessages?: number;
+    /** Token budget reserved for recent messages (kernel `preserveRecentTokens`). */
+    preserveRecentTokens?: number;
+    /** Minimum compressible range size in tokens; smaller ranges are skipped
+     *  (kernel `compress.minCompressRange`). */
+    minCompressRange?: number;
+    /** Enable multi-tier (T2/T3) distillation (kernel `tiers.enabled`). */
+    tiers?: boolean;
+};
 export type PromptCacheRouting = "auto" | "enabled" | "disabled";
 export type UpstreamProxyMode = "auto" | "manual" | "direct";
 
@@ -92,39 +148,36 @@ export function resolveContextLimit(
     return resolveConfiguredContextLimit(routes, upstreamUrl, model) ?? lookupContextLimit(model);
 }
 
+/** Longest-URL-prefix match over the providers map. Returns the most specific
+ *  ProviderRoute whose key is a prefix of `upstreamUrl`, or undefined. Shared
+ *  by context-limit / compress-protocol / compress-settings resolution. */
+export function findRoute(routes: ProviderRoutes, upstreamUrl: string | undefined): ProviderRoute | undefined {
+    if (!upstreamUrl) return undefined;
+    // A key matches if upstreamUrl === key OR upstreamUrl starts with key + "/".
+    // The boundary check ("/" or end-of-string) avoids "https://x.com" matching
+    // "https://x.com.evil". Longest (most specific) key wins.
+    let bestKey = "";
+    for (const key of Object.keys(routes)) {
+        if (upstreamUrl === key || upstreamUrl.startsWith(key + "/")) {
+            if (key.length > bestKey.length) bestKey = key;
+        }
+    }
+    return bestKey ? routes[bestKey] : undefined;
+}
+
 export function resolveConfiguredContextLimit(
     routes: ProviderRoutes,
     upstreamUrl: string | undefined,
     model: string | undefined,
 ): number | undefined {
     if (!model || !upstreamUrl) return undefined;
-    // Longest-prefix match: collect all keys that are a prefix of upstreamUrl,
-    // pick the longest (most specific). A key matches if upstreamUrl === key
-    // OR upstreamUrl starts with key + ("/" or key being the full origin). This
-    // avoids "https://x.com" matching "https://x.com.evil" — the boundary check
-    // requires the next char after the key to be "/" or end-of-string.
-    let bestKey = "";
-    for (const key of Object.keys(routes)) {
-        if (upstreamUrl === key || upstreamUrl.startsWith(key + "/")) {
-            if (key.length > bestKey.length) bestKey = key;
-        }
-    }
-    if (bestKey) {
-        const m = routes[bestKey].models?.[model];
-        if (m?.context && m.context > 0) return m.context;
-    }
+    const m = findRoute(routes, upstreamUrl)?.models?.[model];
+    if (m?.context && m.context > 0) return m.context;
     return undefined;
 }
 
 export function resolveCompressProtocol(routes: ProviderRoutes, upstreamUrl: string | undefined): "tools" | "marker" | undefined {
-    if (!upstreamUrl) return undefined;
-    let bestKey = "";
-    for (const key of Object.keys(routes)) {
-        if (upstreamUrl === key || upstreamUrl.startsWith(key + "/")) {
-            if (key.length > bestKey.length) bestKey = key;
-        }
-    }
-    return bestKey ? routes[bestKey].compressProtocol : undefined;
+    return findRoute(routes, upstreamUrl)?.compressProtocol;
 }
 
 export type ProxyOptions = {
@@ -140,7 +193,11 @@ export type ProxyOptions = {
     proxyFallback?: ProxyFallbackOptions;
     modelContextLimit: number;
     kernelConfig: Config;
-    compress: {
+    /** Global-level compression settings (level 1) — the tuning fields from the
+     *  user-facing `compress` block, passed through for per-request resolution
+     *  (provider = level 2, model = level 3). `injectTool` / `injectNudge` are
+     *  the env-resolved booleans (honored globally only). */
+    compress: CompressSettings & {
         injectTool: boolean;
         injectNudge: boolean;
     };
@@ -255,6 +312,7 @@ export function loadOptions(env: NodeJS.ProcessEnv = process.env): ProxyOptions 
         modelContextLimit,
         kernelConfig: defaultConfig(modelContextLimit),
         compress: {
+            ...(fileConfig.compress ?? {}),
             injectTool: (env.ACP_COMPRESS_TOOL ?? (fileConfig.compress?.injectTool === false ? "0" : "1")) !== "0",
             injectNudge: (env.ACP_COMPRESS_NUDGE ?? (fileConfig.compress?.injectNudge === false ? "0" : "1")) !== "0",
         },
@@ -301,7 +359,11 @@ type FileConfig = {
     upstreamProxy?: string;
     upstreamProxyMode?: string;
     logFile?: string;
-    compress?: { injectTool?: boolean; injectNudge?: boolean };
+    /** Global compression block (level 1 of 3). Holds the injection toggles
+     *  (`injectTool` / `injectNudge`, honored globally) plus the tuning fields
+     *  (see CompressSettings), overridden per-field by provider- and model-level
+     *  `compress`. */
+    compress?: CompressSettings & { injectTool?: boolean; injectNudge?: boolean };
     promptCache?: { routing?: string };
     mitm?: { enabled?: boolean; domains?: string[] };
 };
@@ -378,10 +440,11 @@ export function parseRouteEntry(v: unknown): ProviderRoute | undefined {
     // is the KEY in the providers map (identical to the /bili/<url> string),
     // so it is NOT repeated inside the value.
     if (v && typeof v === "object" && !Array.isArray(v)) {
-        const obj = v as { models?: Record<string, { context?: number; output?: number }>; proxy?: string; compressProtocol?: string };
+        const obj = v as { models?: Record<string, ModelEntry>; proxy?: string; compressProtocol?: string; compress?: CompressSettings };
         const route: ProviderRoute = { models: obj.models };
         if (typeof obj.proxy === "string") route.proxy = obj.proxy;
         if (obj.compressProtocol === "marker" || obj.compressProtocol === "tools") route.compressProtocol = obj.compressProtocol;
+        if (obj.compress) route.compress = obj.compress;
         return route;
     }
     // A bare value (e.g. null) means "this upstream exists, no overrides".

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,6 +5,7 @@ import type { ProxyOptions } from "./config.js";
 import { loadOptions, loadRoutes } from "./config.js";
 import { resetProxyCache } from "./upstream-proxy.js";
 import { resolveContextLimit, resolveCompressProtocol } from "./config.js";
+import { resolveCompress, applyCompressSettings, hasCompressSettings, resolveContextLimitValue } from "./compress-settings.js";
 import { contextFromRegistry, loadRegistry } from "./registry.js";
 import { fetchWithTimeout, MAX_REQUEST_BYTES } from "./fetch-util.js";
 import { formatUpstreamError, getUpstreamConnectionStatus, recordUpstreamConnection, resolveProxy, resolveProxyDecision, proxyDispatcher } from "./upstream-proxy.js";
@@ -475,22 +476,27 @@ async function handle(
             fs.writeFileSync(`${rawDir}/${Date.now()}-INCOMING.txt`, `${req.method} ${req.url}\n${hdrs}\n\n${bodyBuffer.toString("utf8")}`);
         } catch { /* best-effort dump */ }
     }
-    // Per-request context limit: look up body.model against the per-route
-    // model declaration first, then the built-in table.
+    // Per-request context limit + compression tuning: look up body.model against
+    // the per-route model declaration first, then the built-in table / registry.
+    // Compress settings (global → provider → model) merge deepest-field-wins and
+    // are applied on top of the resolved limit. `compress.contextLimit` (an
+    // absolute number, a "70%" string of the native window, or unset → native)
+    // overrides the table.
     let reqConfig = config;
     if (parsed && typeof parsed === "object") {
         const model = (parsed as { model?: string }).model;
         if (model) {
-            // Match config by the embedded upstream URL (the /bili/<this> string).
-            // The registry is a middle layer when config doesn't cover this URL/model.
             const embeddedUrl = route?.rewrittenUrl;
-            let limit = resolveContextLimit(opts.routes, embeddedUrl, model);
-            if (!limit && embeddedUrl) {
+            const compress = resolveCompress(opts.routes, embeddedUrl, model, opts.compress);
+            let native = resolveContextLimit(opts.routes, embeddedUrl, model);
+            if (!native && embeddedUrl) {
                 const host = (() => { try { return new URL(embeddedUrl).host; } catch { return undefined; } })();
-                limit = await contextFromRegistry(model, host);
+                native = await contextFromRegistry(model, host);
             }
-            if (limit && limit !== config.modelContextLimit) {
-                reqConfig = { ...config, modelContextLimit: limit };
+            const limit = resolveContextLimitValue(compress.modelContextLimit, native ?? config.modelContextLimit);
+            const tuned = hasCompressSettings(compress);
+            if (tuned || limit !== config.modelContextLimit) {
+                reqConfig = applyCompressSettings(config, limit, compress);
             }
         }
     }
@@ -655,7 +661,7 @@ function prepareAnthropic(
         }
         // Nudge as a separate trailing user message (cache-friendly): the
         // system block stays byte-stable so the prefix cache survives.
-        if (turn.nudge?.shouldInject) {
+        if (opts.compress.injectNudge && turn.nudge?.shouldInject) {
             try {
                 const rendered = renderNudgeText(turn.nudge);
                 if (rendered.text) {
@@ -736,7 +742,7 @@ function prepareOpenai(
             toolsOut = injectOpenaiTool(parsed.tools);
         }
         // Nudge as a separate trailing user message (cache-friendly).
-        if (turn.nudge?.shouldInject && shouldInject) {
+        if (opts.compress.injectNudge && turn.nudge?.shouldInject && shouldInject) {
             try {
                 const rendered = renderNudgeText(turn.nudge);
                 if (rendered.text) {
@@ -826,7 +832,7 @@ function prepareResponses(
         } else if (projection.systemParts.length > 0) {
             rebuiltInput = injectResponsesDeveloperMessage(rebuiltInput, projection.systemParts.join("\n\n---\n\n"));
         }
-        if (turn.nudge?.shouldInject && shouldInject) {
+        if (opts.compress.injectNudge && turn.nudge?.shouldInject && shouldInject) {
             try {
                 const rendered = renderNudgeText(turn.nudge);
                 if (rendered.text) {

--- a/tests/compress-settings.test.ts
+++ b/tests/compress-settings.test.ts
@@ -1,0 +1,191 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { defaultConfig } from "acp-kernel";
+import {
+    mergeCompress,
+    resolveCompress,
+    applyCompressSettings,
+    hasCompressSettings,
+    resolveContextLimitValue,
+} from "../src/compress-settings.ts";
+import { parseRouteEntry, type ProviderRoutes } from "../src/config.ts";
+
+test("mergeCompress: model beats provider beats global, per field", () => {
+    const merged = mergeCompress(
+        { nudgeGrowthTokens: 50000, emergencyThresholdPercent: 0.8, preserveRecentMessages: 10 },
+        { nudgeGrowthTokens: 70000, minCompressRange: 4000 },
+        { nudgeGrowthTokens: 90000, emergencyThresholdPercent: 0.9 },
+    );
+    assert.equal(merged.nudgeGrowthTokens, 90000);
+    assert.equal(merged.emergencyThresholdPercent, 0.9);
+    assert.equal(merged.preserveRecentMessages, 10);
+    assert.equal(merged.minCompressRange, 4000);
+});
+
+test("mergeCompress: undefined at deeper level does not clear shallower value", () => {
+    const merged = mergeCompress({ nudgeGrowthTokens: 50000 }, undefined, { emergencyThresholdPercent: 0.85 });
+    assert.equal(merged.nudgeGrowthTokens, 50000);
+    assert.equal(merged.emergencyThresholdPercent, 0.85);
+    assert.equal(merged.preserveRecentMessages, undefined);
+});
+
+test("mergeCompress: all undefined yields all-undefined settings", () => {
+    const merged = mergeCompress(undefined, undefined, undefined);
+    assert.equal(hasCompressSettings(merged), false);
+});
+
+test("hasCompressSettings: true when any field set", () => {
+    assert.equal(hasCompressSettings({}), false);
+    assert.equal(hasCompressSettings({ nudgeGrowthTokens: 50000 }), true);
+});
+
+test("resolveCompress: deepest matching URL key wins; model compress on a shallower key does NOT apply", () => {
+    const routes: ProviderRoutes = {
+        "https://api.example.com": {
+            models: { "big-model": { compress: { nudgeGrowthTokens: 90000, emergencyThresholdPercent: 0.85 } } },
+        },
+        "https://api.example.com/v1": {
+            compress: { tiers: false },
+        },
+    };
+    const merged = resolveCompress(routes, "https://api.example.com/v1/chat", "big-model", { nudgeGrowthTokens: 50000 });
+    assert.equal(merged.tiers, false);
+    assert.equal(merged.nudgeGrowthTokens, 50000);
+    assert.equal(merged.emergencyThresholdPercent, undefined);
+});
+
+test("resolveCompress: model compress overrides provider compress on the same route", () => {
+    const routes: ProviderRoutes = {
+        "https://api.example.com": {
+            compress: { nudgeGrowthTokens: 60000, preserveRecentMessages: 8 },
+            models: { "big-model": { compress: { nudgeGrowthTokens: 90000, emergencyThresholdPercent: 0.85 } } },
+        },
+    };
+    const merged = resolveCompress(routes, "https://api.example.com/chat", "big-model", undefined);
+    assert.equal(merged.nudgeGrowthTokens, 90000);
+    assert.equal(merged.emergencyThresholdPercent, 0.85);
+    assert.equal(merged.preserveRecentMessages, 8);
+});
+
+test("resolveCompress: shallow key applies when no deeper key matches", () => {
+    const routes: ProviderRoutes = {
+        "https://api.example.com": {
+            compress: { nudgeGrowthTokens: 60000 },
+        },
+    };
+    const merged = resolveCompress(routes, "https://api.example.com/chat", "any-model", undefined);
+    assert.equal(merged.nudgeGrowthTokens, 60000);
+});
+
+test("resolveCompress: returns empty when URL unknown", () => {
+    const routes: ProviderRoutes = { "https://other.com": { compress: { nudgeGrowthTokens: 60000 } } };
+    const merged = resolveCompress(routes, "https://api.example.com/chat", "m", undefined);
+    assert.equal(hasCompressSettings(merged), false);
+});
+
+test("applyCompressSettings: nudgeGrowthTokens flattens growthFloor and growthCap", () => {
+    const base = defaultConfig(200000);
+    const out = applyCompressSettings(base, 200000, { nudgeGrowthTokens: 50000 });
+    assert.equal(out.nudge.growthFloor, 50000);
+    assert.equal(out.nudge.growthCap, 50000);
+});
+
+test("applyCompressSettings: emergencyThresholdPercent maps to emergencyThresholdPct", () => {
+    const base = defaultConfig(200000);
+    const out = applyCompressSettings(base, 200000, { emergencyThresholdPercent: 0.85 });
+    assert.equal(out.nudge.emergencyThresholdPct, 0.85);
+    assert.equal(out.truncate.threshold, 0.85);
+});
+
+test("applyCompressSettings: maxContextLimit maps to maxContextLimitPct", () => {
+    const base = defaultConfig(200000);
+    const out = applyCompressSettings(base, 200000, { maxContextLimit: "80%" });
+    assert.equal(out.nudge.maxContextLimitPct, 0.8);
+});
+
+test("applyCompressSettings: emergencyThresholdPercent accepts percent string", () => {
+    const base = defaultConfig(200000);
+    const out = applyCompressSettings(base, 200000, { emergencyThresholdPercent: "90%" });
+    assert.equal(out.nudge.emergencyThresholdPct, 0.9);
+    assert.equal(out.truncate.threshold, 0.9);
+});
+
+test("applyCompressSettings: tiers.enabled mapping", () => {
+    const base = defaultConfig(200000);
+    const out = applyCompressSettings(base, 200000, { tiers: false });
+    assert.equal(out.tiers.enabled, false);
+});
+
+test("applyCompressSettings: preserveRecent + minCompressRange + modelContextLimit", () => {
+    const base = defaultConfig(200000);
+    const out = applyCompressSettings(base, 500000, {
+        preserveRecentMessages: 7,
+        preserveRecentTokens: 30000,
+        minCompressRange: 4000,
+    });
+    assert.equal(out.preserveRecentMessages, 7);
+    assert.equal(out.preserveRecentTokens, 30000);
+    assert.equal(out.compress.minCompressRange, 4000);
+    assert.equal(out.modelContextLimit, 500000);
+});
+
+test("applyCompressSettings: does not mutate the base config", () => {
+    const base = defaultConfig(200000);
+    const originalFloor = base.nudge.growthFloor;
+    applyCompressSettings(base, 200000, { nudgeGrowthTokens: 99999 });
+    assert.equal(base.nudge.growthFloor, originalFloor);
+});
+
+test("applyCompressSettings: unset fields inherit the base value", () => {
+    const base = defaultConfig(200000);
+    const out = applyCompressSettings(base, 200000, { nudgeGrowthTokens: 50000 });
+    assert.equal(out.preserveRecentMessages, base.preserveRecentMessages);
+    assert.equal(out.tiers.enabled, base.tiers.enabled);
+});
+
+test("applyCompressSettings: nudgeGrowthTokens <= 0 is ignored (keeps base band)", () => {
+    const base = defaultConfig(200000);
+    const out = applyCompressSettings(base, 200000, { nudgeGrowthTokens: 0 });
+    assert.equal(out.nudge.growthFloor, base.nudge.growthFloor);
+    assert.equal(out.nudge.growthCap, base.nudge.growthCap);
+});
+
+test("resolveContextLimitValue: absolute number used as-is", () => {
+    assert.equal(resolveContextLimitValue(200000, 1000000), 200000);
+    assert.equal(resolveContextLimitValue(1, 1000000), 1);
+});
+
+test("resolveContextLimitValue: percentage string is a fraction of native", () => {
+    assert.equal(resolveContextLimitValue("70%", 200000), 140000);
+    assert.equal(resolveContextLimitValue("50%", 200000), 100000);
+    assert.equal(resolveContextLimitValue("100%", 128000), 128000);
+    assert.equal(resolveContextLimitValue("12.5%", 200000), 25000);
+});
+
+test("resolveContextLimitValue: undefined falls back to the native window", () => {
+    assert.equal(resolveContextLimitValue(undefined, 200000), 200000);
+    assert.equal(resolveContextLimitValue(undefined, 1000000), 1000000);
+});
+
+test("resolveContextLimitValue: bare numeric string treated as absolute", () => {
+    assert.equal(resolveContextLimitValue("300000", 1000000), 300000);
+});
+
+test("resolveContextLimitValue: percentage floor is always an integer >= 1", () => {
+    assert.equal(resolveContextLimitValue("0.0001%", 200000), 1);
+});
+
+test("parseRouteEntry: preserves provider-level and model-level compress", () => {
+    const route = parseRouteEntry({
+        compress: { nudgeGrowthTokens: 60000 },
+        models: { "big-model": { context: 200000, compress: { nudgeGrowthTokens: 90000 } } },
+    });
+    assert.equal(route?.compress?.nudgeGrowthTokens, 60000);
+    assert.equal(route?.models?.["big-model"]?.compress?.nudgeGrowthTokens, 90000);
+    assert.equal(route?.models?.["big-model"]?.context, 200000);
+});
+
+test("parseRouteEntry: no compress leaves the field absent", () => {
+    const route = parseRouteEntry({ models: { "m": { context: 128000 } } });
+    assert.equal(route?.compress, undefined);
+});


### PR DESCRIPTION
## Three-level compression tuning (global > provider > model)

Adds a user-facing `compress` JSON block at three levels — **global** → **provider** (URL-keyed) → **model** — with per-field deepest-wins merging (`model` overrides `provider` overrides `global`; unset deeper fields never clear shallower ones).

### Unified field schema (aligns with opencode-acp + billion-context-pi)

| Field | Kernel 0.0.20 mapping | Default |
|-------|----------------------|---------|
| `modelContextLimit` | `modelContextLimit` (window denominator, **not** truncation) | native window |
| `maxContextLimit` | `nudge.maxContextLimitPct` | `0.75` ("75%") |
| `emergencyThresholdPercent` | `nudge.emergencyThresholdPct` + `truncate.threshold` | `0.95` ("95%") |
| `nudgeGrowthTokens` | `nudge.growthFloor` + `nudge.growthCap` (flattens adaptive band) | `50000` |
| `preserveRecentMessages` | `preserveRecentMessages` | — |
| `preserveRecentTokens` | `preserveRecentTokens` | — |
| `minCompressRange` | `compress.minCompressRange` | — |
| `tiers` | `tiers.enabled` | `true` |

`maxContextLimit` and `emergencyThresholdPercent` accept a number (`0.75`) or percentage string (`"75%"`).

### Escalation model (kernel 0.0.20)

```
0–75%   growth-driven nudge (every ~nudgeGrowthTokens tokens)
75–95%  maxContextLimit → force-nudge (bypass growth gate, lossless)
95%+    emergencyThreshold → emergency reason + truncate large tool outputs (lossy)
```

### Example

```json
{
  "compress": { "nudgeGrowthTokens": 50000, "emergencyThresholdPercent": "95%" },
  "providers": {
    "https://api.anthropic.com": {
      "models": {
        "claude-sonnet-4": {
          "compress": { "maxContextLimit": "75%", "preserveRecentMessages": 6 }
        }
      }
    }
  }
}
```

### Files
- **src/compress-settings.ts**: `CompressSettings` type, `mergeCompress` (per-field cascade), `resolveCompress` (findRoute longest-URL-prefix), `applyCompressSettings` (maps user fields → kernel 0.0.20 names), `parsePercent` helper.
- **src/config.ts**: `compress?` at global/provider/model levels; `findRoute` helper (shared with context-limit/compressProtocol lookups).
- **src/server.ts**: per-request merge (zero-cost when no `compress` configured).
- **tests/compress-settings.test.ts**: 20 tests — merge precedence, field mapping, string/number percent, contextLimit cascade.
- **README.md** + **README.zh-CN.md**: documented the 3-level rule + field table.

### Pre-flight
- `npm run typecheck` clean (tsconfig.build.json)
- `npm test` — **347 pass / 0 fail** (340 existing + 7 new/renamed)
- `npm run build` — 2.02 MB self-contained

Built on acp-kernel **0.0.20**.
