### PR TITLE
fix(upstream): direct-connect path gets a 10s handshake timeout

### DIFF
--- a/src/upstream-proxy.ts
+++ b/src/upstream-proxy.ts
@@ -302,13 +302,47 @@ function openProxySocket(proxy: ParsedHttpProxy): net.Socket {
     return net.connect(proxy.port, proxy.host);
 }
 
+const CONNECT_TIMEOUT_MS = 10_000;
+
+// Test seam: lets tests substitute a connect factory that never completes,
+// so the direct-path timeout can be asserted in milliseconds instead of
+// simulating a black-holed port (ESM namespaces are immutable — the repo's
+// established _...ForTest pattern instead of module mocking).
+let connectFactory: (port: number, host: string) => net.Socket = (port, host) => net.connect(port, host);
+
+export function _setConnectFactoryForTest(factory: ((port: number, host: string) => net.Socket) | undefined): void {
+    connectFactory = factory ?? ((port, host) => net.connect(port, host));
+}
+
+/** Plain (non-proxied) outbound TCP connect with a bounded handshake:
+ *  a black-holed upstream (firewall drop, routing hole) must fail in seconds,
+ *  not after the OS default ~127s (tcp_syn_retries). Mirrors the proxied
+ *  branch's 10s handshake timeout (see #78). */
+export function connectDirect(host: string, port: number, timeoutMs: number = CONNECT_TIMEOUT_MS): Promise<net.Socket> {
+    return new Promise((resolve, reject) => {
+        const socket = connectFactory(port, host);
+        let settled = false;
+        const finishError = (error: Error) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timer);
+            socket.destroy();
+            reject(error);
+        };
+        const timer = setTimeout(() => finishError(new Error(`upstream connect ${host}:${port} timed out after ${timeoutMs}ms`)), timeoutMs);
+        socket.once("error", finishError);
+        socket.once("connect", () => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timer);
+            resolve(socket);
+        });
+    });
+}
+
 export function connectThroughProxy(host: string, port: number, proxyUrl: string | undefined): Promise<net.Socket> {
     if (!proxyUrl) {
-        return new Promise((resolve, reject) => {
-            const socket = net.connect(port, host);
-            socket.once("connect", () => resolve(socket));
-            socket.once("error", reject);
-        });
+        return connectDirect(host, port);
     }
     const proxy = parseHttpProxy(proxyUrl);
     if (!proxy) return Promise.reject(new Error(`invalid upstream proxy: ${redactProxyUrl(proxyUrl)}`));
@@ -322,7 +356,7 @@ export function connectThroughProxy(host: string, port: number, proxyUrl: string
             socket.destroy();
             reject(error);
         };
-        const timer = setTimeout(() => finishError(new Error(`upstream proxy CONNECT ${host}:${port} handshake timeout`)), 10_000);
+        const timer = setTimeout(() => finishError(new Error(`upstream proxy CONNECT ${host}:${port} handshake timeout`)), CONNECT_TIMEOUT_MS);
         socket.once("error", finishError);
         const connectedEvent = proxy.protocol === "https:" ? "secureConnect" : "connect";
         socket.once(connectedEvent, () => {

--- a/tests/fix-78-connect-timeout.test.ts
+++ b/tests/fix-78-connect-timeout.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert";
+import net from "node:net";
+import test from "node:test";
+
+import { connectDirect, connectThroughProxy, _setConnectFactoryForTest } from "../src/upstream-proxy.ts";
+
+function listen(server: net.Server): Promise<void> {
+    if (server.listening) return Promise.resolve();
+    return new Promise((resolve) => server.once("listening", resolve));
+}
+
+test("direct connect resolves against a real server", async () => {
+    const server = net.createServer((sock) => sock.end());
+    server.listen(0, "127.0.0.1");
+    await listen(server);
+    const port = (server.address() as { port: number }).port;
+    try {
+        const socket = await connectDirect("127.0.0.1", port);
+        assert.ok(socket.readable && socket.writable, "resolved with a live socket");
+        socket.destroy();
+    } finally {
+        server.close();
+    }
+});
+
+test("connectThroughProxy delegates to the direct path when no proxy is set", async () => {
+    const server = net.createServer((sock) => sock.end());
+    server.listen(0, "127.0.0.1");
+    await listen(server);
+    const port = (server.address() as { port: number }).port;
+    try {
+        const socket = await connectThroughProxy("127.0.0.1", port, undefined);
+        assert.ok(socket.readable && socket.writable);
+        socket.destroy();
+    } finally {
+        server.close();
+    }
+});
+
+test("direct connect fails fast (milliseconds, not the OS ~127s) when the connection hangs", async () => {
+    // A socket that neither connects nor errors simulates a black-holed
+    // upstream (firewall drops SYNs). The timeout handler must reject and
+    // destroy the socket — that is the whole point of #78.
+    const hung = new net.Socket();
+    const destroyed = new Promise<void>((resolve) => hung.once("close", resolve));
+    _setConnectFactoryForTest(() => hung);
+    try {
+        const t0 = Date.now();
+        await assert.rejects(
+            connectDirect("127.0.0.1", 1, 50),
+            /upstream connect 127\.0\.0\.1:1 timed out after 50ms/,
+        );
+        assert.ok(Date.now() - t0 < 2_000, "rejected in milliseconds, not minutes");
+        await destroyed; // the timeout handler destroyed the hung socket
+    } finally {
+        _setConnectFactoryForTest(undefined);
+    }
+});
+
+test("direct connect: immediate errors (connection refused) still surface right away", async () => {
+    // Find a closed port: listen, note it, close.
+    const server = net.createServer();
+    server.listen(0, "127.0.0.1");
+    await listen(server);
+    const port = (server.address() as { port: number }).port;
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+
+    const t0 = Date.now();
+    await assert.rejects(connectDirect("127.0.0.1", port), /ECONNREFUSED/);
+    assert.ok(Date.now() - t0 < 2_000, "refusal is immediate, not a timeout");
+});


### PR DESCRIPTION
## Closes #78

The direct (no upstream proxy) connect path in `src/upstream-proxy.ts` had **no connection timeout** — it relied on the OS default `tcp_syn_retries` (~127s). A black-holed upstream (firewall drops SYNs, routing hole) left half-open sockets hanging for ~2 minutes while the proxied branch (same file) already had a 10s CONNECT handshake timeout. Inconsistent behavior, resource hold, no user feedback.

## Change

- Extract the direct path into `connectDirect(host, port, timeoutMs = 10_000)` with the same settled-guard + destroy + timer-cleanup pattern as the proxied branch
- `connectThroughProxy` delegates to it when no proxy is set → covers both plain and TLS outbound (`connectTlsThroughProxy` reuses `connectThroughProxy`)
- The proxy branch's hardcoded `10_000` now shares the `CONNECT_TIMEOUT_MS` constant — both paths fail in 10s by construction

## Tests (+4, 441/441 green)

- real-server success via both `connectDirect` and `connectThroughProxy(…, undefined)`
- immediate `ECONNREFUSED` still surfaces right away (no timeout tax on the fast-fail path)
- hang simulation: a never-completing socket (injected via the repo's established `_setConnectFactoryForTest` seam — ESM namespaces preclude `net.connect` monkey-patching) rejects with `upstream connect … timed out after 50ms` in milliseconds and destroys the socket

## Behavior delta

Only the failure path changes: unreachable upstreams now error in ~10s instead of ~127s. Successful connections are byte-for-byte unchanged (same socket, same events, timer just cleared earlier).