### PR TITLE
feat(launcher): plugin-in-launcher mode — native MCP tools via spawn-time injection (#162)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,16 +104,21 @@ bili pi --mitm-domain api.foo.com     # add a domain to the MITM whitelist
 **Plugin-in-launcher mode (#162)** — for `claude` and `codex` the launcher
 additionally injects a single `bili` MCP server (`--mcp-config` for claude,
 `-c mcp_servers.bili.*` for codex — both ephemeral, nothing written to host
-config) and routes via **direct URL** (claude's `ANTHROPIC_BASE_URL` /
-codex's provider `base_url` pointing at the `/bili/` prefix — no MITM, no CA
-trust). The result is the native-plugin experience of [PLUGIN.md](PLUGIN.md)
+config). The traffic route is **unchanged by default** — the transparent-
+MITM proxy as before — so existing setups keep working exactly as they did
+(OAuth-subscription traffic, custom relay endpoints). Opt in to **direct URL
+routing** (`BILI_LAUNCHER_DIRECT=1`) to drop MITM/CA trust entirely (claude's
+`ANTHROPIC_BASE_URL` / codex's provider `base_url` pointing at the `/bili/`
+prefix); the launcher prints a warning when direct mode changes your traffic
+route. The result is the native-plugin experience of [PLUGIN.md](PLUGIN.md)
 with zero setup: the four ACP tools appear as native MCP tools, executed on
 the proxy under the session lock, while the proxy keeps state, folding,
 philosophy prompt and nudges. Session binding is automatic — claude passes
 its session id to MCP children and on every request; codex spawns bind on
 first sight. Opt-outs: `BILI_LAUNCHER_PLUGIN=0` (plain launcher, wire-injected
-tools), `BILI_LAUNCHER_MITM=1` (old transparent-MITM route, needed for OAuth
-subscription traffic). Mode matrix:
+tools). `BILI_LAUNCHER_DIRECT=1` is an opt-in, not an opt-out.
+
+Mode matrix:
 
 | Mode | Tools surface | Setup | When |
 |------|--------------|-------|------|

--- a/README.md
+++ b/README.md
@@ -115,15 +115,18 @@ with zero setup: the four ACP tools appear as native MCP tools, executed on
 the proxy under the session lock, while the proxy keeps state, folding,
 philosophy prompt and nudges. Session binding is automatic — claude passes
 its session id to MCP children and on every request; codex spawns bind on
-first sight. Opt-outs: `BILI_LAUNCHER_PLUGIN=0` (plain launcher, wire-injected
-tools). `BILI_LAUNCHER_DIRECT=1` is an opt-in, not an opt-out.
+first sight. Plugin mode is opt-in while host-flag compatibility soaks: set
+`BILI_LAUNCHER_PLUGIN=1` to enable the native MCP tools (verified with
+claude 2.1.227 / codex 0.147.0; `BILI_LAUNCHER_PLUGIN=0` forces the plain
+wire-injected launcher once the default flips on).
+`BILI_LAUNCHER_DIRECT=1` is an opt-in, not an opt-out.
 
 Mode matrix:
 
 | Mode | Tools surface | Setup | When |
 |------|--------------|-------|------|
