### PR TITLE
feat(compress): configurable compression prompts (three-level, risk-gated)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to **billion-context** are documented here.
 Versions follow the merge of a `*_release-v*` branch; CI publishes to npm on tag.
 
+## [Unreleased]
+
+### Features
+
+- **Customizable compression prompts** (#156): the `compress` block now accepts `prompts` — an override object for the compression prompt text (`compressPhilosophy`, `howToCompressRules`, `tier2DistillRules`, `tier3CondenseRules`) — merged sub-field-wise across the three config levels (global → provider → model) and applied consistently to the system prompt, the nudge text, and the compress loop. Because the kernel's default rules are load-bearing (tuned over months of production use), overrides are **inert until `acknowledgePromptsRisk: true`** is set at the winning level; without it they are ignored and a one-time warning is logged. Non-string fields are silently dropped. Mainly useful for non-English or small-model prompt tuning.
+
 ## [0.1.40] — 2026-08-13
 
 ### Features

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -241,6 +241,20 @@ For each request, the proxy resolves the settings by longest-URL-prefix match (t
 - **Status:** ACTIVE
 - **Description:** Enable multi-tier compression — tier-2 distillation of old summaries and tier-3 condensation. Set `false` to run in tier-1-only mode (every summary is a flat tier-1 summary). Maps to the kernel field `tiers.enabled`.
 
+#### `prompts`
+
+- **Type:** `object` (`{ compressPhilosophy?, howToCompressRules?, tier2DistillRules?, tier3CondenseRules? }`, all strings)
+- **Default:** *(kernel defaults — see `acp-kernel` `defaultPrompts`)*
+- **Status:** ACTIVE
+- **Description:** Override the compression prompt text injected into the system prompt and nudge messages. Every field is **load-bearing**: the kernel rules were tuned over months of production use, and overriding them can degrade summary quality (lost paths / signatures / decisions → broken retrieval). Overrides only take effect when `acknowledgePromptsRisk: true` is set at the same (winning) level; otherwise they are ignored and a one-time warning is logged. Non-string fields are silently dropped (a malformed partial never clobbers a good default). Useful mainly for non-English or small-model tuning — see issue #156.
+
+#### `acknowledgePromptsRisk`
+
+- **Type:** `boolean`
+- **Default:** `false`
+- **Status:** ACTIVE
+- **Description:** Must be `true` for `prompts` overrides to take effect. Setting it acknowledges the summary-quality risk documented above.
+
 ### Injection toggles (global only)
 
 These two toggles are honoured only at the **global** level. Setting them inside a per-provider or per-model `compress` block has no effect.

--- a/CONFIGURATION.zh-CN.md
+++ b/CONFIGURATION.zh-CN.md
@@ -241,6 +241,20 @@
 - **状态：** ACTIVE
 - **说明：** 启用多层压缩 —— 对旧摘要进行 tier-2 蒸馏，以及 tier-3 凝缩。设为 `false` 可运行在仅 tier-1 模式（每个摘要都是扁平的 tier-1 摘要）。映射到内核字段 `tiers.enabled`。
 
+#### `prompts`
+
+- **类型：** `object`（`{ compressPhilosophy?, howToCompressRules?, tier2DistillRules?, tier3CondenseRules? }`，均为字符串）
+- **默认值：** *（内核默认值 —— 见 `acp-kernel` 的 `defaultPrompts`）*
+- **状态：** ACTIVE
+- **说明：** 覆盖注入到系统提示词与 nudge 消息中的压缩提示词文本。每个字段都是**承重的（load-bearing）**：内核规则经过数月生产调优，覆盖它们可能降低摘要质量（丢失路径 / 签名 / 决策 → 检索失效）。只有当同一（胜出的）层级同时设置了 `acknowledgePromptsRisk: true` 时覆盖才生效；否则会被忽略并记录一次警告。非字符串字段会被静默丢弃（畸形的局部配置不会破坏正常默认值）。主要用于非英文或小模型调优 —— 见 issue #156。
+
+#### `acknowledgePromptsRisk`
+
+- **类型：** `boolean`
+- **默认值：** `false`
+- **状态：** ACTIVE
+- **说明：** 必须为 `true`，`prompts` 覆盖才会生效。设置它即表示知悉上文所述的摘要质量风险。
+
 ### 注入开关（仅全局生效）
 
 这两个开关只在**全局**层级生效。在按 provider 或按模型的 `compress` 块中设置它们无效。

--- a/src/compress-settings.ts
+++ b/src/compress-settings.ts
@@ -1,5 +1,6 @@
-import type { Config } from "acp-kernel";
+import { defaultPrompts, resolvePrompts, type Config, type Prompts } from "acp-kernel";
 import { findRoute, type CompressSettings, type ProviderRoutes } from "./config.js";
+import { log as loggerLog } from "./logger.js";
 
 /** Resolve a raw `contextLimit` value to an absolute token count.
  *  - `number` → used as-is (absolute window).
@@ -34,6 +35,12 @@ export function mergeCompress(
 ): CompressSettings {
     const pick = <K extends keyof CompressSettings>(k: K): CompressSettings[K] =>
         model?.[k] ?? provider?.[k] ?? global?.[k];
+    // `prompts` is the one nested-object field: merge SUB-field-wise across
+    // levels (global → provider → model) instead of whole-object replace, so a
+    // model-level override of howToCompressRules does not discard a
+    // provider-level compressPhilosophy. The kernel's resolvePrompts then
+    // fills any still-missing sub-fields from defaultPrompts.
+    const promptLevels = [global?.prompts, provider?.prompts, model?.prompts].filter(Boolean) as Partial<Prompts>[];
     return {
         modelContextLimit: pick("modelContextLimit"),
         maxContextLimit: pick("maxContextLimit"),
@@ -43,6 +50,8 @@ export function mergeCompress(
         preserveRecentTokens: pick("preserveRecentTokens"),
         minCompressRange: pick("minCompressRange"),
         tiers: pick("tiers"),
+        prompts: promptLevels.length > 0 ? Object.assign({}, ...promptLevels) : undefined,
+        acknowledgePromptsRisk: pick("acknowledgePromptsRisk"),
     };
 }
 
@@ -58,6 +67,30 @@ export function resolveCompress(
 ): CompressSettings {
     const route = findRoute(routes, upstreamUrl);
     return mergeCompress(global, route?.compress, model ? route?.models?.[model]?.compress : undefined);
+}
+
+let warnedPromptsRisk = false;
+
+/** Resolve the effective compression prompts from merged settings. `prompts`
+ *  overrides only take effect with `acknowledgePromptsRisk: true` at the
+ *  winning level (the kernel rules are load-bearing; see Prompts docs). When
+ *  ignored, a one-time warning is logged so the misconfiguration is visible.
+ *  Non-string fields inside `prompts` are silently dropped by the kernel's
+ *  resolvePrompts (a malformed partial never clobbers a good default). */
+export function resolveCompressPrompts(s: CompressSettings): Prompts {
+    if (!s.prompts) return defaultPrompts;
+    if (s.acknowledgePromptsRisk !== true) {
+        if (!warnedPromptsRisk) {
+            warnedPromptsRisk = true;
+            loggerLog("warn", "[compress] prompts override IGNORED: acknowledgePromptsRisk !== true. Set it to true to acknowledge the summary-quality risk.");
+        }
+        return defaultPrompts;
+    }
+    try {
+        return resolvePrompts(s.prompts, { acknowledgeRisk: true });
+    } catch {
+        return defaultPrompts;
+    }
 }
 
 /** True when a CompressSettings carries at least one configured field (i.e. it

--- a/src/compress-tool.ts
+++ b/src/compress-tool.ts
@@ -121,7 +121,7 @@ export const COMPRESS_TOOL_OPENAI = {
 
 export function buildCompressSystemPrompt(prompts: Prompts = defaultPrompts): string {
     return `${prompts.compressPhilosophy}
- 
+
 ${prompts.howToCompressRules}
 
 ACP TAGS
@@ -153,7 +153,7 @@ When you see past compress tool calls in the conversation, their summary paramet
  *  require real tools). */
 export function buildCompressTextSystemPrompt(prompts: Prompts = defaultPrompts): string {
     return `${prompts.compressPhilosophy}
- 
+
 ${prompts.howToCompressRules}
 
 ACP TAGS
@@ -203,7 +203,7 @@ Rules for ALL triggers:
  *  coexist in one turn. */
 export function buildCompressHybridSystemPrompt(prompts: Prompts = defaultPrompts): string {
     return `${prompts.compressPhilosophy}
- 
+
 ${prompts.howToCompressRules}
 
 ACP TAGS

--- a/src/compress-tool.ts
+++ b/src/compress-tool.ts
@@ -1,4 +1,4 @@
-import { COMPRESS_PHILOSOPHY, HOW_TO_COMPRESS_RULES } from "acp-kernel";
+import { defaultPrompts, type Prompts } from "acp-kernel";
 import { log as loggerLog } from "./logger.js";
 
 export const COMPRESS_TOOL_NAME = "compress";
@@ -119,10 +119,10 @@ export const COMPRESS_TOOL_OPENAI = {
     },
 };
 
-export function buildCompressSystemPrompt(): string {
-    return `${COMPRESS_PHILOSOPHY}
-
-${HOW_TO_COMPRESS_RULES}
+export function buildCompressSystemPrompt(prompts: Prompts = defaultPrompts): string {
+    return `${prompts.compressPhilosophy}
+ 
+${prompts.howToCompressRules}
 
 ACP TAGS
 
@@ -151,10 +151,10 @@ When you see past compress tool calls in the conversation, their summary paramet
  *  the trigger tags in its text output instead of calling a function tool.
  *  Only compress is available via this protocol (decompress/search/status
  *  require real tools). */
-export function buildCompressTextSystemPrompt(): string {
-    return `${COMPRESS_PHILOSOPHY}
-
-${HOW_TO_COMPRESS_RULES}
+export function buildCompressTextSystemPrompt(prompts: Prompts = defaultPrompts): string {
+    return `${prompts.compressPhilosophy}
+ 
+${prompts.howToCompressRules}
 
 ACP TAGS
 
@@ -201,10 +201,10 @@ Rules for ALL triggers:
  *  acp_status are real function tools the model calls directly. The compress
  *  loop already merges text triggers and function tool_calls, so both paths
  *  coexist in one turn. */
-export function buildCompressHybridSystemPrompt(): string {
-    return `${COMPRESS_PHILOSOPHY}
-
-${HOW_TO_COMPRESS_RULES}
+export function buildCompressHybridSystemPrompt(prompts: Prompts = defaultPrompts): string {
+    return `${prompts.compressPhilosophy}
+ 
+${prompts.howToCompressRules}
 
 ACP TAGS
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-import { defaultConfig, type Config } from "acp-kernel";
+import { defaultConfig, type Config, type Prompts } from "acp-kernel";
 import { readFileSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { configFile } from "./paths.js";
@@ -96,6 +96,18 @@ export type CompressSettings = {
     minCompressRange?: number;
     /** Enable multi-tier (T2/T3) distillation (kernel `tiers.enabled`). */
     tiers?: boolean;
+    /** Override the kernel's compression prompt text (compressPhilosophy /
+     *  howToCompressRules / tier2DistillRules / tier3CondenseRules). All four
+     *  fields are LOAD-BEARING: the kernel rules were tuned in production and
+     *  overriding them can degrade summary quality (lost paths / signatures /
+     *  decisions → broken retrieval). Ignored unless `acknowledgePromptsRisk`
+     *  is also true at the winning level. Same three-level merge as the other
+     *  fields, but the object is merged via kernel `resolvePrompts` (non-string
+     *  fields silently dropped), not a raw pass-through. */
+    prompts?: Partial<Prompts>;
+    /** Must be true for `prompts` overrides to take effect. Acknowledges the
+     *  summary-quality risk documented on `prompts`. */
+    acknowledgePromptsRisk?: boolean;
 };
 export type PromptCacheRouting = "auto" | "enabled" | "disabled";
 export type UpstreamProxyMode = "auto" | "manual" | "direct";

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,11 +1,11 @@
 import http from "node:http";
 import fs from "node:fs";
-import { createCore, type CompressionCore, type Config, type CoreMessage, type NudgeDecision, estimateTokensFast, renderNudgeText, deactivateBlock } from "acp-kernel";
+import { createCore, type CompressionCore, type Config, type CoreMessage, type NudgeDecision, type Prompts, defaultPrompts, estimateTokensFast, renderNudgeText, deactivateBlock } from "acp-kernel";
+import { resolveCompress, resolveCompressPrompts, resolveRequestConfig } from "./compress-settings.js";
 import type { ProxyOptions } from "./config.js";
 import { loadOptions, loadRoutes } from "./config.js";
 import { resetProxyCache } from "./upstream-proxy.js";
 import { resolveContextLimit, resolveCompressProtocol } from "./config.js";
-import { resolveRequestConfig } from "./compress-settings.js";
 import { contextFromRegistry, loadRegistry } from "./registry.js";
 import { fetchWithTimeout, MAX_REQUEST_BYTES } from "./fetch-util.js";
 import { formatUpstreamError, getUpstreamConnectionStatus, recordUpstreamConnection, resolveProxy, resolveProxyDecision, proxyDispatcher } from "./upstream-proxy.js";
@@ -289,6 +289,11 @@ type Prepared = {
     responsesProjection?: ResponsesProjection;
     anthropicSystem?: AnthropicRequestBody["system"];
     nudge?: NudgeDecision;
+    /** Effective compression prompts for this request (three-level cascade,
+     *  defaults to the kernel's defaultPrompts). Carried so the compress loop
+     *  in forward() rebuilds the SAME system prompt the request was prepared
+     *  with. */
+    prompts?: Prompts;
 };
 
 
@@ -527,6 +532,12 @@ async function handle(
     // absolute number, a "70%" string of the native window, or unset → native)
     // overrides the table.
     let reqConfig = config;
+    // Effective compression prompts for this request: resolved from the same
+    // three-level cascade (global → provider → model) as the limit above, then
+    // threaded into every prepare* path so the system prompt, the nudge text,
+    // and the compress-loop system prompt all use one consistent Prompts set
+    // (kernel contract: renderNudgeText and the adapter prompt must match).
+    let reqPrompts: Prompts = defaultPrompts;
     if (parsed && typeof parsed === "object") {
         const model = (parsed as { model?: string }).model;
         if (model) {
@@ -537,6 +548,7 @@ async function handle(
                 native = await contextFromRegistry(model, host);
             }
             reqConfig = resolveRequestConfig(config, opts.routes, embeddedUrl, model, native, opts.compress);
+            reqPrompts = resolveCompressPrompts(resolveCompress(opts.routes, embeddedUrl, model, opts.compress));
         }
     }
     let prepared: Prepared | null = null;
@@ -591,12 +603,12 @@ async function handle(
                     countTokens
                         ? prepareCountTokens(parsed as AnthropicRequestBody, core, reqConfig, log, session)
                         : protocol === "anthropic"
-                          ? prepareAnthropic(parsed as AnthropicRequestBody, req, opts, core, reqConfig, log, session)
+                          ? prepareAnthropic(parsed as AnthropicRequestBody, req, opts, core, reqConfig, reqPrompts, log, session)
                           : protocol === "openai"
-                            ? prepareOpenai(parsed as OpenAIRequestBody, req, opts, core, reqConfig, log, session)
+                            ? prepareOpenai(parsed as OpenAIRequestBody, req, opts, core, reqConfig, reqPrompts, log, session)
                             : responsesCompact
                               ? prepareResponsesCompact(bodyBuffer, parsed as ResponsesRequestBody, session)
-                              : prepareResponses(parsed as ResponsesRequestBody, req, opts, core, reqConfig, log, session, responsesIdentity!);
+                              : prepareResponses(parsed as ResponsesRequestBody, req, opts, core, reqConfig, reqPrompts, log, session, responsesIdentity!);
                 await forward(req, res, opts, prepared!.body, prepared!, core, reqConfig, log, route, affinity);
             });
         } finally {
@@ -653,6 +665,7 @@ function prepareAnthropic(
     opts: ProxyOptions,
     core: CompressionCore,
     config: Config,
+    prompts: Prompts,
     log: (level: string, msg: string) => void,
     session: Session,
 ): Prepared {
@@ -694,7 +707,7 @@ function prepareAnthropic(
         reapOrphanBlocks(session, msgs, deactivateBlock);
         rebuiltMessages = coreToAnthropic(processedMessages as BiliMessage[], cacheControls);
 
-        systemOut = injectSystem(parsed, opts);
+        systemOut = injectSystem(parsed, opts, prompts);
         if (opts.compress.injectTool) {
             toolsOut = injectTool(parsed.tools);
         }
@@ -702,7 +715,7 @@ function prepareAnthropic(
         // system block stays byte-stable so the prefix cache survives.
         if (opts.compress.injectNudge && turn.nudge?.shouldInject) {
             try {
-                const rendered = renderNudgeText(turn.nudge);
+                const rendered = renderNudgeText(turn.nudge, prompts);
                 if (rendered.text) {
                     rebuiltMessages = [...rebuiltMessages, { role: "user", content: rendered.text }];
                 }
@@ -713,10 +726,10 @@ function prepareAnthropic(
         log("warn", `[${sessionId}] kernel transform failed, forwarding unchanged: ${String(err)}`);
         processedMessages = [];
     }
+    markDirty(session);
 
     const rebuilt: AnthropicRequestBody = { ...parsed, messages: rebuiltMessages, system: systemOut, tools: toolsOut };
-    markDirty(session);
-    return { body: JSON.stringify(rebuilt), session, processedMessages, originalMessages, anthropicSystem: parsed.system, protocol: "anthropic", stream, compressInjected: opts.compress.injectTool, nudge } as Prepared;
+    return { body: JSON.stringify(rebuilt), session, processedMessages, originalMessages, anthropicSystem: parsed.system, protocol: "anthropic", stream, compressInjected: opts.compress.injectTool, nudge, prompts } as Prepared;
 }
 
 function prepareOpenai(
@@ -725,6 +738,7 @@ function prepareOpenai(
     opts: ProxyOptions,
     core: CompressionCore,
     config: Config,
+    prompts: Prompts,
     log: (level: string, msg: string) => void,
     session: Session,
 ): Prepared {
@@ -775,7 +789,7 @@ function prepareOpenai(
         // instead, mirroring pai-acp's design. Putting the nudge in system
         // would invalidate the cache every turn.
         const sysParts: string[] = [];
-        if (shouldInject) sysParts.push(buildCompressSystemPrompt());
+        if (shouldInject) sysParts.push(buildCompressSystemPrompt(prompts));
         rebuiltMessages = injectOpenaiSystem(rebuiltMessages, sysParts);
         if (shouldInject) {
             toolsOut = injectOpenaiTool(parsed.tools);
@@ -783,7 +797,7 @@ function prepareOpenai(
         // Nudge as a separate trailing user message (cache-friendly).
         if (opts.compress.injectNudge && turn.nudge?.shouldInject && shouldInject) {
             try {
-                const rendered = renderNudgeText(turn.nudge);
+                const rendered = renderNudgeText(turn.nudge, prompts);
                 if (rendered.text) {
                     rebuiltMessages = [...rebuiltMessages, { role: "user", content: rendered.text }];
                 }
@@ -806,7 +820,7 @@ function prepareOpenai(
         (rebuilt as Record<string, unknown>).stream_options = { include_usage: true };
     }
     markDirty(session);
-    return { body: JSON.stringify(rebuilt), session, processedMessages, originalMessages, protocol: "openai", stream, compressInjected: shouldInject, nudge } as Prepared;
+    return { body: JSON.stringify(rebuilt), session, processedMessages, originalMessages, protocol: "openai", stream, compressInjected: shouldInject, nudge, prompts } as Prepared;
 }
 
 function prepareResponses(
@@ -815,6 +829,7 @@ function prepareResponses(
     opts: ProxyOptions,
     core: CompressionCore,
     config: Config,
+    prompts: Prompts,
     log: (level: string, msg: string) => void,
     session: Session,
     identity: ConversationIdentity,
@@ -860,7 +875,7 @@ function prepareResponses(
         reapOrphanBlocks(session, msgs, deactivateBlock);
         rebuiltInput = patchResponsesInput(projection, processedMessages);
         if (shouldInject && !process.env.ACP_NO_COMPRESS_PROMPT) {
-            const prompt = responsesTextProtocol ? buildCompressHybridSystemPrompt() : buildCompressSystemPrompt();
+            const prompt = responsesTextProtocol ? buildCompressHybridSystemPrompt(prompts) : buildCompressSystemPrompt(prompts);
             const devContent = [...projection.systemParts, prompt].join("\n\n---\n\n");
             rebuiltInput = injectResponsesDeveloperMessage(rebuiltInput, devContent);
             if (!process.env.ACP_NO_INJECT_TOOL) {
@@ -873,7 +888,7 @@ function prepareResponses(
         }
         if (opts.compress.injectNudge && turn.nudge?.shouldInject && shouldInject) {
             try {
-                const rendered = renderNudgeText(turn.nudge);
+                const rendered = renderNudgeText(turn.nudge, prompts);
                 if (rendered.text) {
                     const inputItems: ResponseInputItem[] = typeof rebuiltInput === "string"
                         ? [{ type: "message", role: "user", content: rebuiltInput }]
@@ -932,6 +947,7 @@ function prepareResponses(
         compressInjected: shouldInject,
         responsesTextProtocol,
         nudge,
+        prompts,
     };
 }
 
@@ -1038,6 +1054,7 @@ export function resolvePromptCacheKey(
 function injectSystem(
     parsed: AnthropicRequestBody,
     opts: ProxyOptions,
+    prompts: Prompts = defaultPrompts,
 ): string | AnthropicRequestBody["system"] {
     // ONLY the static compress prompt goes into the system block — it is the
     // prefix-cache anchor and must stay byte-stable across turns. The nudge
@@ -1045,7 +1062,7 @@ function injectSystem(
     // the caller (prepareAnthropic), never merged into system.
     const baseText = extractSystem(parsed.system);
     const parts: string[] = [];
-    if (opts.compress.injectTool) parts.push(buildCompressSystemPrompt());
+    if (opts.compress.injectTool) parts.push(buildCompressSystemPrompt(prompts));
     if (parts.length === 0) return parsed.system;
     const full = baseText ? `${baseText}\n\n---\n\n${parts.join("\n\n")}` : parts.join("\n\n");
     return buildSystem(full, parsed.system);
@@ -1333,7 +1350,7 @@ async function forward(
             const parsedReq = JSON.parse(typeof body === "string" ? body : body.toString("utf8"));
             const reqHeaders = buildForwardHeaders(headers);
             const textProtocol = prepared.protocol === "responses" && !!prepared.responsesTextProtocol;
-            const systemPrompt = textProtocol ? buildCompressHybridSystemPrompt() : buildCompressSystemPrompt();
+            const systemPrompt = textProtocol ? buildCompressHybridSystemPrompt(prepared.prompts ?? defaultPrompts) : buildCompressSystemPrompt(prepared.prompts ?? defaultPrompts);
             const adapter = pickAdapter(prepared.protocol, parsedReq, textProtocol, prepared.responsesProjection, prepared.anthropicSystem);
             const abortCtrl = new AbortController();
             req.on("close", () => {

--- a/tests/compress-settings.test.ts
+++ b/tests/compress-settings.test.ts
@@ -1,12 +1,13 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { defaultConfig } from "acp-kernel";
+import { defaultConfig, defaultPrompts } from "acp-kernel";
 import {
     mergeCompress,
     resolveCompress,
     applyCompressSettings,
     hasCompressSettings,
     resolveContextLimitValue,
+    resolveCompressPrompts,
 } from "../src/compress-settings.ts";
 import { parseRouteEntry, type ProviderRoutes } from "../src/config.ts";
 
@@ -188,4 +189,50 @@ test("parseRouteEntry: preserves provider-level and model-level compress", () =>
 test("parseRouteEntry: no compress leaves the field absent", () => {
     const route = parseRouteEntry({ models: { "m": { context: 128000 } } });
     assert.equal(route?.compress, undefined);
+});
+
+test("resolveCompressPrompts: no prompts configured returns kernel defaults", () => {
+    const p = resolveCompressPrompts({ nudgeGrowthTokens: 50000 });
+    assert.equal(p, defaultPrompts);
+});
+
+test("resolveCompressPrompts: prompts ignored without acknowledgePromptsRisk", () => {
+    const p = resolveCompressPrompts({ prompts: { compressPhilosophy: "CUSTOM" } });
+    assert.equal(p, defaultPrompts);
+    assert.notEqual(p.compressPhilosophy, "CUSTOM");
+});
+
+test("resolveCompressPrompts: acknowledgePromptsRisk applies string overrides", () => {
+    const p = resolveCompressPrompts({
+        prompts: { compressPhilosophy: "CUSTOM PHILOSOPHY", howToCompressRules: 42 as unknown as string },
+        acknowledgePromptsRisk: true,
+    });
+    assert.equal(p.compressPhilosophy, "CUSTOM PHILOSOPHY");
+    // Non-string override silently dropped (kernel resolvePrompts), never clobbers a default.
+    assert.equal(p.howToCompressRules, defaultPrompts.howToCompressRules);
+    assert.equal(p.tier2DistillRules, defaultPrompts.tier2DistillRules);
+});
+
+test("mergeCompress: prompts + acknowledgePromptsRisk deepest-wins per field", () => {
+    const merged = mergeCompress(
+        { prompts: { compressPhilosophy: "GLOBAL" }, acknowledgePromptsRisk: true },
+        { prompts: { howToCompressRules: "PROVIDER" } },
+        { prompts: { compressPhilosophy: "MODEL" } },
+    );
+    assert.deepEqual(merged.prompts, { compressPhilosophy: "MODEL", howToCompressRules: "PROVIDER" });
+    // Risk flag from the global level survives when deeper levels don't set it.
+    assert.equal(merged.acknowledgePromptsRisk, true);
+});
+
+test("resolveCompress: prompts cascade end-to-end via provider routes", () => {
+    const routes: ProviderRoutes = {
+        "https://api.example.com": parseRouteEntry({
+            compress: { prompts: { compressPhilosophy: "PROVIDER" } },
+            models: { "m": { context: 128000, compress: { prompts: { howToCompressRules: "MODEL RULES" }, acknowledgePromptsRisk: true } } },
+        })!,
+    };
+    const merged = resolveCompress(routes, "https://api.example.com", "m");
+    const p = resolveCompressPrompts(merged);
+    assert.equal(p.compressPhilosophy, "PROVIDER");
+    assert.equal(p.howToCompressRules, "MODEL RULES");
 });

--- a/tests/e2e-compress-prompts.test.ts
+++ b/tests/e2e-compress-prompts.test.ts
@@ -1,0 +1,134 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import { once } from "node:events";
+import { defaultConfig } from "acp-kernel";
+import { startServer } from "../src/server.ts";
+import { SessionStore, _setStoreForTest } from "../src/persist.ts";
+import type { ProxyOptions } from "../src/config.ts";
+import { _setForTest as setRegistryForTest } from "../src/registry.ts";
+
+// E2E for the configurable compression prompts (PR #157): spins up the REAL
+// proxy (startServer) against a mock upstream and asserts the resolved prompt
+// text actually reaches the wire — i.e. the system message the upstream
+// receives contains the configured override text, not the kernel defaults.
+// Covers: (a) provider+model sub-field merged override end-to-end, (b) the
+// acknowledgePromptsRisk gate keeping overrides inert at the HTTP layer.
+
+type Captured = { body: string };
+
+function listen(server: http.Server): Promise<void> {
+    if (server.listening) return Promise.resolve();
+    return once(server, "listening").then(() => undefined);
+}
+
+function close(server: http.Server): Promise<void> {
+    return new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+}
+
+/** A marker that only exists in the kernel's default compressPhilosophy. */
+const DEFAULT_MARKER = "Compress by need, not by percentage";
+
+async function runProxyWithPrompts(routeCompress: ProxyOptions["routes"][string]): Promise<{ system: string | undefined; messages: { role: string }[] }> {
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    setRegistryForTest({});
+
+    const captured: Captured[] = [];
+    const upstream = http.createServer((req, res) => {
+        const chunks: Buffer[] = [];
+        req.on("data", (chunk: Buffer) => chunks.push(chunk));
+        req.on("end", () => {
+            captured.push({ body: Buffer.concat(chunks).toString("utf8") });
+            res.writeHead(200, { "content-type": "application/json" });
+            res.end(JSON.stringify({ id: "r1", object: "chat.completion", choices: [{ index: 0, message: { role: "assistant", content: "ok" }, finish_reason: "stop" }] }));
+        });
+    });
+    upstream.listen(0, "127.0.0.1");
+    await listen(upstream);
+    const upstreamPort = (upstream.address() as { port: number }).port;
+
+    const opts: ProxyOptions = {
+        port: 0,
+        host: "127.0.0.1",
+        upstream: "http://127.0.0.1",
+        routes: {
+            [`http://127.0.0.1:${upstreamPort}`]: routeCompress,
+        },
+        modelContextLimit: 400_000,
+        kernelConfig: defaultConfig(400_000),
+        compress: { injectTool: true, injectNudge: true },
+        promptCache: { routing: "auto" },
+        sessionHeader: "x-acp-session",
+        log: false,
+        debug: false,
+        passthrough: false,
+        autoUpdate: false,
+        mitm: { enabled: false, domains: [] },
+    };
+    const proxy = await startServer(opts);
+    await listen(proxy);
+    const proxyPort = (proxy.address() as { port: number }).port;
+
+    try {
+        const url = `http://127.0.0.1:${proxyPort}/bili/http://127.0.0.1:${upstreamPort}/v1/chat/completions`;
+        const resp = await fetch(url, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+                model: "gpt-test",
+                stream: false,
+                messages: [{ role: "user", content: "hello" }],
+            }),
+        });
+        assert.equal(resp.status, 200);
+        await resp.text();
+
+        assert.equal(captured.length, 1, `expected exactly 1 upstream request, got ${captured.length}`);
+        const sent = JSON.parse(captured[0]!.body) as { messages: { role: string; content: string }[] };
+        const system = sent.messages.find((m) => m.role === "system")?.content;
+        return { system, messages: sent.messages };
+    } finally {
+        await close(proxy);
+        await close(upstream);
+    }
+}
+
+test("e2e compress prompts: provider+model sub-field merged override reaches the wire", async () => {
+    const { system } = await runProxyWithPrompts({
+        compress: { prompts: { compressPhilosophy: "CUSTOM-E2E-PHILOSOPHY" } },
+        models: {
+            "gpt-test": {
+                context: 400_000,
+                compress: { prompts: { howToCompressRules: "CUSTOM-E2E-RULES" }, acknowledgePromptsRisk: true },
+            },
+        },
+    });
+    assert.ok(system, "upstream request has no system message — compress prompt not injected");
+    // Model-level override present...
+    assert.ok(system.includes("CUSTOM-E2E-RULES"), "model-level howToCompressRules override missing from wire");
+    // ...AND provider-level sub-field survived the merge (deepest-wins is per SUB-field, not per object).
+    assert.ok(system.includes("CUSTOM-E2E-PHILOSOPHY"), "provider-level compressPhilosophy override missing from wire");
+    // Defaults are replaced by the overrides, not concatenated.
+    assert.ok(!system.includes(DEFAULT_MARKER), "default compressPhilosophy still present alongside override");
+    // The rest of the injected prompt (protocol section, tool docs) is intact.
+    assert.ok(system.includes("compress"), "protocol section missing from injected prompt");
+});
+
+test("e2e compress prompts: without acknowledgePromptsRisk the override is inert (defaults on the wire)", async () => {
+    const { system } = await runProxyWithPrompts({
+        compress: { prompts: { compressPhilosophy: "CUSTOM-E2E-PHILOSOPHY" } },
+        models: { "gpt-test": { context: 400_000 } },
+    });
+    assert.ok(system, "upstream request has no system message — compress prompt not injected");
+    assert.ok(!system.includes("CUSTOM-E2E-PHILOSOPHY"), "override leaked to wire without acknowledgePromptsRisk");
+    assert.ok(system.includes(DEFAULT_MARKER), "kernel default compressPhilosophy missing — gate broke the default path");
+});
+
+test("e2e compress prompts: no prompts configured → byte-identical default prompt on the wire", async () => {
+    const { system } = await runProxyWithPrompts({
+        models: { "gpt-test": { context: 400_000 } },
+    });
+    assert.ok(system, "upstream request has no system message — compress prompt not injected");
+    assert.ok(system.includes(DEFAULT_MARKER), "kernel default compressPhilosophy missing with no config");
+    assert.ok(!system.includes("CUSTOM-E2E"), "unexpected custom text with no config");
+});


### PR DESCRIPTION
Partially addresses #156 (the custom-prompts suggestion).

## What

Adds `compress.prompts` + `compress.acknowledgePromptsRisk` to the existing three-level cascade (global → provider → model):

- `prompts` overrides the kernel prompt text (`compressPhilosophy`, `howToCompressRules`, `tier2DistillRules`, `tier3CondenseRules`), merged **sub-field-wise** across levels — a model-level `howToCompressRules` does not discard a provider-level `compressPhilosophy`.
- Resolved via the kernel's `resolvePrompts` (non-string fields silently dropped; a malformed partial never clobbers a good default).
- **Risk gate**: the kernel rules are load-bearing (tuned in production); overrides are inert until `acknowledgePromptsRisk: true` at the winning level. Without it: one-time `[compress] prompts override IGNORED` warning + defaults.
- Threaded consistently into the system prompt (all three protocols), the nudge text (`renderNudgeText`), and the compress loop in `forward()` — kernel contract: both layers must use the same `Prompts`.

Main use case: non-English / small-model prompt tuning (#156: 2B model spinning in the compress loop).

## Stacking

Stacked on #153 (admin follow-up) — merge that first, then retarget this to master.

## Verification

- `npm run typecheck` clean; `npm test` 402/402 (6 new unit tests: three-level sub-field merge, risk-gate fallback, non-string drop, end-to-end route cascade).
- `npm run build` clean (2.04 MB).
- Docs: CONFIGURATION.md + CONFIGURATION.zh-CN.md field entries; CHANGELOG unreleased section. Web UI needs no change (settings page edits raw providers JSON).