### PR TITLE
fix(plugin): codexRemove drops header-only bili block with no trailing newline

### DIFF
--- a/src/plugin-install.ts
+++ b/src/plugin-install.ts
@@ -275,8 +275,9 @@ function codexRemove(): string {
     if (start < 0) return `codex: not installed (${file})`;
     const lineStart = text.lastIndexOf("\n", start - 1) + 1;
     const after = text.slice(start);
-    const nextTable = after.slice(after.indexOf("\n") + 1).search(/^[ \t]*\[/m);
-    const end = nextTable >= 0 ? start + after.indexOf("\n") + 1 + nextTable : text.length;
+    const firstNewline = after.indexOf("\n");
+    const nextTable = firstNewline < 0 ? -1 : after.slice(firstNewline + 1).search(/^[ \t]*\[/m);
+    const end = nextTable >= 0 ? start + firstNewline + 1 + nextTable : text.length;
     const cleaned = (text.slice(0, lineStart).replace(/\n+$/, "\n") + text.slice(end)).replace(/^\n+/, "");
     backupOnce(file);
     fs.writeFileSync(file, cleaned);

--- a/tests/plugin-agent.test.ts
+++ b/tests/plugin-agent.test.ts
@@ -339,6 +339,16 @@ test("plugin install/remove roundtrips for pi/omp/codex/opencode under a fake HO
         assert.doesNotMatch(tomlAfter, /mcp_servers\.bili/);
         assert.match(tomlAfter, /\[mcp_servers\.other\]\ncommand = "x"\n/);
 
+        // Regression: a header-only [mcp_servers.bili] block as the final
+        // line with no trailing newline must be fully removed (previously
+        // the header line survived because the next-table search matched
+        // the header itself when after.indexOf("\n") was -1).
+        fs.writeFileSync(path.join(home, "config.toml"), "[mcp_servers.other]\ncommand = \"x\"\n[mcp_servers.bili]");
+        assert.match(pluginRemove("codex"), /removed/);
+        const tomlEdge = fs.readFileSync(path.join(home, "config.toml"), "utf8");
+        assert.doesNotMatch(tomlEdge, /mcp_servers\.bili/);
+        assert.match(tomlEdge, /\[mcp_servers\.other\]\ncommand = "x"\n/);
+
         assert.match(pluginInstall("opencode"), /installed/);
         const oc = JSON.parse(fs.readFileSync(path.join(home, ".config/opencode/opencode.json"), "utf8")) as { mcp: Record<string, { command: string[]; environment?: Record<string, string> }> };
         assert.equal(oc.mcp.bili.command[1]!.endsWith(path.join("dist", "mcp.js")), true);


### PR DESCRIPTION
## Bug

`codexRemove()` in `src/plugin-install.ts` leaves the `[mcp_servers.bili]` header line behind when the table is **header-only** (no keys) and sits as the **final line with no trailing newline**.

Root cause:

```js
const nextTable = after.slice(after.indexOf("\n") + 1).search(/^[ \t]*\[/m);
const end = nextTable >= 0 ? start + after.indexOf("\n") + 1 + nextTable : text.length;
```

When `after.indexOf("\n")` is `-1` (no newline in the block), `after.slice(0)` still includes the header itself, so the next-table search matches the header at index `0`. `end` collapses to `start` and the header line survives the removal.

Reproduced: a config ending in `...[mcp_servers.bili]` (no trailing `\n`) still contains `mcp_servers.bili` after `pluginRemove("codex")`.

## Fix

Compute `firstNewline` once and treat a missing newline as "block runs to EOF":

```js
const firstNewline = after.indexOf("\n");
const nextTable = firstNewline < 0 ? -1 : after.slice(firstNewline + 1).search(/^[ \t]*\[/m);
const end = nextTable >= 0 ? start + firstNewline + 1 + nextTable : text.length;
```

## Notes

- Very low real-world likelihood: `codexInstall` always writes `command`/`args`/`env` keys, so a header-only block only arises from manual editing, and it additionally requires a missing trailing newline. Fixing it anyway since the removal path should be total.
- Adds a regression test in `tests/plugin-agent.test.ts` covering the header-only, no-trailing-newline case. Verified the test **fails** on the old code (header survives) and **passes** with the fix.
- Full suite: 512 pass / 0 fail.