### PR TITLE
release v0.1.38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to **billion-context** are documented here.
 Versions follow the merge of a `*_release-v*` branch; CI publishes to npm on tag.
 
+## [0.1.38] — 2026-08-13
+
+### Fixes
+
+- **OpenAI `reasoning_content` round-trip for thinking-mode models** (#129): OpenAI-compatible reasoning models (DeepSeek-R1, GLM-4.6 thinking, Qwen-QwQ) emit `reasoning_content` (chain-of-thought) and require it be echoed back on subsequent requests — without it the upstream returns HTTP 400 `The reasoning_content in the thinking mode must be passed back to the API.` bili's OpenAI adapter dropped it (Anthropic `thinking` and Responses paths already handled it). Now `openaiToCore`/`coreToOpenai` round-trip `reasoning_content` through a `contentType:"reasoning"` core message; the streaming adapter captures `delta.reasoning_content`; re-request reconstruction re-emits it so the model never sees a missing-CoT 400. Also fixed double-forwarding when a single chunk carried both `reasoning_content` and `content`.
+
+## [0.1.37] — 2026-08-13
+
+### Features
+
+- **MITM domain auto-discovery** (#125): bili now reads client configs (`~/.zcode/v2/config.json`, `~/.codex/config.toml`, `~/.pi/agent/models.json`, `~/.claude/settings.json`) and auto-builds the MITM whitelist from all discovered HTTPS provider hostnames (mtime-cached, re-scanned on change). No more hardcoded domain assumptions — `open.bigmodel.cn`, `zcode.z.ai`, `api.z.ai` are now discovered, not baked in. Defaults reduced to the three binary-hardcoded endpoints (api.anthropic.com / api.openai.com / chatgpt.com) that have no config file to discover from.
+
+### Fixes
+
+- **Anthropic round-2 streaming framing (vertical-text bug)** (#126): after a proxy tool/compress re-request, round-2 streamed text rendered as vertical text (each ~2-char chunk on its own line). `runCompressLoop` round-2 text now carries the Anthropic `content_block_start/delta/stop` framing with the correct client index. Regression test added.
+- **HTTP-proxy-mode absolute URLs** (#127): bili concatenated its default anthropic upstream with the full absolute request URL in HTTP-proxy mode (`https://api.anthropic.comhttp://127.0.0.1:18081/…`). Absolute URLs (e.g. a local model server) are now forwarded to the host in the URL instead of mangled.
+
 ## [0.1.36] — 2026-08-12
 
 ### Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.37",
+      "version": "0.1.38",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Release v0.1.38

Supersedes `0.1.37` (which had no changelog entry — backfilled here).

### 0.1.38

- **OpenAI `reasoning_content` round-trip for thinking-mode models** (#129): DeepSeek-R1 / GLM-4.6 thinking / Qwen-QwQ emit `reasoning_content` (CoT) and require echo-back. bili's OpenAI adapter dropped it → HTTP 400 `The reasoning_content in the thinking mode must be passed back to the API.` on every re-request. Now round-tripped end-to-end (`openaiToCore`/`coreToOpenai` + streaming + re-request reconstruction), mirroring the existing Anthropic `thinking` handling. Also fixes double-forwarding when a chunk carries both `reasoning_content` + `content`.

### 0.1.37 (backfilled)

- **MITM domain auto-discovery** (#125): bili reads client configs and auto-builds the MITM whitelist from discovered provider hostnames. `open.bigmodel.cn` / `zcode.z.ai` / `api.z.ai` are now discovered, not hardcoded; defaults reduced to the three binary-baked endpoints.
- **Anthropic round-2 streaming framing / vertical-text bug** (#126): round-2 text after a proxy tool/compress re-request rendered as vertical text. Now carries correct `content_block_start/delta/stop` framing.
- **HTTP-proxy-mode absolute URLs** (#127): `bili` mangled absolute URLs (`https://api.anthropic.comhttp://127.0.0.1:18081/…`). Absolute URLs now forwarded to their host.

---
- `release v0.1.38` (package.json + lockfile) + `docs: changelog`
- **343/343 tests**, typecheck clean, build OK.
- `acp-kernel` unchanged at 0.0.19.
