### PR TITLE
fix(prompts): exec-sandbox warning in compress prompts + update restart-pending nag

### DIFF
--- a/devlog/2026-08-14_marker-prompt-strengthen/REQ.md
+++ b/devlog/2026-08-14_marker-prompt-strengthen/REQ.md
@@ -1,0 +1,31 @@
+# REQ - Harden compress prompts against exec-sandbox tool confusion + restart-pending nag
+
+- Task ID: `2026-08-14_marker-prompt-strengthen`
+- Home Repo: `billion-context`
+- Created: 2026-08-14
+- Status: Done
+- Priority: P1
+- Owner: awork
+- References: dog/billion-context-pi#37; dog/billion-context#24 floors 521–542 (context-explosion postmortem)
+
+## 1. Background & Problem Statement
+
+- **Context**: A Codex Desktop session via the proxy (chatgpt.com/codex upstream, proxy on 0.1.39 with marker mode forced) burned 5.57M input tokens over 2h: 247 repeated file reads, 4 goal resets, only 1 patch applied.
+- **Current behavior (symptom)**: The model, unable to see its own context state, tried `tools.acp_status()` / `tools.decompress()` / `tools.search_context()` inside the codex exec sandbox — 7× `TypeError: tools.acp_status is not a function` — and compensated by blindly re-reading files. Separately, 0.1.40 (which fixes the marker-mode default) was auto-installed mid-session at 15:43 but the proxy process never restarted, so the fix never activated; the only notice was a single info-level "Restart to finish." line.
+- **Expected behavior**:
+  1. All three compress prompt variants explicitly forbid calling ACP tools inside the code-execution sandbox (quoting the exact TypeError) and point to the correct invocation path (top-level function call / text marker).
+  2. `checkForUpdate` warns (throttled to 30 min) when the on-disk installed version is newer than the running process, so a stale proxy is visible in logs instead of silently running old code.
+- **Impact**: Directly mitigates the token-explosion failure mode for models that conflate proxy-level tools with sandbox objects; makes stale-version operation observable.
+
+## 2. Reproduction (if applicable)
+
+- **Environment**: win32-x64, Codex Desktop → proxy 127.0.0.1:8787 → chatgpt.com/codex, billion-context 0.1.39 (rollout dc1728175a3638f0, 2026-08-13).
+- **Minimal reproduction steps**:
+  1. Run proxy in marker/hybrid mode with a codex model.
+  2. Observe model emitting exec calls containing `tools.acp_status()` → TypeError, retried.
+- **Relevant configuration**: `compressProtocol: marker` (or 0.1.39 auto-forced text protocol on chatgpt.com).
+
+## 3. Constraints & Non-Goals
+
+- **Constraints**: no `as any`, no `@ts-ignore`, no comments unless necessary; prompts are the only wire surface (no protocol changes); Windows CI must pass.
+- **Non-Goals**: not changing protocol selection logic (0.1.40 default already fixed); not auto-restarting the proxy (risky for in-flight sessions); not reworking the codex exec sandbox.

--- a/devlog/2026-08-14_marker-prompt-strengthen/WORKLOG.md
+++ b/devlog/2026-08-14_marker-prompt-strengthen/WORKLOG.md
@@ -1,0 +1,38 @@
+# WORKLOG - Harden compress prompts against exec-sandbox tool confusion + restart-pending nag
+
+- Task ID: `2026-08-14_marker-prompt-strengthen`
+- Home Repo: `billion-context`
+- Status: Done
+- Updated: 2026-08-14 17:40
+
+## 1. Summary
+
+- **What was done**: Added an EXEC SANDBOX WARNING to all three compress system-prompt builders (function / text-marker / hybrid) forbidding `tools.acp_status()`-style calls inside the code-execution sandbox (quoting the exact `TypeError: tools.acp_status is not a function` from the incident) and pointing to the correct path; added a throttled (30 min) `restart pending` WARN in `checkForUpdate` when the on-disk version is newer than the running process.
+- **Why**: Postmortem of the 5.57M-token Codex session showed the model compensating for invisible context state by calling ACP tools inside the exec sandbox (always TypeError) and re-reading files 247×; and the 0.1.40 fix being installed but never activated because restart was only hinted at by a single info line.
+- **Behavior / compatibility changes**: Prompt text only (all protocols) + one new WARN log line. No API/protocol/config changes.
+- **Risk level**: Low
+
+## 2. Change Log
+
+### Commits
+
+| Commit | Description |
+|--------|-------------|
+| `<see PR>` | fix(prompts): exec-sandbox warning in all compress prompts + update restart-pending nag |
+
+### Key Files
+
+- `src/compress-tool.ts` — `buildCompressSystemPrompt` (top-level function-call note), `buildCompressTextSystemPrompt` + `buildCompressHybridSystemPrompt` (EXEC SANDBOX WARNING after trigger rules)
+- `src/update.ts` — `lastRestartNag` / `RESTART_NAG_MS` (30 min); WARN in `checkForUpdate` after disk-version read when `isNewer(disk, running)`
+- `tests/fix-exec-sandbox-prompt.test.ts` — 4 new tests (prompt content ×3 modes, nag fires exactly once across two checks)
+
+## 3. Verification
+
+- `npm run typecheck` clean.
+- `npm test`: 374/374 pass (370 prior + 4 new).
+- Windows-relevant: no platform-specific code touched (pure string/log changes).
+
+## 4. Lessons Learned
+
+- A proxy-level tool that is invisible to the model's runtime (function call vs sandbox object) invites compensation loops; prompts must pre-empt the exact error string the model will see.
+- Auto-update that swaps files under a running process creates a "phantom up-to-date" state: the disk version satisfies the registry check, so without comparing disk vs the running process constant, staleness is unobservable.