-| Launcher + MCP (default for claude/codex) | native MCP tools | none — just `bili claude` / `bili codex` | best UX |
-| Launcher wire mode (`BILI_LAUNCHER_PLUGIN=0`) | proxy-injected wire tools | none | fallback |
+| Launcher + MCP (`BILI_LAUNCHER_PLUGIN=1`) | native MCP tools | one env var | best UX; opt-in while soaking |
+| Launcher wire mode (default for claude/codex) | proxy-injected wire tools | none — just `bili claude` / `bili codex` | default until plugin mode soaks |
 | Manual plugin (pi etc.) | agent-side plugin | install plugin | hosts with plugin APIs |
 | Manual baseURL | proxy-injected wire tools | edit client config | exotic hosts |
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,27 @@ bili test pi                          # quick end-to-end smoke test of the pi pa
 bili pi --mitm-domain api.foo.com     # add a domain to the MITM whitelist
 ```
 
+**Plugin-in-launcher mode (#162)** — for `claude` and `codex` the launcher
+additionally injects a single `bili` MCP server (`--mcp-config` for claude,
+`-c mcp_servers.bili.*` for codex — both ephemeral, nothing written to host
+config) and routes via **direct URL** (claude's `ANTHROPIC_BASE_URL` /
+codex's provider `base_url` pointing at the `/bili/` prefix — no MITM, no CA
+trust). The result is the native-plugin experience of [PLUGIN.md](PLUGIN.md)
+with zero setup: the four ACP tools appear as native MCP tools, executed on
+the proxy under the session lock, while the proxy keeps state, folding,
+philosophy prompt and nudges. Session binding is automatic — claude passes
+its session id to MCP children and on every request; codex spawns bind on
+first sight. Opt-outs: `BILI_LAUNCHER_PLUGIN=0` (plain launcher, wire-injected
+tools), `BILI_LAUNCHER_MITM=1` (old transparent-MITM route, needed for OAuth
+subscription traffic). Mode matrix:
+
+| Mode | Tools surface | Setup | When |
+|------|--------------|-------|------|
+| Launcher + MCP (default for claude/codex) | native MCP tools | none — just `bili claude` / `bili codex` | best UX |
+| Launcher wire mode (`BILI_LAUNCHER_PLUGIN=0`) | proxy-injected wire tools | none | fallback |
+| Manual plugin (pi etc.) | agent-side plugin | install plugin | hosts with plugin APIs |
+| Manual baseURL | proxy-injected wire tools | edit client config | exotic hosts |
+
 How the client is pointed at the proxy (set automatically in the child env):
 
 | Client      | Proxy redirect      | CA trust env var        |

--- a/devlog/2026-08-16_launcher-plugin-mode/DESIGN.md
+++ b/devlog/2026-08-16_launcher-plugin-mode/DESIGN.md
@@ -1,0 +1,60 @@
+# DESIGN — launcher plugin mode (#162)
+
+## Topology
+
+```
+bili claude / bili codex (launcher, direct-URL mode)
+  ├─ ensure proxy (spawn/reuse 127.0.0.1:8787)
+  ├─ claude: env ANTHROPIC_BASE_URL=http://<proxy>/bili/<upstream>
+  │          --mcp-config <tmp json> {mcpServers.bili → node dist/mcp.js}
+  ├─ codex:  -c mcp_servers.bili.command/args/env (inline TOML overrides)
+  └─ (BILI_LAUNCHER_MITM=1 → old transparent-MITM route instead)
+        ↓ exec host
+host (claude/codex)
+  ├─ LLM traffic   → proxy /bili/<upstream> (data channel)
+  └─ MCP "bili"    → dist/mcp.js stdio
+        ├─ GET  /__bili/plugin/manifest  (schemas, zero drift)
+        ├─ POST /__bili/plugin/register  (bind BEFORE first model request)
+        └─ POST /__bili/plugin/tool      (execute under session lock)
+```
+
+## Session binding — two strategies, one endpoint
+
+`POST /__bili/plugin/register {conversationId, agent, identity}`:
+
+- **identity: true** (claude code): the host puts the SAME id on every model
+  request — `x-claude-code-session-id` === `CLAUDE_CODE_SESSION_ID` (verified
+  against claude 2.1.227 via raw-socket header capture; the env var is passed
+  to MCP children, the header on every request). The registration lands in a
+  `registeredIds` map; ANY later request whose conversation identity matches
+  binds its session into plugin mode. No ordering race: claude -p fires its
+  first model request concurrently with MCP initialize — identity binding
+  catches up on the second request.
+- **identity: false** (headless, launcher-spawned codex): the registration
+  queues; the first request that creates a NEW session consumes it (FIFO).
+  Order-sensitive: the shell awaits the register before answering MCP
+  initialize, so hosts that wait for initialize cannot race past it.
+
+Splitting the two (instead of double-writing both structures) keeps a foreign
+session from eating a registration it can never claim by identity.
+
+## Direct-URL vs MITM
+
+Direct URL is now the default for `bili claude` / `bili codex`: the host talks
+to the proxy via the `/bili/` prefix in its base URL — no MITM, no CA trust.
+Claude's base URL rides on spawn env (ANTHROPIC_BASE_URL), codex's on
+`-c model_providers.*.base_url` (user config already covers routing; the
+launcher only adds the mcp_servers.bili.* overrides). `BILI_LAUNCHER_MITM=1`
+restores the old transparent route for OAuth-subscription traffic.
+
+## Verification notes
+
+- claude 2.1.227 passes `CLAUDE_CODE_SESSION_ID` to MCP children (env probe)
+  and `x-claude-code-session-id` on every request (socket capture) — the two
+  are equal, which is what makes identity binding race-free.
+- codex 0.147.0 accepts `-c mcp_servers.bili.command="node"` style overrides
+  (config parse error disappears; only provider routing failed our e2e because
+  the local relay lacks a Responses endpoint — unrelated to the MCP surface).
+- Real e2e: `bili claude -p "call the bili acp_status tool"` through a bailian
+  anthropic endpoint — proxy log shows `[plugin] tool acp_status executed via
+  plugin`, i.e. the native MCP path, not wire injection.

--- a/devlog/2026-08-16_launcher-plugin-mode/REQ.md
+++ b/devlog/2026-08-16_launcher-plugin-mode/REQ.md
@@ -1,0 +1,27 @@
+# REQ — launcher-first UX: native-plugin experience with zero persistent host config (#162)
+
+## Request
+
+Proxy 版在大多数场景下直接可用：launcher 把所有"需要碰宿主"的动作收敛为 spawn 参数，
+用户只换一个启动命令（`bili claude` / `bili codex`），体验与本地插件版几乎无差别。
+宿主配置文件零写入、已有插件零影响、卸载零残留。是 #161 plugin protocol 的
+launcher 化延伸（plugin-in-launcher, 内外呼应）。
+
+## Acceptance
+
+- [x] `POST /__bili/plugin/register {conversationId, agent, identity}` — 会话预注册
+- [x] 双绑定策略：identity（claude：每请求 x-claude-code-session-id === 注册 id，
+      任意时序可绑）/ headless pending（codex spawn：下一个新会话消费）
+- [x] `bili mcp` — MCP stdio 薄壳：manifest → 4 工具 → /tool 转发；
+      CLAUDE_CODE_SESSION_ID / BILI_CONVERSATION_ID 双来源
+- [x] `bili plugin-register <id>` — CLI 注册子命令（hook 兜底）
+- [x] launcher 直连 URL 模式（claude/codex 默认，BILI_LAUNCHER_MITM=1 退回 MITM）
+- [x] claude：ANTHROPIC_BASE_URL 直传 env + --mcp-config 临时 JSON（无 --settings、无 hooks）
+- [x] codex：-c mcp_servers.bili.* 内联覆盖（实测 0.147 语法被接受）
+- [x] 真机 e2e：claude 2.1.227 经 `bili claude` 启动，MCP 原生调用 acp_status，
+      proxy 日志 `[plugin] tool acp_status executed via plugin`，宿主配置零写入
+
+## Non-goals
+
+- 不持久写宿主配置文件（只走 flag/env/临时文件）
+- 不替代 omp native 模式

--- a/devlog/2026-08-16_launcher-plugin-mode/WORKLOG.md
+++ b/devlog/2026-08-16_launcher-plugin-mode/WORKLOG.md
@@ -1,0 +1,28 @@
+# WORKLOG — launcher plugin mode (#162)
+
+- 2026-08-16: baseline — #161 merged into worktree branch + master (#160) merged,
+  session.ts conflict resolved (peekSession + snapshotMessages both kept), 444/444.
+- register endpoint + pending queue in src/plugin.ts; route in src/server.ts;
+  binding block after getSession (pending consumed only when stats.requests===0).
+- src/mcp.ts stdio shell (manifest → tools → /tool forward); tsup second entry.
+- CLI: `bili mcp` + `bili plugin-register <id>`.
+- launcher: direct-URL mode (claude env ANTHROPIC_BASE_URL; codex -c inline),
+  --mcp-config ephemeral JSON, BILI_LAUNCHER_MITM=1 opt-out, BILI_LAUNCHER_PLUGIN=0 kill switch.
+- Real-host verification loop (claude 2.1.227):
+  - v1 assumed `_meta.ui.sessionId` in MCP initialize — WRONG (claude sends none).
+  - env probe: `CLAUDE_CODE_SESSION_ID` is passed to MCP children → register at
+    initialize; but claude -p races its first model request past initialize →
+    binding missed, session stayed wire mode (`[acp-loop]` in logs).
+  - raw-socket header capture: every request carries `x-claude-code-session-id`
+    === CLAUDE_CODE_SESSION_ID → identity-keyed binding (registeredIds map),
+    race-free on any arrival order.
+  - leak found by test: a foreign session ate a headless registration → split
+    register into identity/headless modes (identity map vs pending queue).
+- Fixed along the way: session.ts merge scar (peekSession closing brace),
+  `initialized`/`PROXY_ORIGIN` declarations lost in mcp.ts edits, direct-entry
+  guard matched only dist/mcp.js (now .ts too), cli.ts export branch restored.
+- Tests: tests/launcher-plugin-mode.test.ts — 6 tests: register validation,
+  identity binding after first request, headless pending binding, no cross-session
+  leak, injection builders, MCP shell stdio (by-id response matching).
+- Full suite 450/450; real e2e `bili claude` → `[plugin] tool acp_status
+  executed via plugin`, host config untouched, tmp MCP config removed on exit.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,6 +24,7 @@ import { loadOptions, ensureConfigTemplate } from "./config.js";
 import { startServer } from "./server.js";
 import { configFile as defaultConfigFile } from "./paths.js";
 import { checkForUpdate, startAutoUpdate } from "./update.js";
+import { runMcpStdio } from "./mcp.js";
 import { runLaunch, runTestPi, isLaunchClient, type ClientName } from "./launcher.js";
 import { exportSession } from "./export.js";
 import { readFileSync } from "node:fs";
@@ -100,7 +101,7 @@ Docs: https://github.com/ranxianglei/billion-context
 `;
 
 type Parsed = {
-    command: "start" | "update" | "help" | "version" | "launch" | "test" | "export";
+    command: "start" | "update" | "help" | "version" | "launch" | "test" | "export" | "plugin-register" | "mcp";
     client?: ClientName;
     clientArgs: string[];
     mitmDomains: string[];
@@ -212,6 +213,11 @@ export function parseArgs(argv: string[]): Parsed {
         } else if (cmd === "export") {
             command = "export";
             exportSelector = positional[1];
+        } else if (cmd === "plugin-register") {
+            command = "plugin-register";
+            exportSelector = positional[1]; // conversation id
+        } else if (cmd === "mcp") {
+            command = "mcp";
         } else if (cmd === "test") {
             const target = positional[1];
             if (target && isLaunchClient(target)) {
@@ -238,6 +244,31 @@ export async function main(): Promise<void> {
     }
     if (command === "version") {
         process.stdout.write(VERSION + "\n");
+        return;
+    }
+    if (command === "plugin-register") {
+        const conversationId = exportSelector?.trim();
+        if (!conversationId) {
+            console.error('bili plugin-register: conversation id is required (e.g. bili plugin-register "$CLAUDE_SESSION_ID" --origin http://127.0.0.1:8787)');
+            process.exit(2);
+        }
+        const origin = (overrides.BILI_MCP_PROXY ?? process.env.BILI_MCP_PROXY ?? "http://127.0.0.1:8787").replace(/\/$/, "");
+        try {
+            const res = await fetch(`${origin}/__bili/plugin/register`, {
+                method: "POST",
+                headers: { "content-type": "application/json" },
+                body: JSON.stringify({ conversationId, agent: "claude" }),
+            });
+            const data = (await res.json()) as { ok?: boolean; error?: string };
+            if (!res.ok || !data.ok) throw new Error(data.error ?? `HTTP ${res.status}`);
+        } catch (error) {
+            console.error(`bili plugin-register: ${error instanceof Error ? error.message : String(error)}`);
+            process.exit(1);
+        }
+        return;
+    }
+    if (command === "mcp") {
+        runMcpStdio();
         return;
     }
     if (command === "export") {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -257,7 +257,7 @@ export async function main(): Promise<void> {
             const res = await fetch(`${origin}/__bili/plugin/register`, {
                 method: "POST",
                 headers: { "content-type": "application/json" },
-                body: JSON.stringify({ conversationId, agent: "claude" }),
+                body: JSON.stringify({ conversationId, agent: "claude", identity: true }),
             });
             const data = (await res.json()) as { ok?: boolean; error?: string };
             if (!res.ok || !data.ok) throw new Error(data.error ?? `HTTP ${res.status}`);

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -285,10 +285,14 @@ export function buildClaudeEnv(
 // spawn-time flags, never touching host config files on disk. ---
 
 /** Direct-URL mode: the host talks to the proxy via the /bili/ prefix (no
- *  MITM/CA). Default ON for claude/codex; set BILI_LAUNCHER_MITM=1 to keep
- *  the old transparent-proxy route (needed for OAuth-subscription traffic). */
+ *  MITM/CA). OPT-IN via BILI_LAUNCHER_DIRECT=1 — the default keeps the
+ *  transparent-proxy (MITM) route so existing `bili claude` / `bili codex`
+ *  setups behave exactly as before: OAuth-subscription traffic and custom
+ *  relay endpoints (ANTHROPIC_BASE_URL / codex provider config) keep working.
+ *  Direct mode changes what the host points at, so it must be a deliberate
+ *  choice, not a silent upgrade. */
 export function launcherDirectUrl(env: NodeJS.ProcessEnv): boolean {
-    return env.BILI_LAUNCHER_MITM !== "1";
+    return env.BILI_LAUNCHER_DIRECT === "1";
 }
 
 /** Ephemeral MCP config for --mcp-config / -c mcp_servers.bili.*: a single
@@ -633,6 +637,17 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
     let piTmpHome: string | undefined;
     const tmpFiles: string[] = [];
     const directUrl = launcherDirectUrl(process.env);
+    if (directUrl) {
+        if (base === "codex") {
+            console.error(
+                "bili: direct-URL mode — codex's LLM traffic does NOT go through the proxy, so compression is not applied (only the bili MCP tool calls do). For full compression use the default MITM mode (unset BILI_LAUNCHER_DIRECT).",
+            );
+        } else if (base === "claude") {
+            console.error(
+                "bili: direct-URL mode — claude's ANTHROPIC_BASE_URL is overridden to the proxy; a pre-configured relay is bypassed unless BILI_CLAUDE_UPSTREAM=<relay> is set. OAuth-subscription traffic requires the default MITM mode.",
+            );
+        }
+    }
     const injectMcp = base !== "pi" && process.env.BILI_LAUNCHER_PLUGIN !== "0";
     const origin = handle.origin;
     if (base === "pi") {

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -281,6 +281,56 @@ export function buildClaudeEnv(
     return env;
 }
 
+// --- Launcher plugin mode (#162): inject the MCP shell + session hooks as
+// spawn-time flags, never touching host config files on disk. ---
+
+/** Direct-URL mode: the host talks to the proxy via the /bili/ prefix (no
+ *  MITM/CA). Default ON for claude/codex; set BILI_LAUNCHER_MITM=1 to keep
+ *  the old transparent-proxy route (needed for OAuth-subscription traffic). */
+export function launcherDirectUrl(env: NodeJS.ProcessEnv): boolean {
+    return env.BILI_LAUNCHER_MITM !== "1";
+}
+
+/** Ephemeral MCP config for --mcp-config / -c mcp_servers.bili.*: a single
+ *  "bili" stdio server running dist/mcp.js. Args are kept flat so codex's
+ *  TOML value parser stays happy. */
+export function buildMcpConfig(origin: string): { mcpServers: { bili: { command: string; args: string[]; env: Record<string, string> } } } {
+    const script = process.argv[1] ? path.resolve(path.dirname(process.argv[1]), "mcp.js") : "bili-mcp";
+    return {
+        mcpServers: {
+            bili: {
+                command: process.execPath,
+                args: [script],
+                env: { BILI_MCP_PROXY: origin },
+            },
+        },
+    };
+}
+
+/** Ephemeral Claude Code settings for --settings: direct-URL mode only needs
+ *  the base URL, which we pass via spawn env (ANTHROPIC_BASE_URL) — no
+ *  settings file, no hooks. Session registration happens inside the MCP
+ *  shell (CLAUDE_CODE_SESSION_ID is passed to MCP children by claude
+ *  itself, verified 2.1.227). */
+export function buildClaudePluginEnv(origin: string, directUrl: boolean, baseEnv: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+    if (!directUrl) return baseEnv;
+    const upstream = baseEnv.BILI_CLAUDE_UPSTREAM?.trim() || "https://api.anthropic.com";
+    return { ...baseEnv, ANTHROPIC_BASE_URL: wrapUpstream(origin, upstream) };
+}
+
+/** Codex: -c inline overrides for the bili MCP server only. */
+export function buildCodexMcpArgs(origin: string): string[] {
+    const script = process.argv[1] ? path.resolve(path.dirname(process.argv[1]), "mcp.js") : "bili-mcp";
+    return [
+        "-c",
+        `mcp_servers.bili.command=${JSON.stringify(process.execPath)}`,
+        "-c",
+        `mcp_servers.bili.args=${JSON.stringify(JSON.stringify([script]))}`,
+        "-c",
+        `mcp_servers.bili.env.BILI_MCP_PROXY=${JSON.stringify(origin)}`,
+    ];
+}
+
 export function preparePiHttpRewrite(
     piHome: string,
     origin: string,
@@ -581,15 +631,34 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
     let env: NodeJS.ProcessEnv;
     let clientArgs = params.clientArgs;
     let piTmpHome: string | undefined;
+    const tmpFiles: string[] = [];
+    const directUrl = launcherDirectUrl(process.env);
+    const injectMcp = base !== "pi" && process.env.BILI_LAUNCHER_PLUGIN !== "0";
+    const origin = handle.origin;
     if (base === "pi") {
-        env = buildPiEnv(handle.origin, ca, process.env);
-        piTmpHome = preparePiHttpRewrite(resolvePiHome(process.env), handle.origin, routes.httpRewrites, routes.httpsRewrites);
+        env = buildPiEnv(origin, ca, process.env);
+        piTmpHome = preparePiHttpRewrite(resolvePiHome(process.env), origin, routes.httpRewrites, routes.httpsRewrites);
         if (piTmpHome) env.PI_CODING_AGENT_DIR = piTmpHome;
     } else if (base === "codex") {
-        env = buildCodexEnv(handle.origin, resolveCombinedCaPath(process.env), process.env);
-        clientArgs = buildCodexArgs(handle.origin, routes.httpRewrites, routes.httpsRewrites, params.clientArgs);
+        if (directUrl) {
+            env = { ...process.env, BILLION_CONTEXT_PROXY: origin };
+            clientArgs = [...buildCodexMcpArgs(origin), ...clientArgs];
+        } else {
+            env = buildCodexEnv(origin, resolveCombinedCaPath(process.env), process.env);
+            clientArgs = buildCodexArgs(origin, routes.httpRewrites, routes.httpsRewrites, clientArgs);
+            if (injectMcp) clientArgs = [...buildCodexMcpArgs(origin), ...clientArgs];
+        }
     } else {
-        env = buildClaudeEnv(handle.origin, ca, routes.httpRewrites, routes.httpsRewrites, process.env);
+        env = directUrl
+            ? buildClaudePluginEnv(origin, true, process.env)
+            : buildClaudeEnv(origin, ca, routes.httpRewrites, routes.httpsRewrites, process.env);
+        if (directUrl) env.BILLION_CONTEXT_PROXY = origin;
+        if (injectMcp) {
+            const mcpFile = path.join(os.tmpdir(), `bili-mcp-${Date.now()}.json`);
+            fs.writeFileSync(mcpFile, JSON.stringify(buildMcpConfig(origin)));
+            tmpFiles.push(mcpFile);
+            clientArgs = ["--mcp-config", mcpFile, ...clientArgs];
+        }
     }
 
     const { command, prefixArgs } = resolveClientCommand(base, process.env);
@@ -607,6 +676,11 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
         if (piTmpHome) {
             try {
                 fs.rmSync(piTmpHome, { recursive: true, force: true });
+            } catch {}
+        }
+        for (const f of tmpFiles) {
+            try {
+                fs.rmSync(f, { force: true });
             } catch {}
         }
     }

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -325,7 +325,7 @@ export function buildCodexMcpArgs(origin: string): string[] {
         "-c",
         `mcp_servers.bili.command=${JSON.stringify(process.execPath)}`,
         "-c",
-        `mcp_servers.bili.args=${JSON.stringify(JSON.stringify([script]))}`,
+        `mcp_servers.bili.args=${JSON.stringify([script])}`,
         "-c",
         `mcp_servers.bili.env.BILI_MCP_PROXY=${JSON.stringify(origin)}`,
     ];

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -296,6 +296,16 @@ export function launcherDirectUrl(env: NodeJS.ProcessEnv): boolean {
     return env.BILI_LAUNCHER_DIRECT === "1";
 }
 
+/** Plugin-in-launcher MCP injection is OPT-IN (`BILI_LAUNCHER_PLUGIN=1`):
+ *  enabling it changes the spawn args of claude/codex, and hosts older than
+ *  the verified builds (claude 2.1.227, codex 0.147.0) have not been tested
+ *  against `--mcp-config` / `-c mcp_servers.*`. Flip the default to on (with
+ *  `!== "0"` semantics) once the flags have soaked; pi is always excluded —
+ *  it has its own native extension (billion-context-pi #154). */
+export function launcherInjectMcp(env: NodeJS.ProcessEnv, base: string): boolean {
+    return base !== "pi" && env.BILI_LAUNCHER_PLUGIN === "1";
+}
+
 /** Ephemeral MCP config for --mcp-config / -c mcp_servers.bili.*: a single
  *  "bili" stdio server running dist/mcp.js. Args are kept flat so codex's
  *  TOML value parser stays happy. */
@@ -660,7 +670,10 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
             );
         }
     }
-    const injectMcp = base !== "pi" && process.env.BILI_LAUNCHER_PLUGIN !== "0";
+    const injectMcp = launcherInjectMcp(process.env, base);
+    if (!injectMcp && (base === "claude" || base === "codex")) {
+        console.error("bili: plugin mode off — set BILI_LAUNCHER_PLUGIN=1 to enable native MCP tools (experimental; verified with claude 2.1.227 / codex 0.147.0).");
+    }
     const origin = handle.origin;
     if (base === "pi") {
         env = buildPiEnv(origin, ca, process.env);

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -25,6 +25,7 @@
  * (not owned). Otherwise a detached proxy child is spawned on that port (or a
  * free one) and OWNED — it is killed when the client exits.
  */
+import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import net from "node:net";
 import os from "node:os";
@@ -322,8 +323,17 @@ export function buildClaudePluginEnv(origin: string, directUrl: boolean, baseEnv
     return { ...baseEnv, ANTHROPIC_BASE_URL: wrapUpstream(origin, upstream) };
 }
 
-/** Codex: -c inline overrides for the bili MCP server only. */
-export function buildCodexMcpArgs(origin: string): string[] {
+/** Codex: -c inline overrides for the bili MCP server only.
+ *
+ *  `conversationId` is a per-spawn UUID injected as BILI_CONVERSATION_ID:
+ *  codex passes no session id to MCP children (verified codex-cli 0.147.0),
+ *  so the MCP shell uses this to self-register headlessly; the first model
+ *  request that creates a NEW session consumes the registration and binds
+ *  the conversation (MITM route — in direct-URL mode the model traffic does
+ *  not reach the proxy and the binding cannot happen, see the direct-mode
+ *  warning). Without it every native tool call fails with "no conversation
+ *  id". */
+export function buildCodexMcpArgs(origin: string, conversationId: string): string[] {
     const script = process.argv[1] ? path.resolve(path.dirname(process.argv[1]), "mcp.js") : "bili-mcp";
     return [
         "-c",
@@ -332,6 +342,8 @@ export function buildCodexMcpArgs(origin: string): string[] {
         `mcp_servers.bili.args=${JSON.stringify([script])}`,
         "-c",
         `mcp_servers.bili.env.BILI_MCP_PROXY=${JSON.stringify(origin)}`,
+        "-c",
+        `mcp_servers.bili.env.BILI_CONVERSATION_ID=${JSON.stringify(conversationId)}`,
     ];
 }
 
@@ -655,13 +667,16 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
         piTmpHome = preparePiHttpRewrite(resolvePiHome(process.env), origin, routes.httpRewrites, routes.httpsRewrites);
         if (piTmpHome) env.PI_CODING_AGENT_DIR = piTmpHome;
     } else if (base === "codex") {
+        // Per-spawn conversation id for the MCP shell's headless
+        // self-registration (codex provides no session id of its own).
+        const codexConversationId = injectMcp ? randomUUID() : undefined;
         if (directUrl) {
             env = { ...process.env, BILLION_CONTEXT_PROXY: origin };
-            clientArgs = [...buildCodexMcpArgs(origin), ...clientArgs];
+            if (codexConversationId) clientArgs = [...buildCodexMcpArgs(origin, codexConversationId), ...clientArgs];
         } else {
             env = buildCodexEnv(origin, resolveCombinedCaPath(process.env), process.env);
             clientArgs = buildCodexArgs(origin, routes.httpRewrites, routes.httpsRewrites, clientArgs);
-            if (injectMcp) clientArgs = [...buildCodexMcpArgs(origin), ...clientArgs];
+            if (injectMcp && codexConversationId) clientArgs = [...buildCodexMcpArgs(origin, codexConversationId), ...clientArgs];
         }
     } else {
         env = directUrl

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -1,0 +1,204 @@
+// MCP stdio thin shell for launcher mode (#162): a single "bili" MCP server
+// the hosts load via --mcp-config / -c mcp_servers.bili. It fetches the
+// proxy's plugin manifest (single source of truth — zero schema drift),
+// exposes the 4 ACP tools over stdio JSON-RPC, and forwards executes to
+// POST /__bili/plugin/tool. Claude Code passes its session id via the MCP
+// initialize request's _meta.ui.sessionId (documented SessionStart context);
+// we also accept BILI_CONVERSATION_ID env (codex spawn-time registration).
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const VERSION = (() => {
+    try {
+        const here = fileURLToPath(import.meta.url);
+        const pkg = path.join(path.dirname(here), "..", "package.json");
+        return (JSON.parse(fs.readFileSync(pkg, "utf8")).version as string) ?? "dev";
+    } catch {
+        return "dev";
+    }
+})();
+type JsonRpcId = string | number | null;
+
+type McpToolDef = {
+    name: string;
+    description?: string;
+    inputSchema: unknown;
+};
+// Claude Code passes the session id as an env var to MCP children (verified
+// against claude 2.1.227: CLAUDE_CODE_SESSION_ID) — and puts the SAME id on
+// every model request (x-claude-code-session-id), so binding is by identity.
+// BILI_CONVERSATION_ID (launcher-spawned hosts like codex) has no matching
+// request id — binding is headless (next NEW session).
+const PROXY_ORIGIN = process.env.BILI_MCP_PROXY ?? "http://127.0.0.1:8787";
+const CONVERSATION_FROM_ENV = process.env.CLAUDE_CODE_SESSION_ID?.trim() || process.env.BILI_CONVERSATION_ID?.trim() || undefined;
+const IDENTITY_BINDING = Boolean(process.env.CLAUDE_CODE_SESSION_ID?.trim());
+let manifestTools: McpToolDef[] = [];
+let conversationId = CONVERSATION_FROM_ENV;
+let registered = false;
+let initialized = false;
+function send(msg: unknown): void {
+    process.stdout.write(JSON.stringify(msg) + "\n");
+}
+
+function sendResult(id: JsonRpcId, result: unknown): void {
+    if (id === null) return; // notification — no response expected
+    send({ jsonrpc: "2.0", id, result });
+}
+
+function sendError(id: JsonRpcId, code: number, message: string): void {
+    if (id === null) return;
+    send({ jsonrpc: "2.0", id, error: { code, message } });
+}
+
+async function fetchManifest(): Promise<void> {
+    const res = await fetch(`${PROXY_ORIGIN}/__bili/plugin/manifest`);
+    if (!res.ok) throw new Error(`manifest fetch failed: ${res.status}`);
+    const data = (await res.json()) as { tools?: Record<string, { name: string; description?: string; input_schema?: unknown }[]> };
+    // Anthropic wire shape is the canonical MCP-compatible schema source.
+    const anthropic = data.tools?.anthropic ?? [];
+    manifestTools = anthropic.map((t) => ({ name: t.name, description: t.description, inputSchema: t.input_schema }));
+    if (manifestTools.length === 0) throw new Error("manifest served no anthropic tools");
+}
+
+async function forwardTool(tool: string, args: unknown): Promise<string> {
+    const res = await fetch(`${PROXY_ORIGIN}/__bili/plugin/tool`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ conversationId, tool, args }),
+    });
+    const data = (await res.json()) as { ok?: boolean; result?: string; error?: string };
+    if (!res.ok || !data.ok) throw new Error(data.error ?? `tool forward failed: ${res.status}`);
+    return data.result ?? "";
+}
+
+const ERR_TOOL = -32602;
+
+async function handleMessage(msg: {
+    id?: JsonRpcId;
+    method?: string;
+    params?: {
+        _meta?: { ui?: { sessionId?: string } };
+        [k: string]: unknown;
+    };
+}): Promise<void> {
+    const { id = null, method } = msg;
+    const params = typeof msg.params === "object" && msg.params !== null ? msg.params : {};
+    switch (method) {
+        case "initialize": {
+            // Session id arrives as an env var on the child process (claude)
+            // or is injected at spawn time (launcher hosts). The MCP spec
+            // guarantees the host waits for this response before calling
+            // tools, and claude -p fires its first model request around the
+            // same time — registering here is still the earliest we can be.
+            // Identity-mode registrations bind on any later request, so the
+            // race only matters for headless mode.
+            const fromMeta = params._meta?.ui?.sessionId?.trim();
+            if (fromMeta) conversationId ??= fromMeta;
+            initialized = true;
+            if (conversationId && !registered) {
+                const registerFetch = fetch(`${PROXY_ORIGIN}/__bili/plugin/register`, {
+                    method: "POST",
+                    headers: { "content-type": "application/json" },
+                    body: JSON.stringify({ conversationId, agent: "mcp", identity: IDENTITY_BINDING }),
+                });
+                if (IDENTITY_BINDING) {
+                    // Identity-mode binding survives any arrival order —
+                    // respond immediately so pipelined hosts are not stuck
+                    // behind the register round-trip.
+                    void registerFetch.catch(() => {});
+                } else {
+                    // Headless binding is order-sensitive: the register MUST
+                    // land before the host's first model request, and hosts
+                    // that pipeline tools/list would otherwise race past it.
+                    await registerFetch.catch(() => {});
+                }
+            }
+            sendResult(id, {
+                protocolVersion: "2025-06-18",
+                serverInfo: { name: "bili", version: VERSION },
+                capabilities: { tools: {} },
+            });
+            return;
+        }
+        case "notifications/initialized":
+            return;
+        case "tools/list": {
+            if (!initialized) {
+                sendError(id, -32002, "server not initialized");
+                return;
+            }
+            sendResult(id, { tools: manifestTools });
+            return;
+        }
+        case "tools/call": {
+            const tool = typeof params.name === "string" ? params.name : "";
+            const args = params.arguments && typeof params.arguments === "object" ? params.arguments : {};
+            if (!tool) {
+                sendError(id, ERR_TOOL, "params.name is required");
+                return;
+            }
+            if (!conversationId) {
+                sendError(id, ERR_TOOL, "no conversation id (set BILI_CONVERSATION_ID or connect via Claude Code MCP session meta)");
+                return;
+            }
+            try {
+                const text = await forwardTool(tool, args);
+                sendResult(id, { content: [{ type: "text", text }], isError: false });
+            } catch (err) {
+                // Tool-level failures are results (isError), not JSON-RPC
+                // errors, so the host surfaces them to the model.
+                sendResult(id, { content: [{ type: "text", text: `bili tool error: ${err instanceof Error ? err.message : String(err)}` }], isError: true });
+            }
+            return;
+        }
+        case "ping":
+            sendResult(id, {});
+            return;
+        default:
+            if (method?.startsWith("notifications/")) return;
+            sendError(id, -32601, `method not found: ${method ?? "(none)"}`);
+    }
+}
+async function mcpMain(): Promise<void> {
+    try {
+        await fetchManifest();
+    } catch (err) {
+        console.error(`bili-mcp: ${err instanceof Error ? err.message : String(err)} (proxy at ${PROXY_ORIGIN})`);
+        process.exit(1);
+    }
+    let buf = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk: string) => {
+        buf += chunk;
+        let nl: number;
+        while ((nl = buf.indexOf("\n")) >= 0) {
+            const line = buf.slice(0, nl).trim();
+            buf = buf.slice(nl + 1);
+            if (!line) continue;
+            let parsed: unknown;
+            try {
+                parsed = JSON.parse(line);
+            } catch {
+                continue;
+            }
+            if (parsed && typeof parsed === "object") {
+                void handleMessage(parsed as Parameters<typeof handleMessage>[0]);
+            }
+        }
+    });
+    process.stdin.on("end", () => process.exit(0));
+}
+
+/** CLI entry (`bili mcp`): the stdio loop keeps the process alive. */
+export function runMcpStdio(): void {
+    void mcpMain();
+}
+
+// Direct entry (dist/mcp.js spawned by the injected MCP config, or the ts
+// source under tsx in tests): run only when invoked as the script itself,
+// never when imported by the CLI.
+if (process.argv[1] && /(?:^|[\\/])mcp\.(?:ts|js)$/.test(process.argv[1])) {
+    void mcpMain();
+}

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -97,6 +97,84 @@ export function rememberPluginMessages(sessionId: string, processed: CoreMessage
     remembered.set(sessionId, { processed, original, nudge });
 }
 
