### PR TITLE
release v0.1.37

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.36",
+  "version": "0.1.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.36",
+      "version": "0.1.37",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.36",
+  "version": "0.1.37",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Release v0.1.37.

## Changes since v0.1.36

- **feat(mitm): auto-discover model domains from client configs** (PR #125) — new `src/discover.ts` + `src/client-config.ts`; reads client configs to auto-populate the MITM domain whitelist instead of manual `--mitm-domain`. `launcher.ts` refactored.
- **fix(anthropic): forward round-2 stream with proper framing** (PR #126) — vertical-text bug where round-2+ text after a tool call buffered instead of streaming.
- **fix(forward): use absolute-URL host for proxy-mode requests** (PR #127) — `/bili/` proxy-mode forwarding now resolves the host from the absolute URL correctly.

## This commit

Version bump only (`package.json` + `package-lock.json`). `acp-kernel` held at 0.0.19 (latest published; 0.0.20 not yet on npm).

## Pre-flight

- `npm run typecheck` ✓
- `npm test` → 335 pass, 0 fail ✓
- `npm run build` → 2.02 MB ✓

Merge → CI publishes `billion-context@0.1.37` + tag `v0.1.37` + GitHub Release.