### PR TITLE
fix: answer WebSocket upgrades with a clean 426 so Codex falls back to HTTP immediately (#2)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -196,6 +196,7 @@ export async function startServer(opts: ProxyOptions): Promise<http.Server> {
     // HTTP POST immediately.
     server.on("upgrade", (req, socket) => {
         log("info", `[ws] rejected ${req.method} ${req.url ?? ""} host=${req.headers.host ?? "?"} with 426`);
+        socket.on("error", () => {}); // client may vanish mid-write; don't let ECONNRESET crash the process
         const body = JSON.stringify({ error: "WebSocket upgrades are not supported; use HTTP POST" });
         socket.end(
             "HTTP/1.1 426 Upgrade Required\r\n" +
@@ -510,13 +511,9 @@ async function handle(
         }
     }
 
-    // Bili does not support WebSocket — reject any upgrade with 426 so clients
-    // with built-in fast-fallback (e.g. Codex supports_websockets=true) retry over HTTP POST.
-    if (req.headers.upgrade === "websocket") {
-        res.writeHead(426, { "content-type": "application/json" });
-        res.end(JSON.stringify({ error: "WebSocket upgrades are not supported; use HTTP POST" }));
-        return;
-    }
+    // NOTE: WebSocket upgrades are answered by the dedicated 'upgrade' listener
+    // in startServer() (above), which is the only reliable path — Node routes
+    // upgrade requests there and never to this request handler.
     let bodyBuffer: Buffer;
     let urlPath: string;
     let responsesCompact: boolean;

--- a/src/server.ts
+++ b/src/server.ts
@@ -189,6 +189,23 @@ export async function startServer(opts: ProxyOptions): Promise<http.Server> {
             }
         }
     });
+    // Bili does not support WebSocket. An explicit 'upgrade' listener is
+    // required: without one Node's behavior is version-dependent (some
+    // versions destroy the socket with no response), delaying clients with
+    // built-in fast-fallback (e.g. Codex) that need a clean 426 to switch to
+    // HTTP POST immediately.
+    server.on("upgrade", (req, socket) => {
+        log("info", `[ws] rejected ${req.method} ${req.url ?? ""} host=${req.headers.host ?? "?"} with 426`);
+        const body = JSON.stringify({ error: "WebSocket upgrades are not supported; use HTTP POST" });
+        socket.end(
+            "HTTP/1.1 426 Upgrade Required\r\n" +
+                "Connection: close\r\n" +
+                "Content-Type: application/json\r\n" +
+                `Content-Length: ${Buffer.byteLength(body)}\r\n` +
+                "\r\n" +
+                body,
+        );
+    });
     if (opts.mitm.enabled) {
         setupMitm(server, opts.mitm.domains, (msg) => log("info", msg), (host) => resolveProxy(opts.routes, opts.proxy, `https://${host}`, opts.proxyFallback));
     }