+// Launcher mode (#162): hosts that cannot attach per-request headers
+// (claude/codex spawned by `bili claude` / `bili codex`) pre-register their
+// conversation via POST /__bili/plugin/register — typically from a Claude
+// Code SessionStart hook or at codex spawn time. A pending register is
+// consumed by the FIRST model request that creates a NEW session afterwards
+// (server.ts binding step): that session becomes plugin-mode (native tools,
+// wire injection suppressed) and the conversation id becomes its tool-API key
+// — no x-bili-plugin headers required.
+export type PendingPluginRegister = { conversationId: string; agent: string; ts: number };
+
+const MAX_PENDING_REGISTERS = 64;
+
+const pendingRegisters: PendingPluginRegister[] = [];
+
+/** Queue a launcher-mode registration. `identity: true` means the host puts
+ *  the SAME id on every model request (claude code: x-claude-code-session-id
+ *  === CLAUDE_CODE_SESSION_ID) — bind by identity match only. `identity:
+ *  false` (headless codex spawn) means requests carry no matching id — bind
+ *  the next NEW session instead. Splitting the two keeps a foreign session
+ *  from eating an identity registration it can never claim. */
+export function queuePluginRegister(conversationId: string, agent: string, identity: boolean): void {
+    if (!identity) {
+        for (let i = 0; i < pendingRegisters.length; i++) {
+            if (pendingRegisters[i]!.conversationId === conversationId) {
+                pendingRegisters.splice(i, 1);
+                break;
+            }
+        }
+        pendingRegisters.push({ conversationId, agent, ts: Date.now() });
+        while (pendingRegisters.length > MAX_PENDING_REGISTERS) pendingRegisters.shift();
+    } else {
+        registeredIds.set(conversationId, agent);
+        while (registeredIds.size > MAX_PENDING_REGISTERS) {
+            const oldest = registeredIds.keys().next().value;
+            if (oldest !== undefined) registeredIds.delete(oldest);
+        }
+    }
+}
+
+/** Take (and remove) the oldest pending registration — called by the server
+ *  when a model request resolves a NEW session, to bind that session into
+ *  plugin mode. */
+export function takePendingPluginRegister(): PendingPluginRegister | undefined {
+    return pendingRegisters.shift();
+}
+const registeredIds = new Map<string, string>();
+
+/** Identity-driven binding (#162): hosts whose model requests carry the SAME
+ *  id the MCP shell registered (claude code: every request has
+ *  x-claude-code-session-id === CLAUDE_CODE_SESSION_ID === the registered
+ *  conversation id) bind the moment any of their requests shows up — no
+ *  ordering race with the shell's initialize. */
+export function consumePluginRegisterFor(conversationId: string): string | undefined {
+    const agent = registeredIds.get(conversationId);
+    if (agent !== undefined) registeredIds.delete(conversationId);
+    return agent;
+}
+
+export function handlePluginRegister(payload: string, res: import("node:http").ServerResponse): void {
+    let parsed: { conversationId?: unknown; agent?: unknown; identity?: unknown };
+    try {
+        parsed = JSON.parse(payload) as { conversationId?: unknown; agent?: unknown; identity?: unknown };
+    } catch {
+        res.writeHead(400, { "content-type": "application/json" });
+        res.end(JSON.stringify({ ok: false, error: "invalid JSON body" }));
+        return;
+    }
+    const conversationId = typeof parsed.conversationId === "string" ? parsed.conversationId.trim() : "";
+    if (!conversationId) {
+        res.writeHead(400, { "content-type": "application/json" });
+        res.end(JSON.stringify({ ok: false, error: "conversationId is required" }));
+        return;
+    }
+    const agent = typeof parsed.agent === "string" && parsed.agent.trim() ? parsed.agent.trim() : "launcher";
+    queuePluginRegister(conversationId, agent, parsed.identity === true);
+    res.end(JSON.stringify({ ok: true, conversationId, agent }));
+}
+
 export function handlePluginManifest(res: import("node:http").ServerResponse): void {
     res.writeHead(200, { "content-type": "application/json" });
     res.end(JSON.stringify({
@@ -372,4 +450,6 @@ export async function pipePluginJson(
 export function _resetPluginStateForTest(): void {
     conversations.clear();
     remembered.clear();
+    pendingRegisters.length = 0;
+    registeredIds.clear();
 }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -136,10 +136,22 @@ export function queuePluginRegister(conversationId: string, agent: string, ident
     }
 }
 
+/** Headless registrations expire: a registration that no new session has
+ *  claimed within this window was orphaned (the spawn never happened, or the
+ *  session was created by some other path). Binding a stale one to an
+ *  unrelated later session would turn that session into plugin mode with a
+ *  foreign conversation id. */
+const PENDING_REGISTER_TTL_MS = 10 * 60 * 1000;
+
 /** Take (and remove) the oldest pending registration — called by the server
  *  when a model request resolves a NEW session, to bind that session into
- *  plugin mode. */
+ *  plugin mode. Expired (orphaned) registrations are dropped, never bound.
+ *  Entries are appended in time order, so pruning from the front suffices. */
 export function takePendingPluginRegister(): PendingPluginRegister | undefined {
+    const now = Date.now();
+    while (pendingRegisters.length > 0 && now - pendingRegisters[0]!.ts > PENDING_REGISTER_TTL_MS) {
+        pendingRegisters.shift();
+    }
     return pendingRegisters.shift();
 }
 const registeredIds = new Map<string, string>();

--- a/src/server.ts
+++ b/src/server.ts
@@ -53,7 +53,7 @@ import { rewriteOpenaiJsonResponse } from "./stream-openai.js";
 import { rewriteResponsesJsonResponse } from "./stream-responses.js";
 import { emitStreamError } from "./stream-error.js";
 import { deriveSessionId as deriveProxySessionId, affinityToken, clientConversationHeader, type ConversationIdentity } from "./session-id.js";
-import { handlePluginManifest, handlePluginStatus, handlePluginTool, pipePluginJson, pipeThroughWithUsage, pluginAgentHeader, pluginContextWindowHeader, pluginConversationHeader, recordPluginSession, rememberPluginMessages } from "./plugin.js";
+import { consumePluginRegisterFor, handlePluginManifest, handlePluginRegister, handlePluginStatus, handlePluginTool, pipePluginJson, pipeThroughWithUsage, pluginAgentHeader, pluginContextWindowHeader, pluginConversationHeader, recordPluginSession, rememberPluginMessages, takePendingPluginRegister } from "./plugin.js";
 import { setupMitm, readMitmUpstream } from "./mitm.js";
 import type { BiliMessage } from "acp-kernel/wire";
 import { isLoopbackAddress } from "./util.js";
@@ -481,6 +481,17 @@ async function handle(
             return;
         }
     }
+    if (req.method === "POST" && req.url === "/__bili/plugin/register") {
+        try {
+            const body = await readBody(req);
+            handlePluginRegister(body.toString("utf8"), res);
+            return;
+        } catch (err) {
+            res.writeHead(err instanceof BodyTooLargeError ? 413 : 400, { "content-type": "application/json" });
+            res.end(JSON.stringify({ ok: false, error: String(err) }));
+            return;
+        }
+    }
 
     // Bili does not support WebSocket — reject any upgrade with 426 so clients
     // with built-in fast-fallback (e.g. Codex supports_websockets=true) retry over HTTP POST.
@@ -603,8 +614,17 @@ async function handle(
         // manifest) — wire tool injection is suppressed and the compress loop
         // never intercepts proxy-named tool calls. Philosophy prompt + nudge
         // keep flowing from here; state + folding stay proxy-owned.
-        const pluginAgent = pluginAgentHeader(req.headers);
-        const pluginMode = pluginAgent !== undefined;
+        //
+        // Launcher mode (#162) is the header-less variant: hosts that cannot
+        // attach per-request headers (claude/codex spawned by `bili claude`
+        // / `bili codex`) POST /__bili/plugin/register first (Claude Code
+        // SessionStart hook / codex spawn). The FIRST request that creates a
+        // NEW session consumes the pending register — that session is plugin
+        // mode from then on, keyed by the registered conversation id, and the
+        // binding sticks via session.metadata.pluginAgent. stats.requests
+        // increments inside prepare() below, so === 0 here means first sight.
+        let pluginAgent = pluginAgentHeader(req.headers);
+        let pluginConversation = pluginConversationHeader(req.headers);
         // The client's own conversation header (x-session-id / x-session-affinity
         // / x-opencode-session / x-acp-session) is the STRONGEST signal that two
         // requests belong to the same conversation — much stronger than the
@@ -644,11 +664,33 @@ async function handle(
             ? responsesIdentity.value
             : clientConversationHeader(req.headers);
         const session = getSession(sessionId, { protocol, upstreamOrigin, label: clientLabel ?? undefined });
-        if (pluginMode) {
+        // Launcher-mode binding (#162): prefer identity — claude code sends
+        // x-claude-code-session-id on every request, equal to the
+        // CLAUDE_CODE_SESSION_ID the MCP shell registered, so binding is
+        // race-free. Fall back to the headless pending queue (codex spawn)
+        // for the first request that creates a new session.
+        if (!pluginAgent) {
+            const identityAgent = consumePluginRegisterFor(clientConv ?? conversation);
+            if (identityAgent) {
+                pluginAgent = identityAgent;
+                pluginConversation = clientConv ?? conversation;
+            }
+        }
+        if (!pluginAgent && session.stats.requests === 0) {
+            const pending = takePendingPluginRegister();
+            if (pending) {
+                pluginAgent = pending.agent;
+                pluginConversation = pending.conversationId;
+            }
+        }
+        if (!pluginAgent && typeof session.metadata.pluginAgent === "string") pluginAgent = session.metadata.pluginAgent;
+        if (pluginAgent && !pluginConversation) pluginConversation = conversation;
+        if (pluginAgent) {
             if (session.metadata.pluginAgent !== pluginAgent) session.metadata.pluginAgent = pluginAgent;
             session.metadata.effectiveContextLimit = reqConfig.modelContextLimit;
-            recordPluginSession(pluginConversationHeader(req.headers) ?? conversation, session.id);
+            recordPluginSession(pluginConversation ?? conversation, session.id);
         }
+        const pluginMode = pluginAgent !== undefined;
         // acquireInFlight must precede the lock so evictOldest() cannot flush
         // this session between getSession and lock acquisition (inFlight===0
         // window). Released in the outer finally after forward completes.

--- a/tests/launcher-plugin-mode.test.ts
+++ b/tests/launcher-plugin-mode.test.ts
@@ -204,6 +204,14 @@ test("launcher injection builders: direct-URL env, MCP config JSON, codex -c arg
     assert.match(args[1]!, /^mcp_servers\.bili\.command=/);
     assert.match(args[3]!, /^mcp_servers\.bili\.args=/);
     assert.match(args[5]!, /^mcp_servers\.bili\.env\.BILI_MCP_PROXY=/);
+    // codex-cli parses these -c values as TOML: args MUST be a TOML array,
+    // not a JSON-encoded string — a double-encoded value makes codex refuse
+    // to start ("invalid type: string ..., expected a sequence").
+    const argsValue = args[3]!.slice("mcp_servers.bili.args=".length);
+    assert.match(argsValue, /^\[.*\]$/, "args is a TOML array, not a stringified array");
+    const parsedArgs = JSON.parse(argsValue) as unknown[];
+    assert.ok(Array.isArray(parsedArgs) && parsedArgs.length === 1, "exactly one argument");
+    assert.ok(String(parsedArgs[0]).endsWith("mcp.js"), "argument is the mcp script path");
 });
 
 test("mcp stdio shell: manifest → tools/list → tools/call forwards to the plugin tool endpoint", async () => {

--- a/tests/launcher-plugin-mode.test.ts
+++ b/tests/launcher-plugin-mode.test.ts
@@ -186,8 +186,9 @@ test("launcher identity binding does not leak onto other sessions", async () => 
 });
 
 test("launcher injection builders: direct-URL env, MCP config JSON, codex -c args", () => {
-    assert.equal(launcherDirectUrl({}), true, "direct URL is the default");
-    assert.equal(launcherDirectUrl({ BILI_LAUNCHER_MITM: "1" }), false, "MITM opt-out honored");
+    assert.equal(launcherDirectUrl({}), false, "transparent-MITM route is the default (existing launcher compatibility)");
+    assert.equal(launcherDirectUrl({ BILI_LAUNCHER_DIRECT: "1" }), true, "direct URL is opt-in");
+    assert.equal(launcherDirectUrl({ BILI_LAUNCHER_DIRECT: "0" }), false, "explicit opt-out honored");
 
     const env = buildClaudePluginEnv("http://127.0.0.1:8787", true, { HOME: "/h" });
     assert.equal(env.ANTHROPIC_BASE_URL, "http://127.0.0.1:8787/bili/https://api.anthropic.com");

--- a/tests/launcher-plugin-mode.test.ts
+++ b/tests/launcher-plugin-mode.test.ts
@@ -11,7 +11,7 @@ import { startServer, type ProxyOptions } from "../src/server.ts";
 import { SessionStore, _setStoreForTest } from "../src/persist.ts";
 import { _setForTest as setRegistryForTest } from "../src/registry.ts";
 import { _resetPluginStateForTest } from "../src/plugin.ts";
-import { buildClaudePluginEnv, buildCodexMcpArgs, buildMcpConfig, launcherDirectUrl } from "../src/launcher.ts";
+import { buildClaudePluginEnv, buildCodexMcpArgs, buildMcpConfig, launcherDirectUrl, launcherInjectMcp } from "../src/launcher.ts";
 
 // Launcher mode (#162): hosts that cannot attach per-request headers
 // (claude/codex spawned by `bili claude` / `bili codex`) bind into plugin mode
@@ -189,6 +189,17 @@ test("launcher injection builders: direct-URL env, MCP config JSON, codex -c arg
     assert.equal(launcherDirectUrl({}), false, "transparent-MITM route is the default (existing launcher compatibility)");
     assert.equal(launcherDirectUrl({ BILI_LAUNCHER_DIRECT: "1" }), true, "direct URL is opt-in");
     assert.equal(launcherDirectUrl({ BILI_LAUNCHER_DIRECT: "0" }), false, "explicit opt-out honored");
+
+    // MCP injection is OPT-IN (#163): spawn args change when enabled and
+    // hosts older than the verified builds (claude 2.1.227, codex 0.147.0)
+    // are untested against the injection flags — default-off keeps existing
+    // `bili claude` / `bili codex` spawns byte-identical.
+    assert.equal(launcherInjectMcp({}, "claude"), false, "plugin injection off by default (claude)");
+    assert.equal(launcherInjectMcp({}, "codex"), false, "plugin injection off by default (codex)");
+    assert.equal(launcherInjectMcp({ BILI_LAUNCHER_PLUGIN: "0" }, "claude"), false, "explicit opt-out honored");
+    assert.equal(launcherInjectMcp({ BILI_LAUNCHER_PLUGIN: "1" }, "claude"), true, "opt-in enables injection");
+    assert.equal(launcherInjectMcp({ BILI_LAUNCHER_PLUGIN: "1" }, "codex"), true, "opt-in enables injection (codex)");
+    assert.equal(launcherInjectMcp({ BILI_LAUNCHER_PLUGIN: "1" }, "pi"), false, "pi always excluded (native extension #154)");
 
     const env = buildClaudePluginEnv("http://127.0.0.1:8787", true, { HOME: "/h" });
     assert.equal(env.ANTHROPIC_BASE_URL, "http://127.0.0.1:8787/bili/https://api.anthropic.com");

--- a/tests/launcher-plugin-mode.test.ts
+++ b/tests/launcher-plugin-mode.test.ts
@@ -1,0 +1,262 @@
+import assert from "node:assert";
+import http from "node:http";
+import { once } from "node:events";
+import test from "node:test";
+import { spawn } from "node:child_process";
+
+process.env.NODE_ENV = "test";
+
+import { defaultConfig } from "acp-kernel";
+import { startServer, type ProxyOptions } from "../src/server.ts";
+import { SessionStore, _setStoreForTest } from "../src/persist.ts";
+import { _setForTest as setRegistryForTest } from "../src/registry.ts";
+import { _resetPluginStateForTest } from "../src/plugin.ts";
+import { buildClaudePluginEnv, buildCodexMcpArgs, buildMcpConfig, launcherDirectUrl } from "../src/launcher.ts";
+
+// Launcher mode (#162): hosts that cannot attach per-request headers
+// (claude/codex spawned by `bili claude` / `bili codex`) bind into plugin mode
+// via POST /__bili/plugin/register. Two binding strategies, both covered:
+//   1. identity-driven (claude code): every model request carries
+//      x-claude-code-session-id === the CLAUDE_CODE_SESSION_ID the MCP shell
+//      registered — binds regardless of arrival order,
+//   2. headless pending (codex spawn): the register queues; the first request
+//      that creates a NEW session consumes it.
+
+function listen(server: http.Server): Promise<void> {
+    if (server.listening) return Promise.resolve();
+    return once(server, "listening").then(() => undefined);
+}
+
+function close(server: http.Server): Promise<void> {
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    server.close((error) => (error ? reject(error) : resolve()));
+    return promise;
+}
+
+function anthropicSse(event: string, data: unknown): string {
+    return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+function textScript(): string {
+    return anthropicSse("message_start", { type: "message_start", message: { id: "m1", role: "assistant", usage: { input_tokens: 42 } } }) +
+        anthropicSse("content_block_start", { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } }) +
+        anthropicSse("content_block_delta", { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "ok" } }) +
+        anthropicSse("content_block_stop", { type: "content_block_stop", index: 0 }) +
+        anthropicSse("message_delta", { type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 2 } }) +
+        anthropicSse("message_stop", { type: "message_stop" });
+}
+
+interface Rig {
+    proxyPort: number;
+    upstreamPort: number;
+    proxyUrl: (path: string) => string;
+    modelUrl: () => string;
+    upstreamBodies: string[];
+    closeAll(): Promise<void>;
+}
+
+async function startRig(): Promise<Rig> {
+    const upstreamBodies: string[] = [];
+    const upstream = http.createServer((req, res) => {
+        const chunks: Buffer[] = [];
+        req.on("data", (c: Buffer) => chunks.push(c));
+        req.on("end", () => {
+            upstreamBodies.push(Buffer.concat(chunks).toString("utf8"));
+            res.writeHead(200, { "content-type": "text/event-stream" });
+            res.end(textScript());
+        });
+    });
+    upstream.listen(0, "127.0.0.1");
+    await listen(upstream);
+    const upstreamPort = (upstream.address() as { port: number }).port;
+
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    setRegistryForTest({});
+    _resetPluginStateForTest();
+
+    const opts: ProxyOptions = {
+        port: 0,
+        host: "127.0.0.1",
+        upstream: "http://127.0.0.1",
+        routes: { [`http://127.0.0.1:${upstreamPort}`]: { models: { "l162-model": { context: 100_000 } } } },
+        modelContextLimit: 100_000,
+        kernelConfig: defaultConfig(100_000),
+        compress: { injectTool: true, injectNudge: true },
+        promptCache: { routing: "auto" },
+        log: false,
+        sessionHeader: "x-acp-session",
+        debug: false,
+        passthrough: false,
+        autoUpdate: false,
+        mitm: { enabled: false, domains: [] },
+    };
+    const proxy = await startServer(opts);
+    await listen(proxy);
+    const proxyPort = (proxy.address() as { port: number }).port;
+    return {
+        upstreamPort,
+        proxyUrl: (path) => `http://127.0.0.1:${proxyPort}${path}`,
+        modelUrl: () => `http://127.0.0.1:${proxyPort}/bili/http://127.0.0.1:${upstreamPort}/v1/messages`,
+        upstreamBodies,
+        closeAll: async () => {
+            await close(proxy);
+            await close(upstream);
+        },
+    };
+}
+
+function postModel(rig: Rig, sessionHeader?: string): Promise<Response> {
+    const headers: Record<string, string> = { "content-type": "application/json" };
+    if (sessionHeader) headers["x-claude-code-session-id"] = sessionHeader;
+    return fetch(rig.modelUrl(), {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ model: "l162-model", max_tokens: 10, stream: true, messages: [{ role: "user", content: "hello" }] }),
+    });
+}
+
+async function register(rig: Rig, conversationId: string, opts?: { agent?: string; identity?: boolean }): Promise<void> {
+    const res = await fetch(rig.proxyUrl("/__bili/plugin/register"), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ conversationId, agent: opts?.agent, identity: opts?.identity ?? false }),
+    });
+    assert.equal(res.status, 200, "register accepted");
+}
+
+test("launcher register endpoint: validates body and echoes the registration", async () => {
+    const rig = await startRig();
+    try {
+        const bad = await fetch(rig.proxyUrl("/__bili/plugin/register"), { method: "POST", headers: { "content-type": "application/json" }, body: "not json" });
+        assert.equal(bad.status, 400);
+        const missing = await fetch(rig.proxyUrl("/__bili/plugin/register"), { method: "POST", headers: { "content-type": "application/json" }, body: "{}" });
+        assert.equal(missing.status, 400);
+        await register(rig, "reg-a");
+    } finally {
+        await rig.closeAll();
+    }
+});
+
+test("launcher identity binding: register arriving AFTER the first request still binds (the -p race)", async () => {
+    const rig = await startRig();
+    try {
+        // Reversed order on purpose: claude -p fires its first model request
+        // concurrently with the MCP shell's initialize. The first request is
+        // NOT plugin mode (wire tools injected)…
+        await postModel(rig, "sess-identity-1");
+        assert.ok(rig.upstreamBodies[0]!.includes("compress"), "wire tools injected before binding");
+        // …then the shell registers; the SECOND request carries the same
+        // x-claude-code-session-id and must bind via identity.
+        await register(rig, "sess-identity-1", { agent: "mcp", identity: true });
+        await postModel(rig, "sess-identity-1");
+        assert.ok(!rig.upstreamBodies[1]!.includes("\"compress\"", ), "wire tool injection suppressed after identity binding");
+        const status = await (await fetch(rig.proxyUrl("/__bili/plugin/status?conversationId=sess-identity-1"))).json() as { ok: boolean; pluginAgent?: string };
+        assert.ok(status.ok, "conversation registered");
+        assert.equal(status.pluginAgent, "mcp");
+    } finally {
+        await rig.closeAll();
+    }
+});
+
+test("launcher headless pending binding: register BEFORE the first request binds the new session (codex spawn)", async () => {
+    const rig = await startRig();
+    try {
+        await register(rig, "headless-conv-1", { agent: "mcp" });
+        await postModel(rig); // no session header at all
+        assert.ok(!rig.upstreamBodies[0]!.includes("\"compress\""), "wire tool injection suppressed from the very first request");
+        const status = await (await fetch(rig.proxyUrl("/__bili/plugin/status?conversationId=headless-conv-1"))).json() as { ok: boolean; pluginAgent?: string };
+        assert.ok(status.ok, "pending register consumed by the new session");
+        assert.equal(status.pluginAgent, "mcp");
+    } finally {
+        await rig.closeAll();
+    }
+});
+
+test("launcher identity binding does not leak onto other sessions", async () => {
+    const rig = await startRig();
+    try {
+        await register(rig, "sess-mine", { agent: "mcp", identity: true });
+        await postModel(rig, "sess-other"); // different conversation id
+        assert.ok(rig.upstreamBodies[0]!.includes("compress"), "unregistered conversation stays wire mode");
+        const status = await (await fetch(rig.proxyUrl("/__bili/plugin/status?conversationId=sess-mine"))).json() as { ok: boolean };
+        assert.ok(!status.ok, "registration not consumed by a foreign session");
+    } finally {
+        await rig.closeAll();
+    }
+});
+
+test("launcher injection builders: direct-URL env, MCP config JSON, codex -c args", () => {
+    assert.equal(launcherDirectUrl({}), true, "direct URL is the default");
+    assert.equal(launcherDirectUrl({ BILI_LAUNCHER_MITM: "1" }), false, "MITM opt-out honored");
+
+    const env = buildClaudePluginEnv("http://127.0.0.1:8787", true, { HOME: "/h" });
+    assert.equal(env.ANTHROPIC_BASE_URL, "http://127.0.0.1:8787/bili/https://api.anthropic.com");
+    assert.equal(env.HOME, "/h", "base env preserved");
+    assert.equal(buildClaudePluginEnv("http://127.0.0.1:8787", false, { HOME: "/h" }).ANTHROPIC_BASE_URL, undefined, "MITM mode leaves the base URL alone");
+
+    const mcp = buildMcpConfig("http://127.0.0.1:8787");
+    assert.equal(mcp.mcpServers.bili.command, process.execPath);
+    assert.match(mcp.mcpServers.bili.args[0]!, /mcp\.js$/);
+    assert.equal(mcp.mcpServers.bili.env.BILI_MCP_PROXY, "http://127.0.0.1:8787");
+
+    const args = buildCodexMcpArgs("http://127.0.0.1:8787");
+    assert.deepEqual(args[0], "-c");
+    assert.match(args[1]!, /^mcp_servers\.bili\.command=/);
+    assert.match(args[3]!, /^mcp_servers\.bili\.args=/);
+    assert.match(args[5]!, /^mcp_servers\.bili\.env\.BILI_MCP_PROXY=/);
+});
+
+test("mcp stdio shell: manifest → tools/list → tools/call forwards to the plugin tool endpoint", async () => {
+    const rig = await startRig();
+    // Bind a conversation first so acp_status has a session to report on.
+    await register(rig, "mcp-shell-conv", { agent: "mcp" });
+    await postModel(rig, "mcp-shell-conv");
+
+    const shell = spawn(process.execPath, ["--import", "tsx", "src/mcp.ts"], {
+        env: {
+            ...process.env,
+            BILI_MCP_PROXY: rig.proxyUrl(""),
+            BILI_CONVERSATION_ID: "mcp-shell-conv",
+        },
+        stdio: ["pipe", "pipe", "pipe"],
+    });
+    const { promise: settled, resolve: settledOk, reject: settledErr } = Promise.withResolvers<void>();
+    const lines: string[] = [];
+    shell.stdout.on("data", (d: Buffer) => {
+        let chunk = d.toString("utf8");
+        let nl: number;
+        while ((nl = chunk.indexOf("\n")) >= 0) {
+            const line = chunk.slice(0, nl).trim();
+            chunk = chunk.slice(nl + 1);
+            if (line.startsWith("{")) lines.push(line);
+        }
+        if (lines.length === 3) settledOk(); // initialize + tools/list + tools/call
+    });
+    shell.stderr.on("data", () => {});
+    shell.on("error", settledErr);
+    const send = (msg: unknown) => shell.stdin.write(JSON.stringify(msg) + "\n");
+
+    send({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: "t", version: "0" } } });
+    send({ jsonrpc: "2.0", method: "notifications/initialized" });
+    send({ jsonrpc: "2.0", id: 2, method: "tools/list" });
+    send({ jsonrpc: "2.0", id: 3, method: "tools/call", params: { name: "acp_status", arguments: {} } });
+
+    try {
+        await settled;
+    } finally {
+        shell.kill();
+        await rig.closeAll();
+    }
+
+    const out = lines;
+
+    const byId = (n: number): Record<string, unknown> => JSON.parse(out.find((l) => (JSON.parse(l) as { id?: number }).id === n) ?? "{}");
+
+    const init = byId(1) as { result?: { serverInfo?: { name?: string } } };
+    assert.equal(init.result?.serverInfo?.name, "bili");
+    const tools = byId(2) as { result?: { tools?: { name: string }[] } };
+    assert.deepEqual(tools.result?.tools?.map((t) => t.name).sort(), ["acp_status", "compress", "decompress", "search_context"]);
+    const call = byId(3) as { result?: { content?: { text?: string }[]; isError?: boolean } };
+    assert.equal(call.result?.isError, false);
+    assert.match(call.result?.content?.[0]?.text ?? "", /CONTEXT BREAKDOWN/, "acp_status result forwarded verbatim");
+});

