### PR TITLE
fix(openai): preserve reasoning_content round-trip for thinking-mode models

### DIFF
--- a/src/bili-message.ts
+++ b/src/bili-message.ts
@@ -37,6 +37,11 @@ export interface BiliMessage extends CoreMessage {
      *  pairs; without it the request is rejected. Stored alongside the
      *  reasoning text so coreToAnthropic can reattach it. */
     thinkingSignature?: string;
+    /** OpenAI reasoning_content (chain-of-thought from DeepSeek-R1, GLM-4.6
+     *  thinking, Qwen-QwQ). These models require reasoning_content be echoed
+     *  back on subsequent requests or the API returns HTTP 400; stored so
+     *  coreToOpenai can reattach it. */
+    reasoningContent?: string;
     /** Anthropic tool_result.is_error. Marks the tool result as an error so
      *  the model knows the tool failed (not just returned an error string). */
     toolIsError?: boolean;

--- a/src/loop/adapter-openai.ts
+++ b/src/loop/adapter-openai.ts
@@ -67,6 +67,18 @@ export function createOpenaiAdapter(requestBody: Record<string, unknown>): Compr
             "utf8",
         );
 
+    const buildReasoning = (content: string): Buffer =>
+        Buffer.from(
+            `data: ${JSON.stringify({
+                id: responseId,
+                object: "chat.completion.chunk",
+                created: Date.now(),
+                model,
+                choices: [{ index: 0, delta: { reasoning_content: content }, finish_reason: null }],
+            })}\n\n`,
+            "utf8",
+        );
+
     const buildToolCall = (call: ToolCallEmit): Buffer => {
         const idx = toolIndex++;
         return Buffer.from(
@@ -177,6 +189,10 @@ export function createOpenaiAdapter(requestBody: Record<string, unknown>): Compr
 
                 if (!delta) continue;
 
+                if (typeof delta.reasoning_content === "string" && delta.reasoning_content.length > 0) {
+                    yield { kind: "reasoning", delta: delta.reasoning_content, raw: rawBuf } as ParsedStreamEvent;
+                }
+
                 if (delta.tool_calls) {
                     const tcs = delta.tool_calls as Array<Record<string, unknown>>;
                     for (const tc of tcs) {
@@ -201,9 +217,10 @@ export function createOpenaiAdapter(requestBody: Record<string, unknown>): Compr
                     continue;
                 }
 
+                const hasReasoning = typeof delta.reasoning_content === "string" && delta.reasoning_content.length > 0;
                 if (typeof delta.content === "string" && delta.content.length > 0) {
-                    yield { kind: "text", delta: delta.content, raw: rawBuf } as ParsedStreamEvent;
-                } else if (delta.role || (Object.keys(delta).length === 0 && !finishReason)) {
+                    yield { kind: "text", delta: delta.content, ...(hasReasoning ? {} : { raw: rawBuf }) } as ParsedStreamEvent;
+                } else if (!hasReasoning && (delta.role || (Object.keys(delta).length === 0 && !finishReason))) {
                     yield { kind: "meta", chunk: rawBuf, firstRoundOnly: true } as ParsedStreamEvent;
                 }
             }
@@ -211,6 +228,10 @@ export function createOpenaiAdapter(requestBody: Record<string, unknown>): Compr
 
         emitText(delta) {
             return buildContent(delta);
+        },
+
+        emitReasoning(delta) {
+            return buildReasoning(delta);
         },
 
         emitToolCall(call) {

--- a/src/loop/core.ts
+++ b/src/loop/core.ts
@@ -9,6 +9,7 @@ import {
     type NudgeDecision,
 } from "acp-kernel";
 import type { Session } from "../session.js";
+import type { BiliMessage } from "../bili-message.js";
 import {
     parseCompressInput,
     PROXY_TOOL_NAMES,
@@ -41,6 +42,7 @@ export interface RequestOptions {
 
 export type ParsedStreamEvent =
     | { kind: "text"; delta: string; raw?: Buffer }
+    | { kind: "reasoning"; delta: string; raw?: Buffer }
     | { kind: "tool_call"; name: string; callId: string; arguments: string }
     | { kind: "usage"; inputTokens?: number; outputTokens?: number; cachedTokens?: number }
     | { kind: "done"; finishReason?: string }
@@ -70,6 +72,7 @@ export interface CompressLoopAdapter {
     ): Record<string, unknown>;
     parseStream(upstream: ReadableStream<Uint8Array>, round: number): AsyncGenerator<ParsedStreamEvent>;
     emitText(delta: string): Buffer;
+    emitReasoning?(delta: string): Buffer;
     emitToolCall(call: ToolCallEmit): Buffer;
     emitMarker(toolName: string, result: string): Buffer;
     emitCompletion(opts?: EmitCompletionOpts): Buffer;
@@ -176,6 +179,7 @@ export async function* runCompressLoop(
         for (let round = 1; round <= MAX_LOOP_ROUNDS; round++) {
             if (signal?.aborted) break;
             let assistantText = "";
+            let assistantReasoning = "";
             const calls: ToolCallEmit[] = [];
             let usage: { inputTokens?: number; outputTokens?: number; cachedTokens?: number } = {};
             let finishReason: string | undefined;
@@ -188,6 +192,15 @@ export async function* runCompressLoop(
                             yield ev.raw;
                         } else if (!ctx.textProtocol && round > 1 && ev.delta.length > 0) {
                             yield adapter.emitText(ev.delta);
+                        }
+                    } else if (ev.kind === "reasoning") {
+                        assistantReasoning += ev.delta;
+                        if (!ctx.textProtocol) {
+                            if (ev.raw) {
+                                yield ev.raw;
+                            } else if (round > 1 && ev.delta.length > 0 && adapter.emitReasoning) {
+                                yield adapter.emitReasoning(ev.delta);
+                            }
                         }
                     } else if (ev.kind === "tool_call") {
                     calls.push({ name: ev.name, callId: ev.callId, arguments: ev.arguments });
@@ -266,6 +279,16 @@ export async function* runCompressLoop(
             // never in coreMessages), and hideConsumedCompressCalls runs each
             // round so consumed compress records cannot re-prime the model.
             if (proxyResults.length > 0) {
+                if (assistantReasoning.length > 0) {
+                    const reasoningMsg: BiliMessage = {
+                        id: `acp_loop_r${round}_reasoning`,
+                        role: "assistant",
+                        contentType: "reasoning",
+                        text: assistantReasoning,
+                        reasoningContent: assistantReasoning,
+                    };
+                    coreMessages.push(reasoningMsg);
+                }
                 if (assistantText.length > 0) {
                     coreMessages.push({
                         id: `acp_loop_r${round}_asst`,

--- a/src/openai.ts
+++ b/src/openai.ts
@@ -17,6 +17,7 @@ export type OpenAIToolCall = {
 export type OpenAIMessage = {
     role: "system" | "developer" | "user" | "assistant" | "tool";
     content?: string | null | OpenAIContentPart[];
+    reasoning_content?: string | null;
     tool_calls?: OpenAIToolCall[];
     tool_call_id?: string;
     name?: string;
@@ -62,6 +63,17 @@ export function openaiToCore(body: OpenAIRequestBody): Flat {
                 break;
             }
             case "assistant": {
+                const reasoning = typeof m.reasoning_content === "string" ? m.reasoning_content : "";
+                if (reasoning) {
+                    const base = deriveMessageId("assistant", "reasoning", reasoning);
+                    msgs.push({
+                        id: clusters.next(base),
+                        role: "assistant",
+                        contentType: "reasoning",
+                        text: reasoning,
+                        reasoningContent: reasoning,
+                    });
+                }
                 const text = stringContent(m.content);
                 if (text) {
                     const base = deriveMessageId("assistant", "text", text);
@@ -105,24 +117,30 @@ export function openaiToCore(body: OpenAIRequestBody): Flat {
 
 export function coreToOpenai(messages: BiliMessage[]): OpenAIMessage[] {
     const out: OpenAIMessage[] = [];
-    let pending: { text: string | null; toolCalls: OpenAIToolCall[] } | null = null;
+    let pending: { text: string | null; toolCalls: OpenAIToolCall[]; reasoning: string | null } | null = null;
     const flush = () => {
         if (!pending) return;
+        const reasoning = pending.reasoning !== null && pending.reasoning.length > 0 ? pending.reasoning : undefined;
         if (pending.toolCalls.length > 0) {
             out.push({
                 role: "assistant",
                 content: pending.text ?? null,
                 tool_calls: pending.toolCalls,
+                ...(reasoning ? { reasoning_content: reasoning } : {}),
             });
         } else if (pending.text !== null) {
-            out.push({ role: "assistant", content: pending.text });
+            out.push({ role: "assistant", content: pending.text, ...(reasoning ? { reasoning_content: reasoning } : {}) });
+        } else if (reasoning) {
+            out.push({ role: "assistant", content: null, reasoning_content: reasoning });
         }
         pending = null;
     };
     for (const m of messages) {
         if (m.role === "assistant") {
-            if (!pending) pending = { text: null, toolCalls: [] };
-            if (m.contentType === "text") {
+            if (!pending) pending = { text: null, toolCalls: [], reasoning: null };
+            if (m.contentType === "reasoning") {
+                pending.reasoning = (pending.reasoning ?? "") + (m.reasoningContent ?? m.text ?? "");
+            } else if (m.contentType === "text") {
                 pending.text = (pending.text ?? "") + (m.text ?? "");
             } else if (m.contentType === "tool-call") {
                 pending.toolCalls.push({

--- a/tests/openai-reasoning-content.test.ts
+++ b/tests/openai-reasoning-content.test.ts
@@ -1,0 +1,177 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { openaiToCore, coreToOpenai } from "../src/openai.ts";
+import type { OpenAIRequestBody } from "../src/openai.ts";
+import { createOpenaiAdapter } from "../src/loop/index.ts";
+import type { ParsedStreamEvent } from "../src/loop/index.ts";
+
+function mockStream(...chunks: string[]): ReadableStream<Uint8Array> {
+    return new ReadableStream<Uint8Array>({
+        start(controller) {
+            const enc = new TextEncoder();
+            for (const c of chunks) controller.enqueue(enc.encode(c));
+            controller.close();
+        },
+    });
+}
+
+function sseChunk(delta: Record<string, unknown>, finishReason: string | null = null): string {
+    return `data: ${JSON.stringify({
+        id: "c1",
+        object: "chat.completion.chunk",
+        created: 1,
+        model: "gpt",
+        choices: [{ index: 0, delta, finish_reason: finishReason }],
+    })}\n\n`;
+}
+
+// 1. reasoning_content round-trips through openaiToCore → coreToOpenai.
+test("openai: reasoning_content round-trips (content + reasoning preserved)", () => {
+    const body: OpenAIRequestBody = {
+        messages: [
+            { role: "assistant", content: "the answer", reasoning_content: "step 1... step 2..." },
+        ],
+    };
+    const { msgs } = openaiToCore(body);
+    const reasoning = msgs.find((m) => m.contentType === "reasoning");
+    assert.ok(reasoning, "reasoning coreMessage emitted");
+    assert.equal(reasoning?.reasoningContent, "step 1... step 2...", "reasoningContent sidecar stored");
+    const text = msgs.find((m) => m.contentType === "text");
+    assert.ok(text, "text coreMessage emitted");
+    assert.ok(msgs.indexOf(reasoning!) < msgs.indexOf(text!), "reasoning ordered before text");
+
+    const rebuilt = coreToOpenai(msgs);
+    assert.equal(rebuilt.length, 1, "single assistant message reconstructed");
+    assert.equal(rebuilt[0]?.role, "assistant");
+    assert.equal(rebuilt[0]?.content, "the answer", "content preserved");
+    assert.equal(rebuilt[0]?.reasoning_content, "step 1... step 2...", "reasoning_content reattached");
+});
+
+// 2. reasoning_content + tool_calls both preserved on the same assistant message.
+test("openai: reasoning_content + tool_calls both preserved", () => {
+    const body: OpenAIRequestBody = {
+        messages: [
+            {
+                role: "assistant",
+                content: null,
+                reasoning_content: "thinking about tools",
+                tool_calls: [
+                    { id: "call_1", type: "function", function: { name: "get_weather", arguments: '{"city":"SF"}' } },
+                ],
+            },
+        ],
+    };
+    const { msgs } = openaiToCore(body);
+    const rebuilt = coreToOpenai(msgs);
+    assert.equal(rebuilt.length, 1, "single assistant message reconstructed");
+    assert.equal(rebuilt[0]?.role, "assistant");
+    assert.equal(rebuilt[0]?.reasoning_content, "thinking about tools", "reasoning_content preserved");
+    assert.equal(rebuilt[0]?.tool_calls?.length, 1, "tool_calls preserved");
+    assert.equal(rebuilt[0]?.tool_calls?.[0]?.function?.name, "get_weather");
+    assert.equal(rebuilt[0]?.tool_calls?.[0]?.function?.arguments, '{"city":"SF"}');
+});
+
+// 3. A normal assistant message (no reasoning_content) is unaffected.
+test("openai: assistant without reasoning_content is unaffected", () => {
+    const body: OpenAIRequestBody = {
+        messages: [{ role: "assistant", content: "plain answer" }],
+    };
+    const { msgs } = openaiToCore(body);
+    assert.ok(!msgs.find((m) => m.contentType === "reasoning"), "no reasoning coreMessage emitted");
+    const rebuilt = coreToOpenai(msgs);
+    assert.equal(rebuilt.length, 1);
+    assert.equal(rebuilt[0]?.content, "plain answer");
+    assert.equal(rebuilt[0]?.reasoning_content, undefined, "no reasoning_content key on output");
+});
+
+// 4. Multi-turn conversation: reasoning_content on an earlier turn survives
+//    alongside a later user/tool exchange.
+test("openai: reasoning_content survives in a multi-turn conversation", () => {
+    const body: OpenAIRequestBody = {
+        messages: [
+            { role: "user", content: "what is 2+2?" },
+            { role: "assistant", content: "4", reasoning_content: "2+2=4" },
+            { role: "user", content: "and 3+3?" },
+        ],
+    };
+    const { msgs } = openaiToCore(body);
+    const rebuilt = coreToOpenai(msgs);
+    const asst = rebuilt.find((m) => m.role === "assistant");
+    assert.ok(asst, "assistant message present");
+    assert.equal(asst?.content, "4");
+    assert.equal(asst?.reasoning_content, "2+2=4", "earlier-turn reasoning preserved");
+});
+
+// 5. parseStream captures delta.reasoning_content as kind:reasoning and still
+//    yields content as kind:text.
+test("openai adapter: parseStream captures delta.reasoning_content as kind:reasoning", async () => {
+    const stream = mockStream(
+        sseChunk({ reasoning_content: "thinking..." }),
+        sseChunk({ content: "answer" }),
+        sseChunk({}, "stop"),
+        `data: [DONE]\n\n`,
+    );
+    const adapter = createOpenaiAdapter({ model: "gpt" });
+    const events: ParsedStreamEvent[] = [];
+    for await (const ev of adapter.parseStream(stream, 1)) events.push(ev);
+
+    const reasoning = events.find((e) => e.kind === "reasoning");
+    assert.ok(reasoning, "reasoning event yielded from delta.reasoning_content");
+    if (reasoning && reasoning.kind === "reasoning") {
+        assert.equal(reasoning.delta, "thinking...", "reasoning delta content intact");
+        assert.ok(reasoning.raw, "raw buffer attached for client passthrough");
+    }
+    const text = events.find((e) => e.kind === "text");
+    assert.ok(text, "text event still yielded alongside reasoning");
+    if (text && text.kind === "text") {
+        assert.equal(text.delta, "answer");
+    }
+});
+
+// 6. emitReasoning produces a well-formed SSE chunk with reasoning_content in
+//    the delta, so round-2+ re-request responses reconstruct the client stream.
+test("openai adapter: emitReasoning builds reasoning_content delta chunk", () => {
+    const adapter = createOpenaiAdapter({ model: "gpt" });
+    assert.equal(typeof adapter.emitReasoning, "function", "emitReasoning implemented");
+    const buf = adapter.emitReasoning!("chain-of-thought");
+    const str = buf.toString("utf8");
+    assert.ok(str.includes('"reasoning_content":"chain-of-thought"'), "delta carries reasoning_content");
+    assert.ok(str.includes("chat.completion.chunk"), "well-formed SSE chunk");
+});
+
+// 7. A reasoning-only assistant message (no content, no tool_calls) still
+//    round-trips so the model receives its prior CoT.
+test("openai: reasoning-only assistant message round-trips", () => {
+    const body: OpenAIRequestBody = {
+        messages: [
+            { role: "assistant", content: null, reasoning_content: "just thinking" },
+        ],
+    };
+    const { msgs } = openaiToCore(body);
+    const rebuilt = coreToOpenai(msgs);
+    assert.equal(rebuilt.length, 1, "assistant message emitted (not dropped)");
+    assert.equal(rebuilt[0]?.role, "assistant");
+    assert.equal(rebuilt[0]?.reasoning_content, "just thinking");
+});
+
+// 8. When a single streaming chunk carries BOTH reasoning_content and content,
+//    the raw buffer is attached only to the reasoning event — not duplicated on
+//    the text event — so the client never receives the same chunk twice.
+test("openai adapter: chunk with reasoning+content forwards raw once", async () => {
+    const stream = mockStream(
+        sseChunk({ reasoning_content: "think", content: "say" }),
+        sseChunk({}, "stop"),
+        `data: [DONE]\n\n`,
+    );
+    const adapter = createOpenaiAdapter({ model: "gpt" });
+    const events: ParsedStreamEvent[] = [];
+    for await (const ev of adapter.parseStream(stream, 1)) events.push(ev);
+
+    const reasoning = events.find((e) => e.kind === "reasoning");
+    const text = events.find((e) => e.kind === "text");
+    assert.ok(reasoning && reasoning.kind === "reasoning", "reasoning event yielded");
+    assert.ok(text && text.kind === "text", "text event yielded");
+    assert.equal(text!.delta, "say", "text delta intact");
+    assert.ok(reasoning!.raw, "raw attached to reasoning event (carries full chunk)");
+    assert.equal(text!.raw, undefined, "raw NOT duplicated on text event (no double-forwarding)");
+});


### PR DESCRIPTION
## Problem

OpenAI-compatible **reasoning models** (DeepSeek-R1, GLM-4.6 thinking, Qwen-QwQ) emit `reasoning_content` (chain-of-thought) and **require it be echoed back** on subsequent requests. After every proxy-tool/compress re-request, the upstream returned HTTP 400:

```
The `reasoning_content` in the thinking mode must be passed back to the API.
```

bili's OpenAI adapter dropped it (`grep reasoning_content dist = 0`). The Anthropic (`thinking`) and Responses paths already handled this — only OpenAI was missing.

## Fix

Mirror the existing **Anthropic thinking** handling for OpenAI `reasoning_content`:

- **`src/bili-message.ts`** — add `reasoningContent?: string` sidecar field (next to `thinkingSignature`).
- **`src/openai.ts`**
  - `openaiToCore`: when an incoming assistant message has non-empty `reasoning_content`, emit a `{contentType:"reasoning", text, reasoningContent}` coreMessage **before** content/tool-calls.
  - `coreToOpenai`: accumulate reasoning from `contentType:"reasoning"` coreMessages; `flush()` re-attaches `reasoning_content` on the output assistant object (handles text+reasoning, tool_calls+reasoning, reasoning-only).
- **`src/loop/core.ts`**
  - `ParsedStreamEvent` + `{kind:"reasoning"; delta; raw?}`; `CompressLoopAdapter` + optional `emitReasoning?(delta):Buffer`.
  - `runCompressLoop` accumulates `assistantReasoning`; forwards to client (raw passthrough round-1 / `emitReasoning` round-2+); **re-request reconstruction pushes the reasoning coreMessage before the text one** so `coreToOpenai` re-emits it → no more 400.
- **`src/loop/adapter-openai.ts`** — `parseStream` yields `{kind:"reasoning", delta:delta.reasoning_content, raw}` for non-empty `reasoning_content` (independent of tool_calls/content); `emitReasoning` rebuilds the `delta:{reasoning_content}` SSE chunk.

## Tests

`tests/openai-reasoning-content.test.ts` (+155): round-trip / reasoning+tool_calls / no-reasoning-unaffected / parseStream captures reasoning.

**342/342 tests pass, typecheck clean, build OK.**
