### PR TITLE
fix(openai): rewrite non-compliant finish_reason=stop to tool_calls when tool calls present

### DIFF
--- a/src/loop/adapter-openai.ts
+++ b/src/loop/adapter-openai.ts
@@ -165,8 +165,10 @@ export function createOpenaiAdapter(requestBody: Record<string, unknown>): Compr
                 const finishReason = typeof choice.finish_reason === "string" ? choice.finish_reason : undefined;
 
                 if (finishReason) {
+                    let yieldedToolCall = false;
                     for (const [, tc] of pending) {
                         if (tc.name.length > 0 || tc.id.length > 0) {
+                            yieldedToolCall = true;
                             yield {
                                 kind: "tool_call",
                                 name: tc.name,
@@ -184,7 +186,10 @@ export function createOpenaiAdapter(requestBody: Record<string, unknown>): Compr
                         outputTokens: typeof u?.completion_tokens === "number" ? u.completion_tokens : undefined,
                         cachedTokens: typeof pd?.cached_tokens === "number" ? pd.cached_tokens : undefined,
                     } as ParsedStreamEvent;
-                    yield { kind: "done", finishReason } as ParsedStreamEvent;
+                    yield {
+                        kind: "done",
+                        finishReason: yieldedToolCall && finishReason === "stop" ? "tool_calls" : finishReason,
+                    } as ParsedStreamEvent;
                 }
 
                 if (!delta) continue;

--- a/tests/openai-toolcall-finish-reason.test.ts
+++ b/tests/openai-toolcall-finish-reason.test.ts
@@ -1,0 +1,75 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createOpenaiAdapter } from "../src/loop/index.ts";
+import type { ParsedStreamEvent } from "../src/loop/core.ts";
+
+const enc = new TextEncoder();
+const sseChunk = (delta: Record<string, unknown>, finishReason?: string) =>
+    enc.encode(
+        `data: ${JSON.stringify({
+            id: "c1",
+            object: "chat.completion.chunk",
+            created: 1,
+            model: "gpt",
+            choices: [{ index: 0, delta, finish_reason: finishReason ?? null }],
+        })}\n\n`,
+    );
+
+const mockStream = (...chunks: Uint8Array[]): ReadableStream<Uint8Array> =>
+    new ReadableStream<Uint8Array>({
+        start(controller) {
+            for (const c of chunks) controller.enqueue(c);
+            controller.enqueue(enc.encode(`data: [DONE]\n\n`));
+            controller.close();
+        },
+    });
+
+const collect = async (stream: ReadableStream<Uint8Array>) => {
+    const adapter = createOpenaiAdapter({ model: "gpt" });
+    const events: ParsedStreamEvent[] = [];
+    for await (const ev of adapter.parseStream(stream, 1)) events.push(ev);
+    return events;
+};
+
+// 1. Non-compliant upstream: tool_calls + finish_reason="stop" → bili rewrites to "tool_calls".
+test("openai adapter: tool_calls with finish_reason=stop rewritten to tool_calls", async () => {
+    const stream = mockStream(
+        sseChunk({ role: "assistant" }),
+        sseChunk({
+            tool_calls: [
+                { index: 0, id: "call_1", type: "function", function: { name: "get_weather", arguments: '{"city":"SF"}' } },
+            ],
+        }),
+        sseChunk({}, "stop"),
+    );
+    const events = await collect(stream);
+    const done = events.find((e) => e.kind === "done");
+    assert.ok(done && done.kind === "done", "done event present");
+    assert.equal(done!.finishReason, "tool_calls", "finish_reason corrected to tool_calls");
+    const toolCall = events.find((e) => e.kind === "tool_call");
+    assert.ok(toolCall, "tool_call event still emitted");
+});
+
+// 2. Compliant upstream: tool_calls + finish_reason="tool_calls" → unchanged.
+test("openai adapter: compliant finish_reason=tool_calls left unchanged", async () => {
+    const stream = mockStream(
+        sseChunk({ role: "assistant" }),
+        sseChunk({
+            tool_calls: [
+                { index: 0, id: "call_1", type: "function", function: { name: "search", arguments: "{}" } },
+            ],
+        }),
+        sseChunk({}, "tool_calls"),
+    );
+    const events = await collect(stream);
+    const done = events.find((e) => e.kind === "done");
+    assert.equal(done?.kind === "done" && done.finishReason, "tool_calls");
+});
+
+// 3. No tool_calls + finish_reason="stop" → unchanged (normal text completion).
+test("openai adapter: text-only finish_reason=stop left unchanged", async () => {
+    const stream = mockStream(sseChunk({ role: "assistant" }), sseChunk({ content: "hello" }), sseChunk({}, "stop"));
+    const events = await collect(stream);
+    const done = events.find((e) => e.kind === "done");
+    assert.equal(done?.kind === "done" && done.finishReason, "stop");
+});


### PR DESCRIPTION
## Problem

Some OpenAI-compatible upstreams (e.g. the model behind openclaw) return `finish_reason="stop"` for a **text + tool_calls** response, violating the OpenAI Chat Completions spec (which requires `"tool_calls"` when the response contains tool calls). bili faithfully re-emitted `"stop"`, and the downstream parser (openclaw `openai-transport-stream-Buv8grEL.js:2796`) dropped **all** `tool_call` chunks because `hasVisibleText=true` kept `stopReason=stop` → tool calls silently lost → the model "replied once and stopped" (工具被丢弃，模型"回复一条就停").

User confirmed root cause: "我尝试修了一下一修就好 所以问题很确定".

## Fix

`src/loop/adapter-openai.ts` — when the streamed response emitted tool calls and the upstream sent non-compliant `finish_reason="stop"`, override it to `"tool_calls"` (spec-compliant):

```ts
yield {
    kind: "done",
    finishReason: yieldedToolCall && finishReason === "stop" ? "tool_calls" : finishReason,
};
```

- `finish_reason="tool_calls"` (already compliant) → unchanged.
- text-only `finish_reason="stop"` → unchanged.
- `finish_reason="length"` with tool calls → unchanged (truncation signal preserved).
- Only the non-compliant `tool_calls + "stop"` case is corrected.

## Tests

`tests/openai-toolcall-finish-reason.test.ts`: rewrite-to-tool_calls / compliant-unchanged / text-only-unchanged. **346/346 tests pass**, typecheck clean, build OK.
