### PR TITLE
fix(loop): run applyCompression over the unpruned view

### DIFF
--- a/src/loop/core.ts
+++ b/src/loop/core.ts
@@ -28,6 +28,8 @@ export interface LoopCtx {
     core: CompressionCore;
     config: Config;
     messages: CoreMessage[];
+    /** View handed to applyCompression (see RewriteCtx.compressMessages). */
+    compressMessages?: CoreMessage[];
     session: Session;
     log: (msg: string) => void;
     proxyUrl?: string;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1649,7 +1649,7 @@ async function forward(
             const adapter = pickAdapter(prepared.protocol, parsedReq, textProtocol, prepared.responsesProjection, prepared.anthropicSystem);
             const loop = runCompressLoop(
                 streamToRead,
-                { core, config, messages: prepared.processedMessages.length > 0 ? prepared.processedMessages : prepared.originalMessages, session: prepared.session, log: ctx.log, proxyUrl, protocol: prepared.protocol, textProtocol, debug: opts.debug, nudge: prepared.nudge },
+                { core, config, messages: prepared.processedMessages.length > 0 ? prepared.processedMessages : prepared.originalMessages, compressMessages: prepared.originalMessages, session: prepared.session, log: ctx.log, proxyUrl, protocol: prepared.protocol, textProtocol, debug: opts.debug, nudge: prepared.nudge },
                 parsedReq,
                 { url: upstreamUrl, headers: reqHeaders },
                 adapter,

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -8,6 +8,10 @@ export type RewriteCtx = {
     core: CompressionCore;
     config: Config;
     messages: CoreMessage[];
+    /** View handed to applyCompression. Defaults to `messages`; hosts whose
+     *  `messages` view has pruned/hidden content (so block anchors can't
+     *  resolve) pass the unpruned log here (billion-context-pi#195). */
+    compressMessages?: CoreMessage[];
     session: Session;
     log: (msg: string) => void;
     debug?: boolean;
@@ -227,7 +231,7 @@ export function applyRanges(ranges: ReturnType<typeof parseCompressInput>, ctx: 
     try {
         const res = ctx.core.applyCompression({
             ranges,
-            messages: ctx.messages,
+            messages: ctx.compressMessages ?? ctx.messages,
             state: ctx.session.state,
             config: ctx.config,
         });


### PR DESCRIPTION
Feature branch (split out of #194 per review: features and releases stay separate).

## Problem

The streaming compress path fed `applyCompression` a view that had **neither**
the raw messages **nor** the rendered summaries:

- `server.ts` runCompressLoop ctx: `messages: prepared.processedMessages.length > 0 ? prepared.processedMessages : prepared.originalMessages`
- `processedMessages = stripKernelSummaries(turn.messages)` filters every `acp_summary_*` id
- → `loop/core.ts` executeProxyTool → `stream.ts` applyCompression({ messages: ctx.messages })

With kernel ≥0.0.37 (billion-context-pi#195 fix), block anchors resolve via the
rendered summary or surviving raws — a view containing neither can resolve
nothing, so compression of any pruned region fails in streaming mode.

## Fix

Split the two purposes of `LoopCtx.messages`:

- new optional `compressMessages?: CoreMessage[]` on `RewriteCtx` (src/stream.ts) and `LoopCtx` (src/loop/core.ts)
- `applyRanges` uses `ctx.compressMessages ?? ctx.messages` (src/stream.ts)
- `server.ts` runCompressLoop sets `compressMessages: prepared.originalMessages` (full unpruned log — anchors always resolvable)
- wire rebuilds / decompress / status keep using the pruned view (unchanged behavior)

Non-streaming paths already used `originalMessages` — no change for them.

## Validation

- typecheck clean; 512/512 tests; build OK (on pinned acp-kernel 0.0.36)
- e2e grow-and-compress passes with kernel 0.0.41 overlay (upstream body stays bounded)

Ships in the next release together with the acp-kernel bump (≥0.0.40 for
billion-context-pi#195/#199 fixes).