### PR TITLE
fix: compress over unpruned view + acp-kernel 0.0.38 (billion-context-pi#195)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -972,9 +972,9 @@
       }
     },
     "node_modules/acp-kernel": {
-      "version": "0.0.37",
-      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.37.tgz",
-      "integrity": "sha512-H0CfGFgAnbtwYiXODPitctjbKWoljVcF3UYZrWDD5qTWHYwkiIZyw0wcH5UTorNC0FfCiKjQM6KMAwetAbAyqA==",
+      "version": "0.0.41",
+      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.41.tgz",
+      "integrity": "sha512-TFIxqoPkDVmakxDJGkkKitz1gGVjFlOrkRyHG24r3q49Sc2JWkf1YxcnA3KNRbZzoG9R0hsgOMzU078cY3pnJA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@types/node": "^22.0.0",
         "@types/node-forge": "^1.3.14",
-        "acp-kernel": "0.0.36",
+        "acp-kernel": "0.0.37",
         "fzstd": "0.1.1",
         "node-forge": "^1.4.0",
         "tar": "^7.5.22",
@@ -972,9 +972,9 @@
       }
     },
     "node_modules/acp-kernel": {
-      "version": "0.0.36",
-      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.36.tgz",
-      "integrity": "sha512-w3lyfah74H35HHBzmw/jwLVixPRfC1K7wbFjKrwoV1qdw5847kjzNxiJ3i6upEY3YPJI517A5FyPhne0vbvSVg==",
+      "version": "0.0.37",
+      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.37.tgz",
+      "integrity": "sha512-H0CfGFgAnbtwYiXODPitctjbKWoljVcF3UYZrWDD5qTWHYwkiIZyw0wcH5UTorNC0FfCiKjQM6KMAwetAbAyqA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/node-forge": "^1.3.14",
-    "acp-kernel": "0.0.36",
+    "acp-kernel": "0.0.37",
     "fzstd": "0.1.1",
     "node-forge": "^1.4.0",
     "tar": "^7.5.22",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/node-forge": "^1.3.14",
-    "acp-kernel": "0.0.37",
+    "acp-kernel": "0.0.41",
     "fzstd": "0.1.1",
     "node-forge": "^1.4.0",
     "tar": "^7.5.22",

--- a/src/loop/adapter-openai.ts
+++ b/src/loop/adapter-openai.ts
@@ -43,7 +43,7 @@ async function* iterSseChunks(stream: ReadableStream<Uint8Array>): AsyncGenerato
     }
 }
 
