### PR TITLE
fix(anthropic): forward round-2 stream with proper framing (vertical-text bug)

### DIFF
--- a/src/loop/adapter-anthropic.ts
+++ b/src/loop/adapter-anthropic.ts
@@ -175,10 +175,10 @@ export function createAnthropicAdapter(requestBody: Record<string, unknown>, ori
                         const name = typeof block.name === "string" ? block.name : "";
                         const id = typeof block.id === "string" ? block.id : `toolu_${upstreamIndex}`;
                         pending.set(upstreamIndex, { id, name, json: "" });
-                    } else if (round === 1) {
+                    } else {
                         const ci = clientIndex++;
                         indexMap.set(upstreamIndex, ci);
-                        yield { kind: "meta", chunk: remapIndexInEvent(eventStr, ci), firstRoundOnly: true } as ParsedStreamEvent;
+                        yield { kind: "meta", chunk: remapIndexInEvent(eventStr, ci), firstRoundOnly: round === 1 } as ParsedStreamEvent;
                     }
                 } else if (type === "content_block_delta") {
                     const upstreamIndex = (data.index as number) ?? 0;
@@ -188,12 +188,8 @@ export function createAnthropicAdapter(requestBody: Record<string, unknown>, ori
                             pending.get(upstreamIndex)!.json += delta.partial_json;
                         }
                     } else if (delta.type === "text_delta" && typeof delta.text === "string") {
-                        if (round === 1) {
-                            const ci = indexMap.get(upstreamIndex) ?? upstreamIndex;
-                            yield { kind: "text", delta: delta.text, raw: remapIndexInEvent(eventStr, ci) } as ParsedStreamEvent;
-                        } else {
-                            yield { kind: "text", delta: delta.text } as ParsedStreamEvent;
-                        }
+                        const ci = indexMap.get(upstreamIndex) ?? upstreamIndex;
+                        yield { kind: "text", delta: delta.text, raw: remapIndexInEvent(eventStr, ci) } as ParsedStreamEvent;
                     } else if (round === 1) {
                         const ci = indexMap.get(upstreamIndex) ?? upstreamIndex;
                         yield { kind: "meta", chunk: remapIndexInEvent(eventStr, ci), firstRoundOnly: true } as ParsedStreamEvent;
@@ -209,9 +205,9 @@ export function createAnthropicAdapter(requestBody: Record<string, unknown>, ori
                             callId: tb.id,
                             arguments: tb.json,
                         } as ParsedStreamEvent;
-                    } else if (round === 1) {
+                    } else {
                         const ci = indexMap.get(upstreamIndex) ?? upstreamIndex;
-                        yield { kind: "meta", chunk: remapIndexInEvent(eventStr, ci), firstRoundOnly: true } as ParsedStreamEvent;
+                        yield { kind: "meta", chunk: remapIndexInEvent(eventStr, ci), firstRoundOnly: round === 1 } as ParsedStreamEvent;
                     }
                 } else if (type === "message_delta") {
                     const u = (data.usage ?? {}) as Record<string, unknown>;

--- a/src/loop/core.ts
+++ b/src/loop/core.ts
@@ -182,14 +182,14 @@ export async function* runCompressLoop(
 
             for await (const ev of adapter.parseStream(currentUpstream, round)) {
                 if (signal?.aborted) break;
-                if (ev.kind === "text") {
-                    assistantText += ev.delta;
-                    if (!ctx.textProtocol && round === 1 && ev.raw) {
-                        yield ev.raw;
-                    } else if (!ctx.textProtocol && round > 1 && ev.delta.length > 0) {
-                        yield adapter.emitText(ev.delta);
-                    }
-                } else if (ev.kind === "tool_call") {
+                    if (ev.kind === "text") {
+                        assistantText += ev.delta;
+                        if (!ctx.textProtocol && ev.raw) {
+                            yield ev.raw;
+                        } else if (!ctx.textProtocol && round > 1 && ev.delta.length > 0) {
+                            yield adapter.emitText(ev.delta);
+                        }
+                    } else if (ev.kind === "tool_call") {
                     calls.push({ name: ev.name, callId: ev.callId, arguments: ev.arguments });
                 } else if (ev.kind === "usage") {
                     usage = {

--- a/tests/anthropic-round2-stream.test.ts
+++ b/tests/anthropic-round2-stream.test.ts
@@ -1,0 +1,71 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createAnthropicAdapter } from "../src/loop/adapter-anthropic.ts";
+
+interface ParsedEvent {
+    kind: string;
+    delta?: string;
+    raw?: Buffer;
+    chunk?: Buffer;
+    firstRoundOnly?: boolean;
+}
+
+function sse(events: string[]): string {
+    return events.map((e) => e + "\n\n").join("");
+}
+
+function toStream(text: string): ReadableStream<Uint8Array> {
+    return new ReadableStream({
+        start(controller) {
+            controller.enqueue(new TextEncoder().encode(text));
+            controller.close();
+        },
+    });
+}
+
+const ROUND2_STREAM = sse([
+    `event: message_start\ndata: ${JSON.stringify({ type: "message_start", message: { id: "msg_r2", usage: { input_tokens: 10 } } })}`,
+    `event: content_block_start\ndata: ${JSON.stringify({ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } })}`,
+    `event: content_block_delta\ndata: ${JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "Hel" } })}`,
+    `event: content_block_delta\ndata: ${JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "lo" } })}`,
+    `event: content_block_stop\ndata: ${JSON.stringify({ type: "content_block_stop", index: 0 })}`,
+    `event: message_delta\ndata: ${JSON.stringify({ type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 5 } })}`,
+    `event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}`,
+]);
+
+test("anthropic round-2 streaming: deltas carry raw + block start/stop forwarded (regression: vertical-text bug)", async () => {
+    const adapter = createAnthropicAdapter({ model: "claude-1" });
+    const events: ParsedEvent[] = [];
+    for await (const ev of adapter.parseStream(toStream(ROUND2_STREAM), 2) as AsyncIterable<ParsedEvent>) {
+        events.push(ev);
+    }
+    const textEvents = events.filter((e) => e.kind === "text");
+    const metaChunks = events.filter((e) => e.kind === "meta").map((e) => e.chunk?.toString("utf8") ?? "");
+
+    assert.equal(textEvents.length, 2, "two text deltas parsed");
+    assert.ok(
+        textEvents.every((e) => Buffer.isBuffer(e.raw)),
+        "round-2 text deltas carry raw (the actual content_block_delta event) so core.ts forwards them inline",
+    );
+    assert.ok(
+        textEvents.every((e) => !/content_block_start|content_block_stop/.test(e.raw!.toString("utf8"))),
+        "raw is a pure delta (NOT a full block) — OLD code wrapped each delta via emitText/buildTextBlock → one block per chunk → vertical text",
+    );
+    const hasStart = metaChunks.some((c) => c.includes("content_block_start"));
+    const hasStop = metaChunks.some((c) => c.includes("content_block_stop"));
+    assert.ok(hasStart, "content_block_start forwarded in round 2 (opens the text block)");
+    assert.ok(hasStop, "content_block_stop forwarded in round 2 (closes the text block)");
+});
+
+test("anthropic round-2 message_start is NOT re-emitted (one message_start per response)", async () => {
+    const adapter = createAnthropicAdapter({ model: "claude-1" });
+    const events: ParsedEvent[] = [];
+    for await (const ev of adapter.parseStream(toStream(ROUND2_STREAM), 2) as AsyncIterable<ParsedEvent>) {
+        events.push(ev);
+    }
+    const metaChunks = events.filter((e) => e.kind === "meta").map((e) => e.chunk?.toString("utf8") ?? "");
+    assert.ok(
+        !metaChunks.some((c) => c.includes("message_start")),
+        "round 2 skips message_start (already sent in round 1); re-emitting would start a second message",
+    );
+});


### PR DESCRIPTION
## Problem

In ZCode (and any Anthropic client), after a proxy-tool re-request (e.g. `acp_status`), the model's round-2 answer rendered as **vertical text** — each ~2-char streaming chunk on its own line:

```
上下

文

状态
```

## Root cause

PR #122 made round-2 streaming call `emitText(ev.delta)` per delta (`core.ts:190`). For the **Anthropic** adapter, `emitText` → `buildTextBlock` wraps **each call** in a full content block:

```
content_block_start (index N)
content_block_delta  (index N, delta)
content_block_stop   (index N)
```

So every tiny delta became its own complete block → the client rendered each block as a separate paragraph → vertical text. (OpenAI/Responses `emitText` only emits a delta chunk, so they were unaffected.)

The adapter also gated `content_block_start`/`content_block_stop` behind `round === 1` (`adapter-anthropic.ts:166/178/212`), so round 2 emitted **zero framing**.

## Fix

1. **adapter-anthropic.ts**: forward round-2 `content_block_start`/`delta`/`stop` with new client indices (remove the `round === 1` gate; use `firstRoundOnly: round === 1`). Round-2 text deltas now carry `raw` (the actual remapped `content_block_delta` event).
2. **core.ts**: yield `ev.raw` in **all** rounds when the adapter provides it (was `round === 1 && ev.raw`). OpenAI/Responses round-2 (no raw) still falls back to `emitText`. textProtocol (marker) path unchanged.

Result: round 2 now streams ONE `content_block_start` + many inline `content_block_delta` + ONE `content_block_stop` → proper Anthropic framing → text renders inline. `message_start` stays round-1-only (one message per response).

## Tests

- New `tests/anthropic-round2-stream.test.ts` (2 tests): round-2 deltas carry `raw` (pure delta, not a full block) + content_block_start/stop forwarded + message_start not re-emitted.
- Full suite **325/325** pass (323 + 2). typecheck clean. build OK.

## Verification

Captured round-2 raw HTTP shows the model answer is now a single text block with inline deltas (was N separate blocks).