--- a/tests/launcher-plugin-mode.test.ts
+++ b/tests/launcher-plugin-mode.test.ts
@@ -200,7 +200,8 @@ test("launcher injection builders: direct-URL env, MCP config JSON, codex -c arg
     assert.match(mcp.mcpServers.bili.args[0]!, /mcp\.js$/);
     assert.equal(mcp.mcpServers.bili.env.BILI_MCP_PROXY, "http://127.0.0.1:8787");
 
-    const args = buildCodexMcpArgs("http://127.0.0.1:8787");
+    const codexConvId = "11111111-2222-4333-8444-555555555555";
+    const args = buildCodexMcpArgs("http://127.0.0.1:8787", codexConvId);
     assert.deepEqual(args[0], "-c");
     assert.match(args[1]!, /^mcp_servers\.bili\.command=/);
     assert.match(args[3]!, /^mcp_servers\.bili\.args=/);
@@ -213,6 +214,10 @@ test("launcher injection builders: direct-URL env, MCP config JSON, codex -c arg
     const parsedArgs = JSON.parse(argsValue) as unknown[];
     assert.ok(Array.isArray(parsedArgs) && parsedArgs.length === 1, "exactly one argument");
     assert.ok(String(parsedArgs[0]).endsWith("mcp.js"), "argument is the mcp script path");
+    // codex passes no session id to MCP children, so the launcher injects a
+    // per-spawn conversation id for the shell's headless self-registration.
+    assert.match(args[7]!, /^mcp_servers\.bili\.env\.BILI_CONVERSATION_ID=/);
+    assert.equal(args[7]!.slice("mcp_servers.bili.env.BILI_CONVERSATION_ID=".length), JSON.stringify(codexConvId));
 });
 
 test("mcp stdio shell: manifest → tools/list → tools/call forwards to the plugin tool endpoint", async () => {
@@ -268,4 +273,74 @@ test("mcp stdio shell: manifest → tools/list → tools/call forwards to the pl
     const call = byId(3) as { result?: { content?: { text?: string }[]; isError?: boolean } };
     assert.equal(call.result?.isError, false);
     assert.match(call.result?.content?.[0]?.text ?? "", /CONTEXT BREAKDOWN/, "acp_status result forwarded verbatim");
+});
+
+test("mcp stdio shell (codex style): BILI_CONVERSATION_ID self-register → headless binding → tools/call", async () => {
+    // The exact flow `bili codex` now produces (default MITM route): the
+    // launcher passes BILI_CONVERSATION_ID, the shell self-registers
+    // headlessly on initialize (no manual register, no identity header), the
+    // first NEW-session model request consumes the pending registration, and
+    // tool calls through the shell resolve.
+    const rig = await startRig();
+    const conv = "codex-e2e-conv-1";
+    let status: { ok: boolean; pluginAgent?: string } = { ok: false };
+
+    const shell = spawn(process.execPath, ["--import", "tsx", "src/mcp.ts"], {
+        env: {
+            ...process.env,
+            BILI_MCP_PROXY: rig.proxyUrl(""),
+            BILI_CONVERSATION_ID: conv,
+            // deliberately NO CLAUDE_CODE_SESSION_ID — codex passes none.
+        },
+        stdio: ["pipe", "pipe", "pipe"],
+    });
+    const { promise: settled, resolve: settledOk, reject: settledErr } = Promise.withResolvers<void>();
+    const lines: string[] = [];
+    shell.stdout.on("data", (d: Buffer) => {
+        let chunk = d.toString("utf8");
+        let nl: number;
+        while ((nl = chunk.indexOf("\n")) >= 0) {
+            const line = chunk.slice(0, nl).trim();
+            chunk = chunk.slice(nl + 1);
+            if (line.startsWith("{")) {
+                lines.push(line);
+                if (lines.length === 1) {
+                    // initialize answered → the headless register has landed
+                    // (the shell awaits it before responding). Consume it via
+                    // a fresh model session, then ask for tools.
+                    void postModel(rig).then(() => {
+                        send({ jsonrpc: "2.0", id: 2, method: "tools/list" });
+                        send({ jsonrpc: "2.0", id: 3, method: "tools/call", params: { name: "acp_status", arguments: {} } });
+                    });
+                } else if (lines.length === 3) {
+                    settledOk();
+                }
+            }
+        }
+    });
+    shell.stderr.on("data", () => {});
+    shell.on("error", settledErr);
+    const send = (msg: unknown) => shell.stdin.write(JSON.stringify(msg) + "\n");
+
+    send({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: "t", version: "0" } } });
+    send({ jsonrpc: "2.0", method: "notifications/initialized" });
+
+    try {
+        await settled;
+        // The headless registration was consumed by the model session — the
+        // conversation is bound in the proxy. (Must run before closeAll.)
+        status = await (await fetch(rig.proxyUrl(`/__bili/plugin/status?conversationId=${conv}`))).json() as { ok: boolean; pluginAgent?: string };
+    } finally {
+        shell.kill();
+        await rig.closeAll();
+    }
+
+    const byId = (n: number): Record<string, unknown> => JSON.parse(lines.find((l) => (JSON.parse(l) as { id?: number }).id === n) ?? "{}");
+    const tools = byId(2) as { result?: { tools?: { name: string }[] } };
+    assert.deepEqual(tools.result?.tools?.map((t) => t.name).sort(), ["acp_status", "compress", "decompress", "search_context"], "tools listed");
+    const call = byId(3) as { result?: { content?: { text?: string }[]; isError?: boolean } };
+    assert.equal(call.result?.isError, false, `tools/call succeeded (self-registered conversation bound)${call.result?.isError ? ": " + (call.result?.content?.[0]?.text ?? "") : ""}`);
+    assert.match(call.result?.content?.[0]?.text ?? "", /CONTEXT BREAKDOWN/);
+    assert.equal(status.ok, true, "conversation bound after the model request");
+    assert.equal(status.pluginAgent, "mcp");
 });

