### PR TITLE
release v0.1.44

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.43",
+  "version": "0.1.44",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.43",
+      "version": "0.1.44",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.43",
+  "version": "0.1.44",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## What

Release **v0.1.44** from master (version bump only; all content below already merged).

## Changes since v0.1.43

**Features**
- #161 — plugin protocol: `x-bili-plugin` header gating, codex MCP TOML array args, identity register, pending TTL
- #163 — launcher plugin mode: `BILI_LAUNCHER_PLUGIN=1` opt-in MCP injection, codex MCP shell conversation id, transparent-MITM default
- #170 — usage/cache accounting per protocol; ignore zero `input_tokens` in Anthropic `message_delta`
- #172 — overflow-window self-heal (per-model scope, output headroom, persist on error path)
- #177/#178 — VSCode Copilot BYOK: `total_tokens` in final chunk + cancel propagation

**Fixes**
- #168 — direct-connect 10s handshake timeout (#78)
- #169 — clean 426 on WebSocket upgrade so clients fall back to HTTP (#2)
- #171 — plugin remembered-snapshot locking + registered flag
- #174 — log non-2xx upstream responses (status + x-request-id + body snippet)
- #175 — bind host `localhost`→`127.0.0.1`; codex web card url-only
- #176 — compress tool accepts JSON-string `content`

**Internal**
- #179 — updater hardening: staged-entry `node --check`, backup, post-install verify + rollback

## Deviation from AGENTS.md §5 (noted deliberately)

#179 changes `src/update.ts` and ships in this release without a preceding no-op validation release. Rationale:
- The 0.1.43→0.1.44 upgrade hop is executed by the **old** 0.1.43 updater code regardless of what 0.1.44 contains, so the existing path is not affected by bundling.
- #179 is fail-closed: staged entry verified with `node --check`, previous install backed up to `<cacheDir>/.update-backup-<version>`, post-install re-verify with automatic rollback on failure.
- The existing chain has been validated by 43 consecutive releases.

## Pre-flight

- `npm run typecheck` — clean
- `npm test` — 498/498 pass
- `npm run build` — success

Merging publishes to npm via `release.yml` (tag `v0.1.44`).