### PR TITLE
chore: bump acp-kernel to 0.0.23 (fixes #133 reasoning-pairing)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@types/node": "^22.0.0",
         "@types/node-forge": "^1.3.14",
-        "acp-kernel": "0.0.21",
+        "acp-kernel": "0.0.23",
         "fzstd": "0.1.1",
         "node-forge": "^1.4.0",
         "tar": "^7.5.22",
@@ -972,9 +972,9 @@
       }
     },
     "node_modules/acp-kernel": {
-      "version": "0.0.21",
-      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.21.tgz",
-      "integrity": "sha512-BSBQzBle5LdiRseXXcDIah6QmdrE4JgrKvz1Y33yOaxIGFkLgaztoOC4QqPYSBxg4yTJLSvEcHWzvVhuc6AseQ==",
+      "version": "0.0.23",
+      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.23.tgz",
+      "integrity": "sha512-bG28aYfBda8z34fsaoNc4QBix4gRtQDQznR6G4XBaz9z1xgxdmdYtazQQMBjxnfEL9yCrDb9CTpkl7IXWiuviA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/node-forge": "^1.3.14",
-    "acp-kernel": "0.0.21",
+    "acp-kernel": "0.0.23",
     "fzstd": "0.1.1",
     "node-forge": "^1.4.0",
     "tar": "^7.5.22",


### PR DESCRIPTION
## Fixes #133 (DeepSeek thinking 400) via acp-kernel 0.0.23

The root-cause fix shipped in **acp-kernel 0.0.23** ([acp-kernel#68](https://github.com/ranxianglei/acp-kernel/pull/68), released via [acp-kernel#69](https://github.com/ranxianglei/acp-kernel/pull/69)). This PR picks it up by bumping the `acp-kernel` pin `0.0.21 → 0.0.23`.

### What 0.0.23 fixes
`adjustBoundariesForReasoningPairs` + `stripOrphanedReasoning` + `applyPairBoundaryAdjustments` (mirroring the existing tool-pair mechanism) guarantee that an assistant turn's `reasoning_content` and its companion text/tool-call **always compress together** — they can never be split. The DeepSeek 400 (`"reasoning_content in the thinking mode must be passed back to the API"`) is structurally impossible after this. Same latent class fixed on the Anthropic and Responses paths too.

### Why no adapter-side workaround
An earlier revision of this PR added an `ACP_REASONING_KEEP=none` opt-in to the chat/completions path. It was removed — with the kernel fix, it is no longer needed for correctness, and dropping reasoning entirely is an untested (possibly broken) interaction with DeepSeek thinking specifically. The kernel pairing fix is the reliable path.

### Verified
```
typecheck: clean
test: 370/370 pass
build: success (2.03 MB)
```

Diff: `package.json` (pin bump) + `package-lock.json` (lockfile version-sync).