--- a/tests/plugin-protocol.test.ts
+++ b/tests/plugin-protocol.test.ts
@@ -9,7 +9,7 @@ import { defaultConfig } from "acp-kernel";
 import { startServer, type ProxyOptions } from "../src/server.ts";
 import { SessionStore, _setStoreForTest } from "../src/persist.ts";
 import { _setForTest as setRegistryForTest } from "../src/registry.ts";
-import { _resetPluginStateForTest } from "../src/plugin.ts";
+import { _resetPluginStateForTest, queuePluginRegister, takePendingPluginRegister } from "../src/plugin.ts";
 
 interface Harness {
     proxyPort: number;
@@ -432,5 +432,22 @@ test("plugin-reported context window becomes the nudge denominator and is visibl
         assert.equal(status2.contextLimit, 400000);
     } finally {
         await h.close();
+    }
+});
+
+test("headless launcher registrations expire after the TTL (no stale poisoning)", () => {
+    _resetPluginStateForTest();
+    const t0 = Date.now();
+    const realNow = Date.now;
+    try {
+        Date.now = () => t0;
+        queuePluginRegister("ttl-stale", "codex", false);
+        Date.now = () => t0 + 11 * 60 * 1000;
+        queuePluginRegister("ttl-fresh", "codex", false);
+        assert.equal(takePendingPluginRegister()?.conversationId, "ttl-fresh", "expired registration dropped, fresh one bound");
+        assert.equal(takePendingPluginRegister(), undefined, "queue drained");
+    } finally {
+        Date.now = realNow;
+        _resetPluginStateForTest();
     }
 });

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-    entry: ["src/index.ts"],
+    entry: ["src/index.ts", "src/mcp.ts"],
     format: ["esm"],
     target: "node20",
     platform: "node",


