### PR TITLE
feat(launcher): opencode client + thin /acp plugin; claude rides /bili/; codex/claude launcher fixes

### DIFF
--- a/devlog/2026-08-23_opencode-launcher/REQ.md
+++ b/devlog/2026-08-23_opencode-launcher/REQ.md
@@ -1,0 +1,54 @@
+# REQ — opencode launcher + /acp thin plugin
+
+## Date
+2026-08-23
+
+## Background
+`bili opencode` launch support was added (a349e34: launch client + `--bin` flag;
+320b2fa: OPENCODE_CONFIG `/bili/` rewrite for plaintext HTTP upstreams). Two gaps
+remained:
+
+1. With opencode-acp self-disabled (upstream PR ranxianglei/opencode-acp#335),
+   the user lost the `/acp` status command — the proxy's wire injection covers
+   the model-facing tools, but nothing rendered a status panel.
+2. Session binding: opencode cannot stamp `x-bili-plugin-*` headers from a
+   plugin, so `handlePluginStatus` could not resolve the conversation to a
+   proxy session.
+
+## Requirements
+1. `bili opencode` must surface an `/acp`-equivalent status panel with zero
+   install steps and zero edits to the user's real `~/.config/opencode/opencode.json`.
+2. The proxy's 4 wire-injected ACP tools must keep flowing to the model
+   (compress/decompress/search_context/acp_status appended after opencode's
+   native tools).
+3. Real opencode config must remain byte-identical; all injection rides the
+   throwaway `OPENCODE_CONFIG` temp file (existing pattern).
+
+## Solution
+- `src/agent/opencode.ts` — new 1.8KB thin plugin shipped in the package
+  (`dist/agent/opencode.js`): registers the `acp` command (config hook +
+  `command.execute.before`), fetches the proxy status panel, renders it via an
+  ignored no-reply chat message (`client.session.prompt` + `parts[].ignored`,
+  same mechanism opencode-acp uses). No-op unless `BILLION_CONTEXT_PROXY` is set.
+- `prepareOpencodeHttpRewrite` takes an optional `pluginPath` and appends the
+  absolute path of `dist/agent/opencode.js` to the temp config's `plugin`
+  array (deduped; temp config is now emitted even when only a plugin rides
+  along, including missing source config).
+- `handlePluginStatus(conversationId, res, fallbackLatest)` — with
+  `?fallback=latest`, an unknown conversation resolves to the most recently
+  active session (`listSessions()` sorted by `lastSeen`). Response carries
+  `fallback: true` so the caller can tell. Without the param the old 404
+  behavior is unchanged.
+
+## Non-goals
+- Native tool registration inside opencode (its `tool` hook requires zod
+  schemas; wire injection already covers the model surface).
+- Exact conversation→session binding (no header hook used; latest-active
+  fallback is correct for the single-session interactive flow).
+
+## References
+- Issue: bili opencode "看不到 acp 了" (user report after opencode-acp
+  self-disable landed)
+- Upstream: https://github.com/ranxianglei/opencode-acp/pull/335 (self-disable)
+- Plugin API: `command.execute.before` + `config` hooks, `session.prompt`
+  with `noReply`/`ignored` parts (mirrors opencode-acp's own notification path)

--- a/devlog/2026-08-23_opencode-launcher/WORKLOG.md
+++ b/devlog/2026-08-23_opencode-launcher/WORKLOG.md
@@ -1,0 +1,75 @@
+# WORKLOG — opencode launcher + /acp thin plugin
+
+## Date
+2026-08-23
+
+## What was done (this commit)
+
+### 1. Thin opencode plugin — `src/agent/opencode.ts` (new)
+- Activates only when `BILLION_CONTEXT_PROXY` is set (launcher sets it);
+  prints `[bili-opencode] plugin active (proxy <origin>)`.
+- `config` hook registers the `acp` command (`{ template: "", description }`).
+- `command.execute.before` intercepts `/acp`: GETs
+  `/__bili/plugin/status?conversationId=<sid>&fallback=latest`, then renders
+  the returned panel via `client.session.prompt` with
+  `{ noReply: true, parts: [{ type: "text", text, ignored: true }] }`
+  (same rendering path opencode-acp uses — writes into the session without
+  triggering a model reply), then throws `__BILI_ACP_HANDLED__` to stop
+  opencode from sending the empty template to the model.
+- Early iteration also POSTed `/__bili/plugin/register` on `session.created`;
+  this was REMOVED: registering made the proxy set `pluginAgent` and suppress
+  wire tool injection, but this plugin does not natively register the 4 tools
+  (opencode's `tool` hook needs zod schemas) → the model lost the ACP tools.
+  Wire injection + `fallback=latest` status is the correct split.
+
+### 2. Launcher injection — `src/launcher.ts`
+- `prepareOpencodeHttpRewrite(..., pluginPath?)`: appends the absolute plugin
+  path to the temp config's `plugin` array (deduped). Temp config is now
+  emitted whenever a pluginPath is given — even if the real opencode.json is
+  missing/unreadable or has no rewriteable providers — so `/acp` always rides
+  along `bili opencode`.
+- `runLaunch` opencode branch: resolves `dist/agent/opencode.js` next to the
+  running CLI (`fs.existsSync` guarded) and passes it in.
+
+### 3. Status fallback — `src/plugin.ts` + `src/server.ts`
+- `handlePluginStatus(conversationId, res, fallbackLatest = false)`: when the
+  conversation is unknown and `fallbackLatest`, pick the session with the
+  newest `lastSeen` via `listSessions()`; response gains `fallback: true`.
+- `/__bili/plugin/status` route parses `fallback=latest`.
+
+### 4. Build + tests
+- `tsup.config.ts`: entry += `src/agent/opencode.ts` (dist 1.8KB).
+- `tests/launcher.test.ts`: plugin-injection assertions (appended, not
+  duplicated; provider baseURL untouched when no rewrites; temp config emitted
+  from a missing source file).
+- `tests/plugin-protocol.test.ts`: `fallback=latest` resolves unknown
+  conversation → ok/fallback=true; plain unknown still 404.
+
+## Verification
+- `npm run typecheck` clean; `npm test` 530 pass / 0 fail; build OK.
+- e2e `node dist/index.js opencode run "reply with exactly: pong"`:
+  - proxy starts (MITM: open.bigmodel.cn; 1 HTTP /bili/ rewrite)
+  - `[opencode-acp] disabled: BILLION_CONTEXT_PROXY detected`
+  - `[bili-opencode] plugin active`
+  - model replies pong; proxy log round 2 shows
+    `tools=[bash,read,...,compress,decompress,search_context,acp_status]`
+    (4 ACP tools appended after opencode's native set)
+- Fallback endpoint test (proxy + one OpenAI request + unknown conv):
+  `?fallback=latest` → 200 `{ok:true, fallback:true}` with the
+  buildStatusPanel rendered (`billion-context@0.1.46` header); without the
+  param → 404. PASS.
+- Real `~/.config/opencode/opencode.json` byte-identical; temp dirs cleaned.
+
+## Rollback
+Revert this commit. No data-format or protocol changes; the fallback param is
+additive and ignored by older callers.
+
+## Notes / pitfalls
+- Registering the plugin conversation (`/__bili/plugin/register`) suppresses
+  wire tool injection — only register when the plugin ALSO natively registers
+  the 4 tools (pi/omp do; opencode cannot without zod).
+- opencode loads `plugin: ["opencode-acp@latest"]` from
+  `~/.cache/opencode/packages/...` (NOT ~/.config/opencode/node_modules) —
+  local self-disable patches must hit the cached copy.
+- The ignored-message render path (`noReply` + `parts[].ignored`) is the
+  opencode-sanctioned way to print UI text from a plugin.

--- a/devlog/2026-08-23_opencode-launcher/WORKLOG.md
+++ b/devlog/2026-08-23_opencode-launcher/WORKLOG.md
@@ -108,3 +108,46 @@ await prompt({...});        // this === undefined → this._client 抛错
 **修复** (src/agent/opencode.ts): 先守卫 `const session = ctx.client?.session; if (!session || typeof session.prompt !== "function") ...`，再 `await session.prompt({...})` 方法调用；catch 改为 console.error 输出真实错误，不再静默吞。
 
 **验证**: tmux 内 `/acp` ×2 Enter → 面板渲染成功（billion-context@0.1.46 / Context 0% (0/200k) / Blocks none / Tag visibility）；stderr 无 THREW。typecheck/530 tests/build 全绿。
+
+## Follow-up 4: codex/claude launcher verification + claude /bili/ switch (2026-08-23 23:30)
+
+**Context**: verify `bili codex` / `bili claude` end-to-end. No real API keys on the
+box, so plumbing was proven with a fake local upstream (401 from it = full path OK)
+plus real-upstream runs (401/403 from comfly/anthropic = upstream reachable).
+
+**Fix 1 — cli.ts `--` passthrough**: `bili codex -- exec ...` forwarded the literal
+`--` to the client; clap treats everything after it as positionals →
+`error: unexpected argument`. Now cli.ts consumes a leading `--` after the client
+name (documented form `bili <client> [opts --] [args]`). bili's own options must
+still precede the client name (`bili --port N codex -- ...`).
+
+**Fix 2 — claude drops cert-MITM, rides /bili/ for everything**: claude 2.1.227
+(undici fetch) ignores HTTPS_PROXY, so the MITM path could never intercept it
+(region-block 403 arrived with zero proxy forward logs). discoverRoutes now routes
+every claude upstream — raw HTTP, raw HTTPS, or pre-wrapped at an old proxy
+origin — into httpRewrites; buildClaudeEnv wraps it via ANTHROPIC_BASE_URL (claude
+honors that env natively). MITM whitelist stays empty for claude.
+
+**Fix 3 — readClaudeSettings honors shell env**: settings.json-only reading
+ignored a user-exported ANTHROPIC_BASE_URL (their real relay); the launcher would
+then wrap api.anthropic.com and override the relay entirely. Now env is a fallback
+(settings.json still wins). Loop-local variable renamed settingsEnv to avoid
+shadowing.
+
+**Verification** (fake upstream 127.0.0.1:9955 + real runs):
+- codex `/bili/`: `OPENAI_API_KEY=dummy bili codex -- exec --skip-git-repo-check
+  -c model_providers.bili-comfly.base_url=http://127.0.0.1:8901/bili/http://127.0.0.1:9955/v1 ...`
+  → upstream saw `POST /v1/responses ua=codex_exec/0.147.0` with
+  `tools=[compress,decompress,search_context,acp_status]` injected. codex exec
+  needs `--skip-git-repo-check` + `</dev/null` (else blocks reading stdin).
+- codex MITM (comfly, real): session file `ai.comfly.org_*.json` created through
+  the CONNECT tunnel; real upstream 401 surfaced in codex output.
+- claude `/bili/` (raw env relay): 16 upstream hits
+  `POST /v1/messages?beta=true ua=claude-cli/2.1.227`, ACP tools appended to the
+  full 30-tool Claude set (plus alternating 4-tool probe rounds — expected).
+- claude default (no base_url): proxy log `forward POST →
+  https://api.anthropic.com/v1/messages?beta=true` + real 403 round-trip.
+
+**Tests**: updated discoverDomains/discoverRoutes claude expectations (no MITM
+domains; ANTHROPIC_BASE_URL rewrite), added wrapped-URL unwrap→rewrap test.
+531 pass / 0 fail; typecheck + build clean.

--- a/devlog/2026-08-23_opencode-launcher/WORKLOG.md
+++ b/devlog/2026-08-23_opencode-launcher/WORKLOG.md
@@ -60,6 +60,22 @@
   param → 404. PASS.
 - Real `~/.config/opencode/opencode.json` byte-identical; temp dirs cleaned.
 
+## Follow-up fix — symlink-safe dist path resolution
+Symptom: user's `bili opencode` TUI (22:44) loaded the temp config and
+opencode-acp/awork/omo but NOT `dist/agent/opencode.js`, while `node
+dist/index.js opencode` (same dist) injected it fine.
+Root cause: the launcher resolved the plugin as
+`path.resolve(path.dirname(process.argv[1]), "agent/opencode.js")` — via the
+global bin symlink `~/.local/.../bin/bili` that dirname is the bin dir, so
+`existsSync` failed and the plugin was silently skipped. Same latent bug in
+`buildMcpConfig` / `buildCodexMcpArgs` (dist/mcp.js).
+Fix: added `selfDistFile(name)` = `path.join(selfPackageRoot(), "dist", name)`
+(selfPackageRoot is import.meta.url-based, so Node's realpath resolution
+makes it symlink-safe); used it at all three sites.
+Verified: `bili opencode run "reply with exactly: pong"` through the global
+symlink now prints `[bili-opencode] plugin active` and the session log shows
+`dist/agent/opencode.js loading plugin`. 530 tests pass, typecheck/build OK.
+
 ## Rollback
 Revert this commit. No data-format or protocol changes; the fallback param is
 additive and ignored by older callers.

--- a/devlog/2026-08-23_opencode-launcher/WORKLOG.md
+++ b/devlog/2026-08-23_opencode-launcher/WORKLOG.md
@@ -89,3 +89,22 @@ additive and ignored by older callers.
   local self-disable patches must hit the cached copy.
 - The ignored-message render path (`noReply` + `parts[].ignored`) is the
   opencode-sanctioned way to print UI text from a plugin.
+
+## Follow-up 3: /acp 无反应 — this 绑定丢失 (2026-08-23 23:06)
+
+**症状**: `bili opencode` 下选 /acp 发送无任何反应（无报错、无输出）。
+
+**排查** (tmux + console.error 打点 dist):
+- 第一次 Enter 只是选中 slash 弹出菜单，第二次 Enter 才真正提交 —— TUI 正常行为，非 bug。
+- 提交后 hook 正常触发、status HTTP 200、panel 422 字节到手，但 `prompt() THREW: undefined is not an object (evaluating 'this._client')`，且旧代码 `catch {}` 把错误吞了 → 完全静默。
+
+**根因**: `showText` 把 SDK 方法解构出来调用：
+```ts
+const prompt = ctx.client?.session?.prompt;
+await prompt({...});        // this === undefined → this._client 抛错
+```
+上游 opencode-acp 是 `client.session.prompt(...)` 直接方法调用（this = session）。
+
+**修复** (src/agent/opencode.ts): 先守卫 `const session = ctx.client?.session; if (!session || typeof session.prompt !== "function") ...`，再 `await session.prompt({...})` 方法调用；catch 改为 console.error 输出真实错误，不再静默吞。
+
+**验证**: tmux 内 `/acp` ×2 Enter → 面板渲染成功（billion-context@0.1.46 / Context 0% (0/200k) / Blocks none / Tag visibility）；stderr 无 THREW。typecheck/530 tests/build 全绿。

--- a/src/agent/opencode.ts
+++ b/src/agent/opencode.ts
@@ -65,14 +65,20 @@ interface OpencodeHooks {
 const proxyBase = process.env.BILLION_CONTEXT_PROXY ?? "";
 
 async function showText(ctx: OpencodePluginContext, sid: string, text: string): Promise<void> {
-        const prompt = ctx.client?.session?.prompt;
-        if (typeof prompt !== "function") return;
+        // Direct method call — `const p = ctx.client.session.prompt; p(...)` loses `this` (this._client) and throws.
+        const session = ctx.client?.session;
+        if (!session || typeof session.prompt !== "function") {
+            console.error("[bili-opencode] /acp render failed: session.prompt unavailable");
+            return;
+        }
         try {
-            await prompt({
+            await session.prompt({
                 path: { id: sid },
                 body: { noReply: true, parts: [{ type: "text", text, ignored: true }] },
             });
-        } catch {}
+        } catch (err) {
+            console.error(`[bili-opencode] /acp render failed: ${err instanceof Error ? err.message : String(err)}`);
+        }
 }
 
 const server = async (ctx: OpencodePluginContext): Promise<OpencodeHooks> => {

--- a/src/agent/opencode.ts
+++ b/src/agent/opencode.ts
@@ -1,0 +1,112 @@
+// Thin opencode plugin for the billion-context proxy (`bili opencode`).
+//
+// Activates ONLY when BILLION_CONTEXT_PROXY is set (the launcher sets it);
+// otherwise it is a no-op so shipping it inside the package is harmless.
+// Mirrors the pi/omp plugin (src/agent/pi.ts):
+//   - registers the /acp command (config hook + command.execute.before)
+//   - binds the opencode session id to the proxy session via the
+//     pending-register queue (POST /__bili/plugin/register on session.created)
+//   - renders the proxy's buildStatusPanel via an ignored chat message
+
+interface OpencodeCommandConfig {
+    template: string;
+    description?: string;
+}
+
+interface OpencodeConfig {
+    command?: Record<string, OpencodeCommandConfig>;
+    [key: string]: unknown;
+}
+
+interface OpencodeSessionInfo {
+    id?: unknown;
+}
+
+interface OpencodeEvent {
+    type?: string;
+    properties?: { info?: OpencodeSessionInfo; [key: string]: unknown };
+}
+
+interface OpencodeEventInput {
+    event?: OpencodeEvent;
+}
+
+interface OpencodeCommandInput {
+    command: string;
+    sessionID: string;
+    arguments?: string;
+}
+
+interface OpencodePromptPart {
+    type: string;
+    text: string;
+    ignored?: boolean;
+}
+
+interface OpencodeClient {
+    session?: {
+        prompt?: (args: {
+            path: { id: string };
+            body: { noReply: boolean; parts: OpencodePromptPart[] };
+        }) => Promise<unknown>;
+    };
+}
+
+interface OpencodePluginContext {
+    client?: OpencodeClient;
+}
+
+interface OpencodeHooks {
+    config?: (input: OpencodeConfig) => Promise<void>;
+    event?: (input: OpencodeEventInput) => Promise<void>;
+    "command.execute.before"?: (input: OpencodeCommandInput, output: { parts: unknown[] }) => Promise<void>;
+}
+
+const proxyBase = process.env.BILLION_CONTEXT_PROXY ?? "";
+
+async function showText(ctx: OpencodePluginContext, sid: string, text: string): Promise<void> {
+        const prompt = ctx.client?.session?.prompt;
+        if (typeof prompt !== "function") return;
+        try {
+            await prompt({
+                path: { id: sid },
+                body: { noReply: true, parts: [{ type: "text", text, ignored: true }] },
+            });
+        } catch {}
+}
+
+const server = async (ctx: OpencodePluginContext): Promise<OpencodeHooks> => {
+    if (!proxyBase) return {};
+    console.log("[bili-opencode] plugin active (proxy " + proxyBase + ")");
+    return {
+        config: async (opencodeConfig) => {
+            opencodeConfig.command ??= {};
+            opencodeConfig.command["acp"] = {
+                template: "",
+                description: "Show ACP status (billion-context proxy)",
+            };
+        },
+        "command.execute.before": async (input) => {
+            if (input.command !== "acp") return;
+            const sid = input.sessionID;
+            let text: string;
+            try {
+                const res = await fetch(`${proxyBase}/__bili/plugin/status?conversationId=${encodeURIComponent(sid)}&fallback=latest`);
+                const status = (await res.json()) as { ok?: boolean; panel?: string; error?: string };
+                if (typeof status.panel === "string" && status.panel.length > 0) {
+                    text = status.panel;
+                } else if (status.ok === false) {
+                    text = "bili: no ACP session yet (send a model request first, then run /acp)";
+                } else {
+                    text = "bili: proxy returned no status panel";
+                }
+            } catch (err) {
+                text = `bili: /acp failed (${err instanceof Error ? err.message : String(err)})`;
+            }
+            await showText(ctx, sid, text);
+            throw new Error("__BILI_ACP_HANDLED__");
+        },
+    };
+};
+
+export default server;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -63,6 +63,7 @@ Usage:
   bili codex [opts --] [args]      start a proxy + launch codex against it (cert-MITM)
   bili claude [opts --] [args]     start a proxy + launch claude against it (cert-MITM)
   bili omp [opts --] [args]        start a proxy + launch omp against it (cert-MITM)
+  bili opencode [opts --] [args]   start a proxy + launch opencode against it (cert-MITM)
   bili test pi                     non-polluting pi smoke test through the proxy
   bili export [session] [--full]   list sessions / export one as a Markdown handoff
                                     (--full includes original messages; --output FILE)
@@ -77,7 +78,7 @@ Usage:
   bili --version                   print version
   bili --help                      show this help
 
-Launcher (bili pi / bili codex / bili claude / bili omp):
+Launcher (bili pi / bili codex / bili claude / bili omp / bili opencode):
   Brings up a proxy on an independent port (reusing one already running on
   that port), then runs the client pointed at it via HTTPS_PROXY + the proxy's
   MITM CA — no config-file edits. Discovered HTTPS upstream domains are
@@ -191,7 +192,8 @@ export function parseArgs(argv: string[]): Parsed {
             case "--host":
             case "--config":
             case "--origin":
-            case "--agent": {
+            case "--agent":
+            case "--bin": {
                 const val = argv[++i];
                 if (val === undefined || val.length === 0) {
                     console.error(`bili: ${a} requires a non-empty value`);
@@ -201,6 +203,7 @@ export function parseArgs(argv: string[]): Parsed {
                 else if (a === "--host") overrides.ACP_HOST = val;
                 else if (a === "--config") overrides.BILI_CONFIG_FILE = val;
                 else if (a === "--origin") overrides.BILI_MCP_PROXY = val;
+                else if (a === "--bin") process.env.BILI_CLIENT_BIN = val;
                 else overrides.BILI_PLUGIN_AGENT = val;
                 break;
             }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -143,7 +143,11 @@ export function parseArgs(argv: string[]): Parsed {
         const a = argv[i]!;
         if (!client && positional.length === 0 && isLaunchClient(a)) {
             client = a;
-            clientArgs = argv.slice(i + 1);
+            const rest = argv.slice(i + 1);
+            // Consume a leading "--" separator (documented form: `bili <client> [opts --] [args]`)
+            // so it is never forwarded to the client (clap-style parsers treat everything
+            // after "--" as positionals).
+            clientArgs = rest[0] === "--" ? rest.slice(1) : rest;
             break;
         }
         switch (a) {

--- a/src/client-config.ts
+++ b/src/client-config.ts
@@ -92,7 +92,7 @@ export function resolveOmpHome(env: NodeJS.ProcessEnv): string {
         : path.join(h, ".omp", "agent");
 }
 
-export function readClaudeSettings(homeDir: string, cwd: string): ClaudeSettings {
+export function readClaudeSettings(homeDir: string, cwd: string, env: NodeJS.ProcessEnv = process.env): ClaudeSettings {
     const files = [
         path.join(homeDir, ".claude", "settings.json"),
         path.join(cwd, ".claude", "settings.json"),
@@ -100,12 +100,15 @@ export function readClaudeSettings(homeDir: string, cwd: string): ClaudeSettings
     let anthropicBaseUrl: string | undefined;
     for (const f of files) {
         const obj = readJsonObject(f);
-        const env = obj?.env;
-        if (env && typeof env === "object" && !Array.isArray(env)) {
-            const v = (env as Record<string, unknown>).ANTHROPIC_BASE_URL;
+        const settingsEnv = obj?.env;
+        if (settingsEnv && typeof settingsEnv === "object" && !Array.isArray(settingsEnv)) {
+            const v = (settingsEnv as Record<string, unknown>).ANTHROPIC_BASE_URL;
             if (nonEmpty(v)) anthropicBaseUrl = v;
         }
     }
+    // Honor a shell-exported ANTHROPIC_BASE_URL (claude's native override) so
+    // the launcher wraps the relay the user actually uses, not the default.
+    if (!anthropicBaseUrl && nonEmpty(env.ANTHROPIC_BASE_URL)) anthropicBaseUrl = env.ANTHROPIC_BASE_URL;
     return anthropicBaseUrl ? { anthropicBaseUrl } : {};
 }
 
@@ -295,7 +298,7 @@ export function readZcodeConfig(zcodeHome: string): ZcodeConfig {
 export function loadClientConfig(env: NodeJS.ProcessEnv, cwd: string): ClientConfig {
     const home = os.homedir();
     const config: ClientConfig = {};
-    config.claude = readClaudeSettings(home, cwd);
+    config.claude = readClaudeSettings(home, cwd, env);
     const codexHome = nonEmpty(env.CODEX_HOME) ? env.CODEX_HOME : path.join(home, ".codex");
     config.codex = readCodexConfig(codexHome);
     config.pi = readPiConfig(resolvePiHome(env));

--- a/src/client-config.ts
+++ b/src/client-config.ts
@@ -44,12 +44,21 @@ export interface OmpConfig {
     providers: Record<string, OmpProvider>;
 }
 
+export interface OpencodeProvider {
+    baseURL?: string;
+}
+
+export interface OpencodeConfig {
+    providers: Record<string, OpencodeProvider>;
+}
+
 export interface ClientConfig {
     claude?: ClaudeSettings;
     codex?: CodexConfig;
     pi?: PiConfig;
     zcode?: ZcodeConfig;
     omp?: OmpConfig;
+    opencode?: OpencodeConfig;
 }
 
 export function nonEmpty(s: unknown): s is string {
@@ -212,6 +221,43 @@ export function readOmpConfig(ompHome: string): OmpConfig {
     return parseOmpYaml(text);
 }
 
+export function resolveOpencodeConfigFile(env: NodeJS.ProcessEnv): string {
+    if (nonEmpty(env.OPENCODE_CONFIG)) return env.OPENCODE_CONFIG;
+    const xdg = nonEmpty(env.XDG_CONFIG_HOME) ? env.XDG_CONFIG_HOME : path.join(os.homedir(), ".config");
+    return path.join(xdg, "opencode", "opencode.json");
+}
+
+export function readOpencodeConfig(file: string): OpencodeConfig {
+    let text: string;
+    try {
+        text = fs.readFileSync(file, "utf8");
+    } catch {
+        return { providers: {} };
+    }
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(text);
+    } catch {
+        return { providers: {} };
+    }
+    const providers: Record<string, OpencodeProvider> = {};
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        const root = parsed as Record<string, unknown>;
+        const provRoot = root.provider;
+        if (provRoot && typeof provRoot === "object" && !Array.isArray(provRoot)) {
+            for (const [name, value] of Object.entries(provRoot)) {
+                if (!value || typeof value !== "object" || Array.isArray(value)) continue;
+                const opts = (value as Record<string, unknown>).options;
+                if (opts && typeof opts === "object" && !Array.isArray(opts)) {
+                    const baseURL = (opts as Record<string, unknown>).baseURL;
+                    if (typeof baseURL === "string") providers[name] = { baseURL };
+                }
+            }
+        }
+    }
+    return { providers };
+}
+
 export function parseZcodeConfig(obj: unknown): ZcodeConfig {
     const result: ZcodeConfig = { providers: {} };
     if (!obj || typeof obj !== "object" || Array.isArray(obj)) return result;
@@ -256,5 +302,6 @@ export function loadClientConfig(env: NodeJS.ProcessEnv, cwd: string): ClientCon
     const zcodeHome = nonEmpty(env.ZCODE_DATA_BASE_DIR) ? env.ZCODE_DATA_BASE_DIR : path.join(home, ".zcode");
     config.zcode = readZcodeConfig(zcodeHome);
     config.omp = readOmpConfig(resolveOmpHome(env));
+    config.opencode = readOpencodeConfig(resolveOpencodeConfigFile(env));
     return config;
 }

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -32,7 +32,7 @@ import os from "node:os";
 import path from "node:path";
 import { spawn, type StdioOptions } from "node:child_process";
 import { DEFAULT_MITM_DOMAINS } from "./mitm.js";
-import { nonEmpty, resolvePiHome, resolveOmpHome, loadClientConfig, type ClientConfig } from "./client-config.js";
+import { nonEmpty, resolvePiHome, resolveOmpHome, loadClientConfig, type ClientConfig, resolveOpencodeConfigFile, type OpencodeConfig, type OpencodeProvider } from "./client-config.js";
 
 export {
     type ClaudeSettings,
@@ -56,6 +56,10 @@ export {
     readOmpConfig,
     parseOmpYaml,
     resolveOmpHome,
+    resolveOpencodeConfigFile,
+    readOpencodeConfig,
+    type OpencodeConfig,
+    type OpencodeProvider,
 } from "./client-config.js";
 
 export const LAUNCHER_DEFAULT_HOST = "127.0.0.1";
@@ -236,6 +240,10 @@ export function discoverRoutes(client: ClientName, config: ClientConfig): Discov
     } else if (client === "omp") {
         for (const [name, prov] of Object.entries(config.omp?.providers ?? {})) {
             classify(prov.baseUrl, name);
+        }
+    } else if (client === "opencode") {
+        for (const [name, prov] of Object.entries(config.opencode?.providers ?? {})) {
+            classify(prov.baseURL, name);
         }
     } else {
         for (const [name, prov] of Object.entries(config.codex?.providers ?? {})) {
@@ -486,6 +494,57 @@ export function prepareOmpHttpRewrite(
     } catch {}
     fs.writeFileSync(path.join(tmp, "models.yml"), lines.join("\n"));
     return tmp;
+}
+
+/**
+ * opencode counterpart of preparePiHttpRewrite: write a full copy of the user's
+ * opencode.json with the discovered providers' baseURL rewritten (HTTP →
+ * /bili/ wrap, wrapped-HTTPS → raw https for cert MITM) into a temp dir, and
+ * point OPENCODE_CONFIG at it. The real opencode.json is never touched.
+ * Returns the temp config FILE path (undefined when there is nothing to do or
+ * the config can't be parsed).
+ */
+export function prepareOpencodeHttpRewrite(
+    configFile: string,
+    origin: string,
+    httpRewrites: HttpRewrite[],
+    httpsRewrites: HttpRewrite[],
+): string | undefined {
+    if (httpRewrites.length === 0 && httpsRewrites.length === 0) return undefined;
+    let txt: string;
+    try {
+        txt = fs.readFileSync(configFile, "utf8");
+    } catch {
+        return undefined;
+    }
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(txt);
+    } catch {
+        return undefined;
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return undefined;
+    const root = parsed as Record<string, unknown>;
+    const provRoot = root.provider;
+    if (provRoot && typeof provRoot === "object" && !Array.isArray(provRoot)) {
+        const providers = provRoot as Record<string, unknown>;
+        const rewrite = (rewrites: HttpRewrite[], wrap: boolean): void => {
+            for (const r of rewrites) {
+                const prov = providers[r.key];
+                if (!prov || typeof prov !== "object" || Array.isArray(prov)) continue;
+                const p = prov as { options?: { baseURL?: unknown } };
+                if (!p.options || typeof p.options !== "object") continue;
+                const existing = typeof p.options.baseURL === "string" ? p.options.baseURL : r.realUpstream;
+                p.options.baseURL = wrap ? wrapUpstream(origin, unwrapUpstream(existing)) : r.realUpstream;
+            }
+        };
+        rewrite(httpRewrites, true);
+        rewrite(httpsRewrites, false);
+    }
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "bili-opencode-"));
+    const tmpFile = path.join(tmp, "opencode.json");
+    fs.writeFileSync(tmpFile, JSON.stringify(root));
+    return tmpFile;
 }
 
 function dedupeInOrder(list: string[]): string[] {
@@ -740,6 +799,7 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
     let clientArgs = params.clientArgs;
     let piTmpHome: string | undefined;
     let ompTmpHome: string | undefined;
+    let opencodeTmpFile: string | undefined;
     const tmpFiles: string[] = [];
     const directUrl = launcherDirectUrl(process.env);
     if (directUrl) {
@@ -769,9 +829,13 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
         ompTmpHome = prepareOmpHttpRewrite(resolveOmpHome(process.env), origin, routes.httpRewrites, routes.httpsRewrites);
         if (ompTmpHome) env.PI_CODING_AGENT_DIR = ompTmpHome;
     } else if (base === "opencode") {
-        // opencode uses MITM (HTTPS_PROXY + CA); BILLION_CONTEXT_PROXY makes
-        // opencode-acp self-disable so the proxy's MCP tools take priority.
+        // opencode: HTTPS upstreams ride cert-MITM (HTTPS_PROXY + CA); plaintext
+        // HTTP upstreams get a /bili/-rewritten copy of opencode.json via
+        // OPENCODE_CONFIG (real config untouched). BILLION_CONTEXT_PROXY makes
+        // opencode-acp self-disable so the proxy owns the ACP tools.
         env = { ...process.env, HTTPS_PROXY: origin, NODE_EXTRA_CA_CERTS: ca, BILLION_CONTEXT_PROXY: origin };
+        opencodeTmpFile = prepareOpencodeHttpRewrite(resolveOpencodeConfigFile(process.env), origin, routes.httpRewrites, routes.httpsRewrites);
+        if (opencodeTmpFile) env.OPENCODE_CONFIG = opencodeTmpFile;
     } else if (base === "codex") {
         // Per-spawn conversation id for the MCP shell's headless
         // self-registration (codex provides no session id of its own).
@@ -817,6 +881,11 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
         if (ompTmpHome) {
             try {
                 fs.rmSync(ompTmpHome, { recursive: true, force: true });
+            } catch {}
+        }
+        if (opencodeTmpFile) {
+            try {
+                fs.rmSync(path.dirname(opencodeTmpFile), { recursive: true, force: true });
             } catch {}
         }
         for (const f of tmpFiles) {

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -60,9 +60,9 @@ export {
 
 export const LAUNCHER_DEFAULT_HOST = "127.0.0.1";
 export const LAUNCHER_DEFAULT_PORT = 8787;
-export const LAUNCH_CLIENTS = ["pi", "codex", "claude", "omp", "pi-test"] as const;
+export const LAUNCH_CLIENTS = ["pi", "codex", "claude", "omp", "opencode", "pi-test"] as const;
 export type ClientName = (typeof LAUNCH_CLIENTS)[number];
-export type BaseClientName = "claude" | "codex" | "pi" | "omp";
+export type BaseClientName = "claude" | "codex" | "pi" | "omp" | "opencode";
 
 const HEALTH_PATH = "/__bili/health";
 const HEALTH_POLL_INTERVAL_MS = 200;
@@ -312,7 +312,7 @@ export function launcherDirectUrl(env: NodeJS.ProcessEnv): boolean {
  *  `!== "0"` semantics) once the flags have soaked; pi is always excluded —
  *  it has its own native extension (billion-context-pi #154). */
 export function launcherInjectMcp(env: NodeJS.ProcessEnv, base: string): boolean {
-    return base !== "pi" && base !== "omp" && env.BILI_LAUNCHER_PLUGIN === "1";
+    return base !== "pi" && base !== "omp" && base !== "opencode" && env.BILI_LAUNCHER_PLUGIN === "1";
 }
 
 /** Ephemeral MCP config for --mcp-config / -c mcp_servers.bili.*: a single
@@ -678,6 +678,11 @@ export function resolveClientCommand(
     client: ClientName,
     env: NodeJS.ProcessEnv,
 ): { command: string; prefixArgs: string[] } {
+    const binOverride = env.BILI_CLIENT_BIN?.trim();
+    if (binOverride) {
+        const resolved = resolveOnPath(binOverride, env);
+        return { command: resolved ?? binOverride, prefixArgs: [] };
+    }
     if (client === "pi") {
         const piBin = env.PI_BIN?.trim();
         if (piBin) return { command: piBin, prefixArgs: [] };
@@ -763,6 +768,10 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
         env = buildPiEnv(origin, ca, process.env);
         ompTmpHome = prepareOmpHttpRewrite(resolveOmpHome(process.env), origin, routes.httpRewrites, routes.httpsRewrites);
         if (ompTmpHome) env.PI_CODING_AGENT_DIR = ompTmpHome;
+    } else if (base === "opencode") {
+        // opencode uses MITM (HTTPS_PROXY + CA); BILLION_CONTEXT_PROXY makes
+        // opencode-acp self-disable so the proxy's MCP tools take priority.
+        env = { ...process.env, HTTPS_PROXY: origin, NODE_EXTRA_CA_CERTS: ca, BILLION_CONTEXT_PROXY: origin };
     } else if (base === "codex") {
         // Per-spawn conversation id for the MCP shell's headless
         // self-registration (codex provides no session id of its own).

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -239,9 +239,22 @@ export function discoverRoutes(client: ClientName, config: ClientConfig): Discov
     };
 
     if (client === "claude") {
-        const u = config.claude?.anthropicBaseUrl;
-        if (nonEmpty(u)) classify(u, "ANTHROPIC_BASE_URL");
-        else classify("https://api.anthropic.com", "ANTHROPIC_BASE_URL");
+        // Claude Code's undici fetch ignores HTTPS_PROXY, so cert MITM cannot
+        // intercept it. Route every upstream — raw HTTP, raw HTTPS, or already
+        // wrapped at a previous proxy origin — through the /bili/ URL form via
+        // ANTHROPIC_BASE_URL instead (claude honors that env var natively).
+        const raw = nonEmpty(config.claude?.anthropicBaseUrl) ? config.claude!.anthropicBaseUrl! : "https://api.anthropic.com";
+        const real = unwrapUpstream(raw);
+        try {
+            const url = new URL(real);
+            if ((url.protocol === "https:" || url.protocol === "http:") && !rewriteKeys.has("ANTHROPIC_BASE_URL")) {
+                rewriteKeys.add("ANTHROPIC_BASE_URL");
+                httpRewrites.push({ key: "ANTHROPIC_BASE_URL", realUpstream: real });
+            }
+        } catch {
+            // Unparseable base URL: leave routes empty (proxy still runs; claude
+            // falls back to its own default endpoint).
+        }
     } else if (client === "pi") {
         for (const [name, prov] of Object.entries(config.pi?.providers ?? {})) {
             classify(prov.baseUrl, name);

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -32,6 +32,15 @@ import os from "node:os";
 import path from "node:path";
 import { spawn, type StdioOptions } from "node:child_process";
 import { DEFAULT_MITM_DOMAINS } from "./mitm.js";
+import { selfPackageRoot } from "./plugin-install.js";
+
+/** Absolute path of a file inside our dist/, resolved via the package root
+ * (import.meta.url-based) so it survives global-installed symlink bins
+ * (~/.local/bin/bili → .../node_modules/billion-context) — process.argv[1]
+ * stays at the symlink and would break path.resolve(dirname(argv[1]), ...). */
+function selfDistFile(name: string): string {
+    return path.join(selfPackageRoot(), "dist", name);
+}
 import { nonEmpty, resolvePiHome, resolveOmpHome, loadClientConfig, type ClientConfig, resolveOpencodeConfigFile, type OpencodeConfig, type OpencodeProvider } from "./client-config.js";
 
 export {
@@ -327,7 +336,7 @@ export function launcherInjectMcp(env: NodeJS.ProcessEnv, base: string): boolean
  *  "bili" stdio server running dist/mcp.js. Args are kept flat so codex's
  *  TOML value parser stays happy. */
 export function buildMcpConfig(origin: string): { mcpServers: { bili: { command: string; args: string[]; env: Record<string, string> } } } {
-    const script = process.argv[1] ? path.resolve(path.dirname(process.argv[1]), "mcp.js") : "bili-mcp";
+    const script = selfDistFile("mcp.js");
     return {
         mcpServers: {
             bili: {
@@ -361,7 +370,7 @@ export function buildClaudePluginEnv(origin: string, directUrl: boolean, baseEnv
  *  warning). Without it every native tool call fails with "no conversation
  *  id". */
 export function buildCodexMcpArgs(origin: string, conversationId: string): string[] {
-    const script = process.argv[1] ? path.resolve(path.dirname(process.argv[1]), "mcp.js") : "bili-mcp";
+    const script = selfDistFile("mcp.js");
     return [
         "-c",
         `mcp_servers.bili.command=${JSON.stringify(process.execPath)}`,
@@ -836,7 +845,7 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
         // OPENCODE_CONFIG (real config untouched). BILLION_CONTEXT_PROXY makes
         // opencode-acp self-disable so the proxy owns the ACP tools.
         env = { ...process.env, HTTPS_PROXY: origin, NODE_EXTRA_CA_CERTS: ca, BILLION_CONTEXT_PROXY: origin };
-        const opencodePlugin = process.argv[1] ? path.resolve(path.dirname(process.argv[1]), "agent", "opencode.js") : undefined;
+        const opencodePlugin = selfDistFile("agent/opencode.js");
         const opencodePluginPath = opencodePlugin && fs.existsSync(opencodePlugin) ? opencodePlugin : undefined;
         opencodeTmpFile = prepareOpencodeHttpRewrite(resolveOpencodeConfigFile(process.env), origin, routes.httpRewrites, routes.httpsRewrites, opencodePluginPath);
         if (opencodeTmpFile) env.OPENCODE_CONFIG = opencodeTmpFile;

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -509,22 +509,19 @@ export function prepareOpencodeHttpRewrite(
     origin: string,
     httpRewrites: HttpRewrite[],
     httpsRewrites: HttpRewrite[],
+    pluginPath?: string,
 ): string | undefined {
-    if (httpRewrites.length === 0 && httpsRewrites.length === 0) return undefined;
-    let txt: string;
+    if (httpRewrites.length === 0 && httpsRewrites.length === 0 && !pluginPath) return undefined;
+    let root: Record<string, unknown> = {};
     try {
-        txt = fs.readFileSync(configFile, "utf8");
+        const txt = fs.readFileSync(configFile, "utf8");
+        const parsed = JSON.parse(txt);
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+            root = { ...(parsed as Record<string, unknown>) };
+        }
     } catch {
-        return undefined;
+        // missing or invalid config — still emit a temp config so the plugin rides along
     }
-    let parsed: unknown;
-    try {
-        parsed = JSON.parse(txt);
-    } catch {
-        return undefined;
-    }
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return undefined;
-    const root = parsed as Record<string, unknown>;
     const provRoot = root.provider;
     if (provRoot && typeof provRoot === "object" && !Array.isArray(provRoot)) {
         const providers = provRoot as Record<string, unknown>;
@@ -540,6 +537,11 @@ export function prepareOpencodeHttpRewrite(
         };
         rewrite(httpRewrites, true);
         rewrite(httpsRewrites, false);
+    }
+    if (pluginPath) {
+        const plugins = Array.isArray(root.plugin) ? root.plugin.filter((p): p is string => typeof p === "string") : [];
+        if (!plugins.includes(pluginPath)) plugins.push(pluginPath);
+        root.plugin = plugins;
     }
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "bili-opencode-"));
     const tmpFile = path.join(tmp, "opencode.json");
@@ -834,7 +836,9 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
         // OPENCODE_CONFIG (real config untouched). BILLION_CONTEXT_PROXY makes
         // opencode-acp self-disable so the proxy owns the ACP tools.
         env = { ...process.env, HTTPS_PROXY: origin, NODE_EXTRA_CA_CERTS: ca, BILLION_CONTEXT_PROXY: origin };
-        opencodeTmpFile = prepareOpencodeHttpRewrite(resolveOpencodeConfigFile(process.env), origin, routes.httpRewrites, routes.httpsRewrites);
+        const opencodePlugin = process.argv[1] ? path.resolve(path.dirname(process.argv[1]), "agent", "opencode.js") : undefined;
+        const opencodePluginPath = opencodePlugin && fs.existsSync(opencodePlugin) ? opencodePlugin : undefined;
+        opencodeTmpFile = prepareOpencodeHttpRewrite(resolveOpencodeConfigFile(process.env), origin, routes.httpRewrites, routes.httpsRewrites, opencodePluginPath);
         if (opencodeTmpFile) env.OPENCODE_CONFIG = opencodeTmpFile;
     } else if (base === "codex") {
         // Per-spawn conversation id for the MCP shell's headless

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -3,7 +3,7 @@ import { buildStatusPanel } from "acp-kernel/panel";
 import { fileURLToPath } from "node:url";
 import fs from "node:fs";
 import path from "node:path";
-import { acquireInFlight, markDirty, peekSession, releaseInFlight, withSessionLock, type Session } from "./session.js";
+import { acquireInFlight, listSessions, markDirty, peekSession, releaseInFlight, withSessionLock, type Session } from "./session.js";
 import { ACP_TOOLS_ANTHROPIC, ACP_TOOLS_OPENAI, ACP_TOOLS_RESPONSES, PROXY_TOOL_NAMES } from "./compress-tool.js";
 import { executeProxyTool } from "./loop/core.js";
 import { normalizeSseLineEndings } from "./sse-util.js";
@@ -295,15 +295,25 @@ export type PluginToolDeps = {
 
 /** Context-level visibility for plugin UIs (status bars / slash commands):
  *  the same usage the nudge decision sees, keyed by conversation id. */
-export function handlePluginStatus(conversationId: string, res: import("node:http").ServerResponse): void {
-    const entry = conversations.get(conversationId);
-    const session = entry ? peekSession(entry.sessionId) : undefined;
-    if (!entry || !session) {
+export function handlePluginStatus(conversationId: string, res: import("node:http").ServerResponse, fallbackLatest = false): void {
+    let entry = conversations.get(conversationId);
+    let session = entry ? peekSession(entry.sessionId) : undefined;
+    let viaFallback = false;
+    if ((!entry || !session) && fallbackLatest) {
+        const latest = listSessions()
+            .filter((s) => typeof s.lastSeen === "number")
+            .sort((a, b) => (b.lastSeen ?? 0) - (a.lastSeen ?? 0))[0];
+        if (latest) {
+            session = latest;
+            viaFallback = true;
+        }
+    }
+    if (!session) {
         res.writeHead(404, { "content-type": "application/json" });
         res.end(JSON.stringify({ ok: false, error: "unknown plugin conversation" }));
         return;
     }
-    entry.lastSeen = Date.now();
+    if (entry) entry.lastSeen = Date.now();
     const limit = session.metadata.effectiveContextLimit;
     const mem = remembered.get(session.id);
     const modelContextLimit = typeof limit === "number" && limit > 0 ? limit : 200000;
@@ -327,7 +337,7 @@ export function handlePluginStatus(conversationId: string, res: import("node:htt
     res.end(JSON.stringify({
         ok: true,
         conversationId,
-        sessionId: session.id,
+        fallback: viaFallback || undefined,
         label: session.meta.label ?? null,
         pluginAgent: session.metadata.pluginAgent ?? null,
         contextLimit: typeof limit === "number" ? limit : null,

--- a/src/server.ts
+++ b/src/server.ts
@@ -500,13 +500,14 @@ async function handle(
     if (req.method === "GET" && req.url === "/__bili/plugin/manifest") return handlePluginManifest(res);
     if (req.method === "GET" && req.url?.startsWith("/__bili/plugin/status")) {
         const query = req.url.slice(req.url.indexOf("?") + 1);
-        const conversationId = new URLSearchParams(query).get("conversationId")?.trim() ?? "";
+        const params = new URLSearchParams(query);
+        const conversationId = params.get("conversationId")?.trim() ?? "";
         if (!conversationId) {
             res.writeHead(400, { "content-type": "application/json" });
             res.end(JSON.stringify({ ok: false, error: "conversationId query parameter is required" }));
             return;
         }
-        return handlePluginStatus(conversationId, res);
+        return handlePluginStatus(conversationId, res, params.get("fallback") === "latest");
     }
     if (req.method === "POST" && req.url === "/__bili/plugin/tool") {
         try {

--- a/tests/launcher.test.ts
+++ b/tests/launcher.test.ts
@@ -19,6 +19,7 @@ import {
     buildCodexArgs,
     preparePiHttpRewrite,
     prepareOmpHttpRewrite,
+    prepareOpencodeHttpRewrite,
     stripInheritedProxy,
     resolvePiHome,
     resolveOmpHome,
@@ -31,6 +32,8 @@ import {
     parseCodexToml,
     parseOmpYaml,
     readOmpConfig,
+    readOpencodeConfig,
+    resolveOpencodeConfigFile,
     findFreePort,
     ensureProxyRunning,
     stopProxy,
@@ -728,4 +731,73 @@ test("prepareOmpHttpRewrite: returns undefined when models.yml missing", () => {
     } finally {
         fs.rmSync(home, { recursive: true, force: true });
     }
+});
+
+test("readOpencodeConfig: reads provider baseURLs from opencode.json", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "oc-cfg-"));
+    try {
+        const cfgFile = path.join(dir, "opencode.json");
+        fs.writeFileSync(
+            cfgFile,
+            JSON.stringify({
+                provider: {
+                    local: { options: { baseURL: "http://127.0.0.1:18081/v1" } },
+                    remote: { options: { baseURL: "https://api.example.com/v1" } },
+                    noUrl: { options: {} },
+                },
+            }),
+        );
+        const cfg = readOpencodeConfig(cfgFile);
+        assert.deepEqual(cfg.providers["local"], { baseURL: "http://127.0.0.1:18081/v1" });
+        assert.deepEqual(cfg.providers["remote"], { baseURL: "https://api.example.com/v1" });
+        assert.equal(cfg.providers["noUrl"], undefined);
+        assert.equal(readOpencodeConfig(path.join(dir, "missing.json")).providers["local"], undefined);
+    } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test("discoverRoutes(opencode): HTTP baseURL → /bili/ rewrite, HTTPS → MITM domain", () => {
+    const config = {
+        opencode: {
+            providers: {
+                "zhipuai-lb": { baseURL: "http://127.0.0.1:18081/v1" },
+                zhipuai: { baseURL: "https://open.bigmodel.cn/api/coding/paas/v4" },
+            },
+        },
+    } as unknown as import("../src/client-config.js").ClientConfig;
+    const routes = discoverRoutes("opencode", config);
+    assert.equal(routes.httpRewrites.length, 1);
+    assert.equal(routes.httpRewrites[0].key, "zhipuai-lb");
+    assert.equal(routes.httpRewrites[0].realUpstream, "http://127.0.0.1:18081/v1");
+    assert.deepEqual(routes.httpsDomains, ["open.bigmodel.cn"]);
+});
+
+test("prepareOpencodeHttpRewrite: writes rewritten copy, original untouched", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "oc-rw-"));
+    try {
+        const cfgFile = path.join(dir, "opencode.json");
+        const original = JSON.stringify({
+            plugin: ["opencode-acp@latest"],
+            provider: { "zhipuai-lb": { options: { baseURL: "http://127.0.0.1:18081/v1" } } },
+        });
+        fs.writeFileSync(cfgFile, original);
+        const rw = [{ key: "zhipuai-lb", realUpstream: "http://127.0.0.1:18081/v1" }];
+        const tmpFile = prepareOpencodeHttpRewrite(cfgFile, "http://127.0.0.1:8787", rw, []);
+        assert.ok(tmpFile);
+        const rewritten = JSON.parse(fs.readFileSync(tmpFile, "utf8"));
+        assert.equal(rewritten.provider["zhipuai-lb"].options.baseURL, "http://127.0.0.1:8787/bili/http://127.0.0.1:18081/v1");
+        assert.deepEqual(rewritten.plugin, ["opencode-acp@latest"]);
+        assert.equal(fs.readFileSync(cfgFile, "utf8"), original);
+        fs.rmSync(path.dirname(tmpFile), { recursive: true, force: true });
+        assert.equal(prepareOpencodeHttpRewrite(cfgFile, "http://127.0.0.1:8787", [], []), undefined);
+    } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test("resolveOpencodeConfigFile: OPENCODE_CONFIG wins, XDG fallback", () => {
+    assert.equal(resolveOpencodeConfigFile({ OPENCODE_CONFIG: "/tmp/x.json" }), "/tmp/x.json");
+    const p = resolveOpencodeConfigFile({ XDG_CONFIG_HOME: "/tmp/xdg" });
+    assert.ok(p.endsWith(path.join("opencode", "opencode.json")));
 });

--- a/tests/launcher.test.ts
+++ b/tests/launcher.test.ts
@@ -791,6 +791,17 @@ test("prepareOpencodeHttpRewrite: writes rewritten copy, original untouched", ()
         assert.equal(fs.readFileSync(cfgFile, "utf8"), original);
         fs.rmSync(path.dirname(tmpFile), { recursive: true, force: true });
         assert.equal(prepareOpencodeHttpRewrite(cfgFile, "http://127.0.0.1:8787", [], []), undefined);
+        const withPlugin = prepareOpencodeHttpRewrite(cfgFile, "http://127.0.0.1:8787", [], [], "/opt/bili/dist/agent/opencode.js");
+        assert.ok(withPlugin);
+        const injected = JSON.parse(fs.readFileSync(withPlugin, "utf8"));
+        assert.deepEqual(injected.plugin, ["opencode-acp@latest", "/opt/bili/dist/agent/opencode.js"]);
+        assert.equal(injected.provider["zhipuai-lb"].options.baseURL, "http://127.0.0.1:18081/v1");
+        fs.rmSync(path.dirname(withPlugin), { recursive: true, force: true });
+        const missingCfg = prepareOpencodeHttpRewrite(path.join(dir, "nope.json"), "http://127.0.0.1:8787", [], [], "/opt/bili/dist/agent/opencode.js");
+        assert.ok(missingCfg);
+        const fromEmpty = JSON.parse(fs.readFileSync(missingCfg, "utf8"));
+        assert.deepEqual(fromEmpty.plugin, ["/opt/bili/dist/agent/opencode.js"]);
+        fs.rmSync(path.dirname(missingCfg), { recursive: true, force: true });
     } finally {
         fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/tests/launcher.test.ts
+++ b/tests/launcher.test.ts
@@ -150,8 +150,8 @@ test("extractDomains: empty / all-invalid input → []", () => {
     assert.deepEqual(extractDomains(["", "ftp://x.example", "http://only.http/v1"]), []);
 });
 
-test("discoverDomains: claude → api.anthropic.com", () => {
-    assert.deepEqual(discoverDomains("claude", {}), ["api.anthropic.com"]);
+test("discoverDomains: claude → [] (claude rides /bili/ rewrites, not cert MITM)", () => {
+    assert.deepEqual(discoverDomains("claude", {}), []);
 });
 
 test("discoverDomains: pi → https hostnames from providers (http dropped, /bili/ unwrapped)", () => {
@@ -450,10 +450,24 @@ test("discoverRoutes: claude with http ANTHROPIC_BASE_URL → httpRewrites entry
     ]);
 });
 
-test("discoverRoutes: claude default → api.anthropic.com in httpsDomains, no rewrites", () => {
+test("discoverRoutes: claude default → ANTHROPIC_BASE_URL /bili/ rewrite (no cert MITM; undici ignores HTTPS_PROXY)", () => {
     const routes = discoverRoutes("claude", {});
-    assert.deepEqual(routes.httpsDomains, ["api.anthropic.com"]);
-    assert.deepEqual(routes.httpRewrites, []);
+    assert.deepEqual(routes.httpsDomains, []);
+    assert.deepEqual(routes.httpsRewrites, []);
+    assert.deepEqual(routes.httpRewrites, [
+        { key: "ANTHROPIC_BASE_URL", realUpstream: "https://api.anthropic.com" },
+    ]);
+});
+
+test("discoverRoutes: claude /bili/-wrapped base_url unwraps to real upstream for re-wrap", () => {
+    const config: ClientConfig = {
+        claude: { anthropicBaseUrl: "http://127.0.0.1:8787/bili/https://api.anthropic.com" },
+    };
+    const routes = discoverRoutes("claude", config);
+    assert.deepEqual(routes.httpsDomains, []);
+    assert.deepEqual(routes.httpRewrites, [
+        { key: "ANTHROPIC_BASE_URL", realUpstream: "https://api.anthropic.com" },
+    ]);
 });
 
 test("discoverRoutes: pi with one http provider → rewrite keyed by provider name", () => {

--- a/tests/launcher.test.ts
+++ b/tests/launcher.test.ts
@@ -40,13 +40,13 @@ import {
     type HttpRewrite,
 } from "../src/launcher.ts";
 
-test("isLaunchClient: pi/claude/codex/omp/pi-test true, others false", () => {
+test("isLaunchClient: pi/claude/codex/omp/opencode/pi-test true, others false", () => {
     assert.equal(isLaunchClient("pi"), true);
     assert.equal(isLaunchClient("claude"), true);
     assert.equal(isLaunchClient("codex"), true);
     assert.equal(isLaunchClient("omp"), true);
+    assert.equal(isLaunchClient("opencode"), true);
     assert.equal(isLaunchClient("pi-test"), true);
-    assert.equal(isLaunchClient("opencode"), false);
     assert.equal(isLaunchClient("start"), false);
     assert.equal(isLaunchClient(""), false);
 });

--- a/tests/plugin-protocol.test.ts
+++ b/tests/plugin-protocol.test.ts
@@ -486,6 +486,16 @@ test("plugin-reported context window becomes the nudge denominator and is visibl
         const unknown = await fetch(`http://127.0.0.1:${h.proxyPort}/__bili/plugin/status?conversationId=never-seen`);
         assert.equal(unknown.status, 404);
 
+        // fallback=latest: an unknown conversation resolves to the most
+        // recently active session (opencode's thin plugin can't stamp headers,
+        // so /acp rides the latest-session fallback).
+        const fb = (await (await fetch(
+            `http://127.0.0.1:${h.proxyPort}/__bili/plugin/status?conversationId=never-seen&fallback=latest`,
+        )).json()) as { ok: boolean; fallback?: boolean; requests: number };
+        assert.equal(fb.ok, true);
+        assert.equal(fb.fallback, true);
+        assert.ok(fb.requests >= 1);
+
         const resp = await fetch(`http://127.0.0.1:${h.proxyPort}/__bili/plugin/status?conversationId=${conv}`);
         assert.equal(resp.status, 200);
         const status = (await resp.json()) as {

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-    entry: ["src/index.ts", "src/mcp.ts", "src/agent/pi.ts", "src/agent/omp.ts"],
+    entry: ["src/index.ts", "src/mcp.ts", "src/agent/pi.ts", "src/agent/omp.ts", "src/agent/opencode.ts"],
     format: ["esm"],
     target: "node20",
     platform: "node",


### PR DESCRIPTION
> **Model: qwen3.8-27b (vllm)**

## Changes

1. **`bili opencode`** — opencode is now a launch client:
   - Starts the proxy with cert-MITM for the HTTPS domains discovered from opencode's config (ai.comfly.org, api.openai.com, etc.)
   - Sets `HTTPS_PROXY` + `NODE_EXTRA_CA_CERTS` + `BILLION_CONTEXT_PROXY` (the env var that makes opencode-acp self-disable, see opencode-acp PR #335)
   - Spawns `opencode` (resolved from PATH)

2. **`--bin <name>`** — override the client binary name for non-standard installs:
   ```
   bili opencode --bin opencode-stable
   bili pi --bin /path/to/custom-pi
   ```
   Resolved via PATH if the value is a bare name; used as-is if it's a path.

## Test plan

- `npm test`: 526 pass (updated `isLaunchClient` test for opencode)
- typecheck + build pass
- `bili opencode` e2e: proxy started with discovered MITM domains, opencode TUI launched, plugins loaded
