### PR TITLE
release v0.1.45

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.44",
+  "version": "0.1.45",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.44",
+      "version": "0.1.45",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.44",
+  "version": "0.1.45",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Release **v0.1.45** from master (version bump only; content below already merged).

## Changes since v0.1.44

**acp-kernel 0.0.31 → 0.0.32** (#184)
- `KEEP_LAST_ORPHANED` 0 → 2 (kernel #104, reverts #18): the newest two orphaned compress call+result pairs stay visible in the sent view.
- Restores compress-failure observability and removes the fixed-point precondition behind the infinite no-op compress loop — with failed calls visible again, the sent view changes on every retry, so a deterministic model can no longer sit pinned at an unobservable fixed point.
- Residue bounded at 2 pairs in all pipeline paths; #18's unbounded accumulation does not return.
- Test updated: `tests/plugin-protocol.test.ts` — the consumed compress `tool_use` is now kept visible (orphaned, `KEEP_LAST_ORPHANED=2`) instead of hidden; folding assertions unchanged.

tsup inlines the kernel into dist, so this release is the only way users get 0.0.32.

## Pre-flight (on master, which this branch is based on)

- `npm run typecheck` — clean
- `npm test` — 512/512 pass (3 consecutive runs)
- `npm run build` — success (dist/index.js 2.12 MB, contains `KEEP_LAST_ORPHANED = 2`)

Merging publishes to npm via `release.yml` (tag `v0.1.45`).
