### PR TITLE
fix: re-inject the client's openai system around the kernel hoist (0.0.37)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -972,9 +972,9 @@
       }
     },
     "node_modules/acp-kernel": {
-      "version": "0.0.37",
-      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.37.tgz",
-      "integrity": "sha512-H0CfGFgAnbtwYiXODPitctjbKWoljVcF3UYZrWDD5qTWHYwkiIZyw0wcH5UTorNC0FfCiKjQM6KMAwetAbAyqA==",
+      "version": "0.0.41",
+      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.41.tgz",
+      "integrity": "sha512-TFIxqoPkDVmakxDJGkkKitz1gGVjFlOrkRyHG24r3q49Sc2JWkf1YxcnA3KNRbZzoG9R0hsgOMzU078cY3pnJA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@types/node": "^22.0.0",
         "@types/node-forge": "^1.3.14",
-        "acp-kernel": "0.0.36",
+        "acp-kernel": "0.0.37",
         "fzstd": "0.1.1",
         "node-forge": "^1.4.0",
         "tar": "^7.5.22",
@@ -972,9 +972,9 @@
       }
     },
     "node_modules/acp-kernel": {
-      "version": "0.0.36",
-      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.36.tgz",
-      "integrity": "sha512-w3lyfah74H35HHBzmw/jwLVixPRfC1K7wbFjKrwoV1qdw5847kjzNxiJ3i6upEY3YPJI517A5FyPhne0vbvSVg==",
+      "version": "0.0.37",
+      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.37.tgz",
+      "integrity": "sha512-H0CfGFgAnbtwYiXODPitctjbKWoljVcF3UYZrWDD5qTWHYwkiIZyw0wcH5UTorNC0FfCiKjQM6KMAwetAbAyqA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/node-forge": "^1.3.14",
-    "acp-kernel": "0.0.36",
+    "acp-kernel": "0.0.37",
     "fzstd": "0.1.1",
     "node-forge": "^1.4.0",
     "tar": "^7.5.22",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/node-forge": "^1.3.14",
-    "acp-kernel": "0.0.37",
+    "acp-kernel": "0.0.41",
     "fzstd": "0.1.1",
     "node-forge": "^1.4.0",
     "tar": "^7.5.22",

--- a/src/loop/adapter-openai.ts
+++ b/src/loop/adapter-openai.ts
@@ -43,7 +43,7 @@ async function* iterSseChunks(stream: ReadableStream<Uint8Array>): AsyncGenerato
     }
 }
 