--- a/tests/e2e-grow-compress.test.ts
+++ b/tests/e2e-grow-compress.test.ts
@@ -1,0 +1,212 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import { once } from "node:events";
+import { defaultConfig } from "acp-kernel";
+import { startServer } from "../src/server.ts";
+import { SessionStore, _setStoreForTest } from "../src/persist.ts";
+import type { ProxyOptions } from "../src/config.ts";
+import { _setForTest as setRegistryForTest } from "../src/registry.ts";
+import { startChatRelay } from "./e2e/chat-relay.ts";
+
+const TURNS = 120;
+const LIVE_BYTES_THRESHOLD = 24 * 1024;
+const CHARS_PER_TOKEN = 4;
+const MSG_TOKENS = 100;
+
+function listen(server: http.Server): Promise<void> {
+    if (server.listening) return Promise.resolve();
+    return once(server, "listening").then(() => undefined);
+}
+
+function close(server: http.Server): Promise<void> {
+    return new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+}
+
+function sseLine(obj: unknown): string {
+    return `data: ${JSON.stringify(obj)}\n\n`;
+}
+
+function userText(i: number): string {
+    const filler = "the quick brown fox jumps over the lazy dog. ";
+    return `user turn ${i}: ${filler.repeat((MSG_TOKENS * CHARS_PER_TOKEN) / 46 | 0)}`;
+}
+
+function assistantText(i: number): string {
+    const filler = "lorem ipsum dolor sit amet consectetur adipiscing elit ";
+    return `assistant reply ${i}: ${filler.repeat((MSG_TOKENS * CHARS_PER_TOKEN) / 50 | 0)}`;
+}
+
+type RelayState = {
+    upstreamReqs: { bytes: number; msgs: number; body: string }[];
+    compressCalls: number;
+    lastDemandBytes: number;
+    sinceDemand: number;
+    failedCompressions: number;
+};
+
+function parseRefIds(body: string): string[] {
+    const ids: string[] = [];
+    const re = /<(?:acp|dcp-message-id)[^>]*>\s*(m\d+)\s*<\/(?:acp|dcp-message-id)>/g;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(body)) !== null) ids.push(m[1]!);
+    return ids;
+}
+
+function startMockChatRelay(state: RelayState): http.Server {
+    const server = http.createServer((req, res) => {
+        const chunks: Buffer[] = [];
+        req.on("data", (chunk: Buffer) => chunks.push(chunk));
+        req.on("end", () => {
+            const body = Buffer.concat(chunks).toString("utf8");
+            const bytes = Buffer.byteLength(body);
+            let liveMsgs = 0;
+            try {
+                const parsed = JSON.parse(body) as { messages?: Array<{ content?: unknown }> };
+                for (const m of parsed.messages ?? []) {
+                    const c = typeof m.content === "string" ? m.content : JSON.stringify(m.content ?? "");
+                    if (c.length > 60) liveMsgs++;
+                }
+            } catch {
+                liveMsgs = 0;
+            }
+            if (body.includes("Compression FAILED")) state.failedCompressions++;
+            state.upstreamReqs.push({ bytes, msgs: liveMsgs, body });
+            res.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache" });
+            const refIds = parseRefIds(body);
+            state.sinceDemand++;
+            const noShrinkAfterDemand = state.sinceDemand <= 2 && bytes >= state.lastDemandBytes * 0.9;
+            const shouldCompress = bytes > LIVE_BYTES_THRESHOLD && refIds.length >= 12 && !noShrinkAfterDemand;
+            if (shouldCompress) {
+                state.lastDemandBytes = bytes;
+                state.sinceDemand = 0;
+                state.compressCalls++;
+                const from = refIds[2]!;
+                const to = refIds[refIds.length - 10]!;
+                res.write(
+                    sseLine({
+                        id: "g1",
+                        object: "chat.completion.chunk",
+                        choices: [
+                            {
+                                index: 0,
+                                delta: {
+                                    role: "assistant",
+                                    content: null,
+                                    tool_calls: [
+                                        {
+                                            index: 0,
+                                            id: `call_compress_${state.compressCalls}`,
+                                            type: "function",
+                                            function: {
+                                                name: "compress",
+                                                arguments: JSON.stringify({
+                                                    content: [{ startId: from, endId: to, topic: "grow compress e2e", summary: `summary of the compressed middle segment: turns covered by this range discussed incremental context growth, message stuffing, and compression behavior; key results were recorded at each checkpoint and the conversation continued with per-turn overhead measurements and periodic compression cycles. ${from}..${to}` }],
+                                                }),
+                                            },
+                                        },
+                                    ],
+                                },
+                            },
+                        ],
+                    }),
+                );
+                res.write(sseLine({ id: "g1", object: "chat.completion.chunk", choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }], usage: { prompt_tokens: 100, completion_tokens: 2 } }));
+            } else {
+                const text = assistantText(state.upstreamReqs.length);
+                res.write(sseLine({ id: "g1", object: "chat.completion.chunk", choices: [{ index: 0, delta: { role: "assistant", content: text } }] }));
+                res.write(sseLine({ id: "g1", object: "chat.completion.chunk", choices: [{ index: 0, delta: {}, finish_reason: "stop" }], usage: { prompt_tokens: 100, completion_tokens: 50 } }));
+            }
+            res.write("data: [DONE]\n\n");
+            res.end();
+        });
+    });
+    server.listen(0, "127.0.0.1");
+    return server;
+}
+
+type Item = { type: "message"; role: string; content: Array<{ type: string; text: string }> };
+
+test("grow-and-compress keeps upstream context bounded while client history grows", async () => {
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    setRegistryForTest({});
+    const state: RelayState = { upstreamReqs: [], compressCalls: 0, lastDemandBytes: Infinity, sinceDemand: 99, failedCompressions: 0 };
+    const relay = startMockChatRelay(state);
+    await listen(relay);
+    const relayPort = (relay.address() as { port: number }).port;
+    const bridge = await startChatRelay({ upstream: `http://127.0.0.1:${relayPort}/v1/chat/completions` });
+    const opts: ProxyOptions = {
+        port: 0,
+        host: "127.0.0.1",
+        upstream: "http://127.0.0.1",
+        routes: { [`http://127.0.0.1:${bridge.port}`]: { models: { "gpt-test": { context: 1_000_000 } }, compressProtocol: "marker" } } as ProxyOptions["routes"],
+        modelContextLimit: 1_000_000,
+        kernelConfig: defaultConfig(1_000_000, {
+            preserveRecentMessages: 3,
+            preserveRecentTokens: 800,
+            compress: { minCompressRange: 1000, maxSummaryLength: 20000, minSummaryLength: 50 },
+        }),
+        compress: { injectTool: true, injectNudge: true },
+        promptCache: { routing: "auto" },
+        sessionHeader: "x-acp-session",
+        log: false,
+        debug: false,
+        passthrough: false,
+        autoUpdate: false,
+        mitm: { enabled: false, domains: [] },
+    };
+    const proxy = await startServer(opts);
+    await listen(proxy);
+    const proxyPort = (proxy.address() as { port: number }).port;
+    const url = `http://127.0.0.1:${proxyPort}/bili/http://127.0.0.1:${bridge.port}/v1/responses`;
+
+    const history: Item[] = [];
+    let nonEmptyReplies = 0;
+    try {
+        for (let i = 1; i <= TURNS; i++) {
+            history.push({ type: "message", role: "user", content: [{ type: "input_text", text: userText(i) }] });
+            const res = await fetch(url, {
+                method: "POST",
+                headers: { "content-type": "application/json", "x-acp-session": "grow-compress-1" },
+                body: JSON.stringify({ model: "gpt-test", stream: true, instructions: "grow compress", input: history }),
+                duplex: "half",
+            } as RequestInit);
+            if (!res.ok) assert.fail(`turn ${i}: HTTP ${res.status}: ${await res.text()}`);
+            let raw = "";
+            for await (const chunk of res.body!) raw += Buffer.from(chunk).toString("utf8");
+            let reply = "";
+            for (const block of raw.split("\n\n")) {
+                let event = "";
+                let data: { delta?: string } | undefined;
+                for (const line of block.split("\n")) {
+                    if (line.startsWith("event:")) event = line.slice(6).trim();
+                    if (line.startsWith("data:")) {
+                        try {
+                            data = JSON.parse(line.slice(5).trim()) as { delta?: string };
+                        } catch {
+                            data = undefined;
+                        }
+                    }
+                }
+                if (event === "response.output_text.delta" && data?.delta) reply += data.delta;
+            }
+            if (reply) nonEmptyReplies++;
+            else if (state.upstreamReqs[state.upstreamReqs.length - 1]?.body.includes("compress") === false) assert.fail(`turn ${i}: empty reply without pending compress round-trip`);
+            history.push({ type: "message", role: "assistant", content: [{ type: "output_text", text: reply }] });
+        }
+
+        const clientBytes = Buffer.byteLength(JSON.stringify({ model: "gpt-test", stream: true, instructions: "grow compress", input: history }));
+        const maxUpstreamBytes = Math.max(...state.upstreamReqs.map((r) => r.bytes));
+        const maxLiveMsgs = Math.max(...state.upstreamReqs.map((r) => r.msgs));
+        assert.ok(state.compressCalls >= 2, `expected >= 2 compress cycles, got ${state.compressCalls}`);
+        assert.equal(state.failedCompressions, 0, "compress tool calls must not fail");
+        assert.equal(nonEmptyReplies, TURNS, `every turn must produce a reply (${nonEmptyReplies}/${TURNS})`);
+        assert.ok(maxUpstreamBytes < LIVE_BYTES_THRESHOLD * 2, `upstream body must stay bounded (max ${maxUpstreamBytes}B vs threshold ${LIVE_BYTES_THRESHOLD}B)`);
+        assert.ok(maxLiveMsgs < TURNS, `upstream live message count must stay well below client history (max ${maxLiveMsgs} vs ${TURNS} turns)`);
+        assert.ok(clientBytes > maxUpstreamBytes * 2, `client history (${clientBytes}B) should far exceed max upstream body (${maxUpstreamBytes}B) after compression cycles`);
+    } finally {
+        await close(proxy);
+        await bridge.close();
+        await close(relay);
+    }
+});

