### PR TITLE
release v0.1.46

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.45",
+  "version": "0.1.46",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.45",
+      "version": "0.1.46",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@types/node": "^22.0.0",
         "@types/node-forge": "^1.3.14",
-        "acp-kernel": "0.0.37",
+        "acp-kernel": "0.0.41",
         "fzstd": "0.1.1",
         "node-forge": "^1.4.0",
         "tar": "^7.5.22",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.45",
+  "version": "0.1.46",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Release v0.1.46.

Ships on master:
- #197 fix(loop): run applyCompression over the unpruned view (billion-context-pi#195)
- #193 openai system-role re-injection + acp-kernel 0.0.41 (billion-context-pi#195 promote-after-prune + #199 empty-rewrap guard)

This commit: version bump 0.1.45 -> 0.1.46 only (kernel pin already 0.0.41 on master; lockfile root entries synced).

Validated locally with the real npm acp-kernel@0.0.41: typecheck clean, 512/512 tests, build OK.