### PR TITLE
fix(update): verify entry files and never overwrite a working install with a broken one (anti-brick)

### DIFF
--- a/src/update.ts
+++ b/src/update.ts
@@ -114,6 +114,95 @@ async function readDiskVersion(installDir: string): Promise<string | undefined> 
     }
 }
 
+/** Declared loadable entries of a package.json: `main` plus every `bin`
+ *  value (string or map form), deduped. Exported for tests. */
+export function declaredEntryRelPaths(pkg: { main?: unknown; bin?: unknown }): string[] {
+    const entries = new Set<string>();
+    if (typeof pkg.main === "string") entries.add(pkg.main);
+    const bin = pkg.bin;
+    if (typeof bin === "string") entries.add(bin);
+    else if (bin && typeof bin === "object") {
+        for (const v of Object.values(bin)) {
+            if (typeof v === "string") entries.add(v);
+        }
+    }
+    return [...entries];
+}
+
+/** Run `node --check` on a file in a child process. Never throws. */
+function runNodeCheck(file: string): Promise<{ code: number; stderr: string }> {
+    return new Promise((resolve) => {
+        execFile(
+            process.execPath,
+            ["--check", file],
+            { timeout: 15_000, maxBuffer: 4 * 1024 * 1024 },
+            (err, _stdout, stderr) => {
+                resolve({ code: err ? 1 : 0, stderr: String(stderr) });
+            },
+        );
+    });
+}
+
+/**
+ * Syntax-check an ESM entry with `node --check`. The entry is copied to a
+ * `.mjs` temp first: extension-based module-goal detection is the only signal
+ * `--check` honors consistently across Node versions, and the entry must not
+ * be *executed* (running it would start the CLI/server).
+ * Returns null on success or a short reason on failure.
+ */
+async function syntaxCheckEntry(entryAbs: string): Promise<string | null> {
+    let source: string;
+    try {
+        source = await readFile(entryAbs, "utf-8");
+    } catch (e) {
+        return `entry unreadable: ${String(e)}`;
+    }
+    const tmpCheck = path.join(cacheDir(), ".update-syntax-check.mjs");
+    try {
+        await mkdir(cacheDir(), { recursive: true });
+        await writeFile(tmpCheck, source);
+        const r = await runNodeCheck(tmpCheck);
+        if (r.code !== 0) {
+            return `entry does not parse (${path.basename(entryAbs)}): ${r.stderr.split("\n").filter(Boolean).slice(0, 3).join(" | ").slice(0, 300)}`;
+        }
+        return null;
+    } finally {
+        try {
+            await rm(tmpCheck, { force: true });
+        } catch {
+            // best-effort cleanup
+        }
+    }
+}
+
+/**
+ * Verify that every entry a broken publish could forget (main, bins) exists
+ * and parses. Used against the staging dir before the install dir is touched
+ * and against the install dir after the copy. Returns null or the reason.
+ */
+async function verifyEntries(dir: string, label: string): Promise<string | null> {
+    let pkg: { main?: unknown; bin?: unknown };
+    try {
+        pkg = JSON.parse(await readFile(path.join(dir, "package.json"), "utf-8"));
+    } catch (e) {
+        return `${label}: package.json unreadable: ${String(e)}`;
+    }
+    const entries = declaredEntryRelPaths(pkg);
+    if (entries.length === 0) {
+        return `${label}: no declared entry (main/bin)`;
+    }
+    for (const rel of entries) {
+        try {
+            await access(path.join(dir, rel));
+        } catch {
+            return `${label}: entry missing: ${rel}`;
+        }
+        const reason = await syntaxCheckEntry(path.join(dir, rel));
+        if (reason) return `${label}: ${reason}`;
+    }
+    return null;
+}
+
 /**
  * Try to acquire an exclusive cross-process lock for updating.
  * Uses a lock file containing { pid, ts }. If the lock file exists and
@@ -333,7 +422,7 @@ export function verifyTarballIntegrity(buf: Buffer, integrity?: string, shasum?:
 /** Download the npm tarball, extract to a temp staging dir, verify, then copy
  *  over the install directory. */
 