--- a/tests/ws-upgrade.test.ts
+++ b/tests/ws-upgrade.test.ts
@@ -1,0 +1,174 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import net from "node:net";
+import tls from "node:tls";
+import http from "node:http";
+import { once } from "node:events";
+import { defaultConfig } from "acp-kernel";
+import { startServer } from "../src/server.ts";
+import type { ProxyOptions } from "../src/config.ts";
+import { SessionStore, _setStoreForTest } from "../src/persist.ts";
+import { _setForTest as setRegistryForTest } from "../src/registry.ts";
+import { _resetForTest as resetCaForTest } from "../src/ca.ts";
+
+/** #2 (codex WS stall): Codex prefers Responses-over-WebSocket when the
+ *  provider advertises supports_websockets and only switches to HTTP POST
+ *  fast when the WS handshake fails with HTTP 426 (anything else goes through
+ *  the retry/backoff budget first — the reported 十几秒 stall). The proxy must
+ *  therefore answer every WebSocket upgrade with a clean, immediately-closed
+ *  426, both on plain connections and on MITM-decrypted TLS connections (the
+ *  `bili codex` path). */
+
+function close(server: http.Server): Promise<void> {
+    return new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+}
+
+const WS_HANDSHAKE =
+    "GET /backend-api/codex/responses/ws HTTP/1.1\r\n" +
+    "Host: api.openai.com\r\n" +
+    "Upgrade: websocket\r\n" +
+    "Connection: Upgrade\r\n" +
+    "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
+    "Sec-WebSocket-Version: 13\r\n" +
+    "\r\n";
+
+interface UpgradeResult {
+    response: string;
+    closed: boolean;
+    elapsedMs: number;
+}
+
+/** Sends a raw WebSocket handshake and resolves once the server responds
+ *  (capturing whether/how fast the connection is closed afterwards). */
+function sendUpgrade(port: number, write: (socket: net.Socket) => void): Promise<UpgradeResult> {
+    const { promise, resolve, reject } = Promise.withResolvers<UpgradeResult>();
+    const started = Date.now();
+    const socket = net.connect(port, "127.0.0.1", () => write(socket));
+    let buf = "";
+    let closed = false;
+    const finish = (): void => {
+        socket.destroy();
+        resolve({ response: buf, closed, elapsedMs: Date.now() - started });
+    };
+    socket.on("data", (chunk: Buffer) => {
+        buf += chunk.toString("utf8");
+        if (buf.includes("\r\n\r\n")) {
+            // Response head received — wait a bounded time for the close.
+            setTimeout(finish, 100);
+        }
+    });
+    socket.on("close", () => {
+        closed = true;
+    });
+    socket.once("error", reject);
+    setTimeout(() => finish(), 3000);
+    return promise;
+}
+
+function baseOpts(mitm: ProxyOptions["mitm"]): ProxyOptions {
+    return {
+        port: 0,
+        host: "127.0.0.1",
+        upstream: "http://127.0.0.1",
+        routes: {},
+        modelContextLimit: 400_000,
+        kernelConfig: defaultConfig(400_000),
+        compress: { injectTool: false, injectNudge: false },
+        promptCache: { routing: "auto" },
+        sessionHeader: "x-acp-session",
+        log: false,
+        debug: false,
+        passthrough: false,
+        autoUpdate: false,
+        mitm,
+    };
+}
+
+test("ws upgrade: answered with 426 + close on a plain connection", async () => {
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    setRegistryForTest({});
+    const server = await startServer(baseOpts({ enabled: false, domains: [] }));
+    await once(server, "listening");
+    const port = (server.address() as { port: number }).port;
+    try {
+        const result = await sendUpgrade(port, (socket) => socket.write(WS_HANDSHAKE));
+        assert.match(result.response, /^HTTP\/1\.1 426/);
+        assert.match(result.response, /connection: close/i);
+        assert.match(result.response, /not supported/i);
+        assert.equal(result.closed, true, "socket must be closed right after the 426");
+    } finally {
+        await close(server);
+        server.closeAllConnections?.();
+    }
+});
+
+test("ws upgrade: answered with 426 + close on an MITM-decrypted TLS connection (bili codex path)", async () => {
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    setRegistryForTest({});
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "bili-ws-"));
+    const prevDataHome = process.env.XDG_DATA_HOME;
+    process.env.XDG_DATA_HOME = tmp;
+    resetCaForTest();
+    try {
+        const server = await startServer(baseOpts({ enabled: true, domains: ["api.openai.com"] }));
+        await once(server, "listening");
+        const port = (server.address() as { port: number }).port;
+        try {
+            const { promise, resolve, reject } = Promise.withResolvers<{ statusLine: string; socket: net.Socket }>();
+            const conn = net.connect(port, "127.0.0.1", () => {
+                conn.write("CONNECT api.openai.com:443 HTTP/1.1\r\nHost: api.openai.com:443\r\n\r\n");
+            });
+            let connectBuf = "";
+            const onData = (chunk: Buffer): void => {
+                connectBuf += chunk.toString("utf8");
+                if (connectBuf.includes("\r\n\r\n")) {
+                    conn.off("data", onData);
+                    resolve({ statusLine: connectBuf.slice(0, connectBuf.indexOf("\r\n")), socket: conn });
+                }
+            };
+            conn.on("data", onData);
+            conn.once("error", reject);
+            const { statusLine, socket } = await promise;
+            assert.match(statusLine, /^HTTP\/1\.1 200/);
+
+            const { promise: tlsPromise, resolve: resolveTls, reject: rejectTls } = Promise.withResolvers<UpgradeResult>();
+            const tlsSock = tls.connect({ socket, rejectUnauthorized: false, servername: "api.openai.com" });
+            const started = Date.now();
+            let tlsBuf = "";
+            let closed = false;
+            tlsSock.on("secureConnect", () => tlsSock.write(WS_HANDSHAKE));
+            const finish = (): void => {
+                tlsSock.destroy();
+                resolveTls({ response: tlsBuf, closed, elapsedMs: Date.now() - started });
+            };
+            tlsSock.on("data", (chunk: Buffer) => {
+                tlsBuf += chunk.toString("utf8");
+                if (tlsBuf.includes("\r\n\r\n")) setTimeout(finish, 100);
+            });
+            tlsSock.on("close", () => {
+                closed = true;
+            });
+            tlsSock.once("error", rejectTls);
+            setTimeout(finish, 3000);
+            const result = await tlsPromise;
+            assert.match(result.response, /^HTTP\/1\.1 426/);
+            assert.match(result.response, /connection: close/i);
+            assert.equal(result.closed, true, "TLS socket must be closed right after the 426");
+        } finally {
+            await close(server);
+            server.closeAllConnections?.();
+        }
+    } finally {
+        if (prevDataHome === undefined) delete process.env.XDG_DATA_HOME;
+        else process.env.XDG_DATA_HOME = prevDataHome;
+        resetCaForTest();
+        try {
+            fs.rmSync(tmp, { recursive: true, force: true });
+        } catch {
+            /* best-effort */
+        }
+    }
+});


