### PR TITLE
feat(mitm): auto-discover model domains from client configs (no hardcoding)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.35",
+      "version": "0.1.36",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",

--- a/src/client-config.ts
+++ b/src/client-config.ts
@@ -1,0 +1,194 @@
+// Shared client-config readers extracted here (not in launcher.ts) so the MITM
+// discovery module can import them without forming a cycle
+// (discover → client-config is fine; discover → launcher → mitm → discover is not).
+// This module MUST NOT import from mitm.ts or launcher.ts.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export interface ClaudeSettings {
+    anthropicBaseUrl?: string;
+}
+
+export interface CodexProvider {
+    baseUrl?: string;
+}
+
+export interface CodexConfig {
+    modelProvider?: string;
+    openaiBaseUrl?: string;
+    providers: Record<string, CodexProvider>;
+}
+
+export interface PiProvider {
+    baseUrl?: string;
+}
+
+export interface PiConfig {
+    providers: Record<string, PiProvider>;
+}
+
+export interface ZcodeProvider {
+    baseURL?: string;
+}
+
+export interface ZcodeConfig {
+    providers: Record<string, ZcodeProvider>;
+}
+
+export interface ClientConfig {
+    claude?: ClaudeSettings;
+    codex?: CodexConfig;
+    pi?: PiConfig;
+    zcode?: ZcodeConfig;
+}
+
+export function nonEmpty(s: unknown): s is string {
+    return typeof s === "string" && s.trim().length > 0;
+}
+
+export function readJsonObject(filePath: string): Record<string, unknown> | null {
+    try {
+        const txt = fs.readFileSync(filePath, "utf8");
+        const parsed: unknown = JSON.parse(txt);
+        return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+            ? (parsed as Record<string, unknown>)
+            : null;
+    } catch {
+        return null;
+    }
+}
+
+export function resolvePiHome(env: NodeJS.ProcessEnv): string {
+    const h = os.homedir();
+    return nonEmpty(env.PI_CODING_AGENT_DIR) ? env.PI_CODING_AGENT_DIR!
+        : nonEmpty(env.PI_HOME) ? env.PI_HOME!
+        : path.join(h, ".pi", "agent");
+}
+
+export function readClaudeSettings(homeDir: string, cwd: string): ClaudeSettings {
+    const files = [
+        path.join(homeDir, ".claude", "settings.json"),
+        path.join(cwd, ".claude", "settings.json"),
+    ];
+    let anthropicBaseUrl: string | undefined;
+    for (const f of files) {
+        const obj = readJsonObject(f);
+        const env = obj?.env;
+        if (env && typeof env === "object" && !Array.isArray(env)) {
+            const v = (env as Record<string, unknown>).ANTHROPIC_BASE_URL;
+            if (nonEmpty(v)) anthropicBaseUrl = v;
+        }
+    }
+    return anthropicBaseUrl ? { anthropicBaseUrl } : {};
+}
+
+/**
+ * Targeted TOML reader for ~/.codex/config.toml: top-level `model_provider` /
+ * `openai_base_url` and each `[model_providers.<name>]` `base_url`. String
+ * values only; NOT a general TOML parser — intentionally dependency-free.
+ */
+export function parseCodexToml(text: string): CodexConfig {
+    const result: CodexConfig = { providers: {} };
+    let table = "";
+    let curProvider: string | null = null;
+    for (const rawLine of text.split(/\r?\n/)) {
+        const line = rawLine.trim();
+        if (!line || line.startsWith("#")) continue;
+        const tableMatch = /^\[([^\]]+)\]$/.exec(line);
+        if (tableMatch) {
+            table = tableMatch[1].trim();
+            curProvider = table.startsWith("model_providers.")
+                ? table.slice("model_providers.".length).trim()
+                : null;
+            if (curProvider && !result.providers[curProvider]) {
+                result.providers[curProvider] = {};
+            }
+            continue;
+        }
+        const m = /^([A-Za-z0-9_.-]+)\s*=\s*(?:"([^"]*)"|'([^']*)')/.exec(line);
+        if (!m) continue;
+        const key = m[1];
+        const val = m[2] !== undefined ? m[2] : m[3];
+        if (table === "") {
+            if (key === "model_provider") result.modelProvider = val;
+            else if (key === "openai_base_url") result.openaiBaseUrl = val;
+        } else if (curProvider && key === "base_url") {
+            result.providers[curProvider].baseUrl = val;
+        }
+    }
+    return result;
+}
+
+export function readCodexConfig(codexHome: string): CodexConfig {
+    const cfgPath = path.join(codexHome, "config.toml");
+    let text: string;
+    try {
+        text = fs.readFileSync(cfgPath, "utf8");
+    } catch {
+        return { providers: {} };
+    }
+    return parseCodexToml(text);
+}
+
+export function readPiConfig(piHome: string): PiConfig {
+    const cfgPath = path.join(piHome, "models.json");
+    const obj = readJsonObject(cfgPath);
+    const providers: Record<string, PiProvider> = {};
+    const rawProviders = obj?.providers;
+    if (rawProviders && typeof rawProviders === "object" && !Array.isArray(rawProviders)) {
+        for (const [name, val] of Object.entries(rawProviders as Record<string, unknown>)) {
+            if (val && typeof val === "object" && !Array.isArray(val)) {
+                const baseUrl = (val as { baseUrl?: unknown }).baseUrl;
+                providers[name] = typeof baseUrl === "string" ? { baseUrl } : {};
+            }
+        }
+    }
+    return { providers };
+}
+
+export function parseZcodeConfig(obj: unknown): ZcodeConfig {
+    const result: ZcodeConfig = { providers: {} };
+    if (!obj || typeof obj !== "object" || Array.isArray(obj)) return result;
+    const root = obj as Record<string, unknown>;
+    const providerField = root.provider;
+    if (!providerField || typeof providerField !== "object" || Array.isArray(providerField)) return result;
+    const providerMap = providerField as Record<string, unknown>;
+    for (const [name, val] of Object.entries(providerMap)) {
+        if (!val || typeof val !== "object" || Array.isArray(val)) continue;
+        const options = (val as { options?: unknown }).options;
+        if (!options || typeof options !== "object" || Array.isArray(options)) continue;
+        const baseURL = (options as { baseURL?: unknown }).baseURL;
+        if (typeof baseURL === "string") result.providers[name] = { baseURL };
+    }
+    return result;
+}
+
+export function readZcodeConfig(zcodeHome: string): ZcodeConfig {
+    const cfgPath = path.join(zcodeHome, "v2", "config.json");
+    let txt: string;
+    try {
+        txt = fs.readFileSync(cfgPath, "utf8");
+    } catch {
+        return { providers: {} };
+    }
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(txt);
+    } catch {
+        return { providers: {} };
+    }
+    return parseZcodeConfig(parsed);
+}
+
+export function loadClientConfig(env: NodeJS.ProcessEnv, cwd: string): ClientConfig {
+    const home = os.homedir();
+    const config: ClientConfig = {};
+    config.claude = readClaudeSettings(home, cwd);
+    const codexHome = nonEmpty(env.CODEX_HOME) ? env.CODEX_HOME : path.join(home, ".codex");
+    config.codex = readCodexConfig(codexHome);
+    config.pi = readPiConfig(resolvePiHome(env));
+    const zcodeHome = nonEmpty(env.ZCODE_DATA_BASE_DIR) ? env.ZCODE_DATA_BASE_DIR : path.join(home, ".zcode");
+    config.zcode = readZcodeConfig(zcodeHome);
+    return config;
+}

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -1,0 +1,108 @@
+// MITM domain auto-discovery. Cycle-free: imports only from client-config.js.
+// MUST NOT import from launcher.ts (launcher → mitm → discover → launcher).
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { loadClientConfig, resolvePiHome, nonEmpty, type ClientConfig } from "./client-config.js";
+
+const TTL_MS = 2000;
+
+// Local copy of launcher.ts's unwrapUpstream: importing it from launcher.ts
+// would close the discover → launcher → mitm → discover cycle.
+function unwrapUpstream(url: string): string {
+    const idx = url.indexOf("/bili/");
+    return idx >= 0 ? url.slice(idx + "/bili/".length) : url;
+}
+
+export function extractHttpsHosts(config: ClientConfig): string[] {
+    const seen = new Set<string>();
+    const out: string[] = [];
+    const push = (raw: string | undefined): void => {
+        if (typeof raw !== "string" || raw.length === 0) return;
+        let url: URL;
+        try {
+            url = new URL(unwrapUpstream(raw));
+        } catch {
+            return;
+        }
+        if (url.protocol !== "https:") return;
+        const host = url.hostname.toLowerCase();
+        if (!host || seen.has(host)) return;
+        seen.add(host);
+        out.push(host);
+    };
+
+    if (nonEmpty(config.claude?.anthropicBaseUrl)) push(config.claude!.anthropicBaseUrl);
+    if (config.codex) {
+        for (const prov of Object.values(config.codex.providers)) push(prov.baseUrl);
+        push(config.codex.openaiBaseUrl);
+    }
+    if (config.pi) {
+        for (const prov of Object.values(config.pi.providers)) push(prov.baseUrl);
+    }
+    if (config.zcode) {
+        for (const prov of Object.values(config.zcode.providers)) push(prov.baseURL);
+    }
+    return out;
+}
+
+function configFilePaths(env: NodeJS.ProcessEnv): string[] {
+    const home = os.homedir();
+    const codexHome = nonEmpty(env.CODEX_HOME) ? env.CODEX_HOME : path.join(home, ".codex");
+    const zcodeHome = nonEmpty(env.ZCODE_DATA_BASE_DIR) ? env.ZCODE_DATA_BASE_DIR : path.join(home, ".zcode");
+    return [
+        path.join(home, ".claude", "settings.json"),
+        path.join(process.cwd(), ".claude", "settings.json"),
+        path.join(codexHome, "config.toml"),
+        path.join(resolvePiHome(env), "models.json"),
+        path.join(zcodeHome, "v2", "config.json"),
+    ];
+}
+
+function readMtimes(paths: string[]): Map<string, number> {
+    const mtimes = new Map<string, number>();
+    for (const p of paths) {
+        try {
+            const st = fs.statSync(p);
+            mtimes.set(p, st.mtimeMs);
+        } catch {}
+    }
+    return mtimes;
+}
+
+function mtimesEqual(a: Map<string, number>, b: Map<string, number>): boolean {
+    if (a.size !== b.size) return false;
+    for (const [k, v] of a) {
+        if (b.get(k) !== v) return false;
+    }
+    return true;
+}
+
+interface Cache {
+    checkedAt: number;
+    mtimes: Map<string, number>;
+    domains: string[];
+}
+
+let cache: Cache | null = null;
+
+export function discoverMitmDomains(env: NodeJS.ProcessEnv = process.env): string[] {
+    const now = Date.now();
+    if (cache && (now - cache.checkedAt) < TTL_MS) {
+        return cache.domains;
+    }
+    const paths = configFilePaths(env);
+    const mtimes = readMtimes(paths);
+    if (cache && mtimesEqual(mtimes, cache.mtimes)) {
+        cache.checkedAt = now;
+        return cache.domains;
+    }
+    const config = loadClientConfig(env, process.cwd());
+    const domains = extractHttpsHosts(config);
+    cache = { checkedAt: now, mtimes, domains };
+    return domains;
+}
+
+export function _resetDiscoveryCacheForTest(): void {
+    cache = null;
+}

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -31,6 +31,26 @@ import os from "node:os";
 import path from "node:path";
 import { spawn, type StdioOptions } from "node:child_process";
 import { DEFAULT_MITM_DOMAINS } from "./mitm.js";
