### PR TITLE
chore(deps): bump acp-kernel 0.0.31 -> 0.0.32

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@types/node": "^22.0.0",
         "@types/node-forge": "^1.3.14",
-        "acp-kernel": "0.0.31",
+        "acp-kernel": "0.0.32",
         "fzstd": "0.1.1",
         "node-forge": "^1.4.0",
         "tar": "^7.5.22",
@@ -972,9 +972,9 @@
       }
     },
     "node_modules/acp-kernel": {
-      "version": "0.0.31",
-      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.31.tgz",
-      "integrity": "sha512-XVL/8RryOhc4mvqa+5JJTv7P4s2TJvmBHL6l0/3rCrixPfMcAADuHC5wXHlhRdsu8qsb26MFDT27rN8lJ2qCQA==",
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.32.tgz",
+      "integrity": "sha512-iOJPF+X6NMGkpGsAbxHV0Fcvymzf9a0c5Mf/z3padNVgPgMNxwG1snxYravVccRePgHOzWgpNYikqtpGYhiInA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/node-forge": "^1.3.14",
-    "acp-kernel": "0.0.31",
+    "acp-kernel": "0.0.32",
     "fzstd": "0.1.1",
     "node-forge": "^1.4.0",
     "tar": "^7.5.22",

--- a/tests/plugin-protocol.test.ts
+++ b/tests/plugin-protocol.test.ts
@@ -304,7 +304,11 @@ test("plugin tool API executes compress under the session lock; next request fol
         assert.equal(h.captured.length, 2);
         const foldedRaw = JSON.parse(h.captured[1]!.body) as { messages: Array<{ role: string; content: unknown }> };
         const folded = JSON.stringify(foldedRaw);
-        assert.ok(!folded.includes("toolu_c_1"), `consumed compress tool_use must be hidden from upstream: ${folded.slice(0, 400)}`);
+        // acp-kernel 0.0.32 (reverts #18): KEEP_LAST_ORPHANED=2 keeps the newest
+        // two orphaned compress call+result pairs visible for failure observability.
+        // The plugin-side block carries a plugin_<ts> callId (not the model's
+        // tool_use id), so toolu_c_1 is orphaned and stays visible — not hidden.
+        assert.ok(folded.includes("toolu_c_1"), `newest orphaned compress tool_use stays visible (KEEP_LAST_ORPHANED=2): ${folded.slice(0, 400)}`);
         assert.ok(foldedRaw.messages.length < 12, `history must shrink after folding: got ${foldedRaw.messages.length}`);
         assert.ok(!folded.includes("turn-1-marker answer"), "compressed range content must be folded away");
 


### PR DESCRIPTION
Bumps acp-kernel 0.0.31 -> 0.0.32 (tsup inlines the kernel into dist, so this is the only way users get it).

## 0.0.32 — compress failure observability (kernel #104, reverts #18)

- `KEEP_LAST_ORPHANED` 0 → 2: the newest two orphaned compress call+result pairs stay visible in the sent view instead of being hidden.
- Restores failure observability and removes the fixed-point precondition behind the infinite no-op compress loop (billion-context-pi#9): with failed calls visible again, the sent view changes on every retry, so a deterministic model can no longer sit pinned at an unobservable fixed point.
- Residue stays bounded at 2 pairs in all pipeline paths (bounding test added upstream); #18's unbounded accumulation does not return.

## Test change (behavior, not a workaround)

`tests/plugin-protocol.test.ts` — "plugin tool API executes compress under the session lock" asserted the consumed compress `tool_use` is **hidden** from upstream. That was the #18 behavior (`KEEP_LAST_ORPHANED=0`).

With the revert to `KEEP_LAST_ORPHANED=2`, the newest orphaned compress call is now **kept visible**. The plugin-side block carries a `plugin_<ts>` callId (generated in `handlePluginTool`), not the model's `tool_use` id, so the model's `toolu_c_1` is orphaned and stays in the sent view. The assertion is flipped to assert visibility (the folding assertions — history shrinks, range content folded away, summary retrievable via `search_context` — are unchanged and still hold).

## Verification

- lockfile pins acp-kernel 0.0.32
- typecheck clean, **512/512 tests pass** (3 consecutive full runs), build OK (dist/index.js 2.12 MB)
- dist/index.js contains `KEEP_LAST_ORPHANED = 2`

## Notes

- Two tests (`e2e-responses-chat-relay`, `admin-origin`) are timing-sensitive and flake occasionally under full-suite CPU load; both pass in isolation and on master — not related to this bump.
