### PR TITLE
chore: bump acp-kernel to 0.0.34

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@types/node": "^22.0.0",
         "@types/node-forge": "^1.3.14",
-        "acp-kernel": "0.0.32",
+        "acp-kernel": "0.0.34",
         "fzstd": "0.1.1",
         "node-forge": "^1.4.0",
         "tar": "^7.5.22",
@@ -972,9 +972,9 @@
       }
     },
     "node_modules/acp-kernel": {
-      "version": "0.0.32",
-      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.32.tgz",
-      "integrity": "sha512-iOJPF+X6NMGkpGsAbxHV0Fcvymzf9a0c5Mf/z3padNVgPgMNxwG1snxYravVccRePgHOzWgpNYikqtpGYhiInA==",
+      "version": "0.0.34",
+      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.34.tgz",
+      "integrity": "sha512-iB1B7A92xYESmtBNJlUUP27A9t7yP/ULkC+rgnHDrwvC/rGJBMgkm0/P2tnXPRadwUNfXUoL3CGGzg7EkTUF8A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/node-forge": "^1.3.14",
-    "acp-kernel": "0.0.32",
+    "acp-kernel": "0.0.34",
     "fzstd": "0.1.1",
     "node-forge": "^1.4.0",
     "tar": "^7.5.22",


### PR DESCRIPTION
Bumps **acp-kernel 0.0.32 → 0.0.34** (two releases: 0.0.33 responses item.id fix + 0.0.34 inline `<think>` normalization).

## What the proxy gains

- **Inline demoted-thinking normalization** (kernel PR #112): `openaiToCore` now splits `<think>\n…\n</think>` / `<thinking>…</thinking>` / ```thinking fences at offset 0 of assistant content into a separate `reasoning` core message when no `reasoning_content` field is present. Providers that demote thinking inline (glm / qwen3 / deepseek / kimi via openai-completions) previously folded those turns as one opaque text blob:
  - reasoning-pair extraction now works for inline turns,
  - fingerprint/identity space is shared with the `reasoning_content` form, so omp restart replay (issue #64 demoted variant) survives without any mirror retry — omp PR #125 drops its omp-side retry accordingly.
- **Responses reasoning identity fix** (kernel PR #107, 0.0.33): reasoning core id derived from reasoning text instead of host item id.

Protocol/serialization decisions keep consolidating in the kernel; the proxy stays a thin mitm + adapter shell (this PR is dependency-only).

## Tests

- `npm test` 512/512 pass
- `npm run typecheck` clean
