### PR TITLE
release v0.1.41

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.40",
+  "version": "0.1.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.40",
+      "version": "0.1.41",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.40",
+  "version": "0.1.41",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Changes since v0.1.40

- **#144** `fix(responses): pass non-proxy function_call items through raw` — Codex multi-agent emits namespaced `agents.*` function calls the proxy doesn't own; previously dropped/rewritten, now passed through untouched.
- **#140** `ci: add windows-latest to CI matrix` + Windows test fixes (path separator, coarse mtime) + devlog structure (README, REQ/WORKLOG/DESIGN templates).

## Notes

- Version bump only (`package.json` + `package-lock.json`).
- Preflight: typecheck clean, **375/375 tests pass**, build success.
- #145 (exec-sandbox prompt hardening + restart-pending nag) is still open — not included in this release; merge it separately and it ships in the next one.

Merge to trigger CI auto-publish (tag `v0.1.41` + GitHub Release + npm `latest`).