### PR TITLE
fix(forward): handle absolute URLs in HTTP-proxy mode

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -414,7 +414,7 @@ async function handle(
         urlPath = url.split("?", 2)[0];
         responsesCompact = urlPath.endsWith("/responses/compact");
         route = resolveUpstream(opts, req.url ?? "", req);
-        upstreamOrigin = route ? route.upstream : opts.upstream;
+        upstreamOrigin = route ? route.upstream : /^https?:\/\//i.test(url) ? new URL(url).origin : opts.upstream;
         protocol =
             route?.explicitProtocol
             ?? (req.method === "POST" && bodyBuffer.length > 0
@@ -1059,7 +1059,9 @@ async function forward(
     // rewrittenUrl may use a `mitm://` scheme (for config-lookup distinction
     // — see resolveUpstream). fetch needs the real https:// scheme, so strip
     // mitm:// back to https:// for the actual upstream request.
-    const rewritten = route ? route.rewrittenUrl : opts.upstream + (req.url ?? "");
+    const reqUrl = req.url ?? "";
+    const isAbsoluteUrl = /^https?:\/\//i.test(reqUrl);
+    const rewritten = route ? route.rewrittenUrl : isAbsoluteUrl ? reqUrl : opts.upstream + reqUrl;
     const upstreamUrl = rewritten.replace(/^mitm:\/\//, "https://");
     // Show the final proxied URL (where the request actually lands) as the
     // primary signal. The provider label is appended only for named routes —
@@ -1111,7 +1113,7 @@ async function forward(
         if (UPSTREAM_HOP_HEADERS.has(k.toLowerCase()) || v === undefined) continue;
         headers[k] = Array.isArray(v) ? v.join(", ") : v;
     }
-    headers["host"] = new URL(route ? route.upstream : opts.upstream).host;
+    headers["host"] = new URL(upstreamUrl).host;
     // codex advertises its own server-side context compaction via this beta
     // feature. It conflicts with bili's client-side compress (bili IS the
     // compression layer) and third-party aggregators reject it with

--- a/tests/forward-absolute-url.test.ts
+++ b/tests/forward-absolute-url.test.ts
@@ -1,0 +1,105 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import { once } from "node:events";
+import { defaultConfig } from "acp-kernel";
+import { startServer } from "../src/server.ts";
+import { SessionStore, _setStoreForTest } from "../src/persist.ts";
+import type { ProxyOptions } from "../src/config.ts";
+import { _setForTest as setRegistryForTest } from "../src/registry.ts";
+
+function listen(server: http.Server): Promise<void> {
+    if (server.listening) return Promise.resolve();
+    return once(server, "listening").then(() => undefined);
+}
+
+function close(server: http.Server): Promise<void> {
+    return new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+}
+
+test("forward: absolute-URL proxy-mode request reaches the correct upstream (no URL mangling)", async () => {
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    setRegistryForTest({});
+
+    let capturedUrl = "";
+    let capturedHost = "";
+    const upstream = http.createServer((req, res) => {
+        const chunks: Buffer[] = [];
+        req.on("data", (c: Buffer) => chunks.push(c));
+        req.on("end", () => {
+            capturedUrl = req.url ?? "";
+            capturedHost = String(req.headers["host"] ?? "");
+            res.writeHead(200, { "content-type": "application/json" });
+            res.end(JSON.stringify({ ok: true }));
+        });
+    });
+    upstream.listen(0, "127.0.0.1");
+    await listen(upstream);
+    const upstreamPort = (upstream.address() as { port: number }).port;
+    const upstreamHost = `127.0.0.1:${upstreamPort}`;
+
+    const opts: ProxyOptions = {
+        port: 0,
+        host: "127.0.0.1",
+        upstream: "https://api.anthropic.com",
+        routes: {},
+        modelContextLimit: 400_000,
+        kernelConfig: defaultConfig(400_000),
+        compress: { injectTool: true, injectNudge: true },
+        promptCache: { routing: "auto" },
+        sessionHeader: "x-acp-session",
+        log: false,
+        debug: false,
+        passthrough: false,
+        autoUpdate: false,
+        mitm: { enabled: false, domains: [] },
+    };
+    const proxy = await startServer(opts);
+    await listen(proxy);
+    const proxyPort = (proxy.address() as { port: number }).port;
+
+    const body = JSON.stringify({
+        model: "gpt-test",
+        stream: false,
+        messages: [{ role: "user", content: "hi" }],
+    });
+
+    try {
+        await new Promise<void>((resolve, reject) => {
+            const req = http.request(
+                {
+                    host: "127.0.0.1",
+                    port: proxyPort,
+                    method: "POST",
+                    path: `http://${upstreamHost}/v1/chat/completions`,
+                    headers: {
+                        "content-type": "application/json",
+                        host: upstreamHost,
+                        "content-length": String(Buffer.byteLength(body)),
+                    },
+                },
+                (res) => {
+                    res.on("data", () => {});
+                    res.on("end", () => resolve());
+                },
+            );
+            req.on("error", reject);
+            req.write(body);
+            req.end();
+        });
+
+        assert.equal(
+            capturedUrl,
+            "/v1/chat/completions",
+            `upstream must receive the PATH, not a mangled URL; got "${capturedUrl}"`,
+        );
+        assert.equal(
+            capturedHost,
+            upstreamHost,
+            `upstream Host header must be the real upstream host, not the default; got "${capturedHost}"`,
+        );
+    } finally {
+        await close(proxy);
+        await close(upstream);
+    }
+});


### PR DESCRIPTION
## Problem

When a client is configured to use bili as an **HTTP forward proxy** (e.g. ZCode with proxy=`http://127.0.0.1:8787`) and sends requests to a **custom localhost upstream** (e.g. `http://127.0.0.1:18081/v1/messages`, `http://localhost:8199/v1`), bili mangles the URL:

```
forward POST → https://api.anthropic.comhttp://127.0.0.1:18081/v1/messages
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
→ ECONNRESET (garbage hostname)
```

(72 occurrences in the user's `bili.log`.)

**Root cause:** `server.ts` forward assumed `req.url` is always a path and did `opts.upstream + req.url`. But in HTTP-proxy mode the request line carries the **full absolute URL**, so `opts.upstream + fullUrl` produces garbage.

## Fix (`src/server.ts`, 3 edits)

Detect absolute URLs (`/^https?:\/\//i`) and use them as-is instead of prepending the default upstream:

1. **upstreamOrigin** (line ~417): `route ? route.upstream : isAbsolute ? new URL(url).origin : opts.upstream` — so session/upstream tracking sees the real host.
2. **rewritten URL** (line ~1062): `route ? route.rewrittenUrl : isAbsolute ? reqUrl : opts.upstream + reqUrl` — don't prepend for absolute URLs.
3. **Host header** (line ~1114): `new URL(upstreamUrl).host` — derive from the final URL (correct for all modes).

### Unaffected paths
- `/bili/` prefix mode → `route` handles it (`route.rewrittenUrl`), unchanged.
- MITM transparent-proxy mode (path-only `req.url`, e.g. `/v1/messages`) → not absolute → `opts.upstream + path`, unchanged.

## Test

`tests/forward-absolute-url.test.ts`: spins up a stub upstream + bili (with a non-matching default upstream), sends a proxy-mode request with an **absolute** URL via Node `http.request({path: 'http://127.0.0.1:<port>/v1/chat/completions'})`. Asserts the stub receives `/v1/chat/completions` (not mangled) with the correct Host header.

- typecheck: clean
- full suite: **324/324** (was 323, +1)
- build: OK

## Verification

The user's `bili.log` showed the exact mangled URLs (`https://api.anthropic.comhttp://127.0.0.1:18081/...`) → this PR makes those resolve to the real localhost upstream.