-export function createOpenaiAdapter(requestBody: Record<string, unknown>): CompressLoopAdapter {
+export function createOpenaiAdapter(requestBody: Record<string, unknown>, clientSystem?: string): CompressLoopAdapter {
     const model = (requestBody.model as string) ?? "unknown";
     let responseId = `chatcmpl-proxy-${Date.now()}`;
     let toolIndex = 0;
@@ -113,8 +113,13 @@ export function createOpenaiAdapter(requestBody: Record<string, unknown>): Compr
 
     return {
         buildRequest(coreMessages, systemPrompt, body) {
+            // Kernel 0.0.37 hoists the leading system/developer prefix out of
+            // the openai fold space (fingerprints must not depend on host
+            // runtime state), so coreMessages no longer carries it — re-inject
+            // the CLIENT's original system ahead of the compress prompt,
+            // mirroring the anthropic adapter's anthropicSystem path.
             const messages = coreToOpenai(coreMessages);
-            const withSys = injectOpenaiSystem(messages, [systemPrompt]);
+            const withSys = injectOpenaiSystem(messages, [clientSystem, systemPrompt].filter((p): p is string => typeof p === "string" && p.length > 0));
             return { ...body, messages: withSys };
         },
 

--- a/src/loop/core.ts
+++ b/src/loop/core.ts
@@ -28,6 +28,8 @@ export interface LoopCtx {
     core: CompressionCore;
     config: Config;
     messages: CoreMessage[];
+    /** View handed to applyCompression (see RewriteCtx.compressMessages). */
+    compressMessages?: CoreMessage[];
     session: Session;
     log: (msg: string) => void;
     proxyUrl?: string;

--- a/src/loop/index.ts
+++ b/src/loop/index.ts
@@ -24,9 +24,10 @@ export function pickAdapter(
     textProtocol?: boolean,
     responsesProjection?: ResponsesProjection,
     anthropicSystem?: AnthropicRequestBody["system"],
+    openaiSystem?: string,
 ): CompressLoopAdapter {
     if (protocol === "responses") return createResponsesAdapter(textProtocol, responsesProjection);
-    if (protocol === "openai") return createOpenaiAdapter(requestBody);
+    if (protocol === "openai") return createOpenaiAdapter(requestBody, openaiSystem);
     if (protocol === "anthropic") return createAnthropicAdapter(requestBody, anthropicSystem);
     throw new Error(`[acp-loop] unknown protocol: ${protocol}`);
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -326,6 +326,10 @@ type Prepared = {
     resetAfterSuccess?: boolean;
     responsesProjection?: ResponsesProjection;
     anthropicSystem?: AnthropicRequestBody["system"];
+    /** Original leading system/developer prefix text captured by the kernel's
+     *  openai hoist (0.0.37). The fold space no longer carries it, so every
+     *  rebuilt payload and compress-loop round must re-inject it. */
+    openaiSystemText?: string;
     nudge?: NudgeDecision;
     /** Effective compression prompts for this request (three-level cascade,
      *  defaults to the kernel's defaultPrompts). Carried so the compress loop
@@ -926,7 +930,7 @@ function prepareOpenai(
     const sessionId = session.id;
     const stream = parsed.stream === true;
     ++session.stats.requests;
-
+    let openaiSystemText = "";
     let processedMessages: CoreMessage[] = [];
     let originalMessages: CoreMessage[] = [];
     let nudge: NudgeDecision | undefined;
@@ -945,7 +949,12 @@ function prepareOpenai(
     const injectTools = shouldInject && !pluginMode;
 
     try {
-        const { msgs } = openaiToCore(parsed);
+        // Kernel 0.0.37 hoists the contiguous leading system/developer prefix
+        // OUT of the fold space: system content is host runtime state and
+        // must not feed ids/fingerprints. Capture it and re-inject below —
+        // otherwise the proxy would forward payloads without any system.
+        const { msgs, systemText } = openaiToCore(parsed);
+        openaiSystemText = systemText;
         originalMessages = msgs;
         // tokenCount = upstream's real input_tokens from the previous turn
         // (see anthropic branch comment). Never an estimate.
@@ -975,6 +984,7 @@ function prepareOpenai(
         // instead, mirroring pai-acp's design. Putting the nudge in system
         // would invalidate the cache every turn.
         const sysParts: string[] = [];
+        if (systemText) sysParts.push(systemText);
         if (shouldInject) sysParts.push(buildCompressSystemPrompt(prompts));
         rebuiltMessages = injectOpenaiSystem(rebuiltMessages, sysParts);
         if (injectTools) {
@@ -1007,7 +1017,7 @@ function prepareOpenai(
     }
     snapshotMessages(session, originalMessages);
     markDirty(session);
-    return { body: JSON.stringify(rebuilt), session, processedMessages, originalMessages, protocol: "openai", stream, compressInjected: injectTools, pluginMode, nudge, prompts } as Prepared;
+    return { body: JSON.stringify(rebuilt), session, processedMessages, originalMessages, protocol: "openai", stream, compressInjected: injectTools, pluginMode, nudge, prompts, openaiSystemText } as Prepared;
 }
 
 function prepareResponses(
@@ -1646,7 +1656,7 @@ async function forward(
             const reqHeaders = buildForwardHeaders(headers);
             const textProtocol = prepared.protocol === "responses" && !!prepared.responsesTextProtocol;
             const systemPrompt = textProtocol ? buildCompressHybridSystemPrompt(prepared.prompts ?? defaultPrompts) : buildCompressSystemPrompt(prepared.prompts ?? defaultPrompts);
-            const adapter = pickAdapter(prepared.protocol, parsedReq, textProtocol, prepared.responsesProjection, prepared.anthropicSystem);
+            const adapter = pickAdapter(prepared.protocol, parsedReq, textProtocol, prepared.responsesProjection, prepared.anthropicSystem, prepared.openaiSystemText);
             const loop = runCompressLoop(
                 streamToRead,
                 { core, config, messages: prepared.processedMessages.length > 0 ? prepared.processedMessages : prepared.originalMessages, session: prepared.session, log: ctx.log, proxyUrl, protocol: prepared.protocol, textProtocol, debug: opts.debug, nudge: prepared.nudge },

--- a/src/server.ts
+++ b/src/server.ts
@@ -1649,7 +1649,7 @@ async function forward(
             const adapter = pickAdapter(prepared.protocol, parsedReq, textProtocol, prepared.responsesProjection, prepared.anthropicSystem);
             const loop = runCompressLoop(
                 streamToRead,
-                { core, config, messages: prepared.processedMessages.length > 0 ? prepared.processedMessages : prepared.originalMessages, session: prepared.session, log: ctx.log, proxyUrl, protocol: prepared.protocol, textProtocol, debug: opts.debug, nudge: prepared.nudge },
+                { core, config, messages: prepared.processedMessages.length > 0 ? prepared.processedMessages : prepared.originalMessages, compressMessages: prepared.originalMessages, session: prepared.session, log: ctx.log, proxyUrl, protocol: prepared.protocol, textProtocol, debug: opts.debug, nudge: prepared.nudge },
                 parsedReq,
                 { url: upstreamUrl, headers: reqHeaders },
                 adapter,

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -8,6 +8,10 @@ export type RewriteCtx = {
     core: CompressionCore;
     config: Config;
     messages: CoreMessage[];
+    /** View handed to applyCompression. Defaults to `messages`; hosts whose
+     *  `messages` view has pruned/hidden content (so block anchors can't
+     *  resolve) pass the unpruned log here (billion-context-pi#195). */
+    compressMessages?: CoreMessage[];
     session: Session;
     log: (msg: string) => void;
     debug?: boolean;
@@ -227,7 +231,7 @@ export function applyRanges(ranges: ReturnType<typeof parseCompressInput>, ctx: 
     try {
         const res = ctx.core.applyCompression({
             ranges,
-            messages: ctx.messages,
+            messages: ctx.compressMessages ?? ctx.messages,
             state: ctx.session.state,
             config: ctx.config,
         });

--- a/tests/bili-message-roundtrip.test.ts
+++ b/tests/bili-message-roundtrip.test.ts
@@ -92,24 +92,41 @@ test("anthropic: tool_result without is_error stays clean", () => {
     assert.equal(tr.is_error, undefined, "no spurious is_error");
 });
 
-// 4. OpenAI developer role round-trips (was collapsed to system).
-test("openai: developer role is restored", () => {
-    const body: OpenAIRequestBody = { messages: [{ role: "developer", content: "you are a dev" }] };
-    const { msgs } = openaiToCore(body);
-    assert.equal(msgs[0]?.role, "system", "kernel sees system");
-    assert.equal(msgs[0]?.originalRole, "developer", "originalRole sidecar stored");
+// 4. OpenAI developer role: leading prefixes are HOISTED out of the fold
+// space (kernel 0.0.37 — system content is host runtime state and must not
+// feed ids/fingerprints); a MID-conversation developer message still
+// round-trips via the originalRole sidecar.
+test("openai: leading developer prefix is hoisted, mid-conversation developer role is restored", () => {
+    const body: OpenAIRequestBody = {
+        messages: [
+            { role: "developer", content: "you are a dev" },
+            { role: "user", content: "hi" },
+            { role: "developer", content: "mid-turn nudge" },
+        ],
+    };
+    const { msgs, systemText } = openaiToCore(body);
+    assert.equal(systemText, "you are a dev", "leading developer prefix is returned alongside the core stream");
+    const mid = msgs.find((m) => m.role === "system");
+    assert.equal(mid?.originalRole, "developer", "originalRole sidecar stored for the mid-conversation piece");
     const rebuilt = coreToOpenai(msgs);
-    assert.equal(rebuilt[0]?.role, "developer", "developer role reconstructed");
-    assert.equal(rebuilt[0]?.content, "you are a dev");
+    assert.equal(rebuilt.find((m) => m.role === "developer")?.content, "mid-turn nudge", "developer role reconstructed");
 });
 
-// 4b. Sanity: a plain system role is NOT promoted to developer.
+// 4b. A plain (mid-conversation) system role is NOT promoted to developer.
 test("openai: system role stays system", () => {
-    const body: OpenAIRequestBody = { messages: [{ role: "system", content: "sys" }] };
-    const { msgs } = openaiToCore(body);
-    assert.equal(msgs[0]?.originalRole, "system");
+    const body: OpenAIRequestBody = {
+        messages: [
+            { role: "system", content: "head sys" },
+            { role: "user", content: "hi" },
+            { role: "system", content: "mid sys" },
+        ],
+    };
+    const { msgs, systemText } = openaiToCore(body);
+    assert.equal(systemText, "head sys", "leading system hoisted");
+    const mid = msgs.find((m) => m.role === "system");
+    assert.equal(mid?.originalRole, "system");
     const rebuilt = coreToOpenai(msgs);
-    assert.equal(rebuilt[0]?.role, "system");
+    assert.ok(rebuilt.some((m) => m.role === "system" && m.content === "mid sys"), "mid-conversation system reconstructed as system");
 });
 
 // 5. OpenAI image_url round-trips (image was previously dropped entirely).


### PR DESCRIPTION
Two changes, both needed for the #195 promote-after-prune fix to work in this proxy:

**1. Host fix (the important one):** the streaming loop ctx passed `processedMessages` (= pruned view with `acp_summary_*` stripped by `stripKernelSummaries`) to `applyCompression`. Active blocks whose raws were pruned had NO resolvable anchor in that view — not even the kernel 0.0.37+ summary-anchor fix can help when the summaries are stripped. Added a dedicated `compressMessages` field (unpruned `originalMessages`) used only by `applyCompression`; wire rebuilds (`patchResponsesInput`) keep using the pruned view.

   - Found via e2e: naively switching the whole ctx to `originalMessages` broke `grow-and-compress keeps upstream context bounded` (post-compress re-requests would send the full log upstream — 113KB bodies). The split-view design fixes both.

**2. Merged PR #193** (openai-system-hoist adaptation) — required because kernel 0.0.37+ changed openai wire system handling (2 wire tests fail without it). Rides along; close #193 after this merges.

**3. acp-kernel 0.0.36 → 0.0.38** (the #195 fix, acp-kernel PR #122).

Validated locally against the acp-kernel v0.0.38 build (dist overlaid): typecheck clean, **512/512 tests pass** (incl. grow-and-compress e2e + openai wire tests), build OK.

⚠️ **CI will fail at `npm ci` until acp-kernel 0.0.38 is published** (lockfile integrity still carries the 0.0.37 hash). Merge order: acp-kernel PR #122 first → once `npm view acp-kernel version` = 0.0.38, run `npm install && git commit --amend --no-edit && git push -f` on this branch (or ask the bot), then merge.