### PR TITLE
release v0.1.39

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to **billion-context** are documented here.
 Versions follow the merge of a `*_release-v*` branch; CI publishes to npm on tag.
 
+## [0.1.39] — 2026-08-13
+
+### Fixes
+
+- **OpenAI non-compliant `finish_reason="stop"` for tool-call responses** (#131): some OpenAI-compatible upstreams (e.g. the model behind openclaw) return `finish_reason="stop"` for a text + tool_calls response, violating the OpenAI Chat Completions spec (which requires `"tool_calls"`). bili faithfully re-emitted `"stop"`, and the downstream parser (openclaw `openai-transport-stream`) dropped **all** `tool_call` chunks because `hasVisibleText=true` kept `stopReason=stop` — so tool calls were silently lost and the model "replied once and stopped". bili now rewrites the non-compliant `"stop"` to `"tool_calls"` when the streamed response emitted tool calls; compliant `"tool_calls"`, text-only `"stop"`, and `"length"` are unchanged.
+
 ## [0.1.38] — 2026-08-13
 
 ### Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.38",
+  "version": "0.1.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.38",
+      "version": "0.1.39",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.38",
+  "version": "0.1.39",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Release v0.1.39

### 0.1.39

- **OpenAI non-compliant `finish_reason="stop"` for tool-call responses** (#131): some OpenAI-compatible upstreams return `finish_reason="stop"` for a text + tool_calls response (spec violation — should be `"tool_calls"`). bili re-emitted `"stop"`, and the downstream parser (openclaw) silently dropped all tool_call chunks → tools lost → model "replied once and stopped". bili now rewrites the non-compliant `"stop"` to `"tool_calls"` when tool calls are present. Compliant `"tool_calls"`, text-only `"stop"`, and `"length"` unchanged.

---
- `release v0.1.39` (package.json + lockfile) + `docs: changelog`
- **346/346 tests**, typecheck clean, build OK.
- `acp-kernel` unchanged (0.0.19).