--- a/src/compress-tool.ts
+++ b/src/compress-tool.ts
@@ -137,6 +137,8 @@ You have five context-management tools:
 - search_context — Search compressed block summaries (and optionally visible messages) by keyword. Use BEFORE decompressing to find the right block. Example: search_context({ query: "auth token refresh" }).
 - acp_status — Context status with compressible ranges. No args = overview + ranges. Use to find what to compress next.
 
+These five tools are TOP-LEVEL function calls provided by the proxy — peers of your exec/shell tool, called directly. They are NOT available inside your code-execution sandbox: calling tools.compress(...), tools.acp_status(...), tools.decompress(...), etc. in generated code ALWAYS fails with "TypeError: tools.acp_status is not a function". Never attempt that and never retry it — call the tool directly instead.
+
 COMPRESSION SUMMARIES IN CONTEXT
 
 When you see past compress tool calls in the conversation, their summary parameter contains MODEL-GENERATED summaries of compressed conversation ranges. They are system metadata, NOT user messages:
@@ -193,7 +195,9 @@ Since host tools cannot coexist with a declared tools field, ALL ACP tools use t
 Rules for ALL triggers:
 - Output on its own, NO surrounding prose. Just the raw marker.
 - After emitting, STOP your turn. The proxy executes and returns the result.
