### PR TITLE
release v0.1.45

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.44",
+  "version": "0.1.45",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.44",
+      "version": "0.1.45",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@types/node": "^22.0.0",
         "@types/node-forge": "^1.3.14",
-        "acp-kernel": "0.0.31",
+        "acp-kernel": "0.0.32",
         "fzstd": "0.1.1",
         "node-forge": "^1.4.0",
         "tar": "^7.5.22",
@@ -972,9 +972,9 @@
       }
     },
     "node_modules/acp-kernel": {
-      "version": "0.0.31",
-      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.31.tgz",
-      "integrity": "sha512-XVL/8RryOhc4mvqa+5JJTv7P4s2TJvmBHL6l0/3rCrixPfMcAADuHC5wXHlhRdsu8qsb26MFDT27rN8lJ2qCQA==",
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.32.tgz",
+      "integrity": "sha512-iOJPF+X6NMGkpGsAbxHV0Fcvymzf9a0c5Mf/z3padNVgPgMNxwG1snxYravVccRePgHOzWgpNYikqtpGYhiInA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.44",
+  "version": "0.1.45",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/node-forge": "^1.3.14",
-    "acp-kernel": "0.0.31",
+    "acp-kernel": "0.0.32",
     "fzstd": "0.1.1",
     "node-forge": "^1.4.0",
     "tar": "^7.5.22",

--- a/src/server.ts
+++ b/src/server.ts
@@ -801,8 +801,34 @@ const ACP_TAG_MARK = "\x3cacp ";
 // generic-library fallback; this host strips it because the compress tool-call
 // already carries the summary (hideConsumedCompressCalls keeps active-block calls),
 // and a mid-stream insertion would shift the upstream prefix-cache breakpoint.
-function stripKernelSummaries(messages: BiliMessage[]): BiliMessage[] {
-    return messages.filter((m) => !(m.id ?? "").startsWith("acp_summary_"));
+//
+// Kernel >=0.0.32 also keeps the newest two ORPHANED compress pairs visible
+// (KEEP_LAST_ORPHANED=2 — failure observability, billion-context-pi#9). The
+// proxy wants consumed calls OFF the wire: drop orphaned pairs whose result is
+// not a failure. Active-block-linked calls stay (their args carry the live
+// summary); rejected calls stay (the model must see its own failures).
+function stripKernelSummaries(messages: BiliMessage[], state: { blocks: Array<{ active: boolean; compressCallId?: string }> }): BiliMessage[] {
+    const activeCallIds = new Set<string>();
+    for (const b of state.blocks) {
+        if (b.active && b.compressCallId) activeCallIds.add(b.compressCallId);
+    }
+    const compressCallIds = new Set<string>();
+    for (const m of messages) {
+        if (m.contentType === "tool-call" && m.toolName === "compress" && m.toolCallId) compressCallIds.add(m.toolCallId);
+    }
+    const consumedCallIds = new Set<string>();
+    for (const m of messages) {
+        if (m.contentType !== "tool-result" || !m.toolCallId) continue;
+        if (!compressCallIds.has(m.toolCallId)) continue;
+        if (activeCallIds.has(m.toolCallId)) continue;
+        if ((m.text ?? "").includes("FAILED")) continue;
+        consumedCallIds.add(m.toolCallId);
+    }
+    return messages.filter((m) => {
+        if ((m.id ?? "").startsWith("acp_summary_")) return false;
+        if (m.contentType !== "tool-call" && m.contentType !== "tool-result") return true;
+        return !(m.toolCallId && consumedCallIds.has(m.toolCallId));
+    });
 }
 
 function diagTagSummary(messages: CoreMessage[], sessionId: string, strategy: string): string {
@@ -878,7 +904,7 @@ function prepareAnthropic(
         }
         log("info", diagTagSummary(turn.messages, sessionId, "text-only"));
         log("info", diagNudge(turn, sessionId, tokenCount, config.modelContextLimit, parsed.model));
-        processedMessages = stripKernelSummaries(turn.messages);
+        processedMessages = stripKernelSummaries(turn.messages, session.state);
         reapOrphanBlocks(session, msgs, deactivateBlock);
         rebuiltMessages = coreToAnthropic(processedMessages as BiliMessage[], cacheControls);
 
@@ -956,7 +982,7 @@ function prepareOpenai(
         }
         log("info", diagTagSummary(turn.messages, sessionId, "text-only"));
         log("info", diagNudge(turn, sessionId, tokenCount, config.modelContextLimit, parsed.model));
-        processedMessages = stripKernelSummaries(turn.messages);
+        processedMessages = stripKernelSummaries(turn.messages, session.state);
         reapOrphanBlocks(session, msgs, deactivateBlock);
         rebuiltMessages = coreToOpenai(processedMessages as BiliMessage[]);
 
@@ -1052,7 +1078,7 @@ function prepareResponses(
         }
         log("info", diagTagSummary(turn.messages, sessionId, "text-only"));
         log("info", diagNudge(turn, sessionId, tokenCount, config.modelContextLimit, parsed.model));
-        processedMessages = stripKernelSummaries(turn.messages);
+        processedMessages = stripKernelSummaries(turn.messages, session.state);
         reapOrphanBlocks(session, msgs, deactivateBlock);
         rebuiltInput = patchResponsesInput(projection, processedMessages);
         if (shouldInject && !process.env.ACP_NO_COMPRESS_PROMPT) {
@@ -1154,7 +1180,7 @@ export function prepareCountTokens(
     try {
         const { msgs, cacheControls } = anthropicToCore(parsed);
         const turn = core.processTurn({ messages: msgs, state: session.state, config, tokenCount: session.stats.lastInputTokens, renderTags: "text-only" });
-        const stripped = stripKernelSummaries(turn.messages as BiliMessage[]);
+        const stripped = stripKernelSummaries(turn.messages as BiliMessage[], session.state);
         const rebuiltMessages = coreToAnthropic(stripped, cacheControls);
         log("info", `[${sessionId}] count_tokens pruned: ${msgs.length} → ${stripped.length} msgs`);
         return {


### PR DESCRIPTION
## Changes since v0.1.44

- **acp-kernel 0.0.31 → 0.0.32** — `KEEP_LAST_ORPHANED` 0 → 2 (kernel #104): the newest two orphaned compress call+result pairs stay visible in `processTurn` output so models can observe their own failures (removes the fixed-point precondition behind the infinite no-op compress loop, billion-context-pi#9).
- **Wire adaptation (in this branch, commit 48bdbb8)**: the proxy's upstream contract keeps consumed compress calls OFF the wire. `stripKernelSummaries` now also drops compress call+result pairs that are neither active-block-linked (their args carry the live summary) nor failures (`FAILED` marker) — rejections stay visible to the model. Core tool-results carry no `toolName`, so calls and results are paired by `toolCallId` across all four strip sites (anthropic / openai / responses / count_tokens).

## Preflight (against the real 0.0.32 from npm)

- [x] `npm install` (lockfile refreshed)
- [x] `npm run typecheck`
- [x] tests 512/512 (incl. the plugin-protocol "consumed range folds away" regression)
- [x] `npm run build`

acp-kernel 0.0.32 is live on npm.