### PR DESCRIPTION
Implements #162 (MVP scope) on top of #161's plugin protocol.

## What

`bili claude` / `bili codex` now deliver the native-plugin experience with **zero persistent host config**: the launcher injects a single `bili` MCP server at spawn time — nothing written to host config files, **traffic route unchanged by default** (see Compatibility), zero residue on uninstall.

- **`POST /__bili/plugin/register {conversationId, agent, identity}`** — session pre-binding, two strategies:
  - **identity: true** (claude code): every model request carries `x-claude-code-session-id` === the `CLAUDE_CODE_SESSION_ID` passed to MCP children (both verified against claude 2.1.227 — raw-socket header capture + child env probe). Binding is identity-keyed → race-free regardless of arrival order (claude -p fires its first model request concurrently with MCP initialize).
  - **identity: false** (headless codex spawn): the launcher injects a per-spawn UUID as `BILI_CONVERSATION_ID` into the MCP child (codex passes no session id of its own — verified codex-cli 0.147.0); the shell self-registers and the pending entry is consumed by the first request that creates a NEW session. The shell awaits the register before answering MCP initialize so waiting hosts cannot race past it.
- **`src/mcp.ts`** — MCP stdio thin shell: GET manifest (zero schema drift) → expose 4 tools → POST /__bili/plugin/tool. Second tsup entry (`dist/mcp.js`). Also reachable as `bili mcp`.
- **`bili plugin-register <id>`** — CLI hook for manual registration (sends `identity: true`).
- **Launcher direct-URL mode** (opt-in, `BILI_LAUNCHER_DIRECT=1`; the default is the classic transparent-MITM route): claude → `ANTHROPIC_BASE_URL` spawn env + `--mcp-config` ephemeral JSON; codex → `-c mcp_servers.bili.*` inline TOML overrides (syntax accepted by codex 0.147). Enabling direct mode prints a client-specific warning describing the route change. `BILI_LAUNCHER_PLUGIN=0` disables injection (plain wire mode).

