### PR TITLE
feat(launcher): add omp to the bili launcher (no-config /bili/ rewrite + MITM)

### DIFF
--- a/devlog/2026-08-23_omp-launcher/REQ.md
+++ b/devlog/2026-08-23_omp-launcher/REQ.md
@@ -1,0 +1,84 @@
+# REQ - omp launcher support
+
+- Task ID: `2026-08-23_omp-launcher`
+- Home Repo: `billion-context`
+- Created: 2026-08-23
+- Status: Done
+- Priority: P1
+- Owner: agent
+- References: n/a
+
+## 1. Background & Problem Statement
+
+- **Context**: `bili <client>` launcher already brings up a proxy and points a coding
+  agent at it with NO config-file edits, auto-proxying BOTH schemes: HTTPS upstreams
+  via cert-MITM, HTTP/plaintext upstreams via a `/bili/` baseURL rewrite applied
+  through the client's own mechanism (pi → isolated `PI_CODING_AGENT_DIR`, codex →
+  `-c key=value`, claude → `ANTHROPIC_BASE_URL`).
+- **Current behavior (symptom)**: `omp` (oh-my-pi, a pi-based coding agent) is only a
+  *plugin-install* target, not a launcher client. `bili omp` → `unknown command`.
+  Users of omp must hand-edit `~/.omp/agent/models.yml` to route through the proxy.
+- **Expected behavior**: `bili omp [args]` works like `bili pi` — discovers omp's
+  upstreams by *reading* (never editing) `~/.omp/agent/models.yml`, rewrites the HTTP
+  providers' `baseUrl` to the `/bili/` prefix in an isolated `PI_CODING_AGENT_DIR`,
+  whitelists HTTPS providers for MITM, and launches omp pointed at the proxy.
+- **Impact**: omp users get the zero-config compression experience; no manual
+  `models.yml` edits, no persistent config changes.
+
+## 2. Reproduction (if applicable)
+
+- **Environment**:
+  - Node: v25.9.0
+  - OS/Arch: linux-x64
+- **Minimal reproduction steps**:
+  1) `bili omp` → `bili: unknown command "omp"` (before this change).
+  2) After this change: `bili omp -p "reply with exactly: pong"` → proxy starts,
+     omp routes through it, returns `pong`.
+- **Relevant configuration**: `~/.omp/agent/models.yml` (providers with `baseUrl`),
+  `~/.omp/agent/config.yml` (extensions incl. the omp plugin, modelRoles).
+
+## 3. Constraints & Non-Goals
+
+- **Constraints**:
+  - Backward compatibility: must not touch the real `~/.omp/agent/models.yml` (the
+    user's hard requirement: "禁止改models.yml").
+  - Zero new runtime dependencies: omp's `models.yml` is YAML; the project has no YAML
+    parser, so a targeted line-based reader is used (mirrors `parseCodexToml`).
+  - omp is pi-based: it honors `PI_CODING_AGENT_DIR`, so the pi isolated-home pattern
+    applies directly.
+- **Non-Goals** (explicitly out of scope):
+  - No `bili test omp` smoke-test command (pi-test stays pi-only).
+  - No MCP-injection path for omp (it uses the native extension like pi, not MCP).
+
+## 4. Acceptance Criteria (must be testable)
+
+- **Correctness**:
+  - [x] `bili omp` is recognized as a launch client (`isLaunchClient("omp") === true`).
+  - [x] `discoverRoutes("omp", config)` splits omp providers into `httpsDomains`
+        (MITM) + `httpRewrites` (`/bili/`), keyed by provider name.
+  - [x] `prepareOmpHttpRewrite` builds an isolated `PI_CODING_AGENT_DIR` that symlinks
+        every real-home entry except `models.yml`, and writes a `models.yml` whose
+        target providers' `baseUrl` is rewritten (HTTP → `/bili/` wrap) while all other
+        bytes (comments, ordering, other providers) are preserved verbatim.
+  - [x] The real `~/.omp/agent/models.yml` is never modified.
+- **Performance / Stability**:
+  - [x] Launcher-spawned temp dir is removed on client exit; spawned proxy is killed.
+- **Regression**:
+  - [x] New/modified test cases added to `tests/launcher.test.ts` and passing
+        (8 new tests; full suite green).
+
+## 5. Proposed Approach (optional)
+
+- **Affected modules & entry files**:
+  - `src/client-config.ts` — `OmpProvider`/`OmpConfig`, `resolveOmpHome`,
+    `parseOmpYaml`, `readOmpConfig`, wired into `loadClientConfig`.
+  - `src/launcher.ts` — `omp` added to `LAUNCH_CLIENTS`/`BaseClientName`;
+    `launcherInjectMcp` excludes omp; `discoverRoutes` omp branch; new
+    `prepareOmpHttpRewrite`; `runLaunch` omp env branch + cleanup.
+  - `src/cli.ts` — help text mentions `bili omp`.
+  - `tests/launcher.test.ts` — 8 new tests.
+- **Risks**: YAML parsing is targeted (string `baseUrl` values only); a non-standard
+  `models.yml` layout (e.g. flow-style providers) would be skipped, not corrupted —
+  the rewrite is line-based and only rewrites matched `baseUrl:` lines.
+- **Rollback strategy**: revert the single feature commit; no data-format or config
+  schema changes to the proxy itself.

--- a/devlog/2026-08-23_omp-launcher/WORKLOG.md
+++ b/devlog/2026-08-23_omp-launcher/WORKLOG.md
@@ -1,0 +1,131 @@
+# WORKLOG - omp launcher support
+
+- Task ID: `2026-08-23_omp-launcher`
+- Home Repo: `billion-context`
+- Status: Done
+- Updated: 2026-08-23 08:05
+
+## 1. Summary
+
+- **What was done** (1–3 sentences): Wired `omp` (oh-my-pi) into the `bili <client>`
+  launcher so `bili omp` works like `bili pi`. omp is pi-based and honors
+  `PI_CODING_AGENT_DIR`, so the existing pi isolated-home pattern is reused: the
+  launcher reads `~/.omp/agent/models.yml` (never edits it), rewrites the HTTP
+  providers' `baseUrl` to the `/bili/` prefix in a temp agent dir, whitelists HTTPS
+  providers for MITM, and launches omp pointed at the proxy.
+- **Why** (1–3 sentences): omp was only a plugin-install target, so omp users had to
+  hand-edit `models.yml` to route through the proxy. The no-config launcher design
+  already existed for pi/codex/claude; omp just wasn't wired in.
+- **Behavior / compatibility changes**: Yes — `bili omp` is now a valid command. No
+  change to the proxy's wire protocol, config schema, or the real omp config files.
+- **Risk level**: Low
+
+## 2. Change Log
+
+### Commits
+
+| Commit | Description |
+|--------|-------------|
+| `192dcda` | feat: add omp to the bili launcher (no-config /bili/ rewrite + MITM) |
+
+### Key Files
+
+- `src/client-config.ts` — added `OmpProvider`/`OmpConfig` types, `resolveOmpHome`
+  (`PI_CODING_AGENT_DIR` → `~/.omp/agent`), `parseOmpYaml` (targeted line-based YAML
+  reader for `providers.<name>.baseUrl`, mirrors `parseCodexToml`), `readOmpConfig`;
+  wired `config.omp` into `loadClientConfig`.
+- `src/launcher.ts` — `omp` added to `LAUNCH_CLIENTS` + `BaseClientName`;
+  `launcherInjectMcp` now excludes omp (native extension, not MCP); `discoverRoutes`
+  omp branch; new `prepareOmpHttpRewrite` (line-based `models.yml` rewrite + symlink
+  siblings, mirrors `preparePiHttpRewrite`); `runLaunch` omp env branch
+  (`buildPiEnv` + `prepareOmpHttpRewrite` + `PI_CODING_AGENT_DIR`) + temp-dir cleanup.
+- `src/cli.ts` — help text lists `bili omp` (usage line + launcher section + example).
+- `tests/launcher.test.ts` — 8 new tests (parseOmpYaml ×2, readOmpConfig ×2,
+  resolveOmpHome, discoverRoutes omp, prepareOmpHttpRewrite ×3) + `isLaunchClient`
+  updated to assert `omp === true`.
+
+## 3. Design & Implementation Notes
+
+- **Entry point / key function**: `prepareOmpHttpRewrite(ompHome, origin,
+  httpRewrites, httpsRewrites)` in `src/launcher.ts`. It reads `models.yml`, walks the
+  `providers:` block by indentation, and rewrites only the `baseUrl:` line of each
+  provider present in `httpRewrites` (→ `wrapUpstream(origin, realUpstream)`) or
+  `httpsRewrites` (→ raw upstream for cert-MITM). Leading indent and any trailing
+  `# comment` are preserved. It then `mkdtemp`s a `bili-omp-*` dir, symlinks every
+  real-home entry except `models.yml` (so sessions/cache/dbs are shared, not
+  isolated), and writes the rewritten `models.yml`.
+- **Key configuration items**: `~/.omp/agent/models.yml` (providers),
+  `~/.omp/agent/config.yml` (extensions incl. `dist/agent/omp.js`, modelRoles).
+- **Key logic explanation**: omp is pi-based, so it reads its agent dir from
+  `PI_CODING_AGENT_DIR`. Pointing that at the temp dir makes omp use the rewritten
+  `models.yml` while sharing all other state via symlinks. The real `models.yml` is
+  never touched (user hard requirement). HTTPS providers (e.g. zhipuai) are not
+  rewritten — they go through cert-MITM via `HTTPS_PROXY` + the proxy CA, which is why
+  the launcher whitelists their hostnames and (when the running proxy lacks them)
+  spawns a fresh proxy.
+
+## 4. Testing & Verification
+
+### Build & Test Commands
+
+```sh
+npm run typecheck      # tsc --noEmit --project tsconfig.build.json
+npm test               # node --import tsx --test tests/*.test.ts
+npm run build          # tsup
+```
+
+### Test Coverage
+
+- New/modified test files: `tests/launcher.test.ts`
+- Test count: 523 total, 523 pass, 0 fail (was 515 before; +8 new)
+- Key scenarios verified:
+  - `parseOmpYaml` extracts `providers.<name>.baseUrl` and skips non-matching keys.
+  - `readOmpConfig` reads `models.yml`; returns `{}` when missing.
+  - `resolveOmpHome` honors `PI_CODING_AGENT_DIR`, defaults to `~/.omp/agent`.
+  - `discoverRoutes("omp", …)` splits http/https providers correctly.
+  - `prepareOmpHttpRewrite` rewrites the target provider, leaves others, symlinks
+    siblings; returns `undefined` when no rewrites or `models.yml` missing.
+
+### Results
+
+- **PASS/FAIL**: PASS
+- **Key logs/data** (optional): live end-to-end run
+  `node dist/index.js omp -p "reply with exactly: pong"` →
+  `bili: started proxy at http://127.0.0.1:44353 (MITM domains: open.bigmodel.cn)
+  (HTTP /bili/ rewrites: 6)` → omp returned `pong` → proxy log
+  `forward POST → http://127.0.0.1:8199/v1/responses` (traffic routed through the
+  proxy to the real SGLang backend) with the 4 ACP tools injected. Real
+  `~/.omp/agent/models.yml` confirmed untouched (0 `/bili/` occurrences); spawned
+  proxy killed and temp dir removed on client exit.
+
+## 5. Risk Assessment & Rollback
+
+- **Risk points**: `parseOmpYaml` is a targeted reader (string `baseUrl` values only);
+  a non-standard `models.yml` layout would be skipped, not corrupted (line-based
+  rewrite only touches matched `baseUrl:` lines).
+- **Rollback method**:
+  - Revert commit(s): `192dcda`
+  - Rollback impact: `bili omp` becomes `unknown command` again; no other behavior
+    changes.
+- **Compatibility notes** (data format, config schema): No — no proxy config schema or
+  wire-protocol changes; the real omp config files are never modified.
+
+## 6. Lessons Learned (optional)
+
+- What went well: omp being pi-based meant the entire pi isolated-home pattern
+  (`preparePiHttpRewrite` + `PI_CODING_AGENT_DIR`) transferred directly; only the
+  config file format (YAML vs JSON) needed a new targeted reader.
+- What could be improved: running the launcher from source (`node --import tsx
+  src/index.ts omp`) fails because the spawned proxy child uses `process.argv[1]`
+  (the TS source) with plain `node`; test the launcher from the built `dist/index.js`.
+- Reusable conclusions: for any future pi-based client, adding it to the launcher is
+  (1) a config reader in `client-config.ts`, (2) a `discoverRoutes` branch, (3) a
+  `prepare*HttpRewrite` for its config format, (4) a `runLaunch` env branch reusing
+  `buildPiEnv` + `PI_CODING_AGENT_DIR`.
+
+## 7. Follow-ups (optional)
+
+- [ ] Consider a `bili test omp` smoke-test command (currently pi-test is pi-only).
+- [ ] Consider reusing a running proxy when its MITM whitelist already covers the
+      discovered domains (currently a fresh proxy is spawned if the default-port proxy
+      lacks them).

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,7 +10,7 @@
  *   bili start --debug            verbose logging
  *   bili start --config FILE      path to config file (default: XDG)
  *   bili start --passthrough      forward without compression
- *   bili pi/codex/claude [args]   start a proxy + launch a client via cert-MITM
+ *   bili pi/codex/claude/omp [args]   start a proxy + launch a client via cert-MITM
  *   bili export [id] [--full]     export a persisted session as a handoff doc
  *   bili test pi                  non-polluting pi smoke test
  *   bili --version
@@ -62,6 +62,7 @@ Usage:
   bili pi-test [opts --] [args]    like bili pi but injects --no-extensions (clean test)
   bili codex [opts --] [args]      start a proxy + launch codex against it (cert-MITM)
   bili claude [opts --] [args]     start a proxy + launch claude against it (cert-MITM)
+  bili omp [opts --] [args]        start a proxy + launch omp against it (cert-MITM)
   bili test pi                     non-polluting pi smoke test through the proxy
   bili export [session] [--full]   list sessions / export one as a Markdown handoff
                                     (--full includes original messages; --output FILE)
@@ -76,7 +77,7 @@ Usage:
   bili --version                   print version
   bili --help                      show this help
 
-Launcher (bili pi / bili codex / bili claude):
+Launcher (bili pi / bili codex / bili claude / bili omp):
   Brings up a proxy on an independent port (reusing one already running on
   that port), then runs the client pointed at it via HTTPS_PROXY + the proxy's
   MITM CA — no config-file edits. Discovered HTTPS upstream domains are
@@ -88,6 +89,7 @@ Launcher (bili pi / bili codex / bili claude):
     bili pi-test                          # pi through the proxy with extensions off (proxy owns compression)
     bili codex                            # launch codex through the proxy
     bili claude                           # launch claude through the proxy
+    bili omp                              # launch omp through the proxy (pi-based; /bili/ rewrite)
     bili test pi                          # quick end-to-end check of the pi path
     bili pi --mitm-domain api.foo.com     # add a domain to the MITM whitelist
 

--- a/src/client-config.ts
+++ b/src/client-config.ts
@@ -36,11 +36,20 @@ export interface ZcodeConfig {
     providers: Record<string, ZcodeProvider>;
 }
 
+export interface OmpProvider {
+    baseUrl?: string;
+}
+
+export interface OmpConfig {
+    providers: Record<string, OmpProvider>;
+}
+
 export interface ClientConfig {
     claude?: ClaudeSettings;
     codex?: CodexConfig;
     pi?: PiConfig;
     zcode?: ZcodeConfig;
+    omp?: OmpConfig;
 }
 
 export function nonEmpty(s: unknown): s is string {
@@ -64,6 +73,14 @@ export function resolvePiHome(env: NodeJS.ProcessEnv): string {
     return nonEmpty(env.PI_CODING_AGENT_DIR) ? env.PI_CODING_AGENT_DIR!
         : nonEmpty(env.PI_HOME) ? env.PI_HOME!
         : path.join(h, ".pi", "agent");
+}
+
+/** omp (oh-my-pi) is pi-based: it honors PI_CODING_AGENT_DIR and defaults to
+ *  ~/.omp/agent. */
+export function resolveOmpHome(env: NodeJS.ProcessEnv): string {
+    const h = os.homedir();
+    return nonEmpty(env.PI_CODING_AGENT_DIR) ? env.PI_CODING_AGENT_DIR!
+        : path.join(h, ".omp", "agent");
 }
 
 export function readClaudeSettings(homeDir: string, cwd: string): ClaudeSettings {
@@ -147,6 +164,54 @@ export function readPiConfig(piHome: string): PiConfig {
     return { providers };
 }
 
+/**
+ * Targeted YAML reader for omp's ~/.omp/agent/models.yml: each
+ * `providers.<name>.baseUrl`. String values only; NOT a general YAML parser —
+ * intentionally dependency-free (mirrors parseCodexToml). Indentation-relative
+ * so it tolerates the file's base indent.
+ */
+export function parseOmpYaml(text: string): OmpConfig {
+    const result: OmpConfig = { providers: {} };
+    let providersIndent = -1;
+    let providerIndent = -1;
+    let currentProvider: string | null = null;
+    for (const rawLine of text.split(/\r?\n/)) {
+        const trimmed = rawLine.trim();
+        if (!trimmed || trimmed.startsWith("#")) continue;
+        const indent = rawLine.length - rawLine.trimStart().length;
+        if (providersIndent === -1) {
+            if (/^providers:\s*(#.*)?$/.test(trimmed)) providersIndent = indent;
+            continue;
+        }
+        if (indent <= providersIndent) break;
+        if (providerIndent === -1) providerIndent = indent;
+        if (indent === providerIndent) {
+            const m = /^([A-Za-z0-9_.-]+):/.exec(trimmed);
+            if (m) {
+                currentProvider = m[1];
+                if (!result.providers[currentProvider]) result.providers[currentProvider] = {};
+            } else {
+                currentProvider = null;
+            }
+        } else if (indent > providerIndent && currentProvider) {
+            const m = /^baseUrl:\s*(\S+)/.exec(trimmed);
+            if (m) result.providers[currentProvider].baseUrl = m[1];
+        }
+    }
+    return result;
+}
+
+export function readOmpConfig(ompHome: string): OmpConfig {
+    const cfgPath = path.join(ompHome, "models.yml");
+    let text: string;
+    try {
+        text = fs.readFileSync(cfgPath, "utf8");
+    } catch {
+        return { providers: {} };
+    }
+    return parseOmpYaml(text);
+}
+
 export function parseZcodeConfig(obj: unknown): ZcodeConfig {
     const result: ZcodeConfig = { providers: {} };
     if (!obj || typeof obj !== "object" || Array.isArray(obj)) return result;
@@ -190,5 +255,6 @@ export function loadClientConfig(env: NodeJS.ProcessEnv, cwd: string): ClientCon
     config.pi = readPiConfig(resolvePiHome(env));
     const zcodeHome = nonEmpty(env.ZCODE_DATA_BASE_DIR) ? env.ZCODE_DATA_BASE_DIR : path.join(home, ".zcode");
     config.zcode = readZcodeConfig(zcodeHome);
+    config.omp = readOmpConfig(resolveOmpHome(env));
     return config;
 }

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -32,7 +32,7 @@ import os from "node:os";
 import path from "node:path";
 import { spawn, type StdioOptions } from "node:child_process";
 import { DEFAULT_MITM_DOMAINS } from "./mitm.js";
-import { nonEmpty, resolvePiHome, loadClientConfig, type ClientConfig } from "./client-config.js";
+import { nonEmpty, resolvePiHome, resolveOmpHome, loadClientConfig, type ClientConfig } from "./client-config.js";
 
 export {
     type ClaudeSettings,
@@ -51,13 +51,18 @@ export {
     parseZcodeConfig,
     readZcodeConfig,
     resolvePiHome,
+    type OmpProvider,
+    type OmpConfig,
+    readOmpConfig,
+    parseOmpYaml,
+    resolveOmpHome,
 } from "./client-config.js";
 
 export const LAUNCHER_DEFAULT_HOST = "127.0.0.1";
 export const LAUNCHER_DEFAULT_PORT = 8787;
-export const LAUNCH_CLIENTS = ["pi", "codex", "claude", "pi-test"] as const;
+export const LAUNCH_CLIENTS = ["pi", "codex", "claude", "omp", "pi-test"] as const;
 export type ClientName = (typeof LAUNCH_CLIENTS)[number];
-export type BaseClientName = "claude" | "codex" | "pi";
+export type BaseClientName = "claude" | "codex" | "pi" | "omp";
 
 const HEALTH_PATH = "/__bili/health";
 const HEALTH_POLL_INTERVAL_MS = 200;
@@ -228,6 +233,10 @@ export function discoverRoutes(client: ClientName, config: ClientConfig): Discov
         for (const [name, prov] of Object.entries(config.pi?.providers ?? {})) {
             classify(prov.baseUrl, name);
         }
+    } else if (client === "omp") {
+        for (const [name, prov] of Object.entries(config.omp?.providers ?? {})) {
+            classify(prov.baseUrl, name);
+        }
     } else {
         for (const [name, prov] of Object.entries(config.codex?.providers ?? {})) {
             classify(prov.baseUrl, `model_providers.${name}.base_url`);
@@ -303,7 +312,7 @@ export function launcherDirectUrl(env: NodeJS.ProcessEnv): boolean {
  *  `!== "0"` semantics) once the flags have soaked; pi is always excluded —
  *  it has its own native extension (billion-context-pi #154). */
 export function launcherInjectMcp(env: NodeJS.ProcessEnv, base: string): boolean {
-    return base !== "pi" && env.BILI_LAUNCHER_PLUGIN === "1";
+    return base !== "pi" && base !== "omp" && env.BILI_LAUNCHER_PLUGIN === "1";
 }
 
 /** Ephemeral MCP config for --mcp-config / -c mcp_servers.bili.*: a single
@@ -408,6 +417,74 @@ export function preparePiHttpRewrite(
         }
     } catch {}
     fs.writeFileSync(path.join(tmp, "models.json"), JSON.stringify(root));
+    return tmp;
+}
+
+/**
+ * omp counterpart of preparePiHttpRewrite: build an isolated PI_CODING_AGENT_DIR
+ * that symlinks every entry of the real omp home EXCEPT models.yml, and write a
+ * models.yml whose target providers' baseUrl is rewritten (HTTP → /bili/ wrap,
+ * wrapped-HTTPS → raw https for cert MITM). The real models.yml is never
+ * touched. The rewrite is line-based (indentation-tracked) so all other bytes —
+ * comments, ordering, formatting — are preserved verbatim.
+ */
+export function prepareOmpHttpRewrite(
+    ompHome: string,
+    origin: string,
+    httpRewrites: HttpRewrite[],
+    httpsRewrites: HttpRewrite[],
+): string | undefined {
+    if (httpRewrites.length === 0 && httpsRewrites.length === 0) return undefined;
+    const modelsPath = path.join(ompHome, "models.yml");
+    let txt: string;
+    try {
+        txt = fs.readFileSync(modelsPath, "utf8");
+    } catch {
+        return undefined;
+    }
+    const httpMap = new Map(httpRewrites.map((r) => [r.key, wrapUpstream(origin, r.realUpstream)]));
+    const httpsMap = new Map(httpsRewrites.map((r) => [r.key, r.realUpstream]));
+    const lines = txt.split(/\r?\n/);
+    let providersIndent = -1;
+    let providerIndent = -1;
+    let currentProvider: string | null = null;
+    for (let i = 0; i < lines.length; i++) {
+        const rawLine = lines[i];
+        const trimmed = rawLine.trim();
+        if (!trimmed || trimmed.startsWith("#")) continue;
+        const indent = rawLine.length - rawLine.trimStart().length;
+        if (providersIndent === -1) {
+            if (/^providers:\s*(#.*)?$/.test(trimmed)) providersIndent = indent;
+            continue;
+        }
+        if (indent <= providersIndent) break;
+        if (providerIndent === -1) providerIndent = indent;
+        if (indent === providerIndent) {
+            const m = /^([A-Za-z0-9_.-]+):/.exec(trimmed);
+            currentProvider = m ? m[1] : null;
+        } else if (indent > providerIndent && currentProvider) {
+            const baseMatch = /^(baseUrl:\s*)(\S+)/.exec(trimmed);
+            if (baseMatch) {
+                const target = httpMap.get(currentProvider) ?? httpsMap.get(currentProvider);
+                if (target) {
+                    const leading = rawLine.slice(0, rawLine.length - rawLine.trimStart().length);
+                    const commentMatch = /\s+#.*$/.exec(rawLine);
+                    const comment = commentMatch ? commentMatch[0] : "";
+                    lines[i] = `${leading}baseUrl: ${target}${comment}`;
+                }
+            }
+        }
+    }
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "bili-omp-"));
+    try {
+        for (const entry of fs.readdirSync(ompHome)) {
+            if (entry === "models.yml") continue;
+            try {
+                fs.symlinkSync(path.join(ompHome, entry), path.join(tmp, entry));
+            } catch {}
+        }
+    } catch {}
+    fs.writeFileSync(path.join(tmp, "models.yml"), lines.join("\n"));
     return tmp;
 }
 
@@ -657,6 +734,7 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
     let env: NodeJS.ProcessEnv;
     let clientArgs = params.clientArgs;
     let piTmpHome: string | undefined;
+    let ompTmpHome: string | undefined;
     const tmpFiles: string[] = [];
     const directUrl = launcherDirectUrl(process.env);
     if (directUrl) {
@@ -679,6 +757,12 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
         env = buildPiEnv(origin, ca, process.env);
         piTmpHome = preparePiHttpRewrite(resolvePiHome(process.env), origin, routes.httpRewrites, routes.httpsRewrites);
         if (piTmpHome) env.PI_CODING_AGENT_DIR = piTmpHome;
+    } else if (base === "omp") {
+        // omp is pi-based: same env as pi (HTTPS_PROXY + CA + BILLION_CONTEXT_PROXY);
+        // the /bili/ rewrite rides an isolated PI_CODING_AGENT_DIR (real models.yml untouched).
+        env = buildPiEnv(origin, ca, process.env);
+        ompTmpHome = prepareOmpHttpRewrite(resolveOmpHome(process.env), origin, routes.httpRewrites, routes.httpsRewrites);
+        if (ompTmpHome) env.PI_CODING_AGENT_DIR = ompTmpHome;
     } else if (base === "codex") {
         // Per-spawn conversation id for the MCP shell's headless
         // self-registration (codex provides no session id of its own).
@@ -719,6 +803,11 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
         if (piTmpHome) {
             try {
                 fs.rmSync(piTmpHome, { recursive: true, force: true });
+            } catch {}
+        }
+        if (ompTmpHome) {
+            try {
+                fs.rmSync(ompTmpHome, { recursive: true, force: true });
             } catch {}
         }
         for (const f of tmpFiles) {

--- a/tests/launcher.test.ts
+++ b/tests/launcher.test.ts
@@ -18,8 +18,10 @@ import {
     buildClaudeEnv,
     buildCodexArgs,
     preparePiHttpRewrite,
+    prepareOmpHttpRewrite,
     stripInheritedProxy,
     resolvePiHome,
+    resolveOmpHome,
     extractDomains,
     discoverDomains,
     discoverRoutes,
@@ -27,6 +29,8 @@ import {
     resolveClientCommand,
     isOnPath,
     parseCodexToml,
+    parseOmpYaml,
+    readOmpConfig,
     findFreePort,
     ensureProxyRunning,
     stopProxy,
@@ -36,10 +40,11 @@ import {
     type HttpRewrite,
 } from "../src/launcher.ts";
 
-test("isLaunchClient: pi/claude/codex/pi-test true, others false", () => {
+test("isLaunchClient: pi/claude/codex/omp/pi-test true, others false", () => {
     assert.equal(isLaunchClient("pi"), true);
     assert.equal(isLaunchClient("claude"), true);
     assert.equal(isLaunchClient("codex"), true);
+    assert.equal(isLaunchClient("omp"), true);
     assert.equal(isLaunchClient("pi-test"), true);
     assert.equal(isLaunchClient("opencode"), false);
     assert.equal(isLaunchClient("start"), false);
@@ -612,4 +617,115 @@ test("stripInheritedProxy: removes generic proxy redirector vars, keeps the rest
     assert.equal(cleaned.BILI_UPSTREAM_PROXY, "http://relay:9999", "BILI_UPSTREAM_PROXY kept (explicit chaining)");
     assert.equal(cleaned.PATH, "/usr/bin", "PATH kept");
     assert.equal(cleaned.HOME, "/home/dog", "HOME kept");
+});
+
+test("parseOmpYaml: reads providers.<name>.baseUrl (skips non-matching)", () => {
+    const yml = [
+        "providers:",
+        "  sglang-responses:",
+        "    baseUrl: http://127.0.0.1:8199/v1",
+        "    models:",
+        "      - name: qwen3.8-27b",
+        "  zhipuai:",
+        "    baseUrl: https://open.bigmodel.cn/api/coding/paas/v4",
+        "    api: openai",
+        "  ollama-chat:",
+        "    baseUrl: http://127.0.0.1:11435/v1",
+        "modelRoles:",
+        "  default: sglang-responses/qwen3.8-27b:high",
+    ].join("\n");
+    const cfg = parseOmpYaml(yml);
+    assert.equal(cfg.providers["sglang-responses"].baseUrl, "http://127.0.0.1:8199/v1");
+    assert.equal(cfg.providers["zhipuai"].baseUrl, "https://open.bigmodel.cn/api/coding/paas/v4");
+    assert.equal(cfg.providers["ollama-chat"].baseUrl, "http://127.0.0.1:11435/v1");
+    assert.equal(Object.keys(cfg.providers).length, 3);
+});
+
+test("parseOmpYaml: no providers key → {}", () => {
+    assert.deepEqual(parseOmpYaml("modelRoles:\n  default: x\n"), { providers: {} });
+    assert.deepEqual(parseOmpYaml(""), { providers: {} });
+});
+
+test("readOmpConfig: reads models.yml from omp home", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "bili-omphome-"));
+    try {
+        fs.writeFileSync(path.join(home, "models.yml"), "providers:\n  a:\n    baseUrl: http://x:1/v1\n");
+        const cfg = readOmpConfig(home);
+        assert.equal(cfg.providers.a.baseUrl, "http://x:1/v1");
+    } finally {
+        fs.rmSync(home, { recursive: true, force: true });
+    }
+});
+
+test("readOmpConfig: missing models.yml → {}", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "bili-omphome-"));
+    try {
+        assert.deepEqual(readOmpConfig(home), { providers: {} });
+    } finally {
+        fs.rmSync(home, { recursive: true, force: true });
+    }
+});
+
+test("resolveOmpHome: PI_CODING_AGENT_DIR > default ~/.omp/agent", () => {
+    assert.equal(resolveOmpHome({ PI_CODING_AGENT_DIR: "/custom/omp" }), "/custom/omp");
+    assert.equal(resolveOmpHome({}), path.join(os.homedir(), ".omp", "agent"));
+});
+
+test("discoverRoutes: omp http + https providers → splits httpsDomains + httpRewrites", () => {
+    const config: ClientConfig = {
+        omp: {
+            providers: {
+                zhipuai: { baseUrl: "https://open.bigmodel.cn/api/coding/paas/v4" },
+                sglang: { baseUrl: "http://127.0.0.1:8199/v1" },
+            },
+        },
+    };
+    const routes = discoverRoutes("omp", config);
+    assert.deepEqual(routes.httpsDomains, ["open.bigmodel.cn"]);
+    assert.deepEqual(routes.httpRewrites, [
+        { key: "sglang", realUpstream: "http://127.0.0.1:8199/v1" },
+    ]);
+});
+
+test("prepareOmpHttpRewrite: rewrites matching provider, leaves others, symlinks siblings", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "bili-omphome-"));
+    fs.writeFileSync(
+        path.join(home, "models.yml"),
+        [
+            "providers:",
+            "  a:",
+            "    baseUrl: http://example.com/v1",
+            "  b:",
+            "    baseUrl: https://secure.example.com",
+        ].join("\n"),
+    );
+    fs.writeFileSync(path.join(home, "config.yml"), "extensions:\n  - /x/omp.js\n");
+    const tmp = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", [
+        { key: "a", realUpstream: "http://example.com/v1" },
+    ], []);
+    try {
+        assert.ok(typeof tmp === "string" && tmp.length > 0);
+        const out = fs.readFileSync(path.join(tmp!, "models.yml"), "utf8");
+        assert.ok(out.includes("baseUrl: http://127.0.0.1:8787/bili/http://example.com/v1"), "a rewritten");
+        assert.ok(out.includes("baseUrl: https://secure.example.com"), "b unchanged");
+        assert.equal(fs.lstatSync(path.join(tmp!, "config.yml")).isSymbolicLink(), true);
+        assert.equal(fs.realpathSync(path.join(tmp!, "config.yml")), path.join(home, "config.yml"));
+    } finally {
+        if (tmp) fs.rmSync(tmp, { recursive: true, force: true });
+        fs.rmSync(home, { recursive: true, force: true });
+    }
+});
+
+test("prepareOmpHttpRewrite: returns undefined when no rewrites", () => {
+    assert.equal(prepareOmpHttpRewrite("/whatever", "http://127.0.0.1:8787", [], []), undefined);
+});
+
+test("prepareOmpHttpRewrite: returns undefined when models.yml missing", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "bili-omphome-"));
+    try {
+        const rw = [{ key: "a", realUpstream: "http://example.com/v1" }];
+        assert.equal(prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", rw, []), undefined);
+    } finally {
+        fs.rmSync(home, { recursive: true, force: true });
+    }
 });


### PR DESCRIPTION
> **Model: qwen3.8-27b (vllm)**

## Summary

Wires `omp` (oh-my-pi) into the `bili <client>` launcher so `bili omp` works like
`bili pi` — no editing of omp's config files.

## What it does

- `omp` added to `LAUNCH_CLIENTS` (`src/launcher.ts`), so `bili omp` starts the proxy
  and launches omp.
- omp is pi-based and honors `PI_CODING_AGENT_DIR`, so the existing pi isolated-home
  pattern is reused:
  - The launcher **reads** `~/.omp/agent/models.yml` (never edits it).
  - HTTP providers' `baseUrl` are rewritten to the `/bili/` prefix in a **temp** agent
    dir; HTTPS providers are whitelisted for cert-MITM.
  - omp is launched with `PI_CODING_AGENT_DIR` pointed at the temp dir, so all other
    state (sessions/cache/dbs) is shared via symlinks.
- New targeted YAML reader `parseOmpYaml` (`src/client-config.ts`) — mirrors the
  existing dependency-free `parseCodexToml` (the project has zero runtime deps, no YAML
  parser).

## Why

omp was only a plugin-install target, so omp users had to hand-edit `models.yml` to
route through the proxy. The no-config launcher design already existed for
pi/codex/claude; omp just wasn't wired in.

## Testing

- `npm run typecheck` — pass
- `npm test` — 523 pass, 0 fail (+8 new tests in `tests/launcher.test.ts`)
- `npm run build` — pass
- Live e2e: `bili omp -p "reply with exactly: pong"` → proxy started
  (`MITM domains: open.bigmodel.cn`, `HTTP /bili/ rewrites: 6`) → omp returned `pong`
  → proxy log `forward POST → http://127.0.0.1:8199/v1/responses` (traffic routed
  through the proxy to the real SGLang backend). Real `~/.omp/agent/models.yml`
  confirmed untouched.

## Notes

- The real omp config files are never modified (hard requirement).
- devlog: `devlog/2026-08-23_omp-launcher/` (REQ.md + WORKLOG.md)
- Pairs with PR #205 (`/acp` status command) for the full omp experience.
