### PR TITLE
release v0.1.43

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.42",
+  "version": "0.1.43",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.42",
+      "version": "0.1.43",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.42",
+  "version": "0.1.43",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Release 0.1.42 → 0.1.43. Release commit touches only `package.json` + lock; CI `release.yml` publishes on merge.

## Changes since v0.1.42 (21 commits)

**Adopt acp-kernel/wire** (#160, #165)
- `eecd4e8` refactor: adopt acp-kernel/wire — protocol codecs move to the kernel (single source of truth)
- `04f00e1` test: subagent-namespace imports from acp-kernel/wire
- `b8cd1c8` deps: acp-kernel 0.0.26 (subagentNamespace released — unblocks #150 import)
- `4f561f0` merge master: #150 subagentNamespace now sourced from acp-kernel/wire
- `e1130e7` build: align acp-kernel to 0.0.28 (already published on npm — no kernel release needed)
- `90c405f` merge #165

**Export (bili export)** (#151)
- `9e5ad36` feat(cli): `bili export` — Markdown session handoff
- `a638919` fix(export): uncompressed sessions say content is unavailable
- `11b9191` export: persist latest conversation snapshot per session (persist v3)
- `3608d3f` test: true e2e for bili export — real proxy compress tool call → persisted block → handoff doc

**Codex subagent namespace** (#150)
- `5c64384` fix(responses): separate compression namespace for Codex subagent requests

**Web / config** (#154, #155, #157, #152)
- `d92d181` fix(web): accept and hot-reload global compress settings in the web UI (#154)
- `98b1ae4` fix(config): accept `prompts`/`acknowledgePromptsRisk` in `parseCompressSettings` (#155 × #157)
- `17df2c3` fix(config): keep `injectTool`/`injectNudge` through web compress round-trip (#155 follow-up)
- `cd3b73d` fix(ca): write `combined-ca.pem` with system roots for replace-semantics CA env vars (#152)

**Diagnostics** (#164)
- `6c7123b` log: model identity on the nudge diagnostic line

## Preflight
- `npm ci` + typecheck + build + test: **437/437 pass**

## Notes
- `CHANGELOG.md` `[Unreleased]` section is stale (lists #156 prompts which already shipped in 0.1.42) — follow-up, not bundled into the release commit.