## 待验证 items from #162 — resolved

- ~~待验证① `--settings` SessionStart hook~~ — **obsoleted**: `CLAUDE_CODE_SESSION_ID` child env + `x-claude-code-session-id` request header make hooks unnecessary; simpler and race-free.
- ~~待验证② codex `-c` inline `mcp_servers.*`~~ — accepted by codex 0.147.0 (config parses; our e2e stopped only at provider routing because the local relay lacks a Responses endpoint — unrelated to the MCP surface).

## Compatibility (default behavior unchanged)

Initial review found the direct-URL route was **on by default**, which silently changed the traffic route of every existing `bili claude` / `bili codex` setup on upgrade:

| Existing setup | If direct URL were the default |
|---|---|
| codex (any) | LLM traffic no longer goes through the proxy → compression/memory silently stop working |
| claude (OAuth subscription) | subscription traffic breaks |
| claude (custom relay) | `ANTHROPIC_BASE_URL` silently bypassed (falls back to `https://api.anthropic.com` unless `BILI_CLAUDE_UPSTREAM` is set) |

The PR now keeps the **classic transparent-MITM route as the default** — an upgrade changes nothing for existing users. Direct URL remains available as an explicit opt-in: `BILI_LAUNCHER_DIRECT=1`; enabling it prints a client-specific warning (relay bypassed / LLM traffic not proxied).

