### PR TITLE
feat(compress): switch parseCompressInput to kernel parseCompressArgs + remove safeJsonParse (de-JSON)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@types/node": "^22.0.0",
         "@types/node-forge": "^1.3.14",
-        "acp-kernel": "0.0.42",
+        "acp-kernel": "0.0.43",
         "fzstd": "0.1.1",
         "node-forge": "^1.4.0",
         "tar": "^7.5.22",
@@ -988,9 +988,9 @@
       }
     },
     "node_modules/acp-kernel": {
-      "version": "0.0.42",
-      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.42.tgz",
-      "integrity": "sha512-6jNeOL3NmDYB0d0X15TJqPv1RJr1kvg+qXnBeuEdgXdksqSxzEsNJixmnppwg9lHVln9ws1RCityDXLtQwrDXA==",
+      "version": "0.0.43",
+      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.43.tgz",
+      "integrity": "sha512-w5vSovgdj/IpHiuwwOJvXDNwQfVE6Qe+raucvdPt61b19g7jDV+o6wxhkowe5m69gr+/X5+tE00BCEHSuGtuvw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/node-forge": "^1.3.14",
-    "acp-kernel": "0.0.42",
+    "acp-kernel": "0.0.43",
     "fzstd": "0.1.1",
     "node-forge": "^1.4.0",
     "tar": "^7.5.22",

--- a/src/compress-tool.ts
+++ b/src/compress-tool.ts
@@ -8,7 +8,7 @@
  *    kernel's ACP_* names ("proxy" is a misnomer once shared);
  *  - parseCompressInput wires the kernel's onWarn hook into the proxy logger.
  */
-import { parseCompressInput as kernelParseCompressInput } from "acp-kernel";
+import { parseCompressArgs } from "acp-kernel";
 import { log as loggerLog } from "./logger.js";
 
 export {
@@ -48,5 +48,9 @@ export type { ParsedRange } from "acp-kernel";
 export { ACP_TOOL_NAMES as PROXY_TOOL_NAMES, ACP_MUTATING_TOOLS as MUTATING_PROXY_TOOLS, ACP_READONLY_TOOLS as READONLY_PROXY_TOOLS } from "acp-kernel";
 
 export function parseCompressInput(input: unknown, callId?: string) {
-    return kernelParseCompressInput(input, callId, (message) => loggerLog("warn", message));
+    const { ranges, diagnostics } = parseCompressArgs(input, { callId });
+    if (!diagnostics.ok && diagnostics.kind !== "ok") {
+        loggerLog("warn", `[acp-compress-input] rejected: kind=${diagnostics.kind} invalidItems=${diagnostics.invalidItems}${diagnostics.keys ? ` keys=[${diagnostics.keys.join(",")}]` : ""}${diagnostics.length !== undefined ? ` len=${diagnostics.length}` : ""}`);
+    }
+    return ranges;
 }

--- a/src/stream-openai.ts
+++ b/src/stream-openai.ts
@@ -3,7 +3,6 @@ import type { Session } from "./session.js";
 import { COMPRESS_TOOL_NAME, parseCompressInput } from "./compress-tool.js";
 import { applyRanges, type RewriteCtx } from "./stream.js";
 import { normalizeSseLineEndings } from "./sse-util.js";
-import { safeJsonParse } from "./util.js";
 
 type StreamState = {
     compressIndices: Set<number>;
@@ -198,7 +197,7 @@ export function rewriteOpenaiJsonResponse(body: unknown, ctx: RewriteCtx): unkno
         for (const tc of toolCalls) {
             if (tc.function?.name === COMPRESS_TOOL_NAME) {
                 converted = true;
-                noteParts.push(applyRanges(parseCompressInput(safeJsonParse(tc.function?.arguments ?? "")), ctx));
+                noteParts.push(applyRanges(parseCompressInput(tc.function?.arguments ?? ""), ctx));
             } else {
                 sawReal = true;
                 keepToolCalls.push(tc);

--- a/src/stream-responses.ts
+++ b/src/stream-responses.ts
@@ -2,7 +2,6 @@ import type { CompressionCore, Config, CoreMessage } from "acp-kernel";
 import type { Session } from "./session.js";
 import { COMPRESS_TOOL_NAME, parseCompressInput } from "./compress-tool.js";
 import { applyRanges, type RewriteCtx } from "./stream.js";
-import { safeJsonParse } from "./util.js";
 
 /**
  * Responses API (non-streaming) JSON rewriter: strips compress function_call
@@ -25,7 +24,7 @@ export function rewriteResponsesJsonResponse(body: unknown, ctx: RewriteCtx): un
     for (const item of b.output) {
         if (item.type === "function_call" && item.name === COMPRESS_TOOL_NAME) {
             converted = true;
-            noteParts.push(applyRanges(parseCompressInput(safeJsonParse(String(item.arguments ?? ""))), ctx));
+            noteParts.push(applyRanges(parseCompressInput(String(item.arguments ?? "")), ctx));
         } else {
             if (item.type === "function_call") sawReal = true;
             keep.push(item);


### PR DESCRIPTION
> **Model**: qwen3.8-27b (vllm)

## What
Switch proxy's `parseCompressInput` from old kernel parser (no salvage) to new `parseCompressArgs` (lenient + salvage). Remove harmful `safeJsonParse` pre-parse (truncated string -> {} loses salvage; now passes raw string to kernel parser). Diagnostics logged via loggerLog.

## Dependency
**Depends on acp-kernel#111** (`parseCompressArgs`) being merged + published. Until then this branch is RED (import fails on old kernel 0.0.42). After #111 publishes: bump acp-kernel version + refresh lockfile + re-run CI.

## Tests
526/526 pass, typecheck clean (validated against local kernel overlay of #111).