### PR TITLE
chore(deps): bump acp-kernel 0.0.28 -> 0.0.31

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@types/node": "^22.0.0",
         "@types/node-forge": "^1.3.14",
-        "acp-kernel": "0.0.28",
+        "acp-kernel": "0.0.31",
         "fzstd": "0.1.1",
         "node-forge": "^1.4.0",
         "tar": "^7.5.22",
@@ -972,9 +972,9 @@
       }
     },
     "node_modules/acp-kernel": {
-      "version": "0.0.28",
-      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.28.tgz",
-      "integrity": "sha512-1pdpu8xmIlVFxfO3oHzaigX8DhlYVyMr9o5sSYHRzcOfijCwhnnz3yJMeqT8Gb1WBnIyl5UyV9muhTa5A4D/Sg==",
+      "version": "0.0.31",
+      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.31.tgz",
+      "integrity": "sha512-XVL/8RryOhc4mvqa+5JJTv7P4s2TJvmBHL6l0/3rCrixPfMcAADuHC5wXHlhRdsu8qsb26MFDT27rN8lJ2qCQA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/node-forge": "^1.3.14",
-    "acp-kernel": "0.0.28",
+    "acp-kernel": "0.0.31",
     "fzstd": "0.1.1",
     "node-forge": "^1.4.0",
     "tar": "^7.5.22",


### PR DESCRIPTION
Bundles three kernel releases since 0.0.28 (tsup inlines the kernel into dist, so this is the only way users get them):

## 0.0.29 — search performance
- Single-pass CJK segmentation + memoized per-doc features (perf)
- 2-char CJK queries admitted into fuzzy channel (Latin frozen)

## 0.0.30 — compress retry-loop fixes
- **`fc56e64` stale-refs gate message**: when every range in a batch fails boundary resolution, the gate now reports stale refs instead of the misleading "content too small (0 chars)… combine more messages" — root cause of cross-turn compress retry loops (kernel commit cites billion-context-pi#178)
- `79340d3` snap consumed anchors to the active owning block

## 0.0.31 — wire fix
- `626f933` preserve all image_url parts in the OpenAI codec (multi-image)

## Verification
- lockfile pins acp-kernel 0.0.31
- typecheck clean, **498/498 tests pass**, build OK (dist/index.js 2.10 MB)
- dist/index.js contains the new stale-refs reporting (61 matches)

## Notes
- Kernel #86 (decideNudge half-threshold dead code, tracked by #166) is **not** addressed in 0.0.29–0.0.31 — still OPEN upstream; this bump does not change that.