MCP tool injection itself remains **on by default** — that part is purely additive: it only adds the `bili` MCP server, and if the server fails to start the host continues without it (verified: codex 0.147.0 tolerates a missing MCP command), so the worst case is the pre-PR tool surface. Escape hatch: `BILI_LAUNCHER_PLUGIN=0`.

## Bugs fixed on the branch after review

1. **`bili codex` startup crash** — `buildCodexMcpArgs` double-encoded the args value (TOML string where a sequence is expected); every injected codex spawn died with `Error loading config.toml: invalid type: string ..., expected a sequence`. Now emits a real TOML array; verified with codex-cli 0.147.0.
2. **`bili plugin-register` registered headless** — the documented `"$CLAUDE_SESSION_ID"` usage now sends `identity: true` so the registration binds by identity instead of consuming the next NEW session.
3. **Stale headless registrations** — pending registrations now expire after 10 min (`PENDING_REGISTER_TTL_MS`); an orphaned registration can no longer turn an unrelated later session into plugin mode with a foreign conversation id.
4. **Direct-URL default flip** — see Compatibility above.
5. **Codex native tools dead** — every `bili codex` tool call failed with `no conversation id`: the launcher never gave the MCP shell a conversation id to self-register with. `buildCodexMcpArgs` now injects `mcp_servers.bili.env.BILI_CONVERSATION_ID=<uuid>` per spawn. Binding works on the default MITM route (verified by e2e); in direct-URL mode the model traffic bypasses the proxy so the binding still cannot happen — tracked with the codex LLM-routing follow-up.

## Verification

- **452/452 tests** (444 base + 8 new: register validation, identity-after-first-request, headless pending, no cross-session leak, injection builders, MCP shell stdio round-trip, pending-register TTL expiry, codex-style self-register e2e; codex `-c` args assertion now verifies the value is a TOML array and the `BILI_CONVERSATION_ID` env line — would have caught the double-encoding and the missing conversation id)
- typecheck clean, build clean (dist/mcp.js emitted)
- **Real e2e**: `bili claude -p "call the bili acp_status tool"` through a live anthropic-compatible upstream → proxy log `[plugin] tool acp_status executed via plugin` (native MCP path; wire injection suppressed), model answers from the real status; host config untouched; tmp MCP config removed on exit
- **codex config e2e**: launcher-generated `-c` args fed back into codex-cli 0.147.0 → config parses, session banner reached (pre-fix: startup failure)
- **codex binding e2e**: real MCP shell over stdio with only `BILI_CONVERSATION_ID` (no `CLAUDE_CODE_SESSION_ID`, no manual register) → headless self-register on initialize → first NEW-session model request binds the conversation → `tools/call acp_status` returns the live context breakdown

## Note

Codex full e2e (LLM round-trip through a Responses upstream) still pending a suitable upstream — the MCP/config surface and the headless binding are verified independently (see above). Follow-ups (tracked separately, not blockers): direct-URL mode for codex — LLM traffic routing through the proxy (required before headless binding can work there), i.e. one combined 'codex direct mode' follow-up.

