### PR TITLE
fix(launcher): resolve client binaries cross-platform for Windows (bili codex ENOENT)

### DIFF
--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -83,7 +83,7 @@ export interface SpawnChild {
 export type SpawnFn = (
     command: string,
     args: readonly string[],
-    options: { detached?: boolean; stdio?: StdioOptions; env?: NodeJS.ProcessEnv },
+    options: { detached?: boolean; stdio?: StdioOptions; env?: NodeJS.ProcessEnv; shell?: boolean },
 ) => SpawnChild;
 
 export interface LaunchOptions {
@@ -485,7 +485,7 @@ export function runClient(
 ): Promise<number> {
     const spawnImpl = deps?.spawnImpl ?? (spawn as SpawnFn);
     return new Promise((resolve, reject) => {
-        const child = spawnImpl(cmd, args, { stdio: "inherit", env });
+        const child = spawnImpl(cmd, args, { stdio: "inherit", env, shell: process.platform === "win32" });
         child.on?.("error", (...rest: unknown[]) => reject(rest[0]));
         child.on?.("exit", (...rest: unknown[]) => {
             const code = rest[0];
@@ -495,18 +495,25 @@ export function runClient(
     });
 }
 
-export function isOnPath(name: string, env: NodeJS.ProcessEnv): boolean {
+const PATH_EXTS = process.platform === "win32" ? [".cmd", ".bat", ".exe", ""] : [""];
+
+export function resolveOnPath(name: string, env: NodeJS.ProcessEnv): string | undefined {
     const p = env.PATH;
-    if (!p) return false;
-    return p.split(":").some((dir) => {
-        if (!dir) return false;
-        try {
-            const f = path.join(dir, name);
-            return fs.existsSync(f) && fs.statSync(f).isFile();
-        } catch {
-            return false;
+    if (!p) return undefined;
+    for (const dir of p.split(path.delimiter)) {
+        if (!dir) continue;
+        for (const ext of PATH_EXTS) {
+            const f = path.join(dir, name + ext);
+            try {
+                if (fs.existsSync(f) && fs.statSync(f).isFile()) return f;
+            } catch {}
         }
-    });
+    }
+    return undefined;
+}
+
+export function isOnPath(name: string, env: NodeJS.ProcessEnv): boolean {
+    return resolveOnPath(name, env) !== undefined;
 }
 
 export function resolveClientCommand(
@@ -516,14 +523,16 @@ export function resolveClientCommand(
     if (client === "pi") {
         const piBin = env.PI_BIN?.trim();
         if (piBin) return { command: piBin, prefixArgs: [] };
-        if (isOnPath("pi", env)) return { command: "pi", prefixArgs: [] };
+        const piResolved = resolveOnPath("pi", env);
+        if (piResolved) return { command: piResolved, prefixArgs: [] };
         const cli = path.join(
             os.homedir(),
             ".pi/agent/npm/node_modules/@earendil-works/pi-coding-agent/dist/cli.js",
         );
         return { command: process.execPath, prefixArgs: [cli] };
     }
-    return { command: client, prefixArgs: [] };
+    const resolved = resolveOnPath(client, env);
+    return { command: resolved ?? client, prefixArgs: [] };
 }
 
 export interface RunLaunchParams {

--- a/tests/launcher.test.ts
+++ b/tests/launcher.test.ts
@@ -362,13 +362,13 @@ test("resolveClientCommand: pi prefers PI_BIN env", () => {
     });
 });
 
-test("resolveClientCommand: pi on PATH resolves to 'pi'", () => {
+test("resolveClientCommand: pi on PATH resolves to full path", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "bili-path-"));
     const piFile = path.join(tmp, "pi");
     fs.writeFileSync(piFile, "#!/bin/sh\necho pi\n", { mode: 0o755 });
     try {
         assert.deepEqual(resolveClientCommand("pi", { PATH: tmp }), {
-            command: "pi",
+            command: piFile,
             prefixArgs: [],
         });
     } finally {


### PR DESCRIPTION
## Fixes #134

On Windows, `bili codex` (and `bili claude`) failed with `spawn codex ENOENT`. npm-installed CLIs ship as `.cmd` shims; spawning the bare/extensionless name fails — ENOENT on the git-bash shim, EINVAL on `.cmd` without a shell (CVE-2024-27980 security patch in Node 18+).

## Changes (src/launcher.ts + tests/launcher.test.ts)
- `resolveOnPath()` replaces `isOnPath()`: uses `path.delimiter` (was hardcoded `':'`) and a win32 extension order `[".cmd", ".bat", ".exe", ""]`, returning the first existing full path so `pi.cmd`/`codex.cmd` wins over the extensionless git-bash shim.
- `resolveClientCommand()` returns the resolved full path for `pi` and arbitrary clients (`resolveOnPath(client) ?? client`).
- `runClient()` spawns with `shell: process.platform === "win32"` (required to execute `.cmd`/`.bat`).
- `SpawnFn` options type gains `shell?: boolean`.

## Verification
- 370/370 tests, typecheck clean, build OK (on master v0.1.39).
- Original commit was also verified end-to-end on a Win10 VM (`bili test pi` → MITM open.bigmodel.cn → GLM responds → compression active).
