### PR TITLE
build: align acp-kernel to 0.0.28

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@types/node": "^22.0.0",
         "@types/node-forge": "^1.3.14",
-        "acp-kernel": "0.0.26",
+        "acp-kernel": "0.0.28",
         "fzstd": "0.1.1",
         "node-forge": "^1.4.0",
         "tar": "^7.5.22",
@@ -972,9 +972,9 @@
       }
     },
     "node_modules/acp-kernel": {
-      "version": "0.0.26",
-      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.26.tgz",
-      "integrity": "sha512-QUXIFnZRwihifgnvvBEeiILu2oCJVKtmbunefPM1i6aiJ6qpW6XsIuZqOu4R6wL4JoekSq+6PSmbXn+hZ/keXw==",
+      "version": "0.0.28",
+      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.28.tgz",
+      "integrity": "sha512-1pdpu8xmIlVFxfO3oHzaigX8DhlYVyMr9o5sSYHRzcOfijCwhnnz3yJMeqT8Gb1WBnIyl5UyV9muhTa5A4D/Sg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/node-forge": "^1.3.14",
-    "acp-kernel": "0.0.26",
+    "acp-kernel": "0.0.28",
     "fzstd": "0.1.1",
     "node-forge": "^1.4.0",
     "tar": "^7.5.22",

--- a/src/persist.ts
+++ b/src/persist.ts
@@ -111,6 +111,7 @@ function mergeState(parsed: CompressionState): CompressionState {
         stats: { ...fresh.stats, ...(parsed.stats ?? {}) },
         nextBlockId: parsed.nextBlockId ?? fresh.nextBlockId,
         nextRunId: parsed.nextRunId ?? fresh.nextRunId,
+        tokenSnapshot: parsed.tokenSnapshot ?? fresh.tokenSnapshot,
     };
 }
 


### PR DESCRIPTION
Ecosystem alignment (third consumer of the kernel, after omp #84/#85 and billion-context-pi): acp-kernel 0.0.26 → 0.0.28.

0.0.28 contents: #81 effective-gate char unification, #82 subagent-namespace injectable anchor store, #83 token-snapshot docs, #84 wire format detection + transform-channel policy.

Changes:
- `package.json`: acp-kernel 0.0.26 → 0.0.28
- `src/persist.ts`: `mergeState` forward-compat merge carries the new `tokenSnapshot` field (older persisted session files default to an empty snapshot — the kernel's `createInitialState` shape)

Verification: `npm test` 437/437 pass with zero behavior adaptation; `npm run typecheck` clean.