### PR TITLE
release v0.1.42

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.41",
+      "version": "0.1.42",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@types/node": "^22.0.0",
         "@types/node-forge": "^1.3.14",
-        "acp-kernel": "0.0.23",
+        "acp-kernel": "0.0.24",
         "fzstd": "0.1.1",
         "node-forge": "^1.4.0",
         "tar": "^7.5.22",
@@ -972,9 +972,9 @@
       }
     },
     "node_modules/acp-kernel": {
-      "version": "0.0.23",
-      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.23.tgz",
-      "integrity": "sha512-bG28aYfBda8z34fsaoNc4QBix4gRtQDQznR6G4XBaz9z1xgxdmdYtazQQMBjxnfEL9yCrDb9CTpkl7IXWiuviA==",
+      "version": "0.0.24",
+      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.24.tgz",
+      "integrity": "sha512-vuNpkTjeTvNprqTRSlFCRuVpqoqdyHY00ejS+lRfdqQYfrOtA2LgfJNF3Aun7ibu2d+llaA6H5WYznpGkJNC/A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/node-forge": "^1.3.14",
-    "acp-kernel": "0.0.23",
+    "acp-kernel": "0.0.24",
     "fzstd": "0.1.1",
     "node-forge": "^1.4.0",
     "tar": "^7.5.22",

--- a/src/persist.ts
+++ b/src/persist.ts
@@ -297,9 +297,17 @@ export class SessionStore {
         const next = prev.catch(() => {}).then(() => this.writeNowInner(session));
         this.writeChains.set(id, next);
         // Clean up the chain entry once settled so the Map doesn't grow.
-        next.finally(() => {
-            if (this.writeChains.get(id) === next) this.writeChains.delete(id);
-        });
+        // Clean up the chain entry once settled so the Map doesn't grow. The
+        // .catch() is load-bearing: .finally() returns a derived promise that
+        // nobody else holds — when the chain rejects (disk full, ENOENT after
+        // the dir vanished) it would surface as an unhandledRejection, which
+        // crashes the proxy on default Node settings. The real rejection is
+        // still delivered to the caller of writeNow.
+        next
+            .finally(() => {
+                if (this.writeChains.get(id) === next) this.writeChains.delete(id);
+            })
+            .catch(() => {});
         return next;
     }
 

--- a/tests/e2e-compress-cascade.test.ts
+++ b/tests/e2e-compress-cascade.test.ts
@@ -90,7 +90,7 @@ function compressibleMessages(): CoreMessage[] {
             id: `h_${i}`,
             role: i % 2 === 0 ? "user" : "assistant",
             contentType: "text",
-            text: `historical detail ${i}. ${"x".repeat(2000)}`,
+            text: `historical detail ${i}. ${"x".repeat(6000)}`,
         });
     }
     return msgs;
@@ -109,7 +109,7 @@ test("e2e compress cascade: a 2w limit fires the compress nudge at 2w tokens; a 
         tokenCount,
         renderTags: "text-only",
     });
-    assert.ok(smallTurn.nudge?.shouldInject, "2w tokens at a 2w limit crosses the 70% threshold → compress nudge fires");
+    assert.ok(smallTurn.nudge?.shouldInject, "2w tokens at a 2w limit crosses the threshold and the merged compressible range exceeds minCompressRange → nudge fires (kernel ≥0.0.24 gates pressure nudges on effective pending)");
 
     const large = resolveRequestConfig(BASE, routes(), UPSTREAM, "gpt-large", 1_000_000, GLOBAL);
     assert.equal(large.modelContextLimit, 1_000_000, "native 100w window becomes the kernel context limit");

--- a/tests/proxy-persist.test.ts
+++ b/tests/proxy-persist.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { mkdtempSync, rmSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, relative, sep } from "node:path";
 import { SessionStore } from "../src/persist.ts";
@@ -217,6 +217,35 @@ await withTempStore("hasPending reflects the debounce timer", async (store) => {
     assert.equal(store.hasPending(s.id), true);
     await settle();
     assert.equal(store.hasPending(s.id), false);
+});
+
+// Regression (2026-08-15, windows-latest CI flake on PR #158): the writeNow
+// per-session chain cleaned itself up via `next.finally(...)` — a derived
+// promise nobody held. When the chain rejected (the test's tmpdir was
+// removed before the async write hit the disk → ENOENT), that orphan
+// surfaced as a process-level unhandledRejection and failed the whole test
+// file. In production the same leak means a transient persist failure
+// (disk full, EPERM) crashes the proxy. The caller of writeNow still gets
+// the real rejection; only the cleanup side-effect must swallow.
+await withTempStore("writeNow rejection does not leak an unhandled rejection", async (store) => {
+    // Deterministic failure: point the store at a path whose parent is a
+    // regular FILE, so mkdir(recursive) cannot recreate the directory and
+    // the tmp-file write fails with ENOENT.
+    const blocker = join(tmpdir(), `bili-persist-blocker-${Date.now()}-${process.pid}`);
+    writeFileSync(blocker, "x");
+    const dead = new SessionStore({ dir: join(blocker, "sessions"), debounceMs: 5, enabled: true });
+    const unhandled: unknown[] = [];
+    const onUnhandled = (e: unknown) => unhandled.push(e);
+    process.on("unhandledRejection", onUnhandled);
+    try {
+        const s = makeSession("orphan-check");
+        await assert.rejects(dead.writeNow(s), /ENOENT|ENOTDIR/);
+        await settle(50); // give any orphan a chance to surface
+    } finally {
+        process.off("unhandledRejection", onUnhandled);
+        rmSync(blocker, { force: true });
+    }
+    assert.equal(unhandled.length, 0, `orphan rejection leaked: ${unhandled.map(String).join("; ")}`);
 });
 
 await withTempStore("sessions are namespaced by protocol + provider on disk", async (store, dir) => {


### PR DESCRIPTION
## Ships since v0.1.41 (~28 commits — most user-visible batch pending)

### Security hardening (#141 + follow-ups #153)
- update-lock write race, CONNECT relay gate, tunnel leak, cert cap, hop-by-hop handling
- admin Host pinning used the configured port instead of the bound port (regression fix)

### Real user fixes
- **#147 (+follow-ups)**: thinking signature preserved on compressed re-request — DeepSeek 400 fixed (per-block signatures, fragmented signature_delta, emitReasoning)
- **#61**: session hash uses the full first-user message (was first 200 chars → collisions)

### Features
- **#157**: configurable compression prompts (three-level, risk-gated) + byte-stable default prompts
- e2e coverage: GLM chat-completions bridge (chat relay), streaming Responses, Anthropic /v1/messages, compress cascade at 2w/100w limits

### Dependency
- **acp-kernel 0.0.23 → 0.0.24**: pressure-band restore + effective-pending gating (#70), small-range merge + tier-aware emergency arbitration (#57), tier-stamp rebaseline (#71)
- e2e fixture adapted: kernel ≥0.0.24 suppresses emergency nudges when no merged range reaches minCompressRange (T1 effective 0) — fixture messages grown 2000→6000 chars so the merged range legitimately exceeds the threshold (same adaptation pattern as billion-context-pi e2e 03)

418/418 tests, typecheck (tsconfig.build) clean, build green.