+import { nonEmpty, resolvePiHome, loadClientConfig, type ClientConfig } from "./client-config.js";
+
+export {
+    type ClaudeSettings,
+    type CodexProvider,
+    type CodexConfig,
+    type PiProvider,
+    type PiConfig,
+    type ClientConfig,
+    type ZcodeProvider,
+    type ZcodeConfig,
+    readClaudeSettings,
+    parseCodexToml,
+    readCodexConfig,
+    readPiConfig,
+    loadClientConfig,
+    parseZcodeConfig,
+    readZcodeConfig,
+    resolvePiHome,
+} from "./client-config.js";
 
 export const LAUNCHER_DEFAULT_HOST = "127.0.0.1";
 export const LAUNCHER_DEFAULT_PORT = 8787;
@@ -123,34 +143,6 @@ export function unwrapUpstream(url: string): string {
     return idx >= 0 ? url.slice(idx + "/bili/".length) : url;
 }
 
-export interface ClaudeSettings {
-    anthropicBaseUrl?: string;
-}
-
-export interface CodexProvider {
-    baseUrl?: string;
-}
-
-export interface CodexConfig {
-    modelProvider?: string;
-    openaiBaseUrl?: string;
-    providers: Record<string, CodexProvider>;
-}
-
-export interface PiProvider {
-    baseUrl?: string;
-}
-
-export interface PiConfig {
-    providers: Record<string, PiProvider>;
-}
-
-export interface ClientConfig {
-    claude?: ClaudeSettings;
-    codex?: CodexConfig;
-    pi?: PiConfig;
-}
-
 export interface HttpRewrite {
     key: string;
     realUpstream: string;
@@ -162,20 +154,9 @@ export interface DiscoveredRoutes {
     httpsRewrites: HttpRewrite[];
 }
 
-function nonEmpty(s: unknown): s is string {
-    return typeof s === "string" && s.trim().length > 0;
-}
-
 export function resolveCaCertPath(env: NodeJS.ProcessEnv): string {
     const base = env.XDG_DATA_HOME || path.join(os.homedir(), ".local/share");
     return path.join(base, "billion-context", "ca", "root-ca.pem");
-}
-
-export function resolvePiHome(env: NodeJS.ProcessEnv): string {
-    const h = os.homedir();
-    return nonEmpty(env.PI_CODING_AGENT_DIR) ? env.PI_CODING_AGENT_DIR!
-        : nonEmpty(env.PI_HOME) ? env.PI_HOME!
-        : path.join(h, ".pi", "agent");
 }
 
 export function extractDomains(upstreams: string[]): string[] {
@@ -543,109 +524,6 @@ export function resolveClientCommand(
         return { command: process.execPath, prefixArgs: [cli] };
     }
     return { command: client, prefixArgs: [] };
-}
-
-function readJsonObject(filePath: string): Record<string, unknown> | null {
-    try {
-        const txt = fs.readFileSync(filePath, "utf8");
-        const parsed: unknown = JSON.parse(txt);
-        return parsed && typeof parsed === "object" && !Array.isArray(parsed)
-            ? (parsed as Record<string, unknown>)
-            : null;
-    } catch {
-        return null;
-    }
-}
-
-export function readClaudeSettings(homeDir: string, cwd: string): ClaudeSettings {
-    const files = [
-        path.join(homeDir, ".claude", "settings.json"),
-        path.join(cwd, ".claude", "settings.json"),
-    ];
-    let anthropicBaseUrl: string | undefined;
-    for (const f of files) {
-        const obj = readJsonObject(f);
-        const env = obj?.env;
-        if (env && typeof env === "object" && !Array.isArray(env)) {
-            const v = (env as Record<string, unknown>).ANTHROPIC_BASE_URL;
-            if (nonEmpty(v)) anthropicBaseUrl = v;
-        }
-    }
-    return anthropicBaseUrl ? { anthropicBaseUrl } : {};
-}
-
-/**
- * Targeted TOML reader for ~/.codex/config.toml: top-level `model_provider` /
- * `openai_base_url` and each `[model_providers.<name>]` `base_url`. String
- * values only; NOT a general TOML parser — intentionally dependency-free.
- */
-export function parseCodexToml(text: string): CodexConfig {
-    const result: CodexConfig = { providers: {} };
-    let table = "";
-    let curProvider: string | null = null;
-    for (const rawLine of text.split(/\r?\n/)) {
-        const line = rawLine.trim();
-        if (!line || line.startsWith("#")) continue;
-        const tableMatch = /^\[([^\]]+)\]$/.exec(line);
-        if (tableMatch) {
-            table = tableMatch[1].trim();
-            curProvider = table.startsWith("model_providers.")
-                ? table.slice("model_providers.".length).trim()
-                : null;
-            if (curProvider && !result.providers[curProvider]) {
-                result.providers[curProvider] = {};
-            }
-            continue;
-        }
-        const m = /^([A-Za-z0-9_.-]+)\s*=\s*(?:"([^"]*)"|'([^']*)')/.exec(line);
-        if (!m) continue;
-        const key = m[1];
-        const val = m[2] !== undefined ? m[2] : m[3];
-        if (table === "") {
-            if (key === "model_provider") result.modelProvider = val;
-            else if (key === "openai_base_url") result.openaiBaseUrl = val;
-        } else if (curProvider && key === "base_url") {
-            result.providers[curProvider].baseUrl = val;
-        }
-    }
-    return result;
-}
-
-export function readCodexConfig(codexHome: string): CodexConfig {
-    const cfgPath = path.join(codexHome, "config.toml");
-    let text: string;
-    try {
-        text = fs.readFileSync(cfgPath, "utf8");
-    } catch {
-        return { providers: {} };
-    }
-    return parseCodexToml(text);
-}
-
-export function readPiConfig(piHome: string): PiConfig {
-    const cfgPath = path.join(piHome, "models.json");
-    const obj = readJsonObject(cfgPath);
-    const providers: Record<string, PiProvider> = {};
-    const rawProviders = obj?.providers;
-    if (rawProviders && typeof rawProviders === "object" && !Array.isArray(rawProviders)) {
-        for (const [name, val] of Object.entries(rawProviders as Record<string, unknown>)) {
-            if (val && typeof val === "object" && !Array.isArray(val)) {
-                const baseUrl = (val as { baseUrl?: unknown }).baseUrl;
-                providers[name] = typeof baseUrl === "string" ? { baseUrl } : {};
-            }
-        }
-    }
-    return { providers };
-}
-
-export function loadClientConfig(env: NodeJS.ProcessEnv, cwd: string): ClientConfig {
-    const home = os.homedir();
-    const config: ClientConfig = {};
-    config.claude = readClaudeSettings(home, cwd);
-    const codexHome = nonEmpty(env.CODEX_HOME) ? env.CODEX_HOME : path.join(home, ".codex");
-    config.codex = readCodexConfig(codexHome);
-    config.pi = readPiConfig(resolvePiHome(env));
-    return config;
 }
 
 export interface RunLaunchParams {

--- a/src/mitm.ts
+++ b/src/mitm.ts
@@ -3,13 +3,15 @@ import net from "node:net";
 import tls from "node:tls";
 import { ensureRootCA, getSecureContext } from "./ca.js";
 import { connectThroughProxy } from "./upstream-proxy.js";
+import { discoverMitmDomains } from "./discover.js";
 
-/** Domains we transparently MITM: the model-inference endpoints of the
- *  providers billion-context targets. Everything else (banking, mail, …) is
- *  pure tunnelled — we never decrypt it. This whitelist is the security
- *  boundary: expanding it expands the set of hosts whose TLS we terminate. */
+// Domains we transparently MITM. These are ONLY the model-inference endpoints
+// hardcoded in client BINARIES with no config file to discover from
+// (Claude=api.anthropic.com, codex-login=api.openai.com/chatgpt.com).
+// Everything else is auto-discovered at runtime from each client's config
+// (see discoverMitmDomains). Expanding this list expands the set of hosts
+// whose TLS we terminate — the security boundary.
 export const DEFAULT_MITM_DOMAINS = [
-    "open.bigmodel.cn",
     "api.anthropic.com",
     "api.openai.com",
     "chatgpt.com",
@@ -23,10 +25,12 @@ export const MITM_UPSTREAM_KEY = "__biliMitmUpstream";
 
 /** True if `host` should be MITM-decrypted. Matches by exact hostname or a
  *  domain suffix (so `api.openai.com` and `chatgpt.com` both work, and
- *  subdomains like `edge.chatgpt.com` are covered). */
-export function isMitmHost(host: string, extra: string[] = []): boolean {
+ *  subdomains like `edge.chatgpt.com` are covered). The candidate set is the
+ *  binary-hardcoded DEFAULT_MITM_DOMAINS + caller-supplied extras + domains
+ *  auto-discovered from client config files (see discoverMitmDomains). */
+export function isMitmHost(host: string, extraDomains: string[] = []): boolean {
     const h = host.toLowerCase();
-    const all = [...DEFAULT_MITM_DOMAINS, ...extra].map((d) => d.toLowerCase());
+    const all = [...DEFAULT_MITM_DOMAINS, ...extraDomains, ...discoverMitmDomains()].map((d) => d.toLowerCase());
     return all.some((d) => h === d || h.endsWith("." + d));
 }
 

--- a/tests/discover.test.ts
+++ b/tests/discover.test.ts
@@ -1,0 +1,196 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+    extractHttpsHosts,
+    discoverMitmDomains,
+    _resetDiscoveryCacheForTest,
+} from "../src/discover.ts";
+import {
+    parseZcodeConfig,
+    readZcodeConfig,
+    type ClientConfig,
+} from "../src/client-config.ts";
+
+test("parseZcodeConfig: reads baseURL from each provider entry", () => {
+    const obj = {
+        provider: {
+            "builtin:bigmodel": { options: { baseURL: "https://open.bigmodel.cn/api/anthropic" } },
+            "builtin:zai": { options: { baseURL: "https://api.z.ai/api/anthropic" } },
+            "custom:foo": { options: { baseURL: "https://custom.foo.example.com/v1" } },
+        },
+        selectedProviderId: "builtin:bigmodel",
+    };
+    const cfg = parseZcodeConfig(obj);
+    assert.equal(Object.keys(cfg.providers).length, 3);
+    assert.equal(cfg.providers["builtin:bigmodel"].baseURL, "https://open.bigmodel.cn/api/anthropic");
+    assert.equal(cfg.providers["builtin:zai"].baseURL, "https://api.z.ai/api/anthropic");
+    assert.equal(cfg.providers["custom:foo"].baseURL, "https://custom.foo.example.com/v1");
+});
+
+test("parseZcodeConfig: defensive — non-object / missing provider / non-string baseURL", () => {
+    assert.deepEqual(parseZcodeConfig(null), { providers: {} });
+    assert.deepEqual(parseZcodeConfig("nope"), { providers: {} });
+    assert.deepEqual(parseZcodeConfig({}), { providers: {} });
+    assert.deepEqual(parseZcodeConfig({ provider: "wrong" }), { providers: {} });
+    const mixed = parseZcodeConfig({
+        provider: {
+            good: { options: { baseURL: "https://good.example.com" } },
+            noOptions: { baseURL: "https://stripped.example.com" },
+            noBase: { options: { somethingElse: 1 } },
+            notObj: "x",
+        },
+    });
+    assert.equal(mixed.providers.good?.baseURL, "https://good.example.com");
+    assert.equal(mixed.providers.noOptions, undefined);
+    assert.equal(mixed.providers.noBase, undefined);
+    assert.equal(mixed.providers.notObj, undefined);
+});
+
+test("readZcodeConfig: reads <home>/v2/config.json", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "bili-zcode-"));
+    try {
+        const v2 = path.join(tmp, "v2");
+        fs.mkdirSync(v2, { recursive: true });
+        fs.writeFileSync(
+            path.join(v2, "config.json"),
+            JSON.stringify({
+                provider: { p: { options: { baseURL: "https://z.example.com/api" } } },
+            }),
+        );
+        const cfg = readZcodeConfig(tmp);
+        assert.equal(cfg.providers.p.baseURL, "https://z.example.com/api");
+    } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+    }
+});
+
+test("readZcodeConfig: missing dir or unparseable file → empty providers", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "bili-zcode-"));
+    try {
+        assert.deepEqual(readZcodeConfig(tmp), { providers: {} });
+        fs.mkdirSync(path.join(tmp, "v2"), { recursive: true });
+        fs.writeFileSync(path.join(tmp, "v2", "config.json"), "not-json{");
+        assert.deepEqual(readZcodeConfig(tmp), { providers: {} });
+    } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+    }
+});
+
+test("extractHttpsHosts: dedupes, lowercases, drops http, unwraps /bili/", () => {
+    const config: ClientConfig = {
+        claude: { anthropicBaseUrl: "https://Claude.Example.com/api" },
+        codex: {
+            openaiBaseUrl: "https://oai-codex.example.com/backend",
+            providers: {
+                a: { baseUrl: "https://codex.example.com/v1" },
+                b: { baseUrl: "http://127.0.0.1:8787/bili/https://unwrapped.example.com/v1" },
+                dup: { baseUrl: "https://codex.example.com/v2" },
+                junk: { baseUrl: "not-a-url" },
+            },
+        },
+        pi: {
+            providers: {
+                z: { baseUrl: "https://PI.Example.com" },
+                local: { baseUrl: "http://localhost:1234" },
+            },
+        },
+        zcode: {
+            providers: {
+                "builtin:x": { baseURL: "https://zcode.example.com/anthropic" },
+                "builtin:y": { baseURL: "https://ZCODE.example.com/anthropic" },
+            },
+        },
+    };
+    const hosts = extractHttpsHosts(config);
+    assert.deepEqual(hosts, [
+        "claude.example.com",
+        "codex.example.com",
+        "unwrapped.example.com",
+        "oai-codex.example.com",
+        "pi.example.com",
+        "zcode.example.com",
+    ]);
+});
+
+test("extractHttpsHosts: empty config → []", () => {
+    assert.deepEqual(extractHttpsHosts({}), []);
+});
+
+async function withTempHome<T>(fn: (home: string, env: NodeJS.ProcessEnv) => Promise<T>): Promise<T> {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "bili-disc-"));
+    const savedHome = process.env.HOME;
+    process.env.HOME = tmp;
+    try {
+        const env: NodeJS.ProcessEnv = {
+            ...process.env,
+            HOME: tmp,
+            CODEX_HOME: path.join(tmp, ".codex"),
+            ZCODE_DATA_BASE_DIR: path.join(tmp, ".zcode"),
+            PI_CODING_AGENT_DIR: path.join(tmp, ".pi", "agent"),
+        };
+        return await fn(tmp, env);
+    } finally {
+        process.env.HOME = savedHome;
+        _resetDiscoveryCacheForTest();
+        fs.rmSync(tmp, { recursive: true, force: true });
+    }
+}
+
+function writeZcodeConfig(home: string, baseURLs: string[]): void {
+    const v2 = path.join(home, ".zcode", "v2");
+    fs.mkdirSync(v2, { recursive: true });
+    const provider: Record<string, { options: { baseURL: string } }> = {};
+    baseURLs.forEach((u, i) => { provider[`p${i}`] = { options: { baseURL: u } }; });
+    fs.writeFileSync(path.join(v2, "config.json"), JSON.stringify({ provider }));
+}
+
+test("discoverMitmDomains: returns union of https hosts from client configs", async () => {
+    await withTempHome((home, env) => {
+        writeZcodeConfig(home, ["https://open.bigmodel.cn/api/anthropic"]);
+        fs.mkdirSync(path.join(home, ".codex"), { recursive: true });
+        fs.writeFileSync(
+            path.join(home, ".codex", "config.toml"),
+            `[model_providers.openai]\nbase_url = "https://api.openai.com/v1"\n`,
+        );
+        _resetDiscoveryCacheForTest();
+        const domains = discoverMitmDomains(env);
+        assert.ok(domains.includes("open.bigmodel.cn"), `zcode host present: ${domains.join(",")}`);
+        assert.ok(domains.includes("api.openai.com"), `codex host present: ${domains.join(",")}`);
+        return Promise.resolve();
+    });
+});
+
+test("discoverMitmDomains: two calls within TTL return the same array (cache hit, no re-stat)", async () => {
+    await withTempHome((home, env) => {
+        writeZcodeConfig(home, ["https://cached.example.com"]);
+        _resetDiscoveryCacheForTest();
+        const first = discoverMitmDomains(env);
+        const second = discoverMitmDomains(env);
+        assert.strictEqual(first, second);
+        return Promise.resolve();
+    });
+});
+
+test("discoverMitmDomains: mtime change + TTL expiry triggers re-scan", async () => {
+    await withTempHome(async (home, env) => {
+        writeZcodeConfig(home, ["https://v1.example.com"]);
+        _resetDiscoveryCacheForTest();
+        const first = discoverMitmDomains(env);
+        assert.ok(first.includes("v1.example.com"));
+
+        writeZcodeConfig(home, ["https://v2.example.com"]);
+
+        const withinTtl = discoverMitmDomains(env);
+        assert.strictEqual(withinTtl, first, "within TTL: still cached");
+
+        await new Promise<void>((r) => setTimeout(r, 2100));
+
+        const after = discoverMitmDomains(env);
+        assert.ok(after.includes("v2.example.com"), `v2 present after rescan: ${after.join(",")}`);
+        assert.ok(!after.includes("v1.example.com"), `v1 gone: ${after.join(",")}`);
+        assert.notStrictEqual(after, first);
+    });
+});