### PR DESCRIPTION
## Problem

Fixes #2 (codex 版本可能因为默认 socket 模式卡顿, 十几秒自动切 http 恢复).

New Codex versions default to Responses-over-WebSocket (`supports_websockets=true`). In codex source (`codex-rs/core/src/client.rs`), only an **HTTP 426** on the WS handshake triggers *immediate* fallback to HTTP POST; any other failure (e.g. socket destroyed with no response) goes through retry/backoff budgets first — that's the 10-20s stall users see before it auto-recovers on HTTP.

bili already wrote a 426 inside its request handler, but the HTTP server never registered an `'upgrade'` event listener, so Node's handling of upgrade requests is version-dependent — often the socket is destroyed without any response, pushing Codex onto the slow path.

## Fix

- `src/server.ts`: explicit `server.on("upgrade")` handler — always answers `426 Upgrade Required` + `Connection: close` with a JSON error body and closes the socket immediately. Consistent on every Node version; Codex receiving 426 switches to HTTP POST in the same turn.
- Also covers MITM-decrypted TLS connections (`bili codex` mode: chatgpt.com / api.openai.com), since those land on the same server object.

## Tests

- New `tests/ws-upgrade.test.ts`: 426 + immediate close verified on both the plain path and the full CONNECT → TLS → upgrade MITM path.
- `npm run typecheck` ✓, full suite 455/455 ✓, `npm run build` ✓.

Note: `src/update.ts` untouched — no no-op validation release needed; standard §5 release flow after merge.