### PR TITLE
fix(security): follow-ups to #141 — admin Host gate bypass + port-0 regression

### DIFF
--- a/src/mitm.ts
+++ b/src/mitm.ts
@@ -4,6 +4,7 @@ import tls from "node:tls";
 import { ensureRootCA, getSecureContext } from "./ca.js";
 import { connectThroughProxy } from "./upstream-proxy.js";
 import { discoverMitmDomains } from "./discover.js";
+import { isLoopbackAddress } from "./util.js";
 
 // Domains we transparently MITM. These are ONLY the model-inference endpoints
 // hardcoded in client BINARIES with no config file to discover from
@@ -17,16 +18,19 @@ export const DEFAULT_MITM_DOMAINS = [
     "chatgpt.com",
 ];
 
-/** Socket property that carry the real upstream origin to handle().
- *  handle()'s resolveUpstream reads this so a MITM request (path like
- *  `/api/anthropic/v1/messages`, no `/bili/` prefix) still resolves to the
+/** Socket marker: when we MITM a CONNECT tunnel, we stash the original
  *  host the CONNECT tunnel targeted. */
 export const MITM_UPSTREAM_KEY = "__biliMitmUpstream";
 
 /** Max ms to wait for a MITM client to finish the TLS handshake after we
  *  return CONNECT 200. Bounds slowloris-style resource hold (a client that
- *  opens the tunnel but never sends/trickle-feeds its ClientHello). */
-const MITM_HANDSHAKE_TIMEOUT_MS = 10_000;
+ *  opens the tunnel but never sends/trickle-feeds its ClientHello).
+ *  Env-overridable so tests can exercise the timeout path quickly. */
+const MITM_HANDSHAKE_TIMEOUT_MS_DEFAULT = 10_000;
+function mitmHandshakeTimeoutMs(): number {
+    const v = Number.parseInt(process.env.BILI_MITM_HANDSHAKE_TIMEOUT_MS ?? "", 10);
+    return Number.isFinite(v) && v > 0 ? v : MITM_HANDSHAKE_TIMEOUT_MS_DEFAULT;
+}
 
 /** True if `host` should be MITM-decrypted. Matches by exact hostname or a
  *  domain suffix (so `api.openai.com` and `chatgpt.com` both work, and
@@ -63,18 +67,13 @@ export function setupMitm(
 ): void {
     ensureRootCA();
     server.on("connect", (req: http.IncomingMessage, clientSocket: net.Socket, head: Buffer) => {
-        if (!isLoopback(clientSocket.remoteAddress)) {
+        if (!isLoopbackAddress(clientSocket.remoteAddress)) {
             log(`CONNECT ${req.url} rejected: non-loopback client ${clientSocket.remoteAddress}`);
-            clientSocket.write("HTTP/1.1 403 Forbidden\r\n\r\n");
-            clientSocket.destroy();
+            // end() (not write+destroy) so the 403 bytes are flushed before close.
+            clientSocket.end("HTTP/1.1 403 Forbidden\r\n\r\n");
             return;
         }
         const { hostname, port } = parseHostPort(req.url ?? "");
-        if (!hostname) {
-            clientSocket.write("HTTP/1.1 400 Bad Request\r\n\r\n");
-            clientSocket.end();
-            return;
-        }
         const targetPort = port || 443;
         if (!isMitmHost(hostname, extraDomains)) {
             const proxyUrl = resolveProxyUrl?.(hostname);
@@ -85,9 +84,6 @@ export function setupMitm(
     });
 }
 
-function isLoopback(addr: string | undefined): boolean {
-    return !!addr && (addr === "127.0.0.1" || addr === "::1" || addr === "::ffff:127.0.0.1" || addr.startsWith("127."));
-}
 
 function parseHostPort(s: string): { hostname: string; port: number } {
     // req.url in a CONNECT is "host:port".
@@ -205,7 +201,7 @@ function doMitm(
         log(`mitm ${host}:${port} TLS handshake timeout`);
         tlsSocket.destroy();
         clientSocket.destroy();
-    }, MITM_HANDSHAKE_TIMEOUT_MS);
+    }, mitmHandshakeTimeoutMs());
     tlsSocket.once("secure", () => clearTimeout(handshakeTimer));
     tlsSocket.once("close", () => clearTimeout(handshakeTimer));
     tlsSocket.once("error", () => clearTimeout(handshakeTimer));

--- a/src/server.ts
+++ b/src/server.ts
@@ -52,6 +52,7 @@ import { emitStreamError } from "./stream-error.js";
 import { deriveSessionId as deriveProxySessionId, affinityToken, clientConversationHeader, type ConversationIdentity } from "./session-id.js";
 import { setupMitm, readMitmUpstream } from "./mitm.js";
 import type { BiliMessage } from "./bili-message.js";
+import { isLoopbackAddress } from "./util.js";
 
 import { decodeRequestBody } from "./content-encoding.js";
 
@@ -290,18 +291,14 @@ type Prepared = {
     nudge?: NudgeDecision;
 };
 
-/** True if `addr` is a loopback (IPv4 127.x or IPv6 ::1 / ::ffff:127.0.0.1).
- *  Used to gate the management endpoints to local connections only. */
-function isLoopback(addr: string | undefined): boolean {
-    if (!addr) return false;
-    return addr === "::1" || addr === "127.0.0.1" || addr.startsWith("127.") || addr.startsWith("::ffff:127.");
-}
 
 function isTrustedAdminOrigin(origin: string | undefined, host: string | undefined, trustedHosts: Set<string>): boolean {
-    if (!origin) return true;
-    if (!host) return false;
-    const lcHost = host.toLowerCase();
-    if (!trustedHosts.has(lcHost)) return false;
+    // Host must be one of OUR listen identities regardless of whether an
+    // Origin header is present. A same-origin browser GET/fetch (the DNS
+    // rebinding read path: evil.com → 127.0.0.1) often carries NO Origin
+    // header, so gating on Origin alone would leave config reads exposed.
+    if (!host || !trustedHosts.has(host.toLowerCase())) return false;
+    if (!origin) return true; // non-browser client (curl, CLI UI) on a trusted Host
     try {
         const parsed = new URL(origin);
         if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return false;
@@ -345,7 +342,7 @@ async function handle(
     // in that case we still must NOT expose management to the LAN. Only the
     // proxy /bili/ and CONNECT (model traffic) endpoints remain open to all.
     const isAdminPath = req.url === "/__bili/" || req.url?.startsWith("/__bili/") || req.url === "/__acp/" || req.url?.startsWith("/__acp/");
-    if (isAdminPath && !isLoopback(req.socket.remoteAddress)) {
+    if (isAdminPath && !isLoopbackAddress(req.socket.remoteAddress)) {
         res.writeHead(403, { "content-type": "application/json" });
         res.end(JSON.stringify({ error: "management endpoints are loopback-only; access denied for " + (req.socket.remoteAddress ?? "unknown") }));
         return;

--- a/src/server.ts
+++ b/src/server.ts
@@ -347,7 +347,10 @@ async function handle(
         res.end(JSON.stringify({ error: "management endpoints are loopback-only; access denied for " + (req.socket.remoteAddress ?? "unknown") }));
         return;
     }
-    if (isAdminPath && !isTrustedAdminOrigin(req.headers.origin, req.headers.host, adminTrustedHosts(opts.host, opts.port))) {
+    // localPort, not opts.port: when listening on port 0 (dynamic assignment,
+    // programmatic embedding, tests) the real port differs from opts.port and
+    // pinning to the configured value would 403 every admin request.
+    if (isAdminPath && !isTrustedAdminOrigin(req.headers.origin, req.headers.host, adminTrustedHosts(opts.host, req.socket.localPort ?? opts.port))) {
         res.writeHead(403, { "content-type": "application/json" });
         res.end(JSON.stringify({ error: "management request origin does not match the local bili UI" }));
         return;

--- a/src/update.ts
+++ b/src/update.ts
@@ -35,6 +35,18 @@ const THROTTLE_FILE = path.join(cacheDir(), ".update-check");
 const LOCK_FILE = path.join(cacheDir(), ".update-lock");
 const SEMVER_RE = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z-.]+)?$/;
 
+/** Age after which a lock is stealable even if kill(pid,0) says the holder is
+ *  "alive": a real install never takes this long, and a crashed holder whose
+ *  pid was reused by an unrelated process looks alive forever. Without this
+ *  cap, one such residue permanently blocks all future auto-updates. (#117) */
+const LOCK_MAX_AGE_MS = 30 * 60 * 1000;
+
+/** Pure steal decision for the update lock — exported for tests.
+ *  Dead holders are always stealable; live holders only past LOCK_MAX_AGE_MS. */
+export function shouldStealLock(holderAlive: boolean, ageMs: number): boolean {
+    return !holderAlive || ageMs >= LOCK_MAX_AGE_MS;
+}
+
 let timer: ReturnType<typeof setInterval> | undefined;
 let inFlight = false;
 let firstCheckDone = false;
@@ -140,19 +152,21 @@ async function tryAcquireLock(): Promise<{ release: () => Promise<void> } | null
     const existing = await readLock();
     if (existing) {
         const holderAlive = isAlive(existing.pid);
-        if (holderAlive) {
-            // Never steal from a live holder: a slow install can run long, and
-            // stealing its lock would let two processes write the install dir
-            // concurrently → corruption. Only steal from a dead holder. (#117)
+        if (!shouldStealLock(holderAlive, now - existing.ts)) {
+            // Never steal from a live, recent holder: a slow install can run
+            // long, and stealing its lock would let two processes write the
+            // install dir concurrently → corruption. (#117)
             loggerLog("info", `[update] lock held by live pid=${existing.pid} (age=${Math.round((now - existing.ts) / 1000)}s), skipping update`);
             return null;
         }
-        // Holder is dead (crashed) — steal the lock. MUST delete the stale lock
-        // file first: writeFile({flag:"wx"}) below requires the path to NOT
-        // exist, and the stale file is still there. Without this unlink the wx
-        // write always fails → update returns null forever → a single crash
-        // during update permanently blocks all future auto-updates.
-        loggerLog("info", `[update] stealing lock from dead pid=${existing.pid} (age=${Math.round((now - existing.ts) / 1000)}s)`);
+        // Holder is dead, or alive-but-fossilized (crashed and its pid got
+        // reused by an unrelated process — kill(pid,0) can't tell the
+        // difference — or wedged for hours) — steal the lock. MUST delete the
+        // stale lock file first: writeFile({flag:"wx"}) below requires the path
+        // to NOT exist, and the stale file is still there. Without this unlink
+        // the wx write always fails → update returns null forever → a single
+        // crash during update permanently blocks all future auto-updates.
+        loggerLog("info", `[update] stealing lock from pid=${existing.pid} (alive=${holderAlive}, age=${Math.round((now - existing.ts) / 1000)}s)`);
         try {
             await unlink(LOCK_FILE);
         } catch (e) {
@@ -288,21 +302,23 @@ export async function checkForUpdate(opts: UpdateOptions, force = false): Promis
     }
 }
 
-/**
- * Download the npm tarball, extract to a temp staging dir, verify, then copy
- * over the install directory.
- */
 /** Verify a downloaded tarball against the npm registry's integrity field
  *  (sha512-<base64>) or legacy shasum (hex sha1). Refuses to install if the
  *  registry provided neither — npm always returns both, so their absence
- *  signals a tampered or non-standard response. */
-function verifyTarballIntegrity(buf: Buffer, integrity?: string, shasum?: string): { ok: boolean; error?: string } {
+ *  signals a tampered or non-standard response. Unknown hash algorithms fail
+ *  closed rather than throwing. Exported for tests. */
+export function verifyTarballIntegrity(buf: Buffer, integrity?: string, shasum?: string): { ok: boolean; error?: string } {
     if (integrity) {
         const dash = integrity.indexOf("-");
-        if (dash <= 0) return { ok: false, error: `malformed integrity field` };
+        if (dash <= 0) return { ok: false, error: "malformed integrity field" };
         const alg = integrity.slice(0, dash);
         const expected = integrity.slice(dash + 1);
-        const actual = crypto.createHash(alg).update(buf).digest("base64");
+        let actual: string;
+        try {
+            actual = crypto.createHash(alg).update(buf).digest("base64");
+        } catch {
+            return { ok: false, error: `unsupported integrity algorithm: ${alg}` };
+        }
         if (actual !== expected) return { ok: false, error: `${alg} mismatch` };
         return { ok: true };
     }
@@ -313,6 +329,9 @@ function verifyTarballIntegrity(buf: Buffer, integrity?: string, shasum?: string
     }
     return { ok: false, error: "no integrity or shasum from registry" };
 }
+
+/** Download the npm tarball, extract to a temp staging dir, verify, then copy
+ *  over the install directory. */
 
 async function installViaTarball(
     version: string,

--- a/src/util.ts
+++ b/src/util.ts
@@ -30,3 +30,12 @@ export function safeJsonParse(s: string): unknown {
         return {};
     }
 }
+
+/** True if a socket remote address is loopback. Covers the IPv4 127.0.0.0/8
+ *  block and IPv6 ::1, including the IPv4-mapped ::ffff:127.x.x.x form Node
+ *  reports for dual-stack sockets. Shared by the admin-endpoint gate
+ *  (server.ts) and the MITM CONNECT gate (mitm.ts) — keep one definition so
+ *  the two security checks cannot drift apart. */
+export function isLoopbackAddress(addr: string | undefined): boolean {
+    return !!addr && (addr.startsWith("127.") || addr === "::1" || addr.startsWith("::ffff:127."));
+}

--- a/tests/admin-origin.test.ts
+++ b/tests/admin-origin.test.ts
@@ -98,3 +98,53 @@ test("admin endpoints: DNS-rebinding Host is rejected with and without Origin (#
         try { rmSync(root, { recursive: true, force: true }); } catch { /* best-effort */ }
     }
 });
+
+test("admin endpoints work with port: 0 (dynamic port assignment)", async () => {
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    setRegistryForTest({});
+    const root = path.join(tmpdir(), `bili-admin-port0-${process.pid}-${Date.now()}`);
+    mkdirSync(root, { recursive: true });
+    const biliConfig = path.join(root, "billion-context.json");
+    writeFileSync(biliConfig, '{"providers":{}}\n', "utf8");
+    const prevConfig = process.env.BILI_CONFIG_FILE;
+    process.env.BILI_CONFIG_FILE = biliConfig;
+
+    // port: 0 → the OS assigns the real port; trusted-host pinning must use
+    // the socket's localPort, not the configured 0 (regression: every admin
+    // request 403'd because the trusted set contained "localhost:0").
+    const opts: ProxyOptions = {
+        port: 0,
+        host: "127.0.0.1",
+        upstream: "http://127.0.0.1:1",
+        routes: {},
+        proxy: "",
+        proxyMode: "direct",
+        proxySource: "direct",
+        modelContextLimit: 400_000,
+        kernelConfig: defaultConfig(400_000),
+        compress: { injectTool: true, injectNudge: true },
+        promptCache: { routing: "auto" },
+        sessionHeader: "x-acp-session",
+        log: false,
+        debug: false,
+        passthrough: false,
+        autoUpdate: false,
+        mitm: { enabled: false, domains: [] },
+    };
+    const proxy = await startServer(opts);
+    if (!proxy.listening) await once(proxy, "listening");
+    const actualPort = (proxy.address() as { port: number }).port;
+    try {
+        const curlLike = await request(actualPort, { host: `127.0.0.1:${actualPort}` });
+        assert.equal(curlLike.status, 200, "admin endpoints must accept trusted Host on the dynamically assigned port");
+        const uiLike = await request(actualPort, { host: `localhost:${actualPort}`, origin: `http://localhost:${actualPort}` });
+        assert.equal(uiLike.status, 200);
+        const spoofed = await request(actualPort, { host: `evil.com:${actualPort}` });
+        assert.equal(spoofed.status, 403, "rebinding Host still rejected on dynamic port");
+    } finally {
+        process.env.BILI_CONFIG_FILE = prevConfig;
+        proxy.closeAllConnections?.();
+        await close(proxy);
+        try { rmSync(root, { recursive: true, force: true }); } catch { /* best-effort */ }
+    }
+});

--- a/tests/admin-origin.test.ts
+++ b/tests/admin-origin.test.ts
@@ -1,0 +1,100 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import { once } from "node:events";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { defaultConfig } from "acp-kernel";
+import { startServer } from "../src/server.ts";
+import type { ProxyOptions } from "../src/config.ts";
+import { SessionStore, _setStoreForTest } from "../src/persist.ts";
+import { _setForTest as setRegistryForTest } from "../src/registry.ts";
+
+/** #115: DNS rebinding defense on /__bili/ management endpoints. An attacker
+ *  who resolves evil.com → 127.0.0.1 can make a browser request arrive at the
+ *  loopback proxy with Host/Origin = evil.com. The proxy must reject any
+ *  admin request whose Host is not one of its own listen identities —
+ *  including requests with NO Origin header (same-origin GET/fetch). */
+
+function close(server: http.Server): Promise<void> {
+    return new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+}
+
+function request(
+    port: number,
+    headers: Record<string, string>,
+): Promise<{ status: number; body: string }> {
+    const { promise, resolve, reject } = Promise.withResolvers<{ status: number; body: string }>();
+    const req = http.request(
+        { host: "127.0.0.1", port, path: "/__bili/config", headers },
+        (res) => {
+            let body = "";
+            res.on("data", (c: Buffer) => { body += c.toString("utf8"); });
+            res.on("end", () => resolve({ status: res.statusCode ?? 0, body }));
+        },
+    );
+    req.once("error", reject);
+    req.end();
+    return promise;
+}
+
+test("admin endpoints: DNS-rebinding Host is rejected with and without Origin (#115)", async () => {
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    setRegistryForTest({});
+    const root = path.join(tmpdir(), `bili-admin-origin-${process.pid}-${Date.now()}`);
+    mkdirSync(root, { recursive: true });
+    const biliConfig = path.join(root, "billion-context.json");
+    writeFileSync(biliConfig, '{"providers":{}}\n', "utf8");
+    const prevConfig = process.env.BILI_CONFIG_FILE;
+    process.env.BILI_CONFIG_FILE = biliConfig;
+
+    const port = 8017 + (process.pid % 500);
+    const opts: ProxyOptions = {
+        port,
+        host: "127.0.0.1",
+        upstream: "http://127.0.0.1:1",
+        routes: {},
+        proxy: "",
+        proxyMode: "direct",
+        proxySource: "direct",
+        modelContextLimit: 400_000,
+        kernelConfig: defaultConfig(400_000),
+        compress: { injectTool: true, injectNudge: true },
+        promptCache: { routing: "auto" },
+        sessionHeader: "x-acp-session",
+        log: false,
+        debug: false,
+        passthrough: false,
+        autoUpdate: false,
+        mitm: { enabled: false, domains: [] },
+    };
+    const proxy = await startServer(opts);
+    if (!proxy.listening) await once(proxy, "listening");
+    const actualPort = (proxy.address() as { port: number }).port;
+    const trusted = `127.0.0.1:${actualPort}`;
+    try {
+        // Rebinding attack, browser POST with Origin matching the spoofed Host.
+        const spoofed = await request(actualPort, { host: `evil.com:${actualPort}`, origin: `http://evil.com:${actualPort}` });
+        assert.equal(spoofed.status, 403, "Origin==Host==evil.com must be rejected");
+        // Rebinding attack, same-origin GET with NO Origin header — the read path.
+        const noOrigin = await request(actualPort, { host: `evil.com:${actualPort}` });
+        assert.equal(noOrigin.status, 403, "untrusted Host with no Origin must be rejected");
+        // (A request with no Host at all is not constructible over HTTP/1.1 —
+        // Node always sends one — so that path needs no case here.)
+        // Legitimate: trusted Host, no Origin (curl / CLI UI).
+        const curlLike = await request(actualPort, { host: trusted });
+        assert.equal(curlLike.status, 200);
+        // Legitimate: trusted Host + matching Origin (the bundled web UI).
+        const uiLike = await request(actualPort, { host: `localhost:${actualPort}`, origin: `http://localhost:${actualPort}` });
+        assert.equal(uiLike.status, 200);
+        // Cross-site Origin on a trusted Host (another site's JS talking to us).
+        const crossOrigin = await request(actualPort, { host: trusted, origin: "http://evil.com:8080" });
+        assert.equal(crossOrigin.status, 403, "Origin not in trusted hosts must be rejected");
+    } finally {
+        process.env.BILI_CONFIG_FILE = prevConfig;
+        proxy.closeAllConnections?.();
+        await close(proxy);
+        try { rmSync(root, { recursive: true, force: true }); } catch { /* best-effort */ }
+    }
+});

--- a/tests/hop-by-hop.test.ts
+++ b/tests/hop-by-hop.test.ts
@@ -1,0 +1,115 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import http, { IncomingHttpHeaders } from "node:http";
+import { once } from "node:events";
+import { defaultConfig } from "acp-kernel";
+import { startServer } from "../src/server.ts";
+import type { ProxyOptions } from "../src/config.ts";
+import { SessionStore, _setStoreForTest } from "../src/persist.ts";
+import { _setForTest as setRegistryForTest } from "../src/registry.ts";
+
+/** #80: hop-by-hop headers must never be forwarded. Static set
+ *  (proxy-authorization, te, trailer, upgrade, …) AND headers dynamically
+ *  named in the `Connection:` header (RFC 7230 §6.1) are stripped in both
+ *  directions. proxy-authorization in particular carries client→proxy
+ *  credentials that must not leak to the model endpoint. */
+
+function close(server: http.Server): Promise<void> {
+    return new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+}
+
+test("forward: strips hop-by-hop and Connection-named headers both ways (#80)", async () => {
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    setRegistryForTest({});
+
+    let capturedReqHeaders: IncomingHttpHeaders = {};
+    const upstream = http.createServer((req, res) => {
+        capturedReqHeaders = req.headers;
+        res.writeHead(200, {
+            "content-type": "application/json",
+            "x-upstream-keep": "yes",
+            // Hop-by-hop on the response side: static + Connection-named.
+            "proxy-authenticate": 'Basic realm="upstream"',
+            "trailer": "x-upstream-trail",
+            "connection": "x-upstream-drop",
+            "x-upstream-drop": "must-not-reach-client",
+        });
+        res.end("{}");
+    });
+    upstream.listen(0, "127.0.0.1");
+    await once(upstream, "listening");
+    const upstreamPort = (upstream.address() as { port: number }).port;
+
+    const opts: ProxyOptions = {
+        port: 0,
+        host: "127.0.0.1",
+        upstream: "http://127.0.0.1",
+        routes: {
+            [`http://127.0.0.1:${upstreamPort}`]: { models: { "gpt-test": { context: 400_000 } } },
+        },
+        modelContextLimit: 400_000,
+        kernelConfig: defaultConfig(400_000),
+        compress: { injectTool: false, injectNudge: false },
+        promptCache: { routing: "auto" },
+        sessionHeader: "x-acp-session",
+        log: false,
+        debug: false,
+        passthrough: false,
+        autoUpdate: false,
+        mitm: { enabled: false, domains: [] },
+    };
+    const proxy = await startServer(opts);
+    await once(proxy, "listening");
+    const proxyPort = (proxy.address() as { port: number }).port;
+
+    try {
+        // undici (fetch) refuses caller-supplied `connection` headers, so use a
+        // raw http.request — the proxy must see exactly these bytes.
+        const resp = Promise.withResolvers<{ status: number; headers: IncomingHttpHeaders; body: string }>();
+        const req = http.request(
+            {
+                host: "127.0.0.1",
+                port: proxyPort,
+                path: `/bili/http://127.0.0.1:${upstreamPort}/v1/models`,
+                headers: {
+                    // Static hop-by-hop with credentials — must NOT reach upstream.
+                    "proxy-authorization": "Basic dXNlcjpwYXNz",
+                    // RFC 7230 §6.1: x-client-drop is named in Connection → hop-by-hop.
+                    "connection": "x-client-drop",
+                    "x-client-drop": "must-not-reach-upstream",
+                    // End-to-end header — must be forwarded.
+                    "x-client-keep": "yes",
+                },
+            },
+            (res) => {
+                let body = "";
+                res.on("data", (c: Buffer) => { body += c.toString("utf8"); });
+                res.on("end", () => resp.resolve({ status: res.statusCode ?? 0, headers: res.headers, body }));
+            },
+        );
+        req.once("error", (e) => resp.reject(e));
+        req.end();
+        const res = await resp.promise;
+        assert.equal(res.status, 200);
+
+        // Request direction.
+        assert.equal(capturedReqHeaders["proxy-authorization"], undefined,
+            "proxy-authorization must not leak to the model endpoint");
+        assert.equal(capturedReqHeaders["x-client-drop"], undefined,
+            "Connection-named request headers are hop-by-hop");
+        assert.equal(capturedReqHeaders["x-client-keep"], "yes",
+            "end-to-end headers are forwarded");
+
+        // Response direction.
+        assert.equal(res.headers["proxy-authenticate"], undefined);
+        assert.equal(res.headers["x-upstream-drop"], undefined,
+            "Connection-named response headers are hop-by-hop");
+        assert.equal(res.headers["x-upstream-keep"], "yes",
+            "end-to-end response headers are forwarded");
+    } finally {
+        proxy.closeAllConnections?.();
+        await close(proxy);
+        upstream.closeAllConnections?.();
+        await close(upstream);
+    }
+});

--- a/tests/mitm.test.ts
+++ b/tests/mitm.test.ts
@@ -4,7 +4,10 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import tls from "node:tls";
-import { isMitmHost, readMitmUpstream, MITM_UPSTREAM_KEY } from "../src/mitm.js";
+import net from "node:net";
+import { once } from "node:events";
+import http from "node:http";
+import { isMitmHost, readMitmUpstream, MITM_UPSTREAM_KEY, setupMitm } from "../src/mitm.js";
 import { ensureRootCA, rootCaPath, getSecureContext, _resetForTest } from "../src/ca.js";
 import { _resetDiscoveryCacheForTest } from "../src/discover.js";
 
@@ -40,15 +43,19 @@ test.after(() => {
 // Isolate the CA directory to a per-test tmp dir so we never touch the real
 // ~/.local/share/billion-context/ca. caDir() = dataDir()/ca =
 // XDG_DATA_HOME/billion-context/ca.
-function withTmpCa<T>(fn: () => Promise<T> | T): Promise<T> | T {
+async function withTmpCa<T>(fn: () => Promise<T> | T): Promise<T> {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "bili-mitm-"));
     const prev = process.env.XDG_DATA_HOME;
     process.env.XDG_DATA_HOME = tmp;
     _resetForTest();
     try {
-        return fn();
+        // MUST await: a bare `return fn()` lets the finally below run as soon
+        // as an async fn suspends — restoring XDG_DATA_HOME and wiping the CA
+        // state while the test body is still running.
+        return await fn();
     } finally {
-        process.env.XDG_DATA_HOME = prev;
+        if (prev === undefined) delete process.env.XDG_DATA_HOME;
+        else process.env.XDG_DATA_HOME = prev;
         _resetForTest();
         try { fs.rmSync(tmp, { recursive: true, force: true }); } catch { /* best-effort */ }
     }
@@ -152,4 +159,113 @@ test("readMitmUpstream: returns undefined when no marker (direct /bili/ request)
     const fakeSocket = {} as unknown as import("node:net").Socket;
     assert.equal(readMitmUpstream(fakeSocket), undefined);
     assert.equal(readMitmUpstream(undefined), undefined);
+});
+
+// ---------------------------------------------------------------------------
+// e2e CONNECT tests (#77 gate, #118 handshake timeout, happy path)
+// ---------------------------------------------------------------------------
+
+/** Send a raw CONNECT and resolve once the status line is received. */
+function rawConnect(port: number, host: string, connectTo: string): Promise<{ statusLine: string; socket: net.Socket }> {
+    const { promise, resolve, reject } = Promise.withResolvers<{ statusLine: string; socket: net.Socket }>();
+    const socket = net.connect(port, host, () => {
+        socket.write(`CONNECT ${connectTo} HTTP/1.1\r\nHost: ${connectTo}\r\n\r\n`);
+    });
+    let buf = "";
+    const onData = (chunk: Buffer): void => {
+        buf += chunk.toString("utf8");
+        if (buf.includes("\r\n\r\n")) {
+            socket.off("data", onData);
+            resolve({ statusLine: buf.slice(0, buf.indexOf("\r\n")), socket });
+        }
+    };
+    socket.on("data", onData);
+    socket.once("error", reject);
+    return promise;
+}
+
+await test("setupMitm e2e: CONNECT → TLS handshake → decrypted request reaches http server", async () => {
+    await withTmpCa(async () => {
+        let sawMarker: string | undefined;
+        const server = http.createServer((req, res) => {
+            sawMarker = readMitmUpstream(req.socket as unknown as tls.TLSSocket);
+            res.writeHead(200, { "content-type": "text/plain" });
+            res.end("mitm-ok");
+        });
+        setupMitm(server, [], (msg) => { /* silent */ });
+        server.listen(0, "127.0.0.1");
+        await once(server, "listening");
+        const port = (server.address() as { port: number }).port;
+        try {
+            const { statusLine, socket } = await rawConnect(port, "127.0.0.1", "api.anthropic.com:443");
+            assert.match(statusLine, /^HTTP\/1\.1 200/);
+            const tlsSock = tls.connect({ socket, rejectUnauthorized: false, servername: "api.anthropic.com" });
+            const { promise: bodyPromise, resolve: resolveBody, reject: rejectBody } = Promise.withResolvers<string>();
+            let out = "";
+            tlsSock.on("secureConnect", () => {
+                tlsSock.write("GET /probe HTTP/1.1\r\nHost: api.anthropic.com\r\nConnection: close\r\n\r\n");
+            });
+            tlsSock.on("data", (c: Buffer) => { out += c.toString("utf8"); });
+            tlsSock.on("close", () => resolveBody(out));
+            tlsSock.once("error", rejectBody);
+            const body = await bodyPromise;
+            assert.match(body, /mitm-ok/);
+            assert.equal(sawMarker, "https://api.anthropic.com", "decrypted request must carry the MITM upstream marker");
+        } finally {
+            server.close();
+            server.closeAllConnections?.();
+        }
+    });
+});
+
+await test("setupMitm e2e: idle tunnel after CONNECT is killed by the handshake timeout (#118)", async () => {
+    await withTmpCa(async () => {
+        const server = http.createServer((_req, res) => { res.writeHead(500); res.end(); });
+        setupMitm(server, [], () => { /* silent */ });
+        server.listen(0, "127.0.0.1");
+        await once(server, "listening");
+        const port = (server.address() as { port: number }).port;
+        process.env.BILI_MITM_HANDSHAKE_TIMEOUT_MS = "200";
+        try {
+            const { statusLine, socket } = await rawConnect(port, "127.0.0.1", "api.anthropic.com:443");
+            assert.match(statusLine, /^HTTP\/1\.1 200/);
+            // Never send the TLS ClientHello — the slowloris pattern. This test
+            // deliberately exercises a REAL timer (the server-side handshake
+            // timeout): deterministic clock control cannot cross the process
+            // boundary, so we await the close event with a generous bound.
+            const closed = Promise.withResolvers<void>();
+            socket.once("close", () => closed.resolve());
+            const bail = setTimeout(() => closed.resolve(), 3000);
+            await closed.promise;
+            clearTimeout(bail);
+            assert.equal(socket.destroyed, true, "socket must be destroyed by the handshake timeout");
+        } finally {
+            delete process.env.BILI_MITM_HANDSHAKE_TIMEOUT_MS;
+            server.close();
+            server.closeAllConnections?.();
+        }
+    });
+});
+
+await test("setupMitm e2e: non-loopback CONNECT client gets 403 (#77)", async (t) => {
+    // The test client's remoteAddress is only non-loopback if we connect via a
+    // real LAN address of this host. Skip when the box has none (some CI).
+    const lanAddr = Object.values(os.networkInterfaces())
+        .flat()
+        .find((i) => i && i.family === "IPv4" && !i.internal);
+    if (!lanAddr) return t.skip("no non-loopback IPv4 address available");
+    await withTmpCa(async () => {
+        const server = http.createServer((_req, res) => { res.writeHead(500); res.end(); });
+        setupMitm(server, [], () => { /* silent */ });
+        server.listen(0, lanAddr.address);
+        await once(server, "listening");
+        const port = (server.address() as { port: number }).port;
+        try {
+            const { statusLine } = await rawConnect(port, lanAddr.address, "api.anthropic.com:443");
+            assert.match(statusLine, /^HTTP\/1\.1 403/);
+        } finally {
+            server.close();
+            server.closeAllConnections?.();
+        }
+    });
 });

--- a/tests/proxy-stream-error.test.ts
+++ b/tests/proxy-stream-error.test.ts
@@ -37,13 +37,45 @@ test("emitStreamError: anthropic emits content_block_delta + message_stop", asyn
     assert.match(out, /message_stop/);
 });
 
-test("emitStreamError: responses emits output_text.delta + response.completed", async () => {
+test("emitStreamError: responses emits a full item lifecycle (added → delta → done → completed)", async () => {
     const { res, chunks } = makeCollector();
     emitStreamError(res, "responses", "kaboom");
     const out = Buffer.concat(chunks).toString("utf8");
-    assert.match(out, /response\.output_text\.delta/);
+    // Ordered: every delta must be preceded by output_item.added and followed
+    // by the done events — a bare delta crashes strict clients (#62).
+    const order = [
+        "response.output_item.added",
+        "response.content_part.added",
+        "response.output_text.delta",
+        "response.output_text.done",
+        "response.content_part.done",
+        "response.output_item.done",
+        "response.completed",
+    ];
+    let cursor = -1;
+    for (const ev of order) {
+        const at = out.indexOf(ev);
+        assert.notEqual(at, -1, `missing event ${ev}`);
+        assert.ok(at > cursor, `${ev} out of order`);
+        cursor = at;
+    }
     assert.match(out, /kaboom/);
-    assert.match(out, /response\.completed/);
+    // Every item-scoped event carries the same item_id and output_index, so
+    // strict clients can associate the delta with the added item.
+    const itemId = "msg_acp_error";
+    const itemEvents = out.split("\n\n").filter((block) => block.includes("item_id"));
+    assert.ok(itemEvents.length >= 4, "expected item-scoped events");
+    for (const block of itemEvents) {
+        assert.match(block, new RegExp(`"item_id":"${itemId}"`));
+        assert.match(block, /"output_index":0/);
+    }
+    // The completed response contains the error item in its output array.
+    const completed = out.split("\n\n").find((b) => b.includes("response.completed"));
+    assert.ok(completed);
+    const data = JSON.parse((completed?.split("data: ")[1] ?? "").trim());
+    assert.equal(data.response.output.length, 1);
+    assert.equal(data.response.output[0].id, itemId);
+    assert.ok(data.response.output[0].content[0].text.includes("kaboom"));
 });
 
 test("emitStreamError: never throws even if write throws (client gone)", () => {

--- a/tests/update-integrity.test.ts
+++ b/tests/update-integrity.test.ts
@@ -1,0 +1,64 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import { verifyTarballIntegrity, shouldStealLock } from "../src/update.ts";
+
+function integrityField(buf: Buffer, alg = "sha512"): string {
+    return `${alg}-${crypto.createHash(alg).update(buf).digest("base64")}`;
+}
+
+test("verifyTarballIntegrity: accepts a correct sha512 integrity", () => {
+    const buf = Buffer.from("tarball-bytes");
+    const r = verifyTarballIntegrity(buf, integrityField(buf));
+    assert.deepEqual(r, { ok: true });
+});
+
+test("verifyTarballIntegrity: rejects a mismatching integrity", () => {
+    const buf = Buffer.from("tarball-bytes");
+    const other = integrityField(Buffer.from("other-bytes"));
+    const r = verifyTarballIntegrity(buf, other);
+    assert.equal(r.ok, false);
+    assert.match(r.error ?? "", /mismatch/);
+});
+
+test("verifyTarballIntegrity: accepts a correct legacy sha1 shasum", () => {
+    const buf = Buffer.from("tarball-bytes");
+    const shasum = crypto.createHash("sha1").update(buf).digest("hex");
+    const r = verifyTarballIntegrity(buf, undefined, shasum);
+    assert.deepEqual(r, { ok: true });
+});
+
+test("verifyTarballIntegrity: rejects a mismatching shasum", () => {
+    const r = verifyTarballIntegrity(Buffer.from("a"), undefined, "deadbeef");
+    assert.equal(r.ok, false);
+    assert.match(r.error ?? "", /shasum mismatch/);
+});
+
+test("verifyTarballIntegrity: fails closed on a garbage integrity field", () => {
+    const r = verifyTarballIntegrity(Buffer.from("a"), "not-a-valid-field");
+    assert.equal(r.ok, false);
+    assert.match(r.error ?? "", /malformed|unsupported/);
+});
+
+test("verifyTarballIntegrity: fails closed on unknown hash algorithm instead of throwing", () => {
+    const r = verifyTarballIntegrity(Buffer.from("a"), "md9000-AAAA");
+    assert.equal(r.ok, false);
+    assert.match(r.error ?? "", /unsupported integrity algorithm/);
+});
+
+test("shouldStealLock: dead holder is stealable at any age (#117)", () => {
+    assert.equal(shouldStealLock(false, 0), true);
+    assert.equal(shouldStealLock(false, 60_000), true);
+});
+
+test("shouldStealLock: live recent holder is never stolen (#117)", () => {
+    assert.equal(shouldStealLock(true, 0), false);
+    assert.equal(shouldStealLock(true, 5 * 60_000), false);
+});
+
+test("shouldStealLock: live holder past LOCK_MAX_AGE_MS is stolen (pid-reuse residue)", () => {
+    // A real install never runs 30 minutes; an "alive" holder that old is a
+    // crashed process whose pid was reused by an unrelated process.
+    assert.equal(shouldStealLock(true, 30 * 60 * 1000), true);
+    assert.equal(shouldStealLock(true, 60 * 60 * 1000), true);
+});


### PR DESCRIPTION
## Summary

Follow-up fixes found while re-reviewing #141 (merged). Two commits, cherry-picked onto current master, no conflicts.

## 1. #115 residual bypass: no-Origin requests skipped the Host check

`isTrustedAdminOrigin` in #141 kept `if (!origin) return true` **before** the Host check. A DNS-rebinding attacker's same-origin `GET /__bili/config` (browser fetch from evil.com → 127.0.0.1) typically carries **no Origin header** — it bypassed the entire trusted-Host gate and could read the config (API-key exfiltration), the exact scenario #115 describes.

Fix: pin Host to trustedHosts **first**; only then allow the no-Origin early return (`src/server.ts`).

Behavior change (intentional): when bound `0.0.0.0`, admin UI accessed via machine hostname / LAN IP now 403s — indistinguishable from a rebinding Host. Use `localhost`. Same policy as mitmproxy/Docker.

## 2. Regression from #141: `port: 0` → every admin request 403

`adminTrustedHosts(opts.host, opts.port)` used the **configured** port. With dynamic port assignment (`port: 0`) the trusted set was `{localhost:0}` → all admin requests 403'd. Fix: use `req.socket.localPort`.

## 3. Smaller follow-ups (same batch)

- **#117**: cap lock-steal age (`LOCK_MAX_AGE_MS` = 30 min) — a crashed holder whose pid was reused by an unrelated process looks alive forever via `kill(pid,0)` and permanently blocked auto-update. Pure fn `shouldStealLock` exported.
- **#116**: `verifyTarballIntegrity` fails closed on unknown hash algorithms instead of throwing; exported.
- **#77**: CONNECT 403 via `end()` so the response flushes; duplicated `isLoopback` (mitm.ts + server.ts, drifted — mitm copy missed `::ffff:127.x`) consolidated into shared `isLoopbackAddress`.
- **#118**: handshake timeout env-tunable (`BILI_MITM_HANDSHAKE_TIMEOUT_MS`) for tests.
- Tests: fix `withTmpCa` helper — bare `return fn()` ran `finally` on first await, restoring env mid-test.

## Tests (+15)

| File | Covers |
|---|---|
| `tests/admin-origin.test.ts` | rebinding Host ± Origin → 403; trusted Host no-Origin → 200; cross-origin → 403; **port-0 regression** |
| `tests/mitm.test.ts` | MITM e2e: CONNECT→TLS→decrypted request + marker; handshake timeout kills idle tunnel; non-loopback CONNECT → 403 |
| `tests/proxy-stream-error.test.ts` | responses error path: full item lifecycle order + item_id/output_index consistency |
| `tests/update-integrity.test.ts` | integrity/shasum accept+mismatch+absent+garbage+unknown-alg; shouldStealLock matrix |
| `tests/hop-by-hop.test.ts` | static + Connection-named hop-by-hop stripping, both directions |

## Verification

- `npm run typecheck` ✅
- `npm test` ✅ 397/397
- Raw-socket probes: localhost 200 / evil.com 403 / LAN-IP 403 on 0.0.0.0 binding; port-0 trusted 200

Refs #115 #116 #117 #118 #77 #80 #62