### PR TITLE
fix(anthropic): round-2 thinking deltas carry raw — stop per-delta block fragmentation

### DIFF
--- a/src/loop/adapter-anthropic.ts
+++ b/src/loop/adapter-anthropic.ts
@@ -197,7 +197,7 @@ export function createAnthropicAdapter(requestBody: Record<string, unknown>, ori
                         yield {
                             kind: "reasoning",
                             delta: delta.thinking,
-                            ...(round === 1 ? { raw: remapIndexInEvent(eventStr, ci) } : {}),
+                            raw: remapIndexInEvent(eventStr, ci),
                         } as ParsedStreamEvent;
                     } else if (delta.type === "signature_delta" && typeof delta.signature === "string") {
                         const ci = indexMap.get(upstreamIndex) ?? upstreamIndex;
@@ -205,7 +205,7 @@ export function createAnthropicAdapter(requestBody: Record<string, unknown>, ori
                             kind: "reasoning",
                             delta: "",
                             signature: delta.signature,
-                            ...(round === 1 ? { raw: remapIndexInEvent(eventStr, ci) } : {}),
+                            raw: remapIndexInEvent(eventStr, ci),
                         } as ParsedStreamEvent;
                     } else if (round === 1) {
                         const ci = indexMap.get(upstreamIndex) ?? upstreamIndex;
@@ -225,10 +225,8 @@ export function createAnthropicAdapter(requestBody: Record<string, unknown>, ori
                     } else if (thinkingIndexes.delete(upstreamIndex)) {
                         // Seal the current thinking segment so interleaved thinking
                         // blocks each keep their own signature on rebuild.
-                        if (round === 1) {
-                            const ci = indexMap.get(upstreamIndex) ?? upstreamIndex;
-                            yield { kind: "meta", chunk: remapIndexInEvent(eventStr, ci), firstRoundOnly: true } as ParsedStreamEvent;
-                        }
+                        const ci = indexMap.get(upstreamIndex) ?? upstreamIndex;
+                        yield { kind: "meta", chunk: remapIndexInEvent(eventStr, ci), firstRoundOnly: false } as ParsedStreamEvent;
                         yield { kind: "reasoning", delta: "", blockEnd: true } as ParsedStreamEvent;
                     } else {
                         const ci = indexMap.get(upstreamIndex) ?? upstreamIndex;

--- a/tests/anthropic-round2-stream.test.ts
+++ b/tests/anthropic-round2-stream.test.ts
@@ -8,6 +8,8 @@ interface ParsedEvent {
     raw?: Buffer;
     chunk?: Buffer;
     firstRoundOnly?: boolean;
+    signature?: string;
+    blockEnd?: boolean;
 }
 
 function sse(events: string[]): string {
@@ -67,5 +69,48 @@ test("anthropic round-2 message_start is NOT re-emitted (one message_start per r
     assert.ok(
         !metaChunks.some((c) => c.includes("message_start")),
         "round 2 skips message_start (already sent in round 1); re-emitting would start a second message",
+    );
+});
+
+const ROUND2_THINKING = sse([
+    `event: message_start\ndata: ${JSON.stringify({ type: "message_start", message: { id: "msg_r2t", usage: { input_tokens: 10 } } })}`,
+    `event: content_block_start\ndata: ${JSON.stringify({ type: "content_block_start", index: 0, content_block: { type: "thinking", thinking: "" } })}`,
+    `event: content_block_delta\ndata: ${JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "thinking_delta", thinking: "The" } })}`,
+    `event: content_block_delta\ndata: ${JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "thinking_delta", thinking: " ac" } })}`,
+    `event: content_block_delta\ndata: ${JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "thinking_delta", thinking: "p_status" } })}`,
+    `event: content_block_delta\ndata: ${JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "signature_delta", signature: "sig-abc" } })}`,
+    `event: content_block_stop\ndata: ${JSON.stringify({ type: "content_block_stop", index: 0 })}`,
+    `event: message_delta\ndata: ${JSON.stringify({ type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 5 } })}`,
+    `event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}`,
+]);
+
+test("anthropic round-2 thinking: deltas carry raw + signature forwarded — ONE block, not per-delta fragments (regression: zcode duplicate thinking)", async () => {
+    const adapter = createAnthropicAdapter({ model: "claude-1" });
+    const events: ParsedEvent[] = [];
+    for await (const ev of adapter.parseStream(toStream(ROUND2_THINKING), 2) as AsyncIterable<ParsedEvent>) {
+        events.push(ev);
+    }
+    const reasoning = events.filter((e) => e.kind === "reasoning");
+    const thinkingDeltas = reasoning.filter((e) => (e.delta ?? "").length > 0);
+    assert.equal(thinkingDeltas.length, 3, "three thinking deltas parsed");
+    assert.ok(
+        thinkingDeltas.every((e) => Buffer.isBuffer(e.raw)),
+        "round-2 thinking deltas carry raw — OLD code withheld raw and core.ts re-wrapped EACH delta via emitReasoning (start+delta+stop per chunk → one thinking block per token → clients replay them as duplicate '思考过程' entries)",
+    );
+    assert.ok(
+        thinkingDeltas.every((e) => !/content_block_start|content_block_stop/.test(e.raw!.toString("utf8"))),
+        "raw is a pure delta (NOT a full block)",
+    );
+    const sig = reasoning.find((e) => e.signature === "sig-abc");
+    assert.ok(sig && Buffer.isBuffer(sig.raw), "signature_delta forwarded with raw in round 2 (signatures must survive or replayed thinking 400s)");
+
+    const metaChunks = events.filter((e) => e.kind === "meta").map((e) => e.chunk?.toString("utf8") ?? "");
+    const thinkingStarts = metaChunks.filter((c) => c.includes('"thinking"'));
+    const stops = metaChunks.filter((c) => c.includes("content_block_stop"));
+    assert.equal(thinkingStarts.length, 1, "exactly one content_block_start for the thinking block");
+    assert.equal(stops.length, 1, "exactly one content_block_stop — block closes once");
+    assert.ok(
+        reasoning.some((e) => e.blockEnd),
+        "segment seal event still emitted for the server-side accumulator",
     );
 });

--- a/tests/plugin-agent.test.ts
+++ b/tests/plugin-agent.test.ts
@@ -164,6 +164,16 @@ async function flush(): Promise<void> {
     await new Promise((r) => setTimeout(r, 20));
 }
 
+// Windows CI runners can take seconds on a cold loopback connect, so a fixed
+// 20ms flush races the manifest fetch. Poll for registration instead.
+async function waitForTools(pi: FakePi, count: number, timeoutMs = 15000): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    while (pi.tools.length < count) {
+        if (Date.now() > deadline) throw new Error(`timed out waiting for ${count} registered tools; got ${pi.tools.length}`);
+        await new Promise((r) => setTimeout(r, 25));
+    }
+}
+
 test("pi extension registers manifest tools and stamps headers when proxied", async () => {
     const proxy = await startFakeProxy();
     try {
@@ -175,7 +185,7 @@ test("pi extension registers manifest tools and stamps headers when proxied", as
         assert.equal(headers["x-bili-plugin-conversation"], "sess-42");
         assert.equal(headers["x-bili-plugin-context-window"], "1000000");
         await pi.events.get("session_start")!({}, fakeCtx(proxy));
-        await flush();
+        await waitForTools(pi, 2);
         assert.equal(pi.tools.length, 2);
         assert.equal(pi.tools[0]!.name, "compress");
         assert.deepEqual(pi.tools[0]!.parameters, { type: "object", properties: { content: { type: "array" } }, required: ["content"] });
@@ -200,7 +210,7 @@ test("pi extension survives hostile host shapes without throwing", async () => {
         pi.events.get("before_provider_headers")!({ headers: null }, fakeCtx(proxy));
         pi.events.get("before_provider_headers")!({ headers: [] }, { sessionManager: {}, model: { baseUrl: `${proxy.origin}/bili/https://api.example.com/v1` } });
         await pi.events.get("session_start")!({}, {});
-        await flush();
+        await waitForTools(pi, 2);
         // proxied baseUrl above intentionally triggers header-fallback registration
         assert.equal(pi.tools.length, 2);
     } finally {
@@ -214,7 +224,7 @@ test("registration retries are throttled and deduped", async () => {
         const pi = makeFakePi();
         biliPlugin(pi as never);
         await pi.events.get("session_start")!({}, fakeCtx(proxy));
-        await flush();
+        await waitForTools(pi, 2);
         assert.equal(pi.tools.length, 2);
         const calls = proxy.toolCalls.length;
         for (let i = 0; i < 5; i++) pi.events.get("before_provider_headers")!({ headers: {} }, fakeCtx(proxy));


### PR DESCRIPTION
Found via live zcode testing (GLM-5.3 via z.ai anthropic wire) on the #198 build — but the bug is pre-existing on master (introduced alongside the e5edd10 emitReasoning path; the 4deb563 vertical-text fix covered text only).

## Symptom
When a turn runs round >1 (proxy tool executed → re-request, or compress rounds), every `thinking_delta` was re-wrapped by `emitReasoning` as a COMPLETE block (content_block_start + delta + stop). The client received one thinking block per token fragment:

- zcode rendered a stack of duplicate '思考过程' entries
- the client saved the fragments in history and replayed them — session file showed 30 reasoning msgs vs 3 real turns (27 fragments: '', 'The', ' ac', 'p', '_status', …)
- round-2 `signature_delta` was dropped entirely (no re-emit, no raw) — replayed thinking without signatures is a 400 waiting to happen on strict providers

Evidence: session `anthropic/zcode.z.ai_9f37…json` + bili.log `round 1: proxy tool executed` → `round 2` → next `processTurn: 39 msgs`.

## Fix
Mirror the proven 4deb563 text fix for thinking:
- `thinking_delta` / `signature_delta` events carry `raw` in ALL rounds (drop the round-1-only conditional)
- `content_block_stop` for thinking/redacted blocks forwarded in all rounds (previously round-1-only — redacted_thinking blocks never closed in round 2)

core.ts raw passthrough then preserves upstream framing byte-for-byte: one block, signature included. The `emitReasoning` fallback stays for adapters that do not provide raw.

## Tests
- New regression test in tests/anthropic-round2-stream.test.ts: round-2 thinking stream → exactly one block start/stop, deltas carry pure raw, signature forwarded, seal event intact
- 514/514 green, tsc clean, build green