### PR TITLE
feat(launcher): persist spawned proxy for reuse across clients + bili stop

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,7 +23,7 @@ import { loadOptions, ensureConfigTemplate } from "./config.js";
 import { startServer } from "./server.js";
 import { configFile as defaultConfigFile } from "./paths.js";
 import { checkForUpdate, startAutoUpdate } from "./update.js";
-import { runLaunch, runTestPi, isLaunchClient, type ClientName } from "./launcher.js";
+import { runLaunch, runTestPi, isLaunchClient, stopLauncherProxy, type ClientName } from "./launcher.js";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
@@ -60,6 +60,7 @@ Usage:
   bili claude [opts --] [args]     start a proxy + launch claude against it (cert-MITM)
   bili test pi                     non-polluting pi smoke test through the proxy
   bili update                      check for & install a newer version now
+  bili stop                        stop proxy process(es) left running by "bili <client>"
   bili --version                   print version
   bili --help                      show this help
 
@@ -96,7 +97,7 @@ Docs: https://github.com/ranxianglei/billion-context
 `;
 
 type Parsed = {
-    command: "start" | "update" | "help" | "version" | "launch" | "test";
+    command: "start" | "update" | "help" | "version" | "launch" | "test" | "stop";
     client?: ClientName;
     clientArgs: string[];
     mitmDomains: string[];
@@ -196,6 +197,8 @@ function parseArgs(argv: string[]): Parsed {
                 console.error(`bili test: unknown client "${target ?? ""}" (try "bili test pi")`);
                 process.exit(2);
             }
+        } else if (cmd === "stop") {
+            command = "stop";
         } else {
             console.error(`bili: unknown command "${cmd}" (try "bili --help")`);
             process.exit(2);
@@ -230,6 +233,13 @@ export async function main(): Promise<void> {
     }
     if (command === "launch") {
         await runLaunch({ client: client!, clientArgs, mitmDomains, overrides });
+        return;
+    }
+    if (command === "stop") {
+        const { stopped, errors } = stopLauncherProxy(process.env);
+        if (stopped > 0) console.error(`bili: stopped ${stopped} launcher proxy process(es).`);
+        else console.error("bili: no launcher proxy found (nothing to stop).");
+        for (const e of errors) console.error(`bili: ${e}`);
         return;
     }
 

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -100,6 +100,44 @@ export interface ProxyHandle {
     reused: boolean;
     child: SpawnChild | null;
     logPath?: string;
+    pidPath?: string;
+}
+
+export function launcherPidFile(port: number, env: NodeJS.ProcessEnv = process.env): string {
+    const base = env.XDG_DATA_HOME || path.join(os.homedir(), ".local/share");
+    return path.join(base, "billion-context", `launcher-proxy-${port}.pid`);
+}
+
+export function stopLauncherProxy(env: NodeJS.ProcessEnv = process.env): { stopped: number; errors: string[] } {
+    const base = env.XDG_DATA_HOME || path.join(os.homedir(), ".local/share");
+    const dir = path.join(base, "billion-context");
+    const errors: string[] = [];
+    let stopped = 0;
+    let entries: string[] = [];
+    try {
+        entries = fs.readdirSync(dir);
+    } catch {
+        return { stopped: 0, errors };
+    }
+    for (const entry of entries) {
+        if (!/^launcher-proxy-\d+\.pid$/.test(entry)) continue;
+        const pidPath = path.join(dir, entry);
+        let pid: number | undefined;
+        try {
+            pid = parseInt(fs.readFileSync(pidPath, "utf8").trim(), 10);
+        } catch {
+            try { fs.unlinkSync(pidPath); } catch {}
+            continue;
+        }
+        try {
+            if (pid > 0) process.kill(pid);
+            stopped++;
+        } catch (e) {
+            errors.push(`${entry}: ${e instanceof Error ? e.message : String(e)}`);
+        }
+        try { fs.unlinkSync(pidPath); } catch {}
+    }
+    return { stopped, errors };
 }
 
 export interface LauncherDeps {
@@ -456,7 +494,12 @@ export async function ensureProxyRunning(
     while (now() < deadline) {
         await sleepImpl(HEALTH_POLL_INTERVAL_MS);
         if (await probeHealth(spawnedOrigin, fetchImpl)) {
-            return { origin: spawnedOrigin, port, reused: false, child, logPath };
+            const pidPath = launcherPidFile(port, process.env);
+            try {
+                fs.mkdirSync(path.dirname(pidPath), { recursive: true });
+                if (child.pid !== undefined) fs.writeFileSync(pidPath, String(child.pid), "utf8");
+            } catch {}
+            return { origin: spawnedOrigin, port, reused: false, child, logPath, pidPath };
         }
     }
     throw new Error(`bili: proxy did not become healthy at ${spawnedOrigin} within ${SPAWN_WAIT_MS}ms`);
@@ -589,7 +632,11 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
         console.error(`bili: failed to launch ${params.client}: ${err instanceof Error ? err.message : String(err)}`);
         code = 1;
     } finally {
-        if (!handle.reused) stopProxy(handle);
+        if (!handle.reused && handle.pidPath) {
+            console.error(
+                `bili: proxy left running at ${handle.origin} for reuse by other clients (run "bili stop" to terminate).`,
+            );
+        }
         if (piTmpHome) {
             try {
                 fs.rmSync(piTmpHome, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Launcher-spawned proxies now **persist after the client exits** and are **reused** by subsequent `bili <client>` invocations on the same port, instead of one-proxy-per-invocation (deterministic cleanup was fragile — see #24 floor 103: a reused proxy dying when its owning terminal closed broke other terminals' clients).

## Changes

- **`ensureProxyRunning`**: removed the `domainsNeedFreshProxy` gate. After #125 (MITM discovery), the proxy discovers ALL client domains at runtime, so a running proxy covers every client. The gate was obsolete AND harmful (`open.bigmodel.cn` was removed from `DEFAULT_MITM_DOMAINS` in #125, so the gate always forced a fresh spawn for pi/ZCode → never reused). Reuse is now pure health-probe.
- **`runLaunch`**: removed `stopProxy` in the finally block. The spawned proxy (already `detached:true`+`unref`) now **persists** after the client exits; logs `proxy left running at ORIGIN for reuse (run "bili stop" to terminate)`. `runTestPi` (one-off smoke) keeps its cleanup.
- **`bili stop`** (new command): reads `~/.local/share/billion-context/launcher-proxy-<port>.pid` files, kills the persisted proxies, removes stale PID files (handles ESRCH). Only stops launcher-spawned proxies — a standing `bili start` is left alone.
- New exports: `launcherPidFile(port, env)`, `stopLauncherProxy(env)`.

## Verified

- **Reuse confirmed**: standing proxy on 8787 → `bili test pi` logs `reusing existing proxy at http://127.0.0.1:8787` (not a fresh spawn). `bili stop` cleans up.
- **Persist confirmed**: proxy (PID 2513068) survives launcher process exit; `/__bili/health` → 200.
- typecheck clean, 343/343 tests, build OK.
- Regression: `bili test pi` ✓ (GLM via MITM), `bili codex exec` ✓ (MITM ai.comfly.org, replied REGRESS-CODEX). (claude needs ANTHROPIC auth; opencode uses the extension + standing proxy, not the launcher.)

## Lifecycle

- `bili pi` → spawns (or reuses) proxy on 8787 → runs pi → proxy **persists**.
- `bili codex` (next) → **reuses** the persisted 8787 proxy.
- `bili stop` → terminates the persisted launcher proxy(es).
- A standing `bili start` is reused identically (and is NOT stopped by `bili stop`).
