### PR TITLE
fix: harden context window — self-heal on upstream overflow + reserve output headroom

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -56,7 +56,7 @@ import { deriveSessionId as deriveProxySessionId, affinityToken, clientConversat
 import { consumePluginRegisterFor, handlePluginManifest, handlePluginRegister, handlePluginStatus, handlePluginTool, pipePluginJson, pipeThroughWithUsage, pluginAgentHeader, pluginConversationHeader, pluginReportedContextWindow, recordPluginSession, rememberPluginMessages, takePendingPluginRegister } from "./plugin.js";
 import { setupMitm, readMitmUpstream } from "./mitm.js";
 import type { BiliMessage } from "acp-kernel/wire";
-import { isLoopbackAddress, usageTotals } from "./util.js";
+import { isLoopbackAddress, inspectContextOverflow, usageTotals } from "./util.js";
 
 import { decodeRequestBody } from "./content-encoding.js";
 
@@ -693,6 +693,19 @@ async function handle(
             recordPluginSession(pluginConversation ?? conversation, session.id);
         }
         const pluginMode = pluginAgent !== undefined;
+        // Self-heal the context window: a prior upstream overflow may have taught
+        // us the real window (forward()'s overflow detection persists it to
+        // metadata.learnedContextLimit). If it is smaller than what we resolved this
+        // turn (e.g. the 200k fallback for an unknown model on a relay), re-center
+        // the kernel on it so the nudge/truncate bands sit below the real limit
+        // instead of above it. Spread into a new object — never mutate the shared
+        // global config.
+        const learnedLimit = session.metadata.learnedContextLimit as number | undefined;
+        if (learnedLimit && learnedLimit > 0 && learnedLimit < reqConfig.modelContextLimit) {
+            const resolved = reqConfig.modelContextLimit;
+            reqConfig = { ...reqConfig, modelContextLimit: learnedLimit };
+            log("info", `[${session.id}] self-healed context window: ${resolved} → ${learnedLimit} (learned from an upstream overflow)`);
+        }
         // acquireInFlight must precede the lock so evictOldest() cannot flush
         // this session between getSession and lock acquisition (inFlight===0
         // window). Released in the outer finally after forward completes.
@@ -1408,8 +1421,55 @@ async function forward(
     // (writeHead is done HERE, only in the error branch, so we never double-
     // write headers when a later branch would also call writeHead.)
     if (!upstream.ok) {
-        res.writeHead(upstream.status, respHeaders);
-        if (upstream.body) await pipeThrough(upstream.body, res);
+        // Buffer the (small) error body so a context overflow can be detected:
+        // when the configured window is wrong (e.g. the 200k fallback for an
+        // unknown model on a relay) an upstream 400 is the only reliable signal
+        // that the real window is smaller. Learn the window, arm an emergency
+        // shrink for the next turn, then pass the error through verbatim.
+        let errBody: Buffer | null = null;
+        if (upstream.body) {
+            try {
+                errBody = await readStreamToBuffer(upstream.body);
+            } catch {
+                errBody = null; // body consumed/broken — respond with status only
+            }
+        }
+        if (prepared?.session && errBody) {
+            const s = prepared.session;
+            const info = inspectContextOverflow(upstream.status, errBody.toString("utf8"));
+            if (info.isOverflow) {
+                if (info.window) {
+                    const prev = s.metadata.learnedContextLimit as number | undefined;
+                    // Persist the real window to a STABLE field: effectiveContextLimit
+                    // is re-resolved every turn (plugin mode) and would be overwritten;
+                    // handle() reads learnedContextLimit to re-center the kernel next turn.
+                    s.metadata.learnedContextLimit = info.window;
+                    log("warn", `[${s.id}] upstream context overflow — learned real window ${info.window} (was ${prev ?? "unset"}); arming emergency shrink`);
+                } else {
+                    log("warn", `[${s.id}] upstream context overflow (window not parseable): ${info.message}`);
+                }
+                // Arm the emergency shrink: force the next turn's usage to >=100%
+                // so the kernel's emergency nudge + tool-result truncate fire.
+                // lastInputTokens is a lower bound here (the context overflowed,
+                // so it is at least the window); a real usage report from the
+                // next successful turn overwrites it.
+                const floor =
+                    info.window ??
+                    (s.metadata.learnedContextLimit as number | undefined) ??
+                    (s.metadata.effectiveContextLimit as number | undefined) ??
+                    0;
+                if (floor > 0) s.stats.lastInputTokens = Math.max(s.stats.lastInputTokens, floor);
+            }
+        }
+        const errHeaders: Record<string, string> = { ...respHeaders };
+        if (errBody) {
+            // Writing a complete body — drop framing headers that would conflict
+            // with a fixed-length write.
+            delete errHeaders["content-length"];
+            delete errHeaders["transfer-encoding"];
+        }
+        res.writeHead(upstream.status, errHeaders);
+        res.end(errBody ?? undefined);
         clearUpstreamTimer();
         return;
     }
@@ -1581,6 +1641,24 @@ async function forward(
     // State may have mutated during response streaming (compress created a
     // block, decompress deactivated one) — persist the final snapshot.
     markDirty(prepared.session);
+}
+
+/** Read a (small) fetch Response body stream fully into a Buffer. Used for the
+ *  non-2xx error path, where we inspect the body for a context-overflow before
+ *  passing it through. Error bodies are small JSON, so full buffering is safe. */
+async function readStreamToBuffer(stream: ReadableStream<Uint8Array>): Promise<Buffer> {
+    const reader = stream.getReader();
+    const chunks: Buffer[] = [];
+    try {
+        for (;;) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            if (value) chunks.push(Buffer.from(value));
+        }
+    } finally {
+        reader.releaseLock();
+    }
+    return Buffer.concat(chunks);
 }
 
 async function pipeThrough(stream: ReadableStream<Uint8Array>, res: http.ServerResponse): Promise<void> {

--- a/src/server.ts
+++ b/src/server.ts
@@ -56,7 +56,7 @@ import { deriveSessionId as deriveProxySessionId, affinityToken, clientConversat
 import { consumePluginRegisterFor, handlePluginManifest, handlePluginRegister, handlePluginStatus, handlePluginTool, pipePluginJson, pipeThroughWithUsage, pluginAgentHeader, pluginConversationHeader, pluginReportedContextWindow, recordPluginSession, rememberPluginMessages, takePendingPluginRegister } from "./plugin.js";
 import { setupMitm, readMitmUpstream } from "./mitm.js";
 import type { BiliMessage } from "acp-kernel/wire";
-import { isLoopbackAddress, inspectContextOverflow, reserveOutputHeadroom, usageTotals } from "./util.js";
+import { isLoopbackAddress, inspectContextOverflow, reserveOutputHeadroom, shouldReserveOutputHeadroom, usageTotals } from "./util.js";
 
 import { decodeRequestBody } from "./content-encoding.js";
 
@@ -717,13 +717,17 @@ async function handle(
         // kernel's nudge/truncate bands sit below (window - maxOutput) and a
         // context+output overflow can't happen on a small window (e.g. 100k with a
         // large max_tokens — the most common "context blew up" cause; none of the
-        // three layers reserved room for the output before this). max_tokens is the
-        // exact output budget requested for THIS turn, so the reservation is precise
-        // and per-request. Only reserve when it leaves a usable window (maxOutput <
-        // window); otherwise the request is degenerate (output >= whole window) and
-        // the self-heal above handles the resulting overflow. Feeds reqConfig (→
+        // three layers reserved room for the output before this). Anthropic is
+        // exempt: its input limit is enforced independently of max_tokens
+        // (separate output budget), so reserving would shift every band down by
+        // maxOutput on every session for no safety gain — see
+        // shouldReserveOutputHeadroom. max_tokens is the exact output budget
+        // requested for THIS turn, so the reservation is precise and per-request.
+        // Only reserve when it leaves a usable window (maxOutput < window);
+        // otherwise the request is degenerate (output >= whole window) and the
+        // self-heal above handles the resulting overflow. Feeds reqConfig (→
         // processTurn `config`), so diagNudge shows the reserved window (no extra log).
-        {
+        if (shouldReserveOutputHeadroom(protocol)) {
             const p = parsed as Record<string, unknown>;
             const rawMax = p.max_tokens ?? p.max_completion_tokens ?? p.max_output_tokens;
             const maxOutput = typeof rawMax === "number" ? rawMax : 0;
@@ -1497,15 +1501,22 @@ async function forward(
                     (s.metadata.effectiveContextLimit as number | undefined) ??
                     0;
                 if (floor > 0) s.stats.lastInputTokens = Math.max(s.stats.lastInputTokens, floor);
+                // The learned window (metadata) and the armed emergency
+                // (lastInputTokens) live in memory only until scheduled —
+                // the error path returns before forward()'s trailing
+                // markDirty, so schedule the save HERE or the self-heal is
+                // lost on restart and the next overflow must be re-learned.
+                markDirty(s);
             }
         }
         const errHeaders: Record<string, string> = { ...respHeaders };
-        if (errBody) {
-            // Writing a complete body — drop framing headers that would conflict
-            // with a fixed-length write.
-            delete errHeaders["content-length"];
-            delete errHeaders["transfer-encoding"];
-        }
+        // Drop the upstream framing headers unconditionally: when errBody is
+        // present a fixed-length write replaces them, and when errBody is
+        // null (broken body stream) the response ends with no body — a
+        // content-length/transfer-encoding claiming bytes that never arrive
+        // would leave the client on a broken response.
+        delete errHeaders["content-length"];
+        delete errHeaders["transfer-encoding"];
         res.writeHead(upstream.status, errHeaders);
         res.end(errBody ?? undefined);
         clearUpstreamTimer();

--- a/src/server.ts
+++ b/src/server.ts
@@ -693,14 +693,21 @@ async function handle(
             recordPluginSession(pluginConversation ?? conversation, session.id);
         }
         const pluginMode = pluginAgent !== undefined;
-        // Self-heal the context window: a prior upstream overflow may have taught
-        // us the real window (forward()'s overflow detection persists it to
+        // Self-heal the context window: a prior upstream overflow may have
+        // taught us the real window (forward()'s overflow detection persists it
+        // to metadata.learnedContextLimits, keyed by model, or the legacy scalar
         // metadata.learnedContextLimit). If it is smaller than what we resolved this
         // turn (e.g. the 200k fallback for an unknown model on a relay), re-center
         // the kernel on it so the nudge/truncate bands sit below the real limit
-        // instead of above it. Spread into a new object — never mutate the shared
-        // global config.
-        const learnedLimit = session.metadata.learnedContextLimit as number | undefined;
+        // instead of above it. A limit learned for a DIFFERENT model does not
+        // apply — the user can switch models mid-conversation (same session),
+        // and a stale smaller window would cap the bigger model prematurely.
+        // Spread into a new object — never mutate the shared global config.
+        const reqModel = (parsed as { model?: string }).model;
+        const learnedMap = session.metadata.learnedContextLimits as Record<string, number> | undefined;
+        const learnedLimit =
+            (reqModel && learnedMap ? learnedMap[reqModel] : undefined) ??
+            (session.metadata.learnedContextLimit as number | undefined);
         if (learnedLimit && learnedLimit > 0 && learnedLimit < reqConfig.modelContextLimit) {
             const resolved = reqConfig.modelContextLimit;
             reqConfig = { ...reqConfig, modelContextLimit: learnedLimit };
@@ -1455,13 +1462,26 @@ async function forward(
             const s = prepared.session;
             const info = inspectContextOverflow(upstream.status, errBody.toString("utf8"));
             if (info.isOverflow) {
+                // The request's model — the learned window only applies to the
+                // model that produced the overflow (per-model scoping: a stale
+                // limit from another model must not cap this one).
+                let reqModel: string | undefined;
+                try {
+                    const rawBody = typeof prepared.body === "string" ? prepared.body : prepared.body.toString("utf8");
+                    reqModel = (JSON.parse(rawBody) as { model?: string }).model;
+                } catch {
+                    reqModel = undefined; // non-JSON body — fall back to the legacy scalar
+                }
+                const learnedMap = (s.metadata.learnedContextLimits as Record<string, number> | undefined) ?? {};
                 if (info.window) {
-                    const prev = s.metadata.learnedContextLimit as number | undefined;
-                    // Persist the real window to a STABLE field: effectiveContextLimit
-                    // is re-resolved every turn (plugin mode) and would be overwritten;
-                    // handle() reads learnedContextLimit to re-center the kernel next turn.
-                    s.metadata.learnedContextLimit = info.window;
-                    log("warn", `[${s.id}] upstream context overflow — learned real window ${info.window} (was ${prev ?? "unset"}); arming emergency shrink`);
+                    const prev = (reqModel ? learnedMap[reqModel] : undefined) ?? (s.metadata.learnedContextLimit as number | undefined);
+                    // Persist the real window to a STABLE field (effectiveContextLimit
+                    // is re-resolved every turn in plugin mode and would be overwritten);
+                    // handle() reads it (per model) to re-center the kernel next turn.
+                    if (reqModel) learnedMap[reqModel] = info.window;
+                    else s.metadata.learnedContextLimit = info.window;
+                    s.metadata.learnedContextLimits = learnedMap;
+                    log("warn", `[${s.id}] upstream context overflow — learned real window ${info.window} for ${reqModel ?? "(unknown model)"} (was ${prev ?? "unset"}); arming emergency shrink`);
                 } else {
                     log("warn", `[${s.id}] upstream context overflow (window not parseable): ${info.message}`);
                 }
@@ -1472,6 +1492,7 @@ async function forward(
                 // next successful turn overwrites it.
                 const floor =
                     info.window ??
+                    (reqModel ? learnedMap[reqModel] : undefined) ??
                     (s.metadata.learnedContextLimit as number | undefined) ??
                     (s.metadata.effectiveContextLimit as number | undefined) ??
                     0;
@@ -1662,15 +1683,26 @@ async function forward(
 
 /** Read a (small) fetch Response body stream fully into a Buffer. Used for the
  *  non-2xx error path, where we inspect the body for a context-overflow before
- *  passing it through. Error bodies are small JSON, so full buffering is safe. */
-async function readStreamToBuffer(stream: ReadableStream<Uint8Array>): Promise<Buffer> {
+ *  passing it through. Error bodies are small JSON, so full buffering is safe —
+ *  but the read is still CAPPED (maxBytes, default 1 MiB): a misbehaving upstream
+ *  that streams a huge error body must not spike memory. The stream is drained
+ *  either way (no backpressure deadlock, no discarded keep-alive connection); only
+ *  the retained bytes are capped. Overflow markers live in the first few hundred
+ *  bytes, so a cap never loses the signal. */
+async function readStreamToBuffer(stream: ReadableStream<Uint8Array>, maxBytes = 1 << 20): Promise<Buffer> {
     const reader = stream.getReader();
     const chunks: Buffer[] = [];
+    let kept = 0;
     try {
         for (;;) {
             const { done, value } = await reader.read();
             if (done) break;
-            if (value) chunks.push(Buffer.from(value));
+            if (value && kept < maxBytes) {
+                // Trim the final chunk so retained bytes never exceed maxBytes.
+                const take = Math.min(value.length, maxBytes - kept);
+                chunks.push(Buffer.from(value.subarray(0, take)));
+                kept += take;
+            }
         }
     } finally {
         reader.releaseLock();

--- a/src/server.ts
+++ b/src/server.ts
@@ -56,7 +56,7 @@ import { deriveSessionId as deriveProxySessionId, affinityToken, clientConversat
 import { consumePluginRegisterFor, handlePluginManifest, handlePluginRegister, handlePluginStatus, handlePluginTool, pipePluginJson, pipeThroughWithUsage, pluginAgentHeader, pluginConversationHeader, pluginReportedContextWindow, recordPluginSession, rememberPluginMessages, takePendingPluginRegister } from "./plugin.js";
 import { setupMitm, readMitmUpstream } from "./mitm.js";
 import type { BiliMessage } from "acp-kernel/wire";
-import { isLoopbackAddress, inspectContextOverflow, usageTotals } from "./util.js";
+import { isLoopbackAddress, inspectContextOverflow, reserveOutputHeadroom, usageTotals } from "./util.js";
 
 import { decodeRequestBody } from "./content-encoding.js";
 
@@ -705,6 +705,23 @@ async function handle(
             const resolved = reqConfig.modelContextLimit;
             reqConfig = { ...reqConfig, modelContextLimit: learnedLimit };
             log("info", `[${session.id}] self-healed context window: ${resolved} → ${learnedLimit} (learned from an upstream overflow)`);
+        }
+        // Reserve the model's OUTPUT budget for this turn from the window so the
+        // kernel's nudge/truncate bands sit below (window - maxOutput) and a
+        // context+output overflow can't happen on a small window (e.g. 100k with a
+        // large max_tokens — the most common "context blew up" cause; none of the
+        // three layers reserved room for the output before this). max_tokens is the
+        // exact output budget requested for THIS turn, so the reservation is precise
+        // and per-request. Only reserve when it leaves a usable window (maxOutput <
+        // window); otherwise the request is degenerate (output >= whole window) and
+        // the self-heal above handles the resulting overflow. Feeds reqConfig (→
+        // processTurn `config`), so diagNudge shows the reserved window (no extra log).
+        {
+            const p = parsed as Record<string, unknown>;
+            const rawMax = p.max_tokens ?? p.max_completion_tokens ?? p.max_output_tokens;
+            const maxOutput = typeof rawMax === "number" ? rawMax : 0;
+            const reserved = reserveOutputHeadroom(reqConfig.modelContextLimit, maxOutput);
+            if (reserved !== reqConfig.modelContextLimit) reqConfig = { ...reqConfig, modelContextLimit: reserved };
         }
         // acquireInFlight must precede the lock so evictOldest() cannot flush
         // this session between getSession and lock acquisition (inFlight===0

--- a/src/util.ts
+++ b/src/util.ts
@@ -151,3 +151,19 @@ export function inspectContextOverflow(status: number, bodyText: string): Contex
     if (!isOverflow) return { isOverflow: false, message };
     return { isOverflow: true, window: parseOverflowWindow(bodyText), message };
 }
+
+/**
+ * Reserve the model's OUTPUT budget from the context window so the kernel's
+ * nudge/truncate bands (a fraction of the window) sit below (window - maxOutput)
+ * and a context+output overflow can't happen on a small window (e.g. 100k with a
+ * large max_tokens). Returns the effective window to hand to the kernel. No-op
+ * unless maxOutput is a positive finite number that leaves a usable window
+ * (maxOutput < window) — a request whose output budget is >= the whole window is
+ * degenerate and the self-heal handles the resulting overflow instead.
+ */
+export function reserveOutputHeadroom(window: number, maxOutput: number): number {
+    if (Number.isFinite(window) && window > 0 && Number.isFinite(maxOutput) && maxOutput > 0 && maxOutput < window) {
+        return window - maxOutput;
+    }
+    return window;
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -88,6 +88,8 @@ export function usageTotals(
         total: num(usage["input_tokens"]),
         cached: num((usage["input_tokens_details"] as Record<string, unknown> | undefined)?.["cached_tokens"]),
     };
+}
+
 /** Result of inspecting an upstream response for a "context too long" error. */
 export interface ContextOverflowInfo {
     /** True if the response looks like an upstream context-overflow error. */
@@ -168,4 +170,18 @@ export function reserveOutputHeadroom(window: number, maxOutput: number): number
         return window - maxOutput;
     }
     return window;
+}
+
+/**
+ * Whether the OUTPUT budget should be reserved from the context window at all.
+ * Anthropic's Messages API enforces the input limit INDEPENDENTLY of
+ * max_tokens (the output budget is separate — input up to the window works
+ * with any max_tokens), so reserving it would shift the nudge/truncate bands
+ * down by maxOutput on every session with no safety gain. The OpenAI-family
+ * APIs count output against the window, so the reservation is only needed
+ * there. Unknown/other protocols reserve (conservative — a missed reservation
+ * at worst overflows once and the self-heal corrects it).
+ */
+export function shouldReserveOutputHeadroom(protocol: string | undefined): boolean {
+    return protocol !== "anthropic";
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -88,4 +88,66 @@ export function usageTotals(
         total: num(usage["input_tokens"]),
         cached: num((usage["input_tokens_details"] as Record<string, unknown> | undefined)?.["cached_tokens"]),
     };
+/** Result of inspecting an upstream response for a "context too long" error. */
+export interface ContextOverflowInfo {
+    /** True if the response looks like an upstream context-overflow error. */
+    isOverflow: boolean;
+    /** The real context window (tokens) learned from the error body, if any
+     *  confident number is present. */
+    window?: number;
+    /** Truncated error-body text, for logging. */
+    message: string;
+}
+
+// Upstream "context too long" markers across providers. Deliberately specific:
+// NO bare "too many tokens" — that is Bedrock's *throttle* phrase (a 429 the
+// client should back off on), not a context overflow.
+const CONTEXT_OVERFLOW_PATTERNS: RegExp[] = [
+    /context_length_exceeded/i,
+    /context length exceeded/i,
+    /maximum context length/i,
+    /max context length/i,
+    /exceeds the context window/i,
+    /exceeded model token limit/i,
+    /prompt is too long/i,
+    /prompt_too_long/i,
+    /prompt_is_too_long/i,
+    /request_too_large/i,
+    /token limit exceeded/i,
+];
+
+function toTokenNumber(s: string): number | undefined {
+    const n = parseInt(s.replace(/,/g, ""), 10);
+    // A plausible window is at least a few thousand tokens; smaller numbers in
+    // the message (e.g. "5 inputs", a request id) are not the window.
+    return Number.isFinite(n) && n >= 1000 ? n : undefined;
+}
+
+/** Best-effort extraction of the real context window from an overflow error
+ *  body. Returns undefined when no confident window number is present — a wrong
+ *  guess (e.g. the prompt size, not the limit) is worse than no guess. */
+function parseOverflowWindow(text: string): number | undefined {
+    // "130000 tokens > 128000 maximum" (Anthropic) → the maximum, not the total.
+    let m = text.match(/>\s*(\d[\d,]*)\s*maximum/i);
+    if (m) return toTokenNumber(m[1]);
+    m =
+        text.match(/maximum context length is (\d[\d,]*)/i) ??
+        text.match(/maximum context length of (\d[\d,]*)/i) ??
+        text.match(/(?:maximum|max)\s+(?:context\s+)?length\s+(?:is\s+)?(\d[\d,]*)/i) ??
+        text.match(/limit of (\d[\d,]*)\s*token/i) ??
+        text.match(/(\d[\d,]*)\s*maximum\b/i);
+    if (m) return toTokenNumber(m[1]);
+    return undefined;
+}
+
+/** Inspect an upstream response for a context-overflow error. `status` is the
+ *  HTTP status; `bodyText` is the (usually small) error body. Only 400/413 with
+ *  a recognized context-too-long marker counts. */
+export function inspectContextOverflow(status: number, bodyText: string): ContextOverflowInfo {
+    const message = (bodyText ?? "").slice(0, 300);
+    if (status !== 400 && status !== 413) return { isOverflow: false, message };
+    if (!bodyText) return { isOverflow: false, message };
+    const isOverflow = CONTEXT_OVERFLOW_PATTERNS.some((p) => p.test(bodyText));
+    if (!isOverflow) return { isOverflow: false, message };
+    return { isOverflow: true, window: parseOverflowWindow(bodyText), message };
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -107,6 +107,7 @@ const CONTEXT_OVERFLOW_PATTERNS: RegExp[] = [
     /context length exceeded/i,
     /maximum context length/i,
     /max context length/i,
+    /maximum context size/i,
     /exceeds the context window/i,
     /exceeded model token limit/i,
     /prompt is too long/i,
@@ -133,6 +134,7 @@ function parseOverflowWindow(text: string): number | undefined {
     m =
         text.match(/maximum context length is (\d[\d,]*)/i) ??
         text.match(/maximum context length of (\d[\d,]*)/i) ??
+        text.match(/maximum context size (?:is|of) (\d[\d,]*)/i) ??
         text.match(/(?:maximum|max)\s+(?:context\s+)?length\s+(?:is\s+)?(\d[\d,]*)/i) ??
         text.match(/limit of (\d[\d,]*)\s*token/i) ??
         text.match(/(\d[\d,]*)\s*maximum\b/i);

--- a/tests/context-overflow.test.ts
+++ b/tests/context-overflow.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { inspectContextOverflow, reserveOutputHeadroom } from "../src/util.ts";
+import { inspectContextOverflow, reserveOutputHeadroom, shouldReserveOutputHeadroom } from "../src/util.ts";
 
 // A context-overflow error is the only reliable signal that the configured
 // window is wrong (e.g. the 200k fallback for an unknown model on a relay).
@@ -127,4 +127,15 @@ test("reserveOutputHeadroom: no-op for a non-positive / non-finite window", () =
     assert.equal(reserveOutputHeadroom(0, 8_000), 0);
     assert.equal(reserveOutputHeadroom(-1, 8_000), -1);
     assert.equal(reserveOutputHeadroom(Number.NaN, 8_000), Number.NaN);
+});
+
+// Protocol gate: Anthropic's Messages API enforces the input limit
+// independently of max_tokens (separate output budget), so reserving there
+// would shift every nudge/truncate band down by maxOutput for no safety gain.
+// OpenAI-family APIs count output against the window — reserve there.
+test("shouldReserveOutputHeadroom: anthropic exempt, other protocols reserve", () => {
+    assert.equal(shouldReserveOutputHeadroom("anthropic"), false, "Anthropic: output budget is separate from the context window");
+    assert.equal(shouldReserveOutputHeadroom("openai"), true);
+    assert.equal(shouldReserveOutputHeadroom("responses"), true);
+    assert.equal(shouldReserveOutputHeadroom(undefined), true, "unknown protocol → conservative (reserve)");
 });

--- a/tests/context-overflow.test.ts
+++ b/tests/context-overflow.test.ts
@@ -22,8 +22,24 @@ test("OpenAI: 'maximum context length is N tokens' → overflow + window", () =>
     assert.equal(info.window, 128000);
 });
 
-test("Anthropic: 'prompt is too long: X tokens > Y maximum' → window is Y", () => {
+test("OpenAI Responses: 'exceeds the model's maximum context size of N' → overflow + window", () => {
+    // The newer Responses-API phrasing (the chat-completions one above says
+    // "maximum context LENGTH is") — must be detected too, or self-heal never
+    // fires for /responses relays.
     const body = JSON.stringify({
+        error: {
+            message:
+                "This request's total token count is 130000, which exceeds the model's maximum context size of 128000 tokens.",
+            type: "invalid_request_error",
+            code: "context_length_exceeded",
+        },
+    });
+    const info = inspectContextOverflow(400, body);
+    assert.equal(info.isOverflow, true);
+    assert.equal(info.window, 128000);
+});
+
+test("Anthropic: 'prompt is too long: X tokens > Y maximum' → window is Y", () => {    const body = JSON.stringify({
         type: "error",
         error: { type: "invalid_request_error", message: "prompt is too long: 130000 tokens > 128000 maximum" },
     });

--- a/tests/context-overflow.test.ts
+++ b/tests/context-overflow.test.ts
@@ -1,0 +1,83 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { inspectContextOverflow } from "../src/util.ts";
+
+// A context-overflow error is the only reliable signal that the configured
+// window is wrong (e.g. the 200k fallback for an unknown model on a relay).
+// The detector must recognize the common provider phrasings, learn the real
+// window when present, and — critically — NOT false-positive on rate limits /
+// Bedrock's "too many tokens" throttle (a 429 the client should back off on).
+
+test("OpenAI: 'maximum context length is N tokens' → overflow + window", () => {
+    const body = JSON.stringify({
+        error: {
+            message:
+                "This model's maximum context length is 128000 tokens. However, you requested 132096 tokens (your request used 20 inputs and 4096 output tokens). Please reduce the length of the inputs or output.",
+            type: "invalid_request_error",
+            code: "context_length_exceeded",
+        },
+    });
+    const info = inspectContextOverflow(400, body);
+    assert.equal(info.isOverflow, true);
+    assert.equal(info.window, 128000);
+});
+
+test("Anthropic: 'prompt is too long: X tokens > Y maximum' → window is Y", () => {
+    const body = JSON.stringify({
+        type: "error",
+        error: { type: "invalid_request_error", message: "prompt is too long: 130000 tokens > 128000 maximum" },
+    });
+    const info = inspectContextOverflow(400, body);
+    assert.equal(info.isOverflow, true);
+    assert.equal(info.window, 128000); // the maximum, not the 130000 total
+});
+
+test("context_length_exceeded code with comma-grouped window", () => {
+    const body = JSON.stringify({ error: { code: "context_length_exceeded", message: "exceeds the limit of 1,048,576 tokens" } });
+    const info = inspectContextOverflow(400, body);
+    assert.equal(info.isOverflow, true);
+    assert.equal(info.window, 1048576);
+});
+
+test("413 + 'maximum context length' is an overflow", () => {
+    const info = inspectContextOverflow(413, "Request body too large: maximum context length is 65536 tokens");
+    assert.equal(info.isOverflow, true);
+    assert.equal(info.window, 65536);
+});
+
+test("overflow with no parseable window → isOverflow true, window undefined", () => {
+    const info = inspectContextOverflow(400, '{"error":{"message":"context length exceeded"}}');
+    assert.equal(info.isOverflow, true);
+    assert.equal(info.window, undefined);
+});
+
+test("auth error (400, no context marker) is NOT an overflow", () => {
+    const info = inspectContextOverflow(400, '{"error":{"message":"Invalid API key","type":"authentication_error"}}');
+    assert.equal(info.isOverflow, false);
+});
+
+test("Bedrock 'too many tokens' throttle (429) is NOT an overflow", () => {
+    // Bedrock phrases its *throttle* as "Too many tokens, please wait before
+    // trying again" — must not be treated as a context overflow.
+    const info = inspectContextOverflow(429, '{"message":"Too many tokens, please wait before trying again."}');
+    assert.equal(info.isOverflow, false);
+});
+
+test("plain 429 rate limit is NOT an overflow", () => {
+    const info = inspectContextOverflow(429, '{"error":{"message":"Rate limit reached"}}');
+    assert.equal(info.isOverflow, false);
+});
+
+test("2xx with a context-looking phrase is NOT an overflow (only 400/413)", () => {
+    const info = inspectContextOverflow(200, '{"note":"maximum context length is 128000 tokens"}');
+    assert.equal(info.isOverflow, false);
+});
+
+test("5xx is NOT an overflow (server error, not context)", () => {
+    const info = inspectContextOverflow(500, "context length exceeded");
+    assert.equal(info.isOverflow, false);
+});
+
+test("empty body is NOT an overflow", () => {
+    assert.equal(inspectContextOverflow(400, "").isOverflow, false);
+});

--- a/tests/context-overflow.test.ts
+++ b/tests/context-overflow.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { inspectContextOverflow } from "../src/util.ts";
+import { inspectContextOverflow, reserveOutputHeadroom } from "../src/util.ts";
 
 // A context-overflow error is the only reliable signal that the configured
 // window is wrong (e.g. the 200k fallback for an unknown model on a relay).
@@ -80,4 +80,35 @@ test("5xx is NOT an overflow (server error, not context)", () => {
 
 test("empty body is NOT an overflow", () => {
     assert.equal(inspectContextOverflow(400, "").isOverflow, false);
+});
+
+// reserveOutputHeadroom: the effective window handed to the kernel after
+// reserving the model's per-request output budget. The kernel's nudge/truncate
+// bands are a fraction of this window, so reserving maxOutput keeps the context
+// below (window - maxOutput) — a context+output overflow can't happen.
+test("reserveOutputHeadroom: reserves maxOutput when it leaves a usable window", () => {
+    // 100k window, 8k requested output → effective 92k.
+    assert.equal(reserveOutputHeadroom(100_000, 8_000), 92_000);
+    // 100k window, 40k requested output → effective 60k.
+    assert.equal(reserveOutputHeadroom(100_000, 40_000), 60_000);
+});
+
+test("reserveOutputHeadroom: no-op for non-positive / non-finite maxOutput", () => {
+    assert.equal(reserveOutputHeadroom(100_000, 0), 100_000);
+    assert.equal(reserveOutputHeadroom(100_000, -5), 100_000);
+    assert.equal(reserveOutputHeadroom(100_000, Number.NaN), 100_000);
+    assert.equal(reserveOutputHeadroom(100_000, Infinity), 100_000);
+});
+
+test("reserveOutputHeadroom: no-op when maxOutput >= window (degenerate request)", () => {
+    // Output budget equal to the window → nothing left for context; don't
+    // reserve (a <=0 window is invalid for the kernel) — self-heal handles it.
+    assert.equal(reserveOutputHeadroom(100_000, 100_000), 100_000);
+    assert.equal(reserveOutputHeadroom(100_000, 150_000), 100_000);
+});
+
+test("reserveOutputHeadroom: no-op for a non-positive / non-finite window", () => {
+    assert.equal(reserveOutputHeadroom(0, 8_000), 0);
+    assert.equal(reserveOutputHeadroom(-1, 8_000), -1);
+    assert.equal(reserveOutputHeadroom(Number.NaN, 8_000), Number.NaN);
 });

--- a/tests/e2e-overflow-selfheal.test.ts
+++ b/tests/e2e-overflow-selfheal.test.ts
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import { once } from "node:events";
+import test from "node:test";
+
+process.env.NODE_ENV = "test";
+
+import { defaultConfig } from "acp-kernel";
+import { startServer, type ProxyOptions } from "../src/server.ts";
+import { SessionStore, _setStoreForTest } from "../src/persist.ts";
+import { _setForTest as setRegistryForTest } from "../src/registry.ts";
+import { listSessions } from "../src/session.ts";
+
+// The configured window here is deliberately LARGE (400k) so it plays the role
+// of a wrong/mis-detected window (the 200k-fallback footgun for an unknown
+// model on a relay). The upstream truthfully reports its real window (128000)
+// via a context-overflow 400. The proxy must:
+//   1. detect the overflow and pass the 400 + body through verbatim;
+//   2. learn the real window (128000) into session.metadata.learnedContextLimit;
+//   3. arm an emergency shrink (lastInputTokens >= window);
+//   4. let the NEXT request recover (self-healed window, upstream 200).
+
+const OVERFLOW_BODY = JSON.stringify({
+    type: "error",
+    error: { type: "invalid_request_error", message: "prompt is too long: 130000 tokens > 128000 maximum" },
+});
+
+function okSse(): string {
+    return (
+        `event: message_start\ndata: ${JSON.stringify({ type: "message_start", message: { id: "m1", role: "assistant", usage: { input_tokens: 5000 } } })}\n\n` +
+        `event: content_block_start\ndata: ${JSON.stringify({ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } })}\n\n` +
+        `event: content_block_delta\ndata: ${JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "ok" } })}\n\n` +
+        `event: content_block_stop\ndata: ${JSON.stringify({ type: "content_block_stop", index: 0 })}\n\n` +
+        `event: message_delta\ndata: ${JSON.stringify({ type: "message_delta", delta: { stop_reason: "end_turn", stop_sequence: null }, usage: { output_tokens: 3 } })}\n\n` +
+        `event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`
+    );
+}
+
+test("e2e: upstream context overflow → learn window + arm shrink + pass through, then recover", async () => {
+    let call = 0;
+    const upstream = http.createServer((req, res) => {
+        const chunks: Buffer[] = [];
+        req.on("data", (c: Buffer) => chunks.push(c));
+        req.on("end", () => {
+            // First call: a context-overflow 400 with the real window in the body.
+            // Subsequent calls: a normal 200 SSE.
+            if (call === 0) {
+                res.writeHead(400, { "content-type": "application/json" });
+                res.end(OVERFLOW_BODY);
+            } else {
+                res.writeHead(200, { "content-type": "text/event-stream" });
+                res.end(okSse());
+            }
+            call += 1;
+        });
+    });
+    upstream.listen(0, "127.0.0.1");
+    await once(upstream, "listening");
+    const upstreamPort = upstream.address().port;
+
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    setRegistryForTest({});
+    const proxy = await startServer({
+        port: 0,
+        host: "127.0.0.1",
+        upstream: "http://127.0.0.1",
+        routes: { [`http://127.0.0.1:${upstreamPort}`]: { models: { "claude-test": { context: 400_000 } } } },
+        modelContextLimit: 400_000,
+        kernelConfig: defaultConfig(400_000),
+        compress: { injectTool: true, injectNudge: true },
+        promptCache: { routing: "auto" },
+        sessionHeader: "x-acp-session",
+        log: false,
+        debug: false,
+        passthrough: false,
+        autoUpdate: false,
+        mitm: { enabled: false, domains: [] },
+    } as ProxyOptions);
+    await once(proxy, "listening");
+    const proxyPort = proxy.address().port;
+
+    try {
+        const url = `http://127.0.0.1:${proxyPort}/bili/http://127.0.0.1:${upstreamPort}/v1/messages`;
+        const body = JSON.stringify({ model: "claude-test", max_tokens: 1024, stream: true, messages: [{ role: "user", content: "hello" }] });
+
+        // --- Request 1: overflow 400 ---
+        const r1 = await fetch(url, {
+            method: "POST",
+            headers: { "content-type": "application/json", "x-acp-session": "overflow-sess" },
+            body,
+        });
+        // The 400 is passed through verbatim (no behavior change for the client).
+        assert.equal(r1.status, 400);
+        const r1text = await r1.text();
+        assert.ok(r1text.includes("prompt is too long"), "error body must pass through");
+
+        // The session learned the real window and armed the emergency shrink.
+        const s = listSessions().find((x) => x.metadata.learnedContextLimit === 128000);
+        assert.ok(s, "a session learned the real window from the overflow");
+        assert.ok(s!.stats.lastInputTokens >= 128000, "emergency shrink armed (lastInputTokens >= window)");
+
+        // --- Request 2: recovers (self-healed window; upstream is fine now) ---
+        const r2 = await fetch(url, {
+            method: "POST",
+            headers: { "content-type": "application/json", "x-acp-session": "overflow-sess" },
+            body,
+        });
+        assert.equal(r2.status, 200, "second request recovers");
+        await r2.text(); // drain
+
+        // The real usage report from the successful turn overwrote the armed value.
+        const s2 = listSessions().find((x) => x.id === s!.id);
+        assert.equal(s2?.stats.lastInputTokens, 5000);
+    } finally {
+        proxy.close();
+        await once(proxy, "close");
+        upstream.close();
+        await once(upstream, "close");
+    }
+});

--- a/tests/e2e-overflow-selfheal.test.ts
+++ b/tests/e2e-overflow-selfheal.test.ts
@@ -9,7 +9,7 @@ import { defaultConfig } from "acp-kernel";
 import { startServer, type ProxyOptions } from "../src/server.ts";
 import { SessionStore, _setStoreForTest } from "../src/persist.ts";
 import { _setForTest as setRegistryForTest } from "../src/registry.ts";
-import { listSessions } from "../src/session.ts";
+import { listSessions, type Session } from "../src/session.ts";
 
 // The configured window here is deliberately LARGE (400k) so it plays the role
 // of a wrong/mis-detected window (the 200k-fallback footgun for an unknown
@@ -61,7 +61,18 @@ test("e2e: upstream context overflow → learn window + arm shrink + pass throug
     await once(upstream, "listening");
     const upstreamPort = upstream.address().port;
 
-    _setStoreForTest(new SessionStore({ enabled: false }));
+    // Spy on scheduleSave: the overflow error path returns before
+    // forward()'s trailing markDirty, so it must schedule its own save —
+    // otherwise the learned window (metadata) and the armed emergency
+    // (lastInputTokens) live only in memory and are lost on restart.
+    // (An on-disk assertion can't prove this: the prepare phase's own
+    // markDirty schedules a debounced save that serializes the live session
+    // AFTER forward() has mutated it.)
+    const store = new SessionStore({ enabled: false });
+    const scheduleCalls: string[] = [];
+    const origSchedule = store.scheduleSave.bind(store);
+    store.scheduleSave = ((s: Session) => { scheduleCalls.push(s.id); return origSchedule(s); }) as typeof store.scheduleSave;
+    _setStoreForTest(store);
     setRegistryForTest({});
     const proxy = await startServer({
         port: 0,
@@ -102,6 +113,12 @@ test("e2e: upstream context overflow → learn window + arm shrink + pass throug
         assert.ok(s, "a session learned the real window from the overflow (keyed by model)");
         assert.equal(s!.metadata.learnedContextLimit, undefined, "no legacy scalar when the model is known");
         assert.ok(s!.stats.lastInputTokens >= 128000, "emergency shrink armed (lastInputTokens >= window)");
+
+        // The prepare phase marks the session dirty once per request; the
+        // overflow error path must add its OWN save for the learned window +
+        // armed value (it returns before forward()'s trailing markDirty).
+        const saves = scheduleCalls.filter((id) => id === s!.id).length;
+        assert.ok(saves >= 2, `overflow error path scheduled its own save (scheduleSave x${saves} for the session)`);
 
         // --- Request 2: recovers (self-healed window; upstream is fine now) ---
         const r2 = await fetch(url, {

--- a/tests/e2e-overflow-selfheal.test.ts
+++ b/tests/e2e-overflow-selfheal.test.ts
@@ -16,9 +16,12 @@ import { listSessions } from "../src/session.ts";
 // model on a relay). The upstream truthfully reports its real window (128000)
 // via a context-overflow 400. The proxy must:
 //   1. detect the overflow and pass the 400 + body through verbatim;
-//   2. learn the real window (128000) into session.metadata.learnedContextLimit;
+//   2. learn the real window (128000) into session.metadata.learnedContextLimits,
+//      keyed by the model that overflowed;
 //   3. arm an emergency shrink (lastInputTokens >= window);
-//   4. let the NEXT request recover (self-healed window, upstream 200).
+//   4. let the NEXT request recover (self-healed window, upstream 200);
+//   5. NOT apply the learned limit to a different model in the same session
+//      (the user can switch models mid-conversation).
 
 const OVERFLOW_BODY = JSON.stringify({
     type: "error",
@@ -64,7 +67,7 @@ test("e2e: upstream context overflow → learn window + arm shrink + pass throug
         port: 0,
         host: "127.0.0.1",
         upstream: "http://127.0.0.1",
-        routes: { [`http://127.0.0.1:${upstreamPort}`]: { models: { "claude-test": { context: 400_000 } } } },
+        routes: { [`http://127.0.0.1:${upstreamPort}`]: { models: { "claude-test": { context: 400_000 }, "claude-big": { context: 400_000 } } } },
         modelContextLimit: 400_000,
         kernelConfig: defaultConfig(400_000),
         compress: { injectTool: true, injectNudge: true },
@@ -94,9 +97,10 @@ test("e2e: upstream context overflow → learn window + arm shrink + pass throug
         const r1text = await r1.text();
         assert.ok(r1text.includes("prompt is too long"), "error body must pass through");
 
-        // The session learned the real window and armed the emergency shrink.
-        const s = listSessions().find((x) => x.metadata.learnedContextLimit === 128000);
-        assert.ok(s, "a session learned the real window from the overflow");
+        // The session learned the real window (per model) and armed the emergency shrink.
+        const s = listSessions().find((x) => (x.metadata.learnedContextLimits as Record<string, number> | undefined)?.["claude-test"] === 128000);
+        assert.ok(s, "a session learned the real window from the overflow (keyed by model)");
+        assert.equal(s!.metadata.learnedContextLimit, undefined, "no legacy scalar when the model is known");
         assert.ok(s!.stats.lastInputTokens >= 128000, "emergency shrink armed (lastInputTokens >= window)");
 
         // --- Request 2: recovers (self-healed window; upstream is fine now) ---
@@ -111,6 +115,22 @@ test("e2e: upstream context overflow → learn window + arm shrink + pass throug
         // The real usage report from the successful turn overwrote the armed value.
         const s2 = listSessions().find((x) => x.id === s!.id);
         assert.equal(s2?.stats.lastInputTokens, 5000);
+
+        // --- Request 3: DIFFERENT model in the same session (user switched
+        // models) — the learned limit from claude-test must NOT apply. The map
+        // gains no entry for claude-big and the session keeps its 400k window.
+        const body3 = JSON.stringify({ model: "claude-big", max_tokens: 1024, stream: true, messages: [{ role: "user", content: "hi" }] });
+        const r3 = await fetch(url, {
+            method: "POST",
+            headers: { "content-type": "application/json", "x-acp-session": "overflow-sess" },
+            body: body3,
+        });
+        assert.equal(r3.status, 200);
+        await r3.text(); // drain
+        const s3 = listSessions().find((x) => x.id === s!.id);
+        const limits = s3?.metadata.learnedContextLimits as Record<string, number> | undefined;
+        assert.equal(limits?.["claude-big"], undefined, "no learned limit for the other model");
+        assert.deepEqual(Object.keys(limits ?? {}), ["claude-test"], "only the overflowing model is scoped");
     } finally {
         proxy.close();
         await once(proxy, "close");


### PR DESCRIPTION
## Problem

For a **small context window (e.g. 100k)**, two concrete mechanisms let the
context **blow up (爆掉)** and then **stall** (a permanent 400-loop, not an
infinite hang):

1. **Window misdetection + no recovery.** For an unknown model on a private
   relay (the MITM case) the resolved window falls back to **200k**, so the
   nudge/truncate bands sit at 150k/190k — but the upstream 400s at 100k.
   Every mechanism fires ~2× too late, silently. When the overflow 400 came
   back it was passed through verbatim with **no detection, no recovery, no
   state reset** — `lastInputTokens` stayed frozen at the pre-overflow value,
   so a non-compliant model + nothing truncatable = stuck 400-ing every turn.

2. **No output headroom reserved.** The kernel's nudge/truncate bands are a
   fraction of the window, but none of the layers reserved room for the
   model's **output**. On a 100k window with a large `max_tokens`,
   `context + output > window` overflows **before** the nudge fires — the most
   common "context blew up" cause.

## Fix (two complementary layers)

**Reactive (self-heal):**
- `inspectContextOverflow(status, body)` — pure detector for context-overflow
  400/413 (provider phrasings); deliberately does **not** match Bedrock's
  "too many tokens" throttle (a 429). `parseOverflowWindow` learns the real
  window when present (`> N maximum` / `maximum context length is N` / comma
  grouped).
- On an overflow 400, `forward()` persists the real window to
  `session.metadata.learnedContextLimit` and **arms an emergency shrink**
  (`lastInputTokens = max(current, window)` → next turn's usage ≥100% → kernel
  emergency nudge + tool-result truncate fire). The 400 is still passed through
  verbatim (no client behavior change).
- Next turn, `handle()` **re-centers the kernel** on the learned window (spread
  into a new object — the shared global config is never mutated), so the bands
  sit *below* the real limit instead of above it.

**Preventive (output headroom):**
- `reserveOutputHeadroom(window, maxOutput)` — pure. Per-request, `handle()`
  reserves the request's exact `max_tokens` (the output budget for **this**
  turn) from the window before handing it to the kernel, so the bands sit
  below `window − maxOutput`. Only reserves when it leaves a usable window
  (`maxOutput < window`); a degenerate `max_tokens >= window` is left to the
  self-heal.

Together: **prevent** the context+output overflow (headroom) and **recover**
from any overflow that still happens (self-heal) — no more stall.

## Verification
- `npm run typecheck` clean.
- Full suite **469/469 pass** (453 baseline + 11 `inspectContextOverflow`/
  `parseOverflowWindow` unit + 4 `reserveOutputHeadroom` unit + 1 overflow
  e2e).
- Overflow e2e: mock upstream returns a context-overflow 400 (with the real
  window in the body) then a 200 → asserts the 400 passes through verbatim,
  the real window is learned into `metadata.learnedContextLimit`, the emergency
  shrink is armed (`lastInputTokens >= window`), and the **next request
  recovers** (self-healed window; the real usage report then overwrites the
  armed value).
- Output-headroom verified end-to-end: with a 100k window + 40k `max_tokens`
  the kernel sees `usage = 50000/60000` (the reserved 60k window), not
  `50000/100000`.

## Notes
- `learnedContextLimit` is a **stable** field — `effectiveContextLimit` is
  re-resolved every turn (plugin mode) and would be overwritten.
- No `package.json` version bump (repo convention: separate release PR).