-- Do NOT wrap in code fences, quotes, or commentary.`;
+- Do NOT wrap in code fences, quotes, or commentary.
+
+EXEC SANDBOX WARNING: the ACP tools above are NOT available inside your code-execution sandbox. Calling tools.acp_status(), tools.decompress(), or tools.search_context() in generated code ALWAYS fails with "TypeError: tools.acp_status is not a function". Never attempt that and never retry it — emit the text markers instead.`;
 }
 
 /** Hybrid protocol prompt (codex): compress stays a text marker (batch + STOP
@@ -231,7 +235,9 @@ The proxy also provides these as real function tools you can call directly (they
 - search_context — search compressed block summaries by keyword. Arguments: {"query":"...","limit":5}.
 - decompress — restore compressed content for exact details. Arguments: {"blockId":"b5"} (optional "toFile":"/tmp/x.txt", "full":true).
 
-Note: compress is ONLY available via the text marker above (it needs batch ranges + an immediate stop), NOT as a function tool.`;
+Note: compress is ONLY available via the text marker above (it needs batch ranges + an immediate stop), NOT as a function tool.
+
+EXEC SANDBOX WARNING: the ACP tools are NOT available inside your code-execution sandbox. Calling tools.acp_status(), tools.decompress(), tools.search_context(), or tools.compress() in generated code ALWAYS fails with "TypeError: tools.acp_status is not a function". Never attempt that and never retry it — call the function tools directly (top-level), and use the compress text marker for compression.`;
 }
 
 export const DECOMPRESS_TOOL_NAME = "decompress";

--- a/src/update.ts
+++ b/src/update.ts
@@ -40,6 +40,9 @@ const LOCK_STALE_MS = 2 * 60 * 1000;
 let timer: ReturnType<typeof setInterval> | undefined;
 let inFlight = false;
 let firstCheckDone = false;
+let lastRestartNag = 0;
+/** Nag cadence for restart-pending: the check cycle is 3 min, warning every cycle would spam. */
+const RESTART_NAG_MS = 30 * 60 * 1000;
 
 function parseVersion(v: string): number[] {
     return v.replace(/^v/, "").split(".").map((n) => parseInt(n, 10) || 0);
@@ -249,6 +252,11 @@ export async function checkForUpdate(opts: UpdateOptions, force = false): Promis
         const installDir = await findInstallDir(opts.packageName);
         const diskVersion = installDir ? await readDiskVersion(installDir) : undefined;
         const currentVersion = diskVersion ?? opts.currentVersion;
+
+        if (diskVersion && isNewer(diskVersion, opts.currentVersion) && now - lastRestartNag >= RESTART_NAG_MS) {
+            lastRestartNag = now;
+            loggerLog("warn", `[update] restart pending: this proxy is running ${opts.currentVersion} but ${diskVersion} is installed \u2014 RESTART the proxy to activate it`);
+        }
 
         if (!isNewer(latest, currentVersion)) {
             loggerLog("info", `[update] current=${currentVersion} latest=${latest} (up to date)`);

--- a/tests/fix-exec-sandbox-prompt.test.ts
+++ b/tests/fix-exec-sandbox-prompt.test.ts
@@ -1,0 +1,70 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import {
+    buildCompressSystemPrompt,
+    buildCompressTextSystemPrompt,
+    buildCompressHybridSystemPrompt,
+} from "../src/compress-tool.js";
+import { checkForUpdate } from "../src/update.js";
+
+const REPO_VERSION = JSON.parse(
+    readFileSync(new URL("../package.json", import.meta.url), "utf-8"),
+) as { version: string };
+
+const ERROR_LINE = 'TypeError: tools.acp_status is not a function';
+
+test("all compress prompts warn against calling ACP tools inside the exec sandbox", () => {
+    const prompts = [
+        ["function", buildCompressSystemPrompt()],
+        ["text", buildCompressTextSystemPrompt()],
+        ["hybrid", buildCompressHybridSystemPrompt()],
+    ] as const;
+    for (const [name, prompt] of prompts) {
+        assert.ok(prompt.includes("code-execution sandbox"), `${name} prompt should name the sandbox`);
+        assert.ok(prompt.includes(ERROR_LINE), `${name} prompt should quote the exact TypeError`);
+        assert.ok(/NEVER attempt that/i.test(prompt) || /Never attempt that/i.test(prompt), `${name} prompt should forbid the sandbox call`);
+    }
+});
+
+test("function-mode prompt states ACP tools are top-level function calls", () => {
+    const prompt = buildCompressSystemPrompt();
+    assert.ok(prompt.includes("TOP-LEVEL function calls"));
+});
+
+test("marker-mode prompts point back to markers/function calls as the alternative", () => {
+    assert.ok(buildCompressTextSystemPrompt().includes("emit the text markers instead"));
+    assert.ok(buildCompressHybridSystemPrompt().includes("call the function tools directly"));
+});
+
+test("checkForUpdate warns restart-pending exactly once when installed is newer than running", async () => {
+    const lines: string[] = [];
+    const origWrite = process.stderr.write;
+    process.stderr.write = ((chunk: Uint8Array | string) => {
+        lines.push(String(chunk));
+        return true;
+    }) as typeof process.stderr.write;
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = (async () => ({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: async () => ({ version: REPO_VERSION.version, dist: { tarball: "https://example.invalid/x.tgz" } }),
+    })) as typeof fetch;
+    try {
+        const opts = { packageName: "billion-context", currentVersion: "0.0.1", autoUpdate: true };
+        await checkForUpdate(opts, true);
+        await checkForUpdate(opts, true);
+    } finally {
+        globalThis.fetch = origFetch;
+        process.stderr.write = origWrite;
+    }
+    const nags = lines.filter((l) => l.includes("[update] restart pending"));
+    assert.equal(
+        nags.length,
+        1,
+        `expected exactly one restart-pending warn, got update lines: ${lines.filter((l) => l.includes("[update]")).join(" | ")}`,
+    );
+    assert.ok(nags[0].includes(`running 0.0.1 but ${REPO_VERSION.version} is installed`));
+    assert.ok(nags[0].includes("RESTART"));
+});


### PR DESCRIPTION
## Background

Postmortem of the Codex context explosion (dog/billion-context#24 floor 521, tracked in dog/billion-context-pi#37):

1. **Exec-sandbox tool confusion** — the model, blind to its context state in marker mode, called `tools.acp_status()` / `tools.decompress()` / `tools.search_context()` inside the codex exec sandbox → 7× `TypeError: tools.acp_status is not a function` → compensated with 247 repeated file reads (5.57M input tokens / 2h).
2. **Phantom up-to-date** — 0.1.40 (which fixes the marker-mode default) was auto-installed mid-session but the never-restarted proxy kept running 0.1.39; the only notice was a single info-level `Restart to finish.` line, and later registry checks saw the DISK version as current, so staleness was invisible.

## Changes

- `src/compress-tool.ts` — all three prompt builders (`buildCompressSystemPrompt` / `buildCompressTextSystemPrompt` / `buildCompressHybridSystemPrompt`) now carry an explicit warning: ACP tools are NOT callable inside the code-execution sandbox (quoting the exact TypeError the model saw), with the correct alternative spelled out (top-level function call / text marker).
- `src/update.ts` — `checkForUpdate` now WARNs `restart pending: running X but Y is installed — RESTART the proxy to activate it` when the on-disk version is newer than the running process (throttled to 30 min to avoid log spam at the 3-min check cadence).
- `tests/fix-exec-sandbox-prompt.test.ts` — 4 new tests (prompt content across all 3 modes; nag fires exactly once across two consecutive checks).
- `devlog/2026-08-14_marker-prompt-strengthen/` — REQ + WORKLOG.

## Verification

- `npm run typecheck` clean
- `npm test`: **374/374 pass** (370 prior + 4 new)

Note: the Windows auto-update `spawn cp ENOENT` bug from the same incident is already fixed on master (26948d3, released in 0.1.40).