### PR TITLE
ci: per-PR npm preview builds (pr-artifact workflow)

### DIFF
--- a/.github/workflows/pr-artifact.yml
+++ b/.github/workflows/pr-artifact.yml
@@ -1,0 +1,118 @@
+name: PR Build Artifact
+
+on:
+    pull_request:
+        branches: [master]
+
+permissions:
+    contents: read
+    pull-requests: write
+
+jobs:
+    build-artifact:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 22
+                  cache: npm
+                  registry-url: https://registry.npmjs.org
+
+            - run: npm install --ignore-scripts --no-fund --no-audit
+
+            - run: npm run build
+
+            - name: Publish to npm with PR tag
+              run: |
+                  PR_NUMBER="${{ github.event.pull_request.number }}"
+                  RUN_NUMBER="${{ github.run_number }}"
+                  BASE_VERSION=$(node -p "require('./package.json').version")
+                  # Strip any existing prerelease suffix
+                  BASE_VERSION=$(echo "$BASE_VERSION" | sed 's/-.*//')
+                  PR_VERSION="${BASE_VERSION}-pr.${PR_NUMBER}.${RUN_NUMBER}"
+
+                  echo "Publishing version $PR_VERSION with tag pr-${PR_NUMBER}"
+                  npm version "$PR_VERSION" --no-git-tag-version
+                  npm publish --tag "pr-${PR_NUMBER}" --access public --ignore-scripts
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+            - name: Create installable tarball
+              run: |
+                  npm pack
+                  PR_NUM="${{ github.event.pull_request.number }}"
+                  TARBALL=$(ls billion-context-*.tgz | head -1)
+                  if [ -n "$PR_NUM" ] && [ -n "$TARBALL" ]; then
+                    cp "$TARBALL" "billion-context-pr${PR_NUM}.tgz"
+                  fi
+
+            - name: Upload artifact
+              uses: actions/upload-artifact@v4
+              with:
+                  name: billion-context-pr-${{ github.event.pull_request.number }}
+                  path: |
+                      billion-context-pr*.tgz
+                      dist/
+                  retention-days: 30
+
+            - name: Comment on PR with install instructions
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const prNumber = context.payload.pull_request.number;
+                      const sha = context.payload.pull_request.head.sha.slice(0, 7);
+                      const branch = context.payload.pull_request.head.ref;
+                      const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+                      const body = [
+                          '## 📦 Built Package Artifact',
+                          '',
+                          `**Branch:** \`${branch}\` (${sha})`,
+                          '',
+                          '### Option A — Install from npm PR tag (recommended)',
+                          '',
+                          '```bash',
+                          'npm install -g billion-context@pr-' + prNumber,
+                          '```',
+                          '',
+                          'Each push to this PR publishes a new version under the `pr-' + prNumber + '` npm tag.',
+                          '',
+                          '### Option B — Download artifact',
+                          '',
+                          `1. Download the artifact from the [Actions run](${runUrl})`,
+                          '2. Extract the tarball and install:',
+                          '',
+                          '```bash',
+                          'tar xzf billion-context-pr' + prNumber + '.tgz',
+                          'npm install -g package',
+                          '```',
+                          '',
+                          '---',
+                          '*This comment is automatically updated on each push.*',
+                      ].join('\n');
+
+                      // Find and update existing comment, or create new one
+                      const comments = await github.rest.issues.listComments({
+                          ...context.repo,
+                          issue_number: prNumber,
+                      });
+
+                      const existing = comments.data.find(c =>
+                          c.user.type === 'Bot' && c.body.includes('📦 Built Package Artifact')
+                      );
+
+                      if (existing) {
+                          await github.rest.issues.updateComment({
+                              ...context.repo,
+                              comment_id: existing.id,
+                              body,
+                          });
+                      } else {
+                          await github.rest.issues.createComment({
+                              ...context.repo,
+                              issue_number: prNumber,
+                              body,
+                          });
+                      }


### PR DESCRIPTION
**Model: qwen3.8-27b (vllm)** — AI agent (ework-daemon), opened per dog/opencode-acp#2.

Adds the same "new PR → auto npm preview" bot feature that opencode-acp already has (`.github/workflows/pr-artifact.yml`), adapted for `billion-context`:

- On every PR to `master`: `npm install` → `npm run build` → publish to npm as `<base>-pr.<PR>.<run>` under dist-tag `pr-<PR>` (e.g. `0.1.46-pr.201.3`)
- Uploads `billion-context-pr<PR>.tgz` + `dist/` as a 30-day artifact
- Posts/updates a bot comment on the PR with install instructions:
  - `npm install -g billion-context@pr-<N>` (recommended)
  - or download the artifact tarball

Notes:
- Uses the repo's existing `NPM_TOKEN` secret (same as `release.yml`)
- Install step matches this repo's CI convention (`npm install --ignore-scripts`)
- No changes to `version` in package.json (the version bump happens only inside the CI job, on the PR build)
- PR merge left to human per AGENTS.md