### PR TITLE
fix(compress): accept JSON-string content in parseCompressInput

### DIFF
--- a/src/compress-tool.ts
+++ b/src/compress-tool.ts
@@ -57,9 +57,19 @@ export function parseCompressInput(input: unknown, callId?: string): ParsedRange
         return [];
     }
     const obj = input as Record<string, unknown>;
+    // Accept JSON-string content (non-strict-tool providers stringify array args, e.g. vLLM openai-completions).
+    let content: unknown = obj.content;
+    if (typeof content === "string") {
+        try {
+            content = JSON.parse(content);
+        } catch {
+            loggerLog("warn", `[acp-compress-input] content is a string but not valid JSON; parsed 0 valid ranges`);
+            return [];
+        }
+    }
     const single = toRange(obj);
-    const ranges = Array.isArray(obj.content)
-        ? obj.content
+    const ranges = Array.isArray(content)
+        ? content
               .map((r) => toRange(r as Record<string, unknown>))
               .filter((r): r is ParsedRange => r !== null)
         : single

--- a/tests/basic.test.ts
+++ b/tests/basic.test.ts
@@ -143,6 +143,23 @@ test("parseCompressInput returns empty for malformed input", () => {
     assert.deepEqual(parseCompressInput({ content: [{ startId: "m1" }] }), []);
 });
 
+test("parseCompressInput accepts JSON-string content (non-strict providers stringify arrays)", () => {
+    const parsed = parseCompressInput({
+        content: JSON.stringify([
+            { startId: "m00001", endId: "m00010", summary: "first", topic: "intro" },
+            { startId: "m00020", endId: "m00030", summary: "second" },
+        ]),
+    });
+    assert.equal(parsed.length, 2);
+    assert.equal(parsed[0]?.startRef, "m00001");
+    assert.equal(parsed[0]?.endRef, "m00010");
+    assert.equal(parsed[0]?.summary, "first");
+    assert.equal(parsed[0]?.topic, "intro");
+    assert.equal(parsed[1]?.startRef, "m00020");
+    assert.equal(parsed[1]?.endRef, "m00030");
+    assert.deepEqual(parseCompressInput({ content: "not-json" }), []);
+});
+
 test("buildCompressSystemPrompt includes compression philosophy", () => {
     const prompt = buildCompressSystemPrompt();
     assert.ok(prompt.length > 100, "prompt should be substantial");


### PR DESCRIPTION
## 背景

非严格工具 provider(vLLM openai-completions,`supportsStrictTools:false`)会把嵌套数组参数字符串化:模型调用 `compress` 时传的 `content` 是 **JSON 字符串**而非数组。

此前 `parseCompressInput` 里 `Array.isArray(obj.content)` 为 false → 走 `toRange(obj)`(顶层无 startId/endId/summary)→ null → **静默解析出 0 个 range**,压缩从不执行(只有一条 warn 日志,无任何报错)。

## 改动

`src/compress-tool.ts` 的 `parseCompressInput` 在数组判断前,若 `content` 是字符串则先 `JSON.parse`(非法 JSON → warn + 0 ranges,不崩溃)。与 billion-context-pi PR #164(`normalizeRanges`)对称。

`tests/basic.test.ts` 增加 JSON 字符串形式的回归测试。

## 验证

- `npm run typecheck`(tsc --noEmit --project tsconfig.build.json):clean
- `npm test`:**464 pass / 0 fail**

不合并,等 review。