-export function createOpenaiAdapter(requestBody: Record<string, unknown>): CompressLoopAdapter {
+export function createOpenaiAdapter(requestBody: Record<string, unknown>, clientSystem?: string): CompressLoopAdapter {
     const model = (requestBody.model as string) ?? "unknown";
     let responseId = `chatcmpl-proxy-${Date.now()}`;
     let toolIndex = 0;
@@ -113,8 +113,13 @@ export function createOpenaiAdapter(requestBody: Record<string, unknown>): Compr
 
     return {
         buildRequest(coreMessages, systemPrompt, body) {
+            // Kernel 0.0.37 hoists the leading system/developer prefix out of
+            // the openai fold space (fingerprints must not depend on host
+            // runtime state), so coreMessages no longer carries it — re-inject
+            // the CLIENT's original system ahead of the compress prompt,
+            // mirroring the anthropic adapter's anthropicSystem path.
             const messages = coreToOpenai(coreMessages);
-            const withSys = injectOpenaiSystem(messages, [systemPrompt]);
+            const withSys = injectOpenaiSystem(messages, [clientSystem, systemPrompt].filter((p): p is string => typeof p === "string" && p.length > 0));
             return { ...body, messages: withSys };
         },
 

--- a/src/loop/index.ts
+++ b/src/loop/index.ts
@@ -24,9 +24,10 @@ export function pickAdapter(
     textProtocol?: boolean,
     responsesProjection?: ResponsesProjection,
     anthropicSystem?: AnthropicRequestBody["system"],
+    openaiSystem?: string,
 ): CompressLoopAdapter {
     if (protocol === "responses") return createResponsesAdapter(textProtocol, responsesProjection);
-    if (protocol === "openai") return createOpenaiAdapter(requestBody);
+    if (protocol === "openai") return createOpenaiAdapter(requestBody, openaiSystem);
     if (protocol === "anthropic") return createAnthropicAdapter(requestBody, anthropicSystem);
     throw new Error(`[acp-loop] unknown protocol: ${protocol}`);
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -326,6 +326,10 @@ type Prepared = {
     resetAfterSuccess?: boolean;
     responsesProjection?: ResponsesProjection;
     anthropicSystem?: AnthropicRequestBody["system"];
+    /** Original leading system/developer prefix text captured by the kernel's
+     *  openai hoist (0.0.37). The fold space no longer carries it, so every
+     *  rebuilt payload and compress-loop round must re-inject it. */
+    openaiSystemText?: string;
     nudge?: NudgeDecision;
     /** Effective compression prompts for this request (three-level cascade,
      *  defaults to the kernel's defaultPrompts). Carried so the compress loop
@@ -926,7 +930,7 @@ function prepareOpenai(
     const sessionId = session.id;
     const stream = parsed.stream === true;
     ++session.stats.requests;
-
+    let openaiSystemText = "";
     let processedMessages: CoreMessage[] = [];
     let originalMessages: CoreMessage[] = [];
     let nudge: NudgeDecision | undefined;
@@ -945,7 +949,12 @@ function prepareOpenai(
     const injectTools = shouldInject && !pluginMode;
 
     try {
-        const { msgs } = openaiToCore(parsed);
+        // Kernel 0.0.37 hoists the contiguous leading system/developer prefix
+        // OUT of the fold space: system content is host runtime state and
+        // must not feed ids/fingerprints. Capture it and re-inject below —
+        // otherwise the proxy would forward payloads without any system.
+        const { msgs, systemText } = openaiToCore(parsed);
+        openaiSystemText = systemText;
         originalMessages = msgs;
         // tokenCount = upstream's real input_tokens from the previous turn
         // (see anthropic branch comment). Never an estimate.
@@ -975,6 +984,7 @@ function prepareOpenai(
         // instead, mirroring pai-acp's design. Putting the nudge in system
         // would invalidate the cache every turn.
         const sysParts: string[] = [];
+        if (systemText) sysParts.push(systemText);
         if (shouldInject) sysParts.push(buildCompressSystemPrompt(prompts));
         rebuiltMessages = injectOpenaiSystem(rebuiltMessages, sysParts);
         if (injectTools) {
@@ -1007,7 +1017,7 @@ function prepareOpenai(
     }
     snapshotMessages(session, originalMessages);
     markDirty(session);
-    return { body: JSON.stringify(rebuilt), session, processedMessages, originalMessages, protocol: "openai", stream, compressInjected: injectTools, pluginMode, nudge, prompts } as Prepared;
+    return { body: JSON.stringify(rebuilt), session, processedMessages, originalMessages, protocol: "openai", stream, compressInjected: injectTools, pluginMode, nudge, prompts, openaiSystemText } as Prepared;
 }
 
 function prepareResponses(
@@ -1646,7 +1656,7 @@ async function forward(
             const reqHeaders = buildForwardHeaders(headers);
             const textProtocol = prepared.protocol === "responses" && !!prepared.responsesTextProtocol;
             const systemPrompt = textProtocol ? buildCompressHybridSystemPrompt(prepared.prompts ?? defaultPrompts) : buildCompressSystemPrompt(prepared.prompts ?? defaultPrompts);
-            const adapter = pickAdapter(prepared.protocol, parsedReq, textProtocol, prepared.responsesProjection, prepared.anthropicSystem);
+            const adapter = pickAdapter(prepared.protocol, parsedReq, textProtocol, prepared.responsesProjection, prepared.anthropicSystem, prepared.openaiSystemText);
             const loop = runCompressLoop(
                 streamToRead,
                 { core, config, messages: prepared.processedMessages.length > 0 ? prepared.processedMessages : prepared.originalMessages, session: prepared.session, log: ctx.log, proxyUrl, protocol: prepared.protocol, textProtocol, debug: opts.debug, nudge: prepared.nudge },

--- a/tests/bili-message-roundtrip.test.ts
+++ b/tests/bili-message-roundtrip.test.ts
@@ -92,24 +92,41 @@ test("anthropic: tool_result without is_error stays clean", () => {
     assert.equal(tr.is_error, undefined, "no spurious is_error");
 });
 
-// 4. OpenAI developer role round-trips (was collapsed to system).
-test("openai: developer role is restored", () => {
-    const body: OpenAIRequestBody = { messages: [{ role: "developer", content: "you are a dev" }] };
-    const { msgs } = openaiToCore(body);
-    assert.equal(msgs[0]?.role, "system", "kernel sees system");
-    assert.equal(msgs[0]?.originalRole, "developer", "originalRole sidecar stored");
+// 4. OpenAI developer role: leading prefixes are HOISTED out of the fold
+// space (kernel 0.0.37 — system content is host runtime state and must not
+// feed ids/fingerprints); a MID-conversation developer message still
+// round-trips via the originalRole sidecar.
+test("openai: leading developer prefix is hoisted, mid-conversation developer role is restored", () => {
+    const body: OpenAIRequestBody = {
+        messages: [
+            { role: "developer", content: "you are a dev" },
+            { role: "user", content: "hi" },
+            { role: "developer", content: "mid-turn nudge" },
+        ],
+    };
+    const { msgs, systemText } = openaiToCore(body);
+    assert.equal(systemText, "you are a dev", "leading developer prefix is returned alongside the core stream");
+    const mid = msgs.find((m) => m.role === "system");
+    assert.equal(mid?.originalRole, "developer", "originalRole sidecar stored for the mid-conversation piece");
     const rebuilt = coreToOpenai(msgs);
-    assert.equal(rebuilt[0]?.role, "developer", "developer role reconstructed");
-    assert.equal(rebuilt[0]?.content, "you are a dev");
+    assert.equal(rebuilt.find((m) => m.role === "developer")?.content, "mid-turn nudge", "developer role reconstructed");
 });
 
-// 4b. Sanity: a plain system role is NOT promoted to developer.
+// 4b. A plain (mid-conversation) system role is NOT promoted to developer.
 test("openai: system role stays system", () => {
-    const body: OpenAIRequestBody = { messages: [{ role: "system", content: "sys" }] };
-    const { msgs } = openaiToCore(body);
-    assert.equal(msgs[0]?.originalRole, "system");
+    const body: OpenAIRequestBody = {
+        messages: [
+            { role: "system", content: "head sys" },
+            { role: "user", content: "hi" },
+            { role: "system", content: "mid sys" },
+        ],
+    };
+    const { msgs, systemText } = openaiToCore(body);
+    assert.equal(systemText, "head sys", "leading system hoisted");
+    const mid = msgs.find((m) => m.role === "system");
+    assert.equal(mid?.originalRole, "system");
     const rebuilt = coreToOpenai(msgs);
-    assert.equal(rebuilt[0]?.role, "system");
+    assert.ok(rebuilt.some((m) => m.role === "system" && m.content === "mid sys"), "mid-conversation system reconstructed as system");
 });
 
 // 5. OpenAI image_url round-trips (image was previously dropped entirely).


### PR DESCRIPTION
## Symptom

The kernel (PR ranxianglei/acp-kernel#120, released 0.0.37) hoists the contiguous leading system/developer prefix OUT of the openai fold space: system content is host runtime state and must not feed ids/fingerprints, and a compression covering it used to delete the model's system prompt from every rebuilt payload.

Consequence for the proxy: after upgrading the kernel alone, `openaiToCore`'s msgs no longer carry the system at all — without this PR every forwarded payload and every compress-loop round would silently drop the client's system prompt.

## Fix

- `prepareOpenai` captures `systemText` from `openaiToCore` and re-injects it into every rebuilt payload (client system first, compress prompt after — preserves the prefix-cache-anchor ordering)
- `Prepared.openaiSystemText` flows into `pickAdapter` → `createOpenaiAdapter(requestBody, clientSystem)` so compress-loop rounds re-inject it too, mirroring the anthropic adapter's `anthropicSystem` path
- loop adapter `buildRequest` injects `[clientSystem, compressPrompt]` (empty parts filtered)

Note the proxy never had the restart-fingerprint failure (MITM sees the real wire every round) but DID inherit the compression-eats-system bug — and would lose system entirely on 0.0.37 without this change.

## Tests

- 512 pass / 0 fail; round-trip tests updated to the hoist contract (leading prefix hoisted + mid-conversation system/developer still round-trips via originalRole)
- acp-kernel 0.0.37 from npm