### PR TITLE
fix(launcher): resolve client binaries cross-platform for Windows

### DIFF
--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -83,7 +83,7 @@ export interface SpawnChild {
 export type SpawnFn = (
     command: string,
     args: readonly string[],
-    options: { detached?: boolean; stdio?: StdioOptions; env?: NodeJS.ProcessEnv },
+    options: { detached?: boolean; stdio?: StdioOptions; env?: NodeJS.ProcessEnv; shell?: boolean },
 ) => SpawnChild;
 
 export interface LaunchOptions {
@@ -485,7 +485,7 @@ export function runClient(
 ): Promise<number> {
     const spawnImpl = deps?.spawnImpl ?? (spawn as SpawnFn);
     return new Promise((resolve, reject) => {
-        const child = spawnImpl(cmd, args, { stdio: "inherit", env });
+        const child = spawnImpl(cmd, args, { stdio: "inherit", env, shell: process.platform === "win32" });
         child.on?.("error", (...rest: unknown[]) => reject(rest[0]));
         child.on?.("exit", (...rest: unknown[]) => {
             const code = rest[0];
@@ -495,18 +495,25 @@ export function runClient(
     });
 }
 
-export function isOnPath(name: string, env: NodeJS.ProcessEnv): boolean {
+const PATH_EXTS = process.platform === "win32" ? [".cmd", ".bat", ".exe", ""] : [""];
+
+export function resolveOnPath(name: string, env: NodeJS.ProcessEnv): string | undefined {
     const p = env.PATH;
-    if (!p) return false;
-    return p.split(":").some((dir) => {
-        if (!dir) return false;
-        try {
-            const f = path.join(dir, name);
-            return fs.existsSync(f) && fs.statSync(f).isFile();
-        } catch {
-            return false;
+    if (!p) return undefined;
+    for (const dir of p.split(path.delimiter)) {
+        if (!dir) continue;
+        for (const ext of PATH_EXTS) {
+            const f = path.join(dir, name + ext);
+            try {
+                if (fs.existsSync(f) && fs.statSync(f).isFile()) return f;
+            } catch {}
         }
-    });
+    }
+    return undefined;
+}
+
+export function isOnPath(name: string, env: NodeJS.ProcessEnv): boolean {
+    return resolveOnPath(name, env) !== undefined;
 }
 
 export function resolveClientCommand(
@@ -516,14 +523,16 @@ export function resolveClientCommand(
     if (client === "pi") {
         const piBin = env.PI_BIN?.trim();
         if (piBin) return { command: piBin, prefixArgs: [] };
-        if (isOnPath("pi", env)) return { command: "pi", prefixArgs: [] };
+        const piResolved = resolveOnPath("pi", env);
+        if (piResolved) return { command: piResolved, prefixArgs: [] };
         const cli = path.join(
             os.homedir(),
             ".pi/agent/npm/node_modules/@earendil-works/pi-coding-agent/dist/cli.js",
         );
         return { command: process.execPath, prefixArgs: [cli] };
     }
-    return { command: client, prefixArgs: [] };
+    const resolved = resolveOnPath(client, env);
+    return { command: resolved ?? client, prefixArgs: [] };
 }
 
 export interface RunLaunchParams {

--- a/tests/launcher.test.ts
+++ b/tests/launcher.test.ts
@@ -362,13 +362,13 @@ test("resolveClientCommand: pi prefers PI_BIN env", () => {
     });
 });
 
-test("resolveClientCommand: pi on PATH resolves to 'pi'", () => {
+test("resolveClientCommand: pi on PATH resolves to full path", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "bili-path-"));
     const piFile = path.join(tmp, "pi");
     fs.writeFileSync(piFile, "#!/bin/sh\necho pi\n", { mode: 0o755 });
     try {
         assert.deepEqual(resolveClientCommand("pi", { PATH: tmp }), {
-            command: "pi",
+            command: piFile,
             prefixArgs: [],
         });
     } finally {


### PR DESCRIPTION
On Windows, npm-installed CLIs (pi/codex/claude) are `.cmd` shims. Spawning the bare or extensionless name failed two ways:
- **ENOENT** on the extensionless git-bash shim (`pi`, a bourne script — not Windows-executable).
- **EINVAL** on `.cmd` without `shell: true` (Node 18+ CVE-2024-27980 blocks direct .cmd/.bat spawn).

## Fix
- `resolveOnPath()`: use `path.delimiter` (was hardcoded `:`, wrong on Windows which uses `;`) + win32 extension order `[.cmd, .bat, .exe, '']` so `pi.cmd` wins over the extensionless git-bash shim.
- `resolveClientCommand()` returns the resolved full path for pi/codex/claude.
- `runClient()` spawns with `shell: process.platform === "win32"` (required to execute .cmd/.bat on Windows).
- `SpawnFn` options type gains `shell?: boolean`.

## Verified end-to-end on Win10 VM (VirtualBox)
`bili test pi`:
- ✅ Proxy spawns (`bili: started proxy at http://127.0.0.1:8787`, MITM domains discovered: open.bigmodel.cn, coding.dashscope.aliyuncs.com)
- ✅ pi.cmd resolved + spawned
- ✅ MITM: `mitm open.bigmodel.cn:443 tunnel established (TLS terminated locally)`
- ✅ CA generated at `C:\Users\dog\.local\share\billion-context\ca\root-ca.pem`, trusted by pi via `NODE_EXTRA_CA_CERTS`
- ✅ Full compression pipeline active (`tools=[compress,decompress,search_context,acp_status]`, processTurn, multi-round)
- ✅ GLM responds, TEST_EXIT=0

## Tests
346/346 pass, typecheck clean. Updated `resolveClientCommand: pi on PATH` test to expect the resolved full path (was bare name).