-async function installViaTarball(
+export async function installViaTarball(
     version: string,
     tarballUrl: string,
     installDir: string | undefined,
@@ -420,29 +509,81 @@ async function installViaTarball(
         if (stagingVersion !== version) {
             return { ok: false, error: `staging verification failed: version is ${stagingVersion ?? "missing"}, expected ${version}` };
         }
+
+        // Broken-publish guard: a tarball can carry the right version but a
+        // missing or corrupt entry file (broken publish, partial upload).
+        // Catch it in staging — the install dir must never be touched by a
+        // package that cannot load, because a dead install can never update
+        // itself healthy again.
+        const stagingEntryErr = await verifyEntries(stagingDir, "staging verification failed");
+        if (stagingEntryErr) {
+            return { ok: false, error: stagingEntryErr };
+        }
     } catch (e) {
         return { ok: false, error: `extraction failed: ${String(e)}` };
     } finally {
         await rm(tmpFile, { force: true });
     }
 
+    // Back up the current install before overwriting. If anything fails after
+    // the copy (partial copy, version drift, corrupted entry), the backup is
+    // restored so the previously working version keeps running.
+    const backupDir = path.join(cacheDir(), `.update-backup-${version}`);
+    try {
+        await rm(backupDir, { recursive: true, force: true });
+        await cp(installDir, backupDir, { recursive: true, force: true });
+    } catch (e) {
+        // Fail closed: without a backup we refuse to overwrite the running
+        // install — the current version keeps working.
+        return { ok: false, error: `backup of current install failed (install left untouched): ${String(e)}` };
+    }
+
+    const restoreFromBackup = async (): Promise<string | null> => {
+        try {
+            await rm(installDir, { recursive: true, force: true });
+            await cp(backupDir, installDir, { recursive: true, force: true });
+            return null;
+        } catch (e) {
+            // Keep the backup dir — it is the only healthy copy left.
+            return `ROLLBACK FAILED — restore ${backupDir} to ${installDir} manually: ${String(e)}`;
+        }
+    };
+
     // Copy staging over install dir using Node's built-in fs.cp (Node 16.7+).
     // Cross-platform — no dependency on the `cp` binary (absent on Windows).
     // `recursive: true` + the trailing `/.` semantics: fs.cp copies the
     // *contents* of stagingDir into installDir, merging without nesting.
+    let copyError: string | null = null;
     try {
         await cp(stagingDir, installDir, { recursive: true, force: true });
     } catch (e) {
-        return { ok: false, error: `failed to copy to install dir: ${String(e)}` };
+        copyError = `failed to copy to install dir: ${String(e)}`;
     } finally {
         await rm(stagingDir, { recursive: true, force: true });
     }
+    if (copyError !== null) {
+        const rb = await restoreFromBackup();
+        return { ok: false, error: rb ?? copyError };
+    }
 
-    // Final verification
+    // Final verification: version must match and every declared entry must
+    // still parse on disk.
     const newVersion = await readDiskVersion(installDir);
     if (newVersion !== version) {
-        return { ok: false, error: `post-install verification failed: package.json version is ${newVersion ?? "missing"}, expected ${version}` };
+        const rb = await restoreFromBackup();
+        return {
+            ok: false,
+            error: rb ?? `post-install verification failed: package.json version is ${newVersion ?? "missing"}, expected ${version}`,
+        };
     }
+    const postEntryErr = await verifyEntries(installDir, "post-install verification failed");
+    if (postEntryErr) {
+        const rb = await restoreFromBackup();
+        return { ok: false, error: rb ?? postEntryErr };
+    }
+
+    // Success: the backup is no longer needed.
+    await rm(backupDir, { recursive: true, force: true });
 
     return { ok: true };
 }

--- a/tests/update-tarball.test.ts
+++ b/tests/update-tarball.test.ts
@@ -1,0 +1,149 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import * as tar from "tar";
+import { installViaTarball, declaredEntryRelPaths } from "../src/update.ts";
+
+function integrityField(buf: Buffer, alg = "sha512"): string {
+    return `${alg}-${crypto.createHash(alg).update(buf).digest("base64")}`;
+}
+
+interface Fixture {
+    root: string;
+    installDir: string;
+    cacheDir: string;
+    makeTarball(files: Record<string, string>): { tgz: Buffer; integrity: string };
+}
+
+/** A running install at 1.2.3 plus a scratch cache dir, like a real host. */
+function makeFixture(): Fixture {
+    const root = mkdtempSync(path.join(tmpdir(), "bc-update-test-"));
+    const installDir = path.join(root, "install");
+    const cacheDir = path.join(root, "cache");
+    mkdirSync(path.join(installDir, "dist"), { recursive: true });
+    writeFileSync(
+        path.join(installDir, "package.json"),
+        JSON.stringify({
+            name: "billion-context",
+            version: "1.2.3",
+            type: "module",
+            main: "dist/index.js",
+            bin: { bili: "./dist/index.js" },
+        }),
+    );
+    writeFileSync(path.join(installDir, "dist", "index.js"), "export const loaded = '1.2.3';\n");
+    return {
+        root,
+        installDir,
+        cacheDir,
+        makeTarball(files) {
+            const src = path.join(root, "pkg");
+            mkdirSync(path.join(src, "package"), { recursive: true });
+            for (const [rel, body] of Object.entries(files)) {
+                const dest = path.join(src, "package", rel);
+                mkdirSync(path.dirname(dest), { recursive: true });
+                writeFileSync(dest, body);
+            }
+            const tgzPath = path.join(root, "pkg.tgz");
+            tar.c({ cwd: src, file: tgzPath, gzip: true, sync: true }, ["package"]);
+            const tgz = readFileSync(tgzPath);
+            return { tgz, integrity: integrityField(tgz) };
+        },
+    };
+}
+
+/** Serve a crafted tarball through global fetch; never touch the network. */
+function withTarballFetch<T>(tgz: Buffer, fn: () => Promise<T>): Promise<T> {
+    const original = globalThis.fetch;
+    globalThis.fetch = (() => Promise.resolve(new Response(tgz))) as unknown as typeof fetch;
+    return fn().finally(() => {
+        globalThis.fetch = original;
+    });
+}
+
+/** v2.0.0 package.json for tarball payloads. */
+function pkgJson(version: string): string {
+    return JSON.stringify({
+        name: "billion-context",
+        version,
+        type: "module",
+        main: "dist/index.js",
+        bin: { bili: "./dist/index.js" },
+    });
+}
+
+test("declaredEntryRelPaths: main plus bin values (string and map), deduped", () => {
+    assert.deepEqual(
+        declaredEntryRelPaths({ main: "dist/index.js", bin: { bili: "dist/index.js", proxy: "./dist/proxy.js" } }),
+        ["dist/index.js", "./dist/proxy.js"],
+    );
+    assert.deepEqual(declaredEntryRelPaths({ bin: "cli.js" }), ["cli.js"]);
+    assert.deepEqual(declaredEntryRelPaths({}), []);
+});
+
+test("installViaTarball: clean tarball installs and removes the backup", { timeout: 30_000 }, async () => {
+    const fx = makeFixture();
+    process.env.XDG_CACHE_HOME = fx.cacheDir;
+    try {
+        const { tgz, integrity } = fx.makeTarball({
+            "package.json": pkgJson("2.0.0"),
+            "dist/index.js": "export const loaded = '2.0.0';\n",
+        });
+        const r = await withTarballFetch(
+            tgz,
+            () => installViaTarball("2.0.0", "https://registry.test/x.tgz", fx.installDir, integrity),
+        );
+        assert.equal(r.ok, true, r.error);
+        assert.equal(JSON.parse(readFileSync(path.join(fx.installDir, "package.json"), "utf-8")).version, "2.0.0");
+        assert.equal(readFileSync(path.join(fx.installDir, "dist", "index.js"), "utf-8"), "export const loaded = '2.0.0';\n");
+        assert.equal(existsSync(path.join(fx.cacheDir, "billion-context", ".update-backup-2.0.0")), false, "backup must be removed on success");
+    } finally {
+        delete process.env.XDG_CACHE_HOME;
+        rmSync(fx.root, { recursive: true, force: true });
+    }
+});
+
+test("installViaTarball: syntax-broken entry is rejected in staging, install untouched", { timeout: 30_000 }, async () => {
+    const fx = makeFixture();
+    process.env.XDG_CACHE_HOME = fx.cacheDir;
+    try {
+        const { tgz, integrity } = fx.makeTarball({
+            "package.json": pkgJson("2.0.0"),
+            "dist/index.js": "export const broken = (!;\n",
+        });
+        const r = await withTarballFetch(
+            tgz,
+            () => installViaTarball("2.0.0", "https://registry.test/x.tgz", fx.installDir, integrity),
+        );
+        assert.equal(r.ok, false);
+        assert.match(r.error ?? "", /staging verification failed: entry does not parse/);
+        // The anti-brick guarantee: the running install is byte-for-byte intact.
+        assert.equal(JSON.parse(readFileSync(path.join(fx.installDir, "package.json"), "utf-8")).version, "1.2.3");
+        assert.match(readFileSync(path.join(fx.installDir, "dist", "index.js"), "utf-8"), /1\.2\.3/);
+    } finally {
+        delete process.env.XDG_CACHE_HOME;
+        rmSync(fx.root, { recursive: true, force: true });
+    }
+});
+
+test("installViaTarball: tarball missing its declared entry is rejected in staging", { timeout: 30_000 }, async () => {
+    const fx = makeFixture();
+    process.env.XDG_CACHE_HOME = fx.cacheDir;
+    try {
+        // package.json declares dist/index.js but the tarball ships no dist/.
+        const { tgz, integrity } = fx.makeTarball({ "package.json": pkgJson("2.0.0") });
+        const r = await withTarballFetch(
+            tgz,
+            () => installViaTarball("2.0.0", "https://registry.test/x.tgz", fx.installDir, integrity),
+        );
+        assert.equal(r.ok, false);
+        assert.match(r.error ?? "", /staging verification failed: entry missing: dist\/index\.js/);
+        assert.equal(JSON.parse(readFileSync(path.join(fx.installDir, "package.json"), "utf-8")).version, "1.2.3");
+    } finally {
+        delete process.env.XDG_CACHE_HOME;
+        rmSync(fx.root, { recursive: true, force: true });
+    }
+});


### PR DESCRIPTION
## Problem

`installViaTarball` verified the staged tarball only by re-reading `package.json` version, then merged staging over the install dir:

- A tarball can carry the **right version but a missing or corrupt entry file** (broken publish, partial upload). `package.json` check passes, `dist/index.js` is missing or has a syntax error → installed anyway.
- The old copy was **merge-overwrite with no backup**: a partially copied or broken install cannot be undone, and since `bili` itself is what updates `bili`, a dead install can **never update itself healthy again** — permanent brick until the user reinstalls manually.

## Fix

1. **Staging entry guard** (fires before the install dir is touched): every declared entry — `main` plus all `bin` values — must exist and pass `node --check` (syntax-checked via a `.mjs` temp copy; the entry is never *executed*, since importing `dist/index.js` starts the CLI/server).
2. **Backup before overwrite**: the current install is copied to `<cacheDir>/.update-backup-<version>`. If the backup cannot be written, the update is refused — fail closed, the running version keeps working.
3. **Post-install verification + rollback**: after the copy, version and entries are re-verified on disk; any failure (copy error, version drift, broken entry) restores the backup. If restore itself fails, the backup dir is kept and the error says exactly how to restore manually.
4. Backup is removed only on success.

The download path was already integrity-checked (`verifyTarballIntegrity`, sha512/sha1, fail-closed) — this closes the other half: **integrity ≠ loadability**.

## Tests

`tests/update-tarball.test.ts` (4 new, full suite 498/498):
- clean tarball installs and removes the backup
- syntax-broken entry → rejected **in staging**, install dir byte-for-byte intact
- missing declared entry → rejected in staging, install intact
- `declaredEntryRelPaths` unit (main + bin string/map, dedup)

All flow tests build a real tarball (`tar.c` gzip) and serve it through a stubbed `globalThis.fetch` — no network.