--- a/tests/mitm.test.ts
+++ b/tests/mitm.test.ts
@@ -6,6 +6,36 @@ import path from "node:path";
 import tls from "node:tls";
 import { isMitmHost, readMitmUpstream, MITM_UPSTREAM_KEY } from "../src/mitm.js";
 import { ensureRootCA, rootCaPath, getSecureContext, _resetForTest } from "../src/ca.js";
+import { _resetDiscoveryCacheForTest } from "../src/discover.js";
+
+// isMitmHost now calls discoverMitmDomains(), which reads real client config
+// files. Isolate discovery to an empty temp HOME so the isMitmHost assertions
+// are deterministic (only DEFAULT_MITM_DOMAINS apply, no discovered hosts).
+const _discoverySavedEnv: Record<string, string | undefined> = {};
+let _discoveryTmpHome: string | undefined;
+
+test.before(() => {
+    _discoveryTmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "bili-mitm-disc-"));
+    for (const k of ["HOME", "CODEX_HOME", "ZCODE_DATA_BASE_DIR", "PI_CODING_AGENT_DIR", "PI_HOME"]) {
+        _discoverySavedEnv[k] = process.env[k];
+    }
+    process.env.HOME = _discoveryTmpHome;
+    process.env.CODEX_HOME = path.join(_discoveryTmpHome, ".codex");
+    process.env.ZCODE_DATA_BASE_DIR = path.join(_discoveryTmpHome, ".zcode");
+    process.env.PI_CODING_AGENT_DIR = path.join(_discoveryTmpHome, ".pi");
+    _resetDiscoveryCacheForTest();
+});
+
+test.after(() => {
+    for (const [k, v] of Object.entries(_discoverySavedEnv)) {
+        if (v === undefined) delete process.env[k];
+        else process.env[k] = v;
+    }
+    _resetDiscoveryCacheForTest();
+    if (_discoveryTmpHome) {
+        try { fs.rmSync(_discoveryTmpHome, { recursive: true, force: true }); } catch { /* best-effort */ }
+    }
+});
 
 // Isolate the CA directory to a per-test tmp dir so we never touch the real
 // ~/.local/share/billion-context/ca. caDir() = dataDir()/ca =
