### PR TITLE
log: model identity on the nudge diagnostic line

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -652,7 +652,7 @@ function diagTagSummary(messages: CoreMessage[], sessionId: string, strategy: st
     return `[${sessionId}] processTurn: ${messages.length} msgs, renderTags=${strategy}, ${textTagged} text tagged, ${toolTagged} tool tagged (should be 0 with text-only)`;
 }
 
-function diagNudge(turn: { nudge?: { shouldInject: boolean; reason: string; contextUsage: number; tier: number | null; breakdown?: Record<string, number> } | null }, sessionId: string, tokenCount: number, limit: number): string {
+function diagNudge(turn: { nudge?: { shouldInject: boolean; reason: string; contextUsage: number; tier: number | null; breakdown?: Record<string, number> } | null }, sessionId: string, tokenCount: number, limit: number, model?: string): string {
     const n = turn.nudge;
     if (!n) return `[${sessionId}] nudge: unavailable`;
     const b = n.breakdown ?? {};
@@ -663,7 +663,8 @@ function diagNudge(turn: { nudge?: { shouldInject: boolean; reason: string; cont
     const pendingT1 = b["pendingT1"] ?? 0;
     const ref = b["growthReference"] ?? 0;
     const inject = n.shouldInject ? `INJECT T${n.tier ?? "?"}` : "idle";
-    return `[${sessionId}] nudge ${inject}: usage=${pct} (${tokenCount}/${limit}), growth=${growth}/${floor} (ref=${ref}, interval=${interval}), pendingT1=${pendingT1}/${interval}, reason="${n.reason.slice(0, 120)}"`;
+    const modelTag = model ? ` model=${model}` : "";
+    return `[${sessionId}] nudge ${inject}: usage=${pct} (${tokenCount}/${limit}), growth=${growth}/${floor} (ref=${ref}, interval=${interval}), pendingT1=${pendingT1}/${interval}${modelTag}, reason="${n.reason.slice(0, 120)}"`;
 }
 
 function prepareAnthropic(
@@ -709,7 +710,7 @@ function prepareAnthropic(
             if (t) session.meta.title = t;
         }
         log("info", diagTagSummary(turn.messages, sessionId, "text-only"));
-        log("info", diagNudge(turn, sessionId, tokenCount, config.modelContextLimit));
+        log("info", diagNudge(turn, sessionId, tokenCount, config.modelContextLimit, parsed.model));
         processedMessages = stripKernelSummaries(turn.messages);
         reapOrphanBlocks(session, msgs, deactivateBlock);
         rebuiltMessages = coreToAnthropic(processedMessages as BiliMessage[], cacheControls);
@@ -785,7 +786,7 @@ function prepareOpenai(
             if (t) session.meta.title = t;
         }
         log("info", diagTagSummary(turn.messages, sessionId, "text-only"));
-        log("info", diagNudge(turn, sessionId, tokenCount, config.modelContextLimit));
+        log("info", diagNudge(turn, sessionId, tokenCount, config.modelContextLimit, parsed.model));
         processedMessages = stripKernelSummaries(turn.messages);
         reapOrphanBlocks(session, msgs, deactivateBlock);
         rebuiltMessages = coreToOpenai(processedMessages as BiliMessage[]);
@@ -879,7 +880,7 @@ function prepareResponses(
             if (t) session.meta.title = t;
         }
         log("info", diagTagSummary(turn.messages, sessionId, "text-only"));
-        log("info", diagNudge(turn, sessionId, tokenCount, config.modelContextLimit));
+        log("info", diagNudge(turn, sessionId, tokenCount, config.modelContextLimit, parsed.model));
         processedMessages = stripKernelSummaries(turn.messages);
         reapOrphanBlocks(session, msgs, deactivateBlock);
         rebuiltInput = patchResponsesInput(projection, processedMessages);


### PR DESCRIPTION
## Why

Same as omp #78: model identity was absent from the proxy's nudge lines; weak-model loop diagnostics depended on guesswork.

## What

`diagNudge(turn, sessionId, tokenCount, limit, model?)` — all three prepare paths (anthropic / openai / responses) pass `parsed.model`:

```
[sid] nudge idle: usage=24% (42945/180000), growth=.../... (ref=..., interval=...), pendingT1=.../..., model=deepseek-v4-flash, reason="..."
```

No behavior change. tsc clean, 437/437.