### PR TITLE
fix(responses): pass non-proxy function_call items through raw (Codex agents.* unsupported call)

### DIFF
--- a/src/loop/adapter-responses.ts
+++ b/src/loop/adapter-responses.ts
@@ -1,7 +1,7 @@
 import type { CoreMessage } from "acp-kernel";
 import { coreToResponses, injectResponsesDeveloperMessage, patchResponsesInput, type ResponseInputItem, type ResponsesProjection } from "../responses.js";
 import { buildVisibilityMarker } from "../compress-loop.js";
-import { ACP_TEXT_OPEN, ACP_TEXT_CLOSE, ACP_STATUS_OPEN, ACP_STATUS_CLOSE, ACP_SEARCH_OPEN, ACP_SEARCH_CLOSE, ACP_DECOMPRESS_OPEN, ACP_DECOMPRESS_CLOSE, COMPRESS_TOOL_NAME } from "../compress-tool.js";
+import { ACP_TEXT_OPEN, ACP_TEXT_CLOSE, ACP_STATUS_OPEN, ACP_STATUS_CLOSE, ACP_SEARCH_OPEN, ACP_SEARCH_CLOSE, ACP_DECOMPRESS_OPEN, ACP_DECOMPRESS_CLOSE, COMPRESS_TOOL_NAME, PROXY_TOOL_NAMES } from "../compress-tool.js";
 import type { BiliMessage } from "../bili-message.js";
 import type {
     CompressLoopAdapter,
@@ -182,13 +182,18 @@ export function createResponsesAdapter(textProtocol?: boolean, projection?: Resp
                 } else if (type === "response.output_item.added") {
                     const item = obj.item as Record<string, unknown> | undefined;
                     if (item?.type === "function_call") {
-                        const itemId = typeof item.id === "string" ? item.id : "";
-                        pending.set(itemId, {
-                            itemId,
-                            callId: typeof item.call_id === "string" ? item.call_id : "",
-                            name: typeof item.name === "string" ? item.name : "",
-                            arguments: "",
-                        });
+                        const fcName = typeof item.name === "string" ? item.name : "";
+                        if (PROXY_TOOL_NAMES.has(fcName)) {
+                            const itemId = typeof item.id === "string" ? item.id : "";
+                            pending.set(itemId, {
+                                itemId,
+                                callId: typeof item.call_id === "string" ? item.call_id : "",
+                                name: fcName,
+                                arguments: "",
+                            });
+                        } else {
+                            yield { kind: "meta", chunk: rawBuf, firstRoundOnly: false } as ParsedStreamEvent;
+                        }
                     } else if (item?.type === "custom_tool_call") {
                         yield { kind: "meta", chunk: rawBuf, firstRoundOnly: false } as ParsedStreamEvent;
                     } else if (item?.type !== "message" || !suppressTextLifecycle) {
@@ -212,11 +217,13 @@ export function createResponsesAdapter(textProtocol?: boolean, projection?: Resp
                     const delta = typeof obj.delta === "string" ? obj.delta : "";
                     const fc = pending.get(itemId);
                     if (fc) fc.arguments += delta;
+                    else yield { kind: "meta", chunk: rawBuf, firstRoundOnly: false } as ParsedStreamEvent;
                 } else if (type === "response.function_call_arguments.done") {
                     const itemId = typeof obj.item_id === "string" ? obj.item_id : "";
                     const args = typeof obj.arguments === "string" ? obj.arguments : "";
                     const fc = pending.get(itemId);
                     if (fc && args) fc.arguments = args;
+                    else yield { kind: "meta", chunk: rawBuf, firstRoundOnly: false } as ParsedStreamEvent;
                 } else if (type === "response.output_item.done") {
                     const item = obj.item as Record<string, unknown> | undefined;
                     if (item?.type === "function_call") {
@@ -230,6 +237,15 @@ export function createResponsesAdapter(textProtocol?: boolean, projection?: Resp
                                 name: fc.name,
                                 callId: fc.callId,
                                 arguments: fc.arguments,
+                            } as ParsedStreamEvent;
+                        } else {
+                            yield { kind: "meta", chunk: rawBuf, firstRoundOnly: false } as ParsedStreamEvent;
+                            yield {
+                                kind: "tool_call",
+                                name: typeof item.name === "string" ? item.name : "",
+                                callId: typeof item.call_id === "string" ? item.call_id : "",
+                                arguments: typeof item.arguments === "string" ? item.arguments : "",
+                                passthrough: true,
                             } as ParsedStreamEvent;
                         }
                     } else if (item?.type === "custom_tool_call") {

--- a/src/loop/core.ts
+++ b/src/loop/core.ts
@@ -43,7 +43,7 @@ export interface RequestOptions {
 export type ParsedStreamEvent =
     | { kind: "text"; delta: string; raw?: Buffer }
     | { kind: "reasoning"; delta: string; raw?: Buffer }
-    | { kind: "tool_call"; name: string; callId: string; arguments: string }
+    | { kind: "tool_call"; name: string; callId: string; arguments: string; passthrough?: boolean }
     | { kind: "usage"; inputTokens?: number; outputTokens?: number; cachedTokens?: number }
     | { kind: "done"; finishReason?: string }
     | { kind: "meta"; chunk: Buffer; firstRoundOnly?: boolean };
@@ -57,6 +57,7 @@ export interface ToolCallEmit {
     name: string;
     callId: string;
     arguments: string;
+    passthrough?: boolean;
 }
 
 export interface ExtractedTextTriggers {
@@ -203,7 +204,7 @@ export async function* runCompressLoop(
                             }
                         }
                     } else if (ev.kind === "tool_call") {
-                    calls.push({ name: ev.name, callId: ev.callId, arguments: ev.arguments });
+                    calls.push({ name: ev.name, callId: ev.callId, arguments: ev.arguments, passthrough: ev.passthrough });
                 } else if (ev.kind === "usage") {
                     usage = {
                         inputTokens: ev.inputTokens,
@@ -337,6 +338,7 @@ export async function* runCompressLoop(
             }
 
             for (const tc of realToolCalls) {
+                if (tc.passthrough) continue;
                 yield adapter.emitToolCall(tc);
             }
 

--- a/tests/multi-agent-namespace.test.ts
+++ b/tests/multi-agent-namespace.test.ts
@@ -1,0 +1,152 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { Config, CoreMessage } from "acp-kernel";
+import { createCore, createInitialState, defaultConfig } from "acp-kernel";
+import type { Session } from "../src/session.ts";
+import { runCompressLoop, createResponsesAdapter } from "../src/loop/index.ts";
+import type { ParsedStreamEvent } from "../src/loop/core.ts";
+import { buildCompressSystemPrompt } from "../src/compress-tool.ts";
+import { responsesToCore, patchResponsesInput, injectResponsesDeveloperMessage, type ResponseInputItem } from "../src/responses.ts";
+
+function makeCtx(messages: CoreMessage[] = []): {
+    core: ReturnType<typeof createCore>;
+    config: Config;
+    messages: CoreMessage[];
+    session: Session;
+    log: (m: string) => void;
+    proxyUrl?: string;
+    textProtocol?: boolean;
+    debug?: boolean;
+} {
+    return {
+        core: createCore(),
+        config: defaultConfig(200000),
+        messages,
+        session: {
+            id: "ns-test",
+            meta: {},
+            stats: { requests: 0, tokensSaved: 0, inputTokens: 0, cachedTokens: 0, outputTokens: 0, cacheSamples: 0, lastInputTokens: 0, contextTokens: 0 },
+            metadata: {},
+            state: createInitialState(),
+            createdAt: Date.now(),
+            lastSeen: Date.now(),
+            blockContents: new Map(),
+            inFlight: 0,
+            persisted: false,
+        },
+        log: () => {},
+    };
+}
+
+function sse(type: string, data: unknown): string {
+    return `event: ${type}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+function toStream(text: string): ReadableStream<Uint8Array> {
+    return new ReadableStream({
+        start(controller) {
+            controller.enqueue(new TextEncoder().encode(text));
+            controller.close();
+        },
+    });
+}
+
+const NS_NAME = "agents.spawn_agent";
+const NS_ITEM_ID = "fc_ns_1";
+const NS_CALL_ID = "call_ns_1";
+const NS_ARGS = JSON.stringify({ prompt: "review the auth module" });
+
+function nsFunctionCallStream(): string {
+    return [
+        sse("response.created", { response: { id: "resp_ns", status: "in_progress", output: [] } }),
+        sse("response.output_item.added", {
+            output_index: 0,
+            item: { type: "function_call", id: NS_ITEM_ID, call_id: NS_CALL_ID, name: NS_NAME, arguments: "" },
+        }),
+        sse("response.function_call_arguments.delta", { item_id: NS_ITEM_ID, delta: NS_ARGS }),
+        sse("response.function_call_arguments.done", { item_id: NS_ITEM_ID, arguments: NS_ARGS }),
+        sse("response.output_item.done", {
+            output_index: 0,
+            item: { type: "function_call", id: NS_ITEM_ID, call_id: NS_CALL_ID, name: NS_NAME, arguments: NS_ARGS },
+        }),
+        sse("response.completed", {
+            response: {
+                id: "resp_ns",
+                status: "completed",
+                output: [{ type: "function_call", id: NS_ITEM_ID, call_id: NS_CALL_ID, name: NS_NAME, arguments: NS_ARGS }],
+            },
+        }),
+    ].join("");
+}
+
+const SYS_PROMPT = buildCompressSystemPrompt();
+
+async function drain(stream: ReadableStream<Uint8Array>, ctx: ReturnType<typeof makeCtx>, textProtocol: boolean): Promise<string> {
+    const chunks: Buffer[] = [];
+    for await (const chunk of runCompressLoop(
+        stream,
+        ctx,
+        { model: "gpt-test", input: [] },
+        { url: "http://mock", headers: {} },
+        createResponsesAdapter(textProtocol),
+        SYS_PROMPT,
+    )) {
+        chunks.push(chunk);
+    }
+    return Buffer.concat(chunks).toString("utf8");
+}
+
+async function collectParseEvents(stream: ReadableStream<Uint8Array>, textProtocol: boolean): Promise<ParsedStreamEvent[]> {
+    const adapter = createResponsesAdapter(textProtocol);
+    const events: ParsedStreamEvent[] = [];
+    for await (const ev of adapter.parseStream(stream, 1)) events.push(ev);
+    return events;
+}
+
+function metaText(events: ParsedStreamEvent[]): string {
+    return events.filter((e) => e.kind === "meta").map((e) => (e as { chunk: Buffer }).chunk.toString("utf8")).join("");
+}
+
+test("parseStream: proxy function_call (compress) is intercepted, not passed through", async () => {
+    const stream = toStream([
+        sse("response.output_item.added", { output_index: 0, item: { type: "function_call", id: "fc_c", call_id: "call_c", name: "compress", arguments: "" } }),
+        sse("response.function_call_arguments.delta", { item_id: "fc_c", delta: "{}" }),
+        sse("response.output_item.done", { output_index: 0, item: { type: "function_call", id: "fc_c", call_id: "call_c", name: "compress", arguments: "{}" } }),
+    ].join(""));
+    const events = await collectParseEvents(stream, false);
+    const toolCalls = events.filter((e) => e.kind === "tool_call") as { kind: "tool_call"; name: string; passthrough?: boolean }[];
+    assert.ok(toolCalls.some((c) => c.name === "compress" && !c.passthrough), "compress yields an intercepted tool_call");
+    assert.ok(!metaText(events).includes("\"name\":\"compress\""), "compress added/done events are NOT passed through raw");
+});
+
+test("parseStream: non-proxy namespaced function_call is passed through raw with a passthrough signal", async () => {
+    const events = await collectParseEvents(toStream(nsFunctionCallStream()), false);
+    const metaJoined = metaText(events);
+    assert.ok(metaJoined.includes(`"id":"${NS_ITEM_ID}"`), "original item id preserved in raw passthrough");
+    assert.ok(metaJoined.includes(`"name":"${NS_NAME}"`), "namespaced name preserved in raw passthrough");
+    const passthrough = events.filter((e) => e.kind === "tool_call" && (e as { passthrough?: boolean }).passthrough) as { kind: "tool_call"; name: string }[];
+    assert.equal(passthrough.length, 1, "exactly one passthrough tool_call signal");
+    assert.equal(passthrough[0].name, NS_NAME, "passthrough signal carries the namespaced name");
+});
+
+for (const textProtocol of [false, true]) {
+    test(`end-to-end: namespaced function_call survives with ORIGINAL item id — textProtocol=${textProtocol}`, async () => {
+        const ctx = makeCtx([{ id: "u1", role: "user", contentType: "text", text: "spawn a sub-agent to review auth" }]);
+        const out = await drain(toStream(nsFunctionCallStream()), ctx, textProtocol);
+        assert.ok(out.includes(`"name":"${NS_NAME}"`), `namespaced name present in forwarded SSE:\n${out}`);
+        assert.ok(out.includes(`"id":"${NS_ITEM_ID}"`), `ORIGINAL item id preserved (raw passthrough):\n${out}`);
+        assert.ok(!out.includes("fc-proxy-"), `no reconstructed fc-proxy id (raw passthrough):\n${out}`);
+        assert.ok(out.includes(`"call_id":"${NS_CALL_ID}"`), `call_id preserved:\n${out}`);
+        assert.ok(out.includes("review the auth module"), `arguments content preserved:\n${out}`);
+    });
+}
+
+test("namespaced tool declaration survives responsesToCore -> patchResponsesInput -> injectResponsesDeveloperMessage", () => {
+    const spawnTool = { type: "function", name: NS_NAME, description: "spawn sub-agent", parameters: { type: "object", properties: {} } };
+    const input: ResponseInputItem[] = [{ type: "message", role: "user", content: "spawn a sub-agent to review auth" }];
+    const projection = responsesToCore({ model: "gpt-test", input, tools: [spawnTool] });
+    const rebuilt = patchResponsesInput(projection, projection.msgs);
+    const finalInput = injectResponsesDeveloperMessage(rebuilt, "system-prompt");
+    assert.ok(Array.isArray(finalInput), "rebuilt input is an array");
+    assert.ok(finalInput.some((i) => (i as { type: string }).type === "message"), "user message survives rebuild");
+});


### PR DESCRIPTION
## Problem

Fixes #143.

Codex Desktop multi-agent tools (e.g. `agents.spawn_agent`, `agents.list_agents`) return `unsupported call: spawn_agent` (note: the `agents.` namespace is dropped) when routed through billion-context, but work when connecting directly to the upstream. A/B confirmed: only the base_url (`8787/bili/...` vs direct) differs. Reported on 0.1.40 (which already includes #94 and #138).

## Root cause

The Responses adapter swallowed **every** `function_call` item (`output_item.added` / `function_call_arguments.delta` / `.done` / `output_item.done`) into a pending map and re-emitted it via `buildFunctionCallEvents` with:
- a **new synthetic item id** (`fc-proxy-...`), while `response.completed.output` still carries the upstream's **original** id (id mismatch), and
- the arguments collapsed into a single delta.

This reconstruction is required for proxy tools the loop must intercept (`compress`/`decompress`/`search_context`/`acp_status`), but it corrupts the wire format for real client-side tools. `custom_tool_call` items already passed through raw; `function_call` did not — which is exactly why normal (custom-tool) tools kept working while namespaced `function_call` tools (Codex `agents.*`) failed.

I verified exhaustively that billion-context does **not** strip or rewrite the namespaced name itself (new tests prove `agents.spawn_agent` survives both textProtocol and non-textProtocol) — the breakage is the reconstruction, not the name.

## Fix

Only intercept `function_call` items whose name is in `PROXY_TOOL_NAMES`; all other `function_call` items are forwarded as raw meta (byte-identical SSE), exactly like `custom_tool_call`. A `passthrough` flag on the `tool_call` event lets the loop count the call (so it still suppresses the re-request when a real call was made) without re-emitting it.

Files:
- `src/loop/adapter-responses.ts` — proxy/non-proxy branching in the 4 function_call handlers.
- `src/loop/core.ts` — `passthrough` on `ToolCallEmit`/`ParsedStreamEvent`; skip `emitToolCall` for passthrough calls.
- `tests/multi-agent-namespace.test.ts` — proxy interception, raw passthrough (original item id + name + call_id + args preserved, no `fc-proxy` reconstruction), both protocols, tool-declaration survival.

## Verification

- `node --import tsx --test tests/*.test.ts` → **375/375 pass** (no regressions).
- `tsc --noEmit` → `src/loop/*` changes are type-clean (the 4 tsc errors are pre-existing in unrelated test files on master).
- New tests prove the forwarded SSE for `agents.spawn_agent` now carries the **original** item id (`fc_ns_1`), not a reconstructed `fc-proxy-...` id.

## Caveat

I could not run Codex Desktop locally to reproduce end-to-end, so the codex-side dispatch fix is a **strong, well-reasoned hypothesis** grounded in the A/B report + the reconstruction difference vs `custom_tool_call`. The change is a strict improvement regardless (more transparent passthrough of tools billion-context has no business intercepting). Requesting the reporter (@a1langxin) to confirm with a build from this branch.