@@ -25,7 +55,7 @@ function withTmpCa<T>(fn: () => Promise<T> | T): Promise<T> | T {
 }
 
 test("isMitmHost: matches the built-in whitelist exactly", () => {
-    assert.equal(isMitmHost("open.bigmodel.cn"), true);
+    assert.equal(isMitmHost("open.bigmodel.cn"), false);
     assert.equal(isMitmHost("api.anthropic.com"), true);
     assert.equal(isMitmHost("api.openai.com"), true);
     assert.equal(isMitmHost("chatgpt.com"), true);
@@ -57,7 +87,7 @@ test("isMitmHost: honors extra domains from config", () => {
 });
 
 test("isMitmHost: is case-insensitive on the host", () => {
-    assert.equal(isMitmHost("OPEN.BIGMODEL.CN"), true);
+    assert.equal(isMitmHost("CHATGPT.COM"), true);
     assert.equal(isMitmHost("Api.Anthropic.Com"), true);
 });
 


### PR DESCRIPTION
## What

Replace the hardcoded MITM domain whitelist with **auto-discovery**: bili reads each coding client's config file and extracts all model-provider HTTPS hostnames at runtime. Official / third-party / future domains are covered without hardcoding anything (except the 3 endpoints truly baked into client *binaries* with no config).

## Why

`DEFAULT_MITM_DOMAINS` was a hardcoded list (`open.bigmodel.cn`, `api.anthropic.com`, …). It only covered ZCode's `open.bigmodel.cn` provider — `zcode.z.ai` and `api.z.ai` (also official ZCode) were missing, and any third-party relay was invisible. Domains change; hardcoding them is brittle.

bili is a **client-agnostic** proxy: it doesn't (and shouldn't) know which app sent a given CONNECT. So discovery targets *domains*, not *clients* — it builds one global whitelist from the union of all client configs, then MITM-decrypts any CONNECT whose host is in that set and blind-tunnels the rest.

## How

- **New `src/client-config.ts`** — the existing claude/codex/pi config readers moved here out of `launcher.ts` (avoids a circular import: `launcher.ts` already imports `DEFAULT_MITM_DOMAINS` from `mitm.ts`). Plus a **new ZCode reader** (`~/.zcode/v2/config.json` → `provider.*.options.baseURL`). `launcher.ts` re-exports everything for back-compat.
- **New `src/discover.ts`** — `discoverMitmDomains()` reads all client configs, extracts HTTPS hosts (unwrapping `/bili/`-prefixed URLs), dedupes, lowercases. Cached by config-file **mtime + 2s TTL**: at most one `stat` every 2 s, full re-scan only when a config file actually changes. Pure, side-effect-free except the cache.
- **`src/mitm.ts`** — `isMitmHost` now folds in `discoverMitmDomains()`: the candidate set is `DEFAULT + user mitm.domains + discovered`. `DEFAULT_MITM_DOMAINS` reduced to **only** the 3 endpoints hardcoded in client *binaries* with no config to discover from: `api.anthropic.com` (Claude), `api.openai.com` + `chatgpt.com` (codex-login / ChatGPT). `open.bigmodel.cn` removed (now discovered from zcode/pi configs). The security-boundary comment is updated to reflect that the list is now minimal + that discovery is the primary source.

## Verification

```
typecheck: clean (no circular import)
tests: 332/332 pass (323 + 9 new in tests/discover.test.ts)
build: ok
runtime: discoverMitmDomains() against real ~/.zcode + ~/.codex + ~/.pi → 6 domains
         (ai.comfly.org, api.openai.com, open.bigmodel.cn, coding.dashscope.aliyuncs.com, zcode.z.ai, api.z.ai)
         isMitmHost(open.bigmodel.cn|zcode.z.ai|api.z.ai|api.anthropic.com) → true
         isMitmHost(example.com) → false  (non-model hosts still tunneled)
```

Diff: +564/-154 across 7 files (`client-config.ts` +194, `discover.ts` +108, `launcher.ts` −154 net, `mitm.ts` ±20, 2 test files).

## Test plan

- [ ] `bili start --debug` on a machine with ZCode + codex + pi installed → log shows the discovered domains in the MITM whitelist (banner).
- [ ] ZCode pointed at bili (proxy + cert) → all 6 providers route through bili, compression injected (was: only `open.bigmodel.cn`).
- [ ] Add a new provider in `~/.codex/config.toml` while bili runs → within 2 s it's auto-MITM'd (no restart).
- [ ] A non-model HTTPS site (e.g. `example.com`) through bili → blind-tunneled, not decrypted.

Follow-up (separate PRs): the `bili zcode` launcher (Electron `--proxy-server` + `--ignore-certificate-errors-spki-list` injection) + `.desktop` override so the desktop-icon launch is covered.
