### PR TITLE
feat: absorb tool for instant tool-result compression (issue #14)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@types/node": "^22.0.0",
         "@types/node-forge": "^1.3.14",
-        "acp-kernel": "0.0.31",
+        "acp-kernel": "0.0.45-pr.160.14",
         "fzstd": "0.1.1",
         "node-forge": "^1.4.0",
         "tar": "^7.5.22",
@@ -972,9 +972,9 @@
       }
     },
     "node_modules/acp-kernel": {
-      "version": "0.0.31",
-      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.31.tgz",
-      "integrity": "sha512-XVL/8RryOhc4mvqa+5JJTv7P4s2TJvmBHL6l0/3rCrixPfMcAADuHC5wXHlhRdsu8qsb26MFDT27rN8lJ2qCQA==",
+      "version": "0.0.45-pr.160.14",
+      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.45-pr.160.14.tgz",
+      "integrity": "sha512-pY5Xekzipwh2P1QuFoDg6fDjdaGFuy3fU1i3cnA33UTLHLKGcQyyNA811PICd6zG2LjZnMqGq/TQScUZJZbbsA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/node-forge": "^1.3.14",
-    "acp-kernel": "0.0.31",
+    "acp-kernel": "0.0.45-pr.160.14",
     "fzstd": "0.1.1",
     "node-forge": "^1.4.0",
     "tar": "^7.5.22",

--- a/src/absorb.ts
+++ b/src/absorb.ts
@@ -1,0 +1,83 @@
+import {
+    ABSORB_TOOL,
+    ABSORB_TOOL_OPENAI,
+    applyAbsorb as kernelApplyAbsorb,
+    buildAbsorbSystemPrompt,
+    parseAbsorbInput,
+    type CompressionCore,
+    type Config,
+    type CoreMessage,
+} from "acp-kernel";
+import type { AbsorbSettings, CompressSettings } from "./config.js";
+import type { Session } from "./session.js";
+
+export { ABSORB_TOOL, ABSORB_TOOL_OPENAI, ABSORB_TOOL_NAME, buildAbsorbSystemPrompt } from "acp-kernel";
+
+export const ABSORB_TOOL_RESPONSES = {
+    type: "function" as const,
+    name: ABSORB_TOOL_OPENAI.function.name,
+    description: ABSORB_TOOL_OPENAI.function.description,
+    parameters: ABSORB_TOOL_OPENAI.function.parameters,
+};
+
+export function absorbEnabled(s: CompressSettings): boolean {
+    const a = s.absorb;
+    return a === true || (typeof a === "object" && a !== null && a.enabled !== false);
+}
+
+export function applyAbsorbConfig(base: Config, s: CompressSettings): Config {
+    if (!absorbEnabled(s)) return base;
+    const a: AbsorbSettings = typeof s.absorb === "object" && s.absorb !== null ? s.absorb : {};
+    return {
+        ...base,
+        absorb: {
+            enabled: true,
+            toolName: "absorb",
+            minToolTokens: a.minToolTokens ?? 1000,
+            contextThresholdPct: a.contextThresholdPct !== undefined ? parsePercent(a.contextThresholdPct) : 0,
+            excludeTools: a.excludeTools ?? [],
+        },
+    };
+}
+
+export type AbsorbCtx = {
+    core: CompressionCore;
+    config: Config;
+    messages: CoreMessage[];
+    session: Session;
+    log: (msg: string) => void;
+};
+
+/** Execute an absorb call intercepted from the model stream. Unlike the other
+ *  proxy tools the result text MUST carry the model's summary verbatim: the
+ *  absorb tool call itself never reaches the agent's history (it is rewritten
+ *  into text on the wire), so this text is the only durable record of what the
+ *  original tool output contained. */
+export function executeAbsorb(args: Record<string, unknown>, ctx: AbsorbCtx, callId?: string): string {
+    if (!ctx.config.absorb?.enabled) {
+        return "[absorb FAILED: absorb is not enabled for this session]";
+    }
+    const parsed = parseAbsorbInput(args, callId);
+    if (!parsed || !parsed.summary.trim()) {
+        return "[absorb FAILED: provide ref (the mNNNNN from the tool result's acp tag) and summary (the distilled key results that replace it)]";
+    }
+    const outcome = kernelApplyAbsorb({
+        ref: parsed.ref,
+        summary: parsed.summary,
+        absorbCallId: callId,
+        messages: ctx.messages,
+        state: ctx.session.state,
+        config: ctx.config,
+    });
+    if (!outcome.ok) return `[absorb FAILED: ${outcome.resultText}]`;
+    ctx.session.state = outcome.state;
+    ctx.log(`[acp-proxy: absorb ${parsed.ref} → summary ${parsed.summary.length} chars, state now has ${outcome.state.absorbed?.length ?? 0} record(s)]`);
+    return `${outcome.resultText}\n<absorbed-summary>\n${parsed.summary}\n</absorbed-summary>`;
+}
+
+function parsePercent(v: number | string): number {
+    if (typeof v === "number") return v;
+    const s = v.trim();
+    if (s.endsWith("%")) return Number(s.slice(0, -1)) / 100;
+    return Number(s);
+}

--- a/src/compress-loop-responses.ts
+++ b/src/compress-loop-responses.ts
@@ -10,6 +10,7 @@ import { parseCompressInput, PROXY_TOOL_NAMES, MUTATING_PROXY_TOOLS, COMPRESS_TO
 import { log as loggerLog } from "./logger.js";
 import { applyRanges } from "./stream.js";
 import { resolveDecompress } from "./decompress-shared.js";
+import { ABSORB_TOOL_NAME, executeAbsorb } from "./absorb.js";
 import { buildVisibilityMarker } from "./compress-loop.js";
 import { MAX_LOOP_ROUNDS } from "./loop/index.js";
 import { fetchWithTimeout } from "./fetch-util.js";
@@ -102,6 +103,9 @@ function executeProxyTool(
     }
     if (toolName === "acp_status") {
         return buildStatusReport(ctx.session.state, ctx.messages, estimateTokensFast);
+    }
+    if (toolName === ABSORB_TOOL_NAME) {
+        return executeAbsorb(args, ctx);
     }
     return `[Unknown proxy tool: ${toolName}]`;
 }

--- a/src/compress-loop.ts
+++ b/src/compress-loop.ts
@@ -11,11 +11,16 @@ export function buildVisibilityMarker(toolName: string, result: string): string 
         decompress: "📤",
         search_context: "🔍",
         acp_status: "📊",
+        absorb: "🧽",
     };
     const icon = failed ? "❌" : (icons[toolName] ?? "📦");
 
     if (toolName === "acp_status") {
         return `\n${icon} [ACP] acp_status result:\n${result.trim()}\n`;
+    }
+
+    if (toolName === "absorb") {
+        return `\n${icon} [ACP] absorb result (durable record — original tool output is hidden):\n${result.trim()}\n`;
     }
 
     const inner = (lines[0] ?? "").replace(/^\[/, "").replace(/\]$/, "").trim();

--- a/src/compress-settings.ts
+++ b/src/compress-settings.ts
@@ -1,5 +1,6 @@
 import { defaultPrompts, resolvePrompts, type Config, type Prompts } from "acp-kernel";
 import { findRoute, type CompressSettings, type ProviderRoutes } from "./config.js";
+import { applyAbsorbConfig } from "./absorb.js";
 import { log as loggerLog } from "./logger.js";
 
 /** Resolve a raw `contextLimit` value to an absolute token count.
@@ -52,6 +53,7 @@ export function mergeCompress(
         tiers: pick("tiers"),
         prompts: promptLevels.length > 0 ? Object.assign({}, ...promptLevels) : undefined,
         acknowledgePromptsRisk: pick("acknowledgePromptsRisk"),
+        absorb: pick("absorb"),
     };
 }
 
@@ -113,8 +115,9 @@ export function hasCompressSettings(s: CompressSettings): boolean {
  *  - `minCompressRange` → `compress.minCompressRange`.
  *  - `tiers` → `tiers.enabled`. */
 export function applyCompressSettings(base: Config, limit: number, s: CompressSettings): Config {
-    const nudge = { ...base.nudge };
-    const truncate = { ...base.truncate };
+    const withAbsorb = applyAbsorbConfig(base, s);
+    const nudge = { ...withAbsorb.nudge };
+    const truncate = { ...withAbsorb.truncate };
     if (s.maxContextLimit !== undefined) nudge.maxContextLimitPct = parsePercent(s.maxContextLimit);
     if (s.emergencyThresholdPercent !== undefined) {
         const pct = parsePercent(s.emergencyThresholdPercent);
@@ -125,19 +128,19 @@ export function applyCompressSettings(base: Config, limit: number, s: CompressSe
         nudge.growthFloor = s.nudgeGrowthTokens;
         nudge.growthCap = s.nudgeGrowthTokens;
     }
-    const tiers = { ...base.tiers };
+    const tiers = { ...withAbsorb.tiers };
     if (s.tiers !== undefined) tiers.enabled = s.tiers;
     return {
-        ...base,
+        ...withAbsorb,
         modelContextLimit: limit,
         nudge,
         truncate,
         tiers,
-        preserveRecentMessages: s.preserveRecentMessages ?? base.preserveRecentMessages,
-        preserveRecentTokens: s.preserveRecentTokens ?? base.preserveRecentTokens,
+        preserveRecentMessages: s.preserveRecentMessages ?? withAbsorb.preserveRecentMessages,
+        preserveRecentTokens: s.preserveRecentTokens ?? withAbsorb.preserveRecentTokens,
         compress: {
-            ...base.compress,
-            minCompressRange: s.minCompressRange ?? base.compress.minCompressRange,
+            ...withAbsorb.compress,
+            minCompressRange: s.minCompressRange ?? withAbsorb.compress.minCompressRange,
         },
     };
 }

--- a/src/compress-tool.ts
+++ b/src/compress-tool.ts
@@ -377,25 +377,31 @@ export const ACP_TOOLS_RESPONSES = [
  *  decompress/search_context/acp_status are injected as real function tools so
  *  the model can call them directly instead of emitting text triggers.
  *  Empirically (direct comfly A/B) declaring these tools does NOT disable
- *  codex code_mode — the earlier "tools can't coexist" assumption was wrong. */
+ *  codex code_mode — the earlier "tools can't coexist" assumption was wrong.
+ *  absorb is NOT here: it is opt-in (compress.absorb) and injected in addition
+ *  to these when enabled — see prepareResponses. */
 export const ACP_READONLY_TOOLS_RESPONSES = [
     DECOMPRESS_TOOL_RESPONSES,
     SEARCH_CONTEXT_TOOL_RESPONSES,
     ACP_STATUS_TOOL_RESPONSES,
 ] as const;
 
+import { ABSORB_TOOL_NAME } from "./absorb.js";
+
 export const PROXY_TOOL_NAMES: ReadonlySet<string> = new Set([
     COMPRESS_TOOL_NAME,
     DECOMPRESS_TOOL_NAME,
     SEARCH_CONTEXT_TOOL_NAME,
     ACP_STATUS_TOOL_NAME,
+    ABSORB_TOOL_NAME,
 ]);
 
-/** compress/decompress: mutate history → must drive the compress loop (their
- *  result is folded into the request before the model continues). */
+/** compress/decompress/absorb: mutate history → must drive the compress loop
+ *  (their result is folded into the request before the model continues). */
 export const MUTATING_PROXY_TOOLS: ReadonlySet<string> = new Set([
     COMPRESS_TOOL_NAME,
     DECOMPRESS_TOOL_NAME,
+    ABSORB_TOOL_NAME,
 ]);
 
 /** acp_status/search_context: read-only → must NOT loop. Looping them made the

--- a/src/config.ts
+++ b/src/config.ts
@@ -54,6 +54,21 @@ export type ModelEntry = {
     compress?: CompressSettings;
 };
 
+export type AbsorbSettings = {
+    /** Explicit on/off when using the object form (default true). */
+    enabled?: boolean;
+    /** Minimum estimated tokens of a tool result before it gets the forced
+     *  absorb prompt (kernel `absorb.minToolTokens`, default 1000). */
+    minToolTokens?: number;
+    /** Only prompt for absorb once context usage passes this fraction of the
+     *  window. Accepts a ratio (0.3) or percent string ("30%"). 0 = size alone
+     *  decides (kernel `absorb.contextThresholdPct`, default 0). */
+    contextThresholdPct?: number | string;
+    /** Tool names whose results are never absorb-prompted
+     *  (kernel `absorb.excludeTools`). */
+    excludeTools?: string[];
+};
+
 /** User-facing compression tuning. Configurable at three levels — global
  *  (config root `compress`), per-provider (`providers[url].compress`), per-model
  *  (`providers[url].models[model].compress`) — merged deepest-field-wins by
@@ -108,6 +123,14 @@ export type CompressSettings = {
     /** Must be true for `prompts` overrides to take effect. Acknowledges the
      *  summary-quality risk documented on `prompts`. */
     acknowledgePromptsRisk?: boolean;
+    /** Instant tool-result absorption for small contexts: large tool results
+     *  get a forced prompt telling the model to immediately distill them via
+     *  the injected `absorb` tool; the original pair is hidden from later
+     *  turns and the model's summary (carried in the absorb result text) is
+     *  the durable record. `true` = defaults; object form tunes the knobs
+     *  (see AbsorbSettings). Absorbed results stay compressible like any
+     *  other content. Default: off. */
+    absorb?: boolean | AbsorbSettings;
 };
 export type PromptCacheRouting = "auto" | "enabled" | "disabled";
 export type UpstreamProxyMode = "auto" | "manual" | "direct";

--- a/src/loop/core.ts
+++ b/src/loop/core.ts
@@ -16,6 +16,7 @@ import {
 } from "../compress-tool.js";
 import { applyRanges } from "../stream.js";
 import { resolveDecompress } from "../decompress-shared.js";
+import { ABSORB_TOOL_NAME, executeAbsorb } from "../absorb.js";
 import { buildVisibilityMarker } from "../compress-loop.js";
 import { fetchWithTimeout } from "../fetch-util.js";
 import { proxyDispatcher } from "../upstream-proxy.js";
@@ -113,6 +114,9 @@ export function executeProxyTool(
     }
     if (toolName === "acp_status") {
         return handleAcpStatus(args, ctx);
+    }
+    if (toolName === ABSORB_TOOL_NAME) {
+        return executeAbsorb(args, ctx, callId);
     }
     return `[Unknown proxy tool: ${toolName}]`;
 }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { acquireInFlight, markDirty, peekSession, releaseInFlight, withSessionLock, type Session } from "./session.js";
 import { ACP_TOOLS_ANTHROPIC, ACP_TOOLS_OPENAI, ACP_TOOLS_RESPONSES, PROXY_TOOL_NAMES } from "./compress-tool.js";
+import { ABSORB_TOOL, ABSORB_TOOL_OPENAI, ABSORB_TOOL_RESPONSES } from "./absorb.js";
 import { executeProxyTool } from "./loop/core.js";
 import { normalizeSseLineEndings } from "./sse-util.js";
 import type { WireProtocol } from "./util.js";
@@ -210,9 +211,9 @@ export function handlePluginManifest(res: import("node:http").ServerResponse): v
         version: VERSION,
         toolNames: [...PROXY_TOOL_NAMES],
         tools: {
-            anthropic: ACP_TOOLS_ANTHROPIC,
-            openai: ACP_TOOLS_OPENAI,
-            responses: ACP_TOOLS_RESPONSES,
+            anthropic: [...ACP_TOOLS_ANTHROPIC, ABSORB_TOOL],
+            openai: [...ACP_TOOLS_OPENAI, ABSORB_TOOL_OPENAI],
+            responses: [...ACP_TOOLS_RESPONSES, ABSORB_TOOL_RESPONSES],
         },
         headers: { agent: PLUGIN_AGENT_HEADER, conversation: PLUGIN_CONVERSATION_HEADER, contextWindow: PLUGIN_CONTEXT_WINDOW_HEADER },
         toolEndpoint: "/__bili/plugin/tool",

--- a/src/server.ts
+++ b/src/server.ts
@@ -39,7 +39,8 @@ import {
     subagentNamespace,
 } from "acp-kernel/wire";
 import { getSession, listSessions, type Session, initSessions, markDirty, flushAllSessions, acquireInFlight, releaseInFlight, withSessionLock, markNativeCompactionBoundary, reconcileNativeCompactionBoundary, snapshotMessages } from "./session.js";
-import { COMPRESS_TOOL, ACP_TOOLS_ANTHROPIC, ACP_TOOLS_OPENAI, ACP_TOOLS_RESPONSES, ACP_READONLY_TOOLS_RESPONSES, COMPRESS_TOOL_NAME, buildCompressSystemPrompt, buildCompressHybridSystemPrompt } from "./compress-tool.js";
+import { COMPRESS_TOOL, ACP_TOOLS_ANTHROPIC, ACP_TOOLS_OPENAI, ACP_TOOLS_RESPONSES, ACP_READONLY_TOOLS_RESPONSES, COMPRESS_TOOL_NAME, buildCompressSystemPrompt, buildCompressHybridSystemPrompt, parseCompressInput } from "./compress-tool.js";
+import { ABSORB_TOOL, ABSORB_TOOL_OPENAI, ABSORB_TOOL_NAME, ABSORB_TOOL_RESPONSES, buildAbsorbSystemPrompt } from "./absorb.js";
 import { rewriteSseStream, rewriteJsonResponse, type RewriteCtx } from "./stream.js";
 import { applyRanges } from "./stream.js";
 import { renderUI, handleConfigGet, handleConfigPut } from "./web/index.js";
@@ -868,7 +869,7 @@ function prepareAnthropic(
         // estimates to the kernel.
         extractSystem(parsed.system);
         const tokenCount = session.stats.lastInputTokens;
-        const turn = core.processTurn({ messages: msgs, state: session.state, config, tokenCount, renderTags: "text-only" });
+        const turn = core.processTurn({ messages: pluginMode ? hidePluginEchoCompressCalls(msgs, session.state) : msgs, state: session.state, config, tokenCount, renderTags: "text-only" });
         session.state = turn.state;
         nudge = turn.nudge;
         session.stats.contextTokens = tokenCount;
@@ -882,9 +883,9 @@ function prepareAnthropic(
         reapOrphanBlocks(session, msgs, deactivateBlock);
         rebuiltMessages = coreToAnthropic(processedMessages as BiliMessage[], cacheControls);
 
-        systemOut = injectSystem(parsed, opts, prompts);
+        systemOut = injectSystem(parsed, opts, prompts, config.absorb?.enabled === true);
         if (injectTools) {
-            toolsOut = injectTool(parsed.tools);
+            toolsOut = injectTool(parsed.tools, config.absorb?.enabled === true);
         }
         // Nudge as a separate trailing user message (cache-friendly): the
         // system block stays byte-stable so the prefix cache survives.
@@ -906,6 +907,41 @@ function prepareAnthropic(
 
     const rebuilt: AnthropicRequestBody = { ...parsed, messages: rebuiltMessages, system: systemOut, tools: toolsOut };
     return { body: JSON.stringify(rebuilt), session, processedMessages, originalMessages, anthropicSystem: parsed.system, protocol: "anthropic", stream, compressInjected: injectTools, pluginMode, nudge, prompts } as Prepared;
+}
+
+// Plugin mode: the host executes compress natively (tool API) and echoes the
+// tool_use/tool_result pair on the next request. The block records the
+// plugin-side `plugin_*` call id, never the wire id, so the kernel sees an
+// orphan and keeps the pair visible (KEEP_LAST_ORPHANED=2, kernel 0.0.45).
+// The tail pair is a consumed echo — drop it; older echoes keep the kernel's
+// bounded-orphan treatment.
+function hidePluginEchoCompressCalls(
+    msgs: CoreMessage[],
+    state: { blocks?: Array<{ startRef?: string; endRef?: string }> },
+): CoreMessage[] {
+    const blocks = state.blocks ?? [];
+    if (blocks.length === 0) return msgs;
+    const executed = new Set<string>();
+    for (const b of blocks) {
+        if (b.startRef && b.endRef) executed.add(`${b.startRef}:${b.endRef}`);
+    }
+    if (executed.size === 0) return msgs;
+    const windowStart = Math.max(0, msgs.length - 4);
+    const hidden = new Set<string>();
+    for (let i = windowStart; i < msgs.length; i++) {
+        const m = msgs[i];
+        if (m.toolName !== COMPRESS_TOOL_NAME || m.contentType !== "tool-call" || !m.toolCallId) continue;
+        let args: unknown;
+        try {
+            args = JSON.parse(m.text ?? "{}");
+        } catch {
+            continue;
+        }
+        const ranges = parseCompressInput(args, m.toolCallId);
+        if (ranges.some((r) => executed.has(`${r.startRef}:${r.endRef}`))) hidden.add(m.toolCallId);
+    }
+    if (hidden.size === 0) return msgs;
+    return msgs.filter((m) => !(m.toolCallId && hidden.has(m.toolCallId)));
 }
 
 function prepareOpenai(
@@ -941,7 +977,7 @@ function prepareOpenai(
     const injectTools = shouldInject && !pluginMode;
 
     try {
-        const { msgs } = openaiToCore(parsed);
+        const { msgs, systemText } = openaiToCore(parsed);
         originalMessages = msgs;
         // tokenCount = upstream's real input_tokens from the previous turn
         // (see anthropic branch comment). Never an estimate.
@@ -967,10 +1003,17 @@ function prepareOpenai(
         // instead, mirroring pai-acp's design. Putting the nudge in system
         // would invalidate the cache every turn.
         const sysParts: string[] = [];
+        // Kernel >= 0.0.45 hoists the leading system/developer prefix out of
+        // the fold space; without re-injection the host system prompt is lost.
+        if (systemText) sysParts.push(systemText);
         if (shouldInject) sysParts.push(buildCompressSystemPrompt(prompts));
+        if (shouldInject && config.absorb?.enabled) sysParts.push(buildAbsorbSystemPrompt(ABSORB_TOOL_NAME));
         rebuiltMessages = injectOpenaiSystem(rebuiltMessages, sysParts);
+        if (systemText && parsed.messages[0]?.role === "developer" && rebuiltMessages[0]?.role === "system") {
+            rebuiltMessages = [{ ...rebuiltMessages[0], role: "developer" }, ...rebuiltMessages.slice(1)];
+        }
         if (injectTools) {
-            toolsOut = injectOpenaiTool(parsed.tools);
+            toolsOut = injectOpenaiTool(parsed.tools, config.absorb?.enabled === true);
         }
         // Nudge as a separate trailing user message (cache-friendly).
         if (opts.compress.injectNudge && turn.nudge?.shouldInject && shouldInject) {
@@ -1056,13 +1099,14 @@ function prepareResponses(
         reapOrphanBlocks(session, msgs, deactivateBlock);
         rebuiltInput = patchResponsesInput(projection, processedMessages);
         if (shouldInject && !process.env.ACP_NO_COMPRESS_PROMPT) {
-            const prompt = responsesTextProtocol ? buildCompressHybridSystemPrompt(prompts) : buildCompressSystemPrompt(prompts);
+            let prompt = responsesTextProtocol ? buildCompressHybridSystemPrompt(prompts) : buildCompressSystemPrompt(prompts);
+            if (config.absorb?.enabled) prompt += `\n\n${buildAbsorbSystemPrompt(ABSORB_TOOL_NAME)}`;
             const devContent = [...projection.systemParts, prompt].join("\n\n---\n\n");
             rebuiltInput = injectResponsesDeveloperMessage(rebuiltInput, devContent);
             if (!process.env.ACP_NO_INJECT_TOOL && injectTools) {
                 toolsOut = responsesTextProtocol
-                    ? injectResponsesTool(parsed.tools, ACP_READONLY_TOOLS_RESPONSES)
-                    : injectResponsesTool(parsed.tools);
+                    ? injectResponsesTool(parsed.tools, config.absorb?.enabled ? [...ACP_READONLY_TOOLS_RESPONSES, ABSORB_TOOL_RESPONSES] : ACP_READONLY_TOOLS_RESPONSES)
+                    : injectResponsesTool(parsed.tools, config.absorb?.enabled ? [...ACP_TOOLS_RESPONSES, ABSORB_TOOL_RESPONSES] : ACP_TOOLS_RESPONSES);
             }
         } else if (projection.systemParts.length > 0) {
             rebuiltInput = injectResponsesDeveloperMessage(rebuiltInput, projection.systemParts.join("\n\n---\n\n"));
@@ -1238,6 +1282,7 @@ function injectSystem(
     parsed: AnthropicRequestBody,
     opts: ProxyOptions,
     prompts: Prompts = defaultPrompts,
+    absorbOn = false,
 ): string | AnthropicRequestBody["system"] {
     // ONLY the static compress prompt goes into the system block — it is the
     // prefix-cache anchor and must stay byte-stable across turns. The nudge
@@ -1246,26 +1291,29 @@ function injectSystem(
     const baseText = extractSystem(parsed.system);
     const parts: string[] = [];
     if (opts.compress.injectTool) parts.push(buildCompressSystemPrompt(prompts));
+    if (absorbOn) parts.push(buildAbsorbSystemPrompt(ABSORB_TOOL_NAME));
     if (parts.length === 0) return parsed.system;
     const full = baseText ? `${baseText}\n\n---\n\n${parts.join("\n\n")}` : parts.join("\n\n");
     return buildSystem(full, parsed.system);
 }
 
-function injectTool(tools: unknown[] | undefined): unknown[] {
-    if (!Array.isArray(tools)) return [...ACP_TOOLS_ANTHROPIC];
+function injectTool(tools: unknown[] | undefined, absorbOn = false): unknown[] {
+    const all = absorbOn ? [...ACP_TOOLS_ANTHROPIC, ABSORB_TOOL] : [...ACP_TOOLS_ANTHROPIC];
+    if (!Array.isArray(tools)) return all;
     const names = new Set(tools.map((t) => (t as { name?: string })?.name));
-    const missing = ACP_TOOLS_ANTHROPIC.filter((t) => !names.has(t.name));
+    const missing = all.filter((t) => !names.has(t.name));
     return missing.length === 0 ? tools : [...tools, ...missing];
 }
 
-function injectOpenaiTool(tools: OpenAITool[] | undefined): OpenAITool[] {
-    if (!Array.isArray(tools)) return [...ACP_TOOLS_OPENAI] as OpenAITool[];
+function injectOpenaiTool(tools: OpenAITool[] | undefined, absorbOn = false): OpenAITool[] {
+    const all = absorbOn ? [...ACP_TOOLS_OPENAI, ABSORB_TOOL_OPENAI] : [...ACP_TOOLS_OPENAI];
+    if (!Array.isArray(tools)) return all as OpenAITool[];
     const present = new Set(
         tools
             .map((t) => t?.function?.name)
             .filter((n): n is string => typeof n === "string"),
     );
-    const additions = ACP_TOOLS_OPENAI.filter((t) => !present.has(t.function.name));
+    const additions = all.filter((t) => !present.has(t.function.name));
     return [...tools, ...(additions as OpenAITool[])];
 }
 
@@ -1278,8 +1326,7 @@ const FORCE_TEXT_PROTOCOL = process.env.ACP_COMPRESS_PROTOCOL === "text";
 /** Inject all ACP tools (compress/decompress/search_context/acp_status) in
  *  Responses API flat format, matching the PROXY_TOOL_NAMES set the compress
  *  loop dispatches on. Idempotent. */
-function injectResponsesTool(tools: unknown[] | undefined, toolsToAdd: readonly { name: string }[] = ACP_TOOLS_RESPONSES): unknown[] {
-    if (!Array.isArray(tools)) return [...toolsToAdd];
+function injectResponsesTool(tools: unknown[] | undefined, toolsToAdd: readonly { name: string }[] = ACP_TOOLS_RESPONSES): unknown[] {    if (!Array.isArray(tools)) return [...toolsToAdd];
     const present = new Set(
         tools
             .map((t) => (t as { name?: string })?.name)
@@ -1633,7 +1680,8 @@ async function forward(
             const parsedReq = JSON.parse(typeof body === "string" ? body : body.toString("utf8"));
             const reqHeaders = buildForwardHeaders(headers);
             const textProtocol = prepared.protocol === "responses" && !!prepared.responsesTextProtocol;
-            const systemPrompt = textProtocol ? buildCompressHybridSystemPrompt(prepared.prompts ?? defaultPrompts) : buildCompressSystemPrompt(prepared.prompts ?? defaultPrompts);
+            let systemPrompt = textProtocol ? buildCompressHybridSystemPrompt(prepared.prompts ?? defaultPrompts) : buildCompressSystemPrompt(prepared.prompts ?? defaultPrompts);
+            if (config.absorb?.enabled) systemPrompt += `\n\n${buildAbsorbSystemPrompt(ABSORB_TOOL_NAME)}`;
             const adapter = pickAdapter(prepared.protocol, parsedReq, textProtocol, prepared.responsesProjection, prepared.anthropicSystem);
             const loop = runCompressLoop(
                 streamToRead,

--- a/src/stream-openai.ts
+++ b/src/stream-openai.ts
@@ -1,12 +1,14 @@
 import type { CompressionCore, Config, CoreMessage } from "acp-kernel";
 import type { Session } from "./session.js";
 import { COMPRESS_TOOL_NAME, parseCompressInput } from "./compress-tool.js";
+import { ABSORB_TOOL_NAME, executeAbsorb } from "./absorb.js";
 import { applyRanges, type RewriteCtx } from "./stream.js";
 import { normalizeSseLineEndings } from "./sse-util.js";
 import { safeJsonParse } from "./util.js";
 
 type StreamState = {
     compressIndices: Set<number>;
+    absorbIndices: Set<number>;
     args: Record<number, string>;
     converted: boolean;
     sawReal: boolean;
@@ -18,6 +20,7 @@ type StreamState = {
 function newState(): StreamState {
     return {
         compressIndices: new Set(),
+        absorbIndices: new Set(),
         args: {},
         converted: false,
         sawReal: false,
@@ -122,11 +125,14 @@ function routeOpenaiEvent(rawEvent: string, state: StreamState): string | null {
                 if (name === COMPRESS_TOOL_NAME) {
                     state.compressIndices.add(tidx);
                     state.converted = true;
+                } else if (name === ABSORB_TOOL_NAME) {
+                    state.absorbIndices.add(tidx);
+                    state.converted = true;
                 } else {
                     state.sawReal = true;
                 }
             }
-            if (state.compressIndices.has(tidx)) {
+            if (state.compressIndices.has(tidx) || state.absorbIndices.has(tidx)) {
                 const frag = entry.function?.arguments;
                 if (typeof frag === "string") state.args[tidx] = (state.args[tidx] ?? "") + frag;
             } else {
@@ -147,7 +153,7 @@ function buildOpenaiTail(state: StreamState, ctx: RewriteCtx): string {
     if (!state.converted) return "";
     const base = (state.finishObj ?? { object: "chat.completion.chunk" }) as Record<string, unknown>;
     let out = "";
-    const sortedIndices = [...state.compressIndices].sort((a, b) => a - b);
+    const sortedIndices = [...state.compressIndices, ...state.absorbIndices].sort((a, b) => a - b);
     for (const tidx of sortedIndices) {
         const raw = state.args[tidx] ?? "";
         let parsed: unknown = {};
@@ -156,7 +162,10 @@ function buildOpenaiTail(state: StreamState, ctx: RewriteCtx): string {
         } catch {
             parsed = {};
         }
-        const note = applyRanges(parseCompressInput(parsed), ctx);
+        const args = (parsed && typeof parsed === "object" ? parsed : {}) as Record<string, unknown>;
+        const note = state.absorbIndices.has(tidx)
+            ? executeAbsorb(args, ctx)
+            : applyRanges(parseCompressInput(parsed), ctx);
         out += `data: ${JSON.stringify({ ...base, choices: [{ index: 0, delta: { content: note + "\n" }, finish_reason: null }] })}\n\n`;
     }
     let finalReason: string;
@@ -196,9 +205,14 @@ export function rewriteOpenaiJsonResponse(body: unknown, ctx: RewriteCtx): unkno
     const toolCalls = msg.tool_calls as Array<{ function?: { name?: string; arguments?: string } }> | undefined;
     if (Array.isArray(toolCalls)) {
         for (const tc of toolCalls) {
-            if (tc.function?.name === COMPRESS_TOOL_NAME) {
+            const name = tc.function?.name;
+            if (name === COMPRESS_TOOL_NAME) {
                 converted = true;
                 noteParts.push(applyRanges(parseCompressInput(safeJsonParse(tc.function?.arguments ?? "")), ctx));
+            } else if (name === ABSORB_TOOL_NAME) {
+                converted = true;
+                const args = safeJsonParse(tc.function?.arguments ?? "");
+                noteParts.push(executeAbsorb(args && typeof args === "object" ? args as Record<string, unknown> : {}, ctx));
             } else {
                 sawReal = true;
                 keepToolCalls.push(tc);

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1,6 +1,7 @@
 import { buildStatusReport, collectBlockContent, estimateTokensFast, type CompressionCore, type Config, type CoreMessage, type CompressionState } from "acp-kernel";
 import { type Session, cacheBlockContent } from "./session.js";
 import { COMPRESS_TOOL_NAME, parseCompressInput, PROXY_TOOL_NAMES } from "./compress-tool.js";
+import { ABSORB_TOOL_NAME, executeAbsorb } from "./absorb.js";
 import { resolveDecompress } from "./decompress-shared.js";
 import { normalizeSseLineEndings } from "./sse-util.js";
 
@@ -209,6 +210,9 @@ function executeAnthropicProxyTool(toolName: string, args: Record<string, unknow
     }
     if (toolName === "acp_status") {
         return buildStatusReport(ctx.session.state, ctx.messages, estimateTokensFast);
+    }
+    if (toolName === ABSORB_TOOL_NAME) {
+        return executeAbsorb(args, ctx);
     }
     return `[Unknown proxy tool: ${toolName}]`;
 }

--- a/tests/absorb-tool.test.ts
+++ b/tests/absorb-tool.test.ts
@@ -1,0 +1,81 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createCore, createInitialState, defaultConfig, type Config, type CoreMessage } from "acp-kernel";
+import { absorbEnabled, applyAbsorbConfig, executeAbsorb, type AbsorbCtx } from "../src/absorb.js";
+import type { Session } from "../src/session.js";
+
+function baseMessages(): CoreMessage[] {
+    return [
+        { id: "m1", role: "user", contentType: "text", text: "run the build" },
+        { id: "m2", role: "assistant", contentType: "tool-call", toolName: "bash", toolCallId: "call_1", text: "{}" },
+        { id: "m3", role: "tool", contentType: "tool-result", toolName: "bash", toolCallId: "call_1", text: "build ok: 512 tests pass" },
+        { id: "m4", role: "assistant", contentType: "text", text: "done" },
+    ];
+}
+
+function makeCtx(absorb: Config["absorb"]): { ctx: AbsorbCtx; session: Session } {
+    const core = createCore();
+    const config: Config = { ...defaultConfig(), absorb };
+    const turn = core.processTurn({ messages: baseMessages(), state: createInitialState(), config, tokenCount: 0 });
+    const session = { state: turn.state } as unknown as Session;
+    const ctx: AbsorbCtx = { core, config, messages: turn.messages, session, log: () => {} };
+    return { ctx, session };
+}
+
+test("absorbEnabled: boolean shorthand and object forms", () => {
+    assert.equal(absorbEnabled({}), false);
+    assert.equal(absorbEnabled({ absorb: true }), true);
+    assert.equal(absorbEnabled({ absorb: false }), false);
+    assert.equal(absorbEnabled({ absorb: { enabled: true } }), true);
+    assert.equal(absorbEnabled({ absorb: { enabled: false } }), false);
+    assert.equal(absorbEnabled({ absorb: { minToolTokens: 500 } }), true);
+});
+
+test("applyAbsorbConfig: disabled keeps base; settings map with percent parsing", () => {
+    const base: Config = { ...defaultConfig() };
+    assert.equal(applyAbsorbConfig(base, {}), base, "disabled keeps the base config untouched");
+    const on = applyAbsorbConfig(base, { absorb: { minToolTokens: 500, contextThresholdPct: "20%" } });
+    assert.deepEqual(on.absorb, { enabled: true, toolName: "absorb", minToolTokens: 500, contextThresholdPct: 0.2, excludeTools: [] });
+    const defaults = applyAbsorbConfig(base, { absorb: true });
+    assert.deepEqual(defaults.absorb, { enabled: true, toolName: "absorb", minToolTokens: 1000, contextThresholdPct: 0, excludeTools: [] });
+});
+
+test("executeAbsorb: disabled session fails fast without touching state", () => {
+    const { ctx, session } = makeCtx(undefined);
+    const before = session.state;
+    const out = executeAbsorb({ ref: "m00003", summary: "build passed" }, ctx);
+    assert.match(out, /\[absorb FAILED: absorb is not enabled/);
+    assert.equal(session.state, before);
+});
+
+test("executeAbsorb: missing summary returns usage guidance", () => {
+    const { ctx } = makeCtx({ enabled: true, toolName: "absorb", minToolTokens: 1, contextThresholdPct: 0, excludeTools: [] });
+    const out = executeAbsorb({ ref: "m00003" }, ctx);
+    assert.match(out, /\[absorb FAILED: provide ref/);
+});
+
+test("executeAbsorb: success records the pair, hides the original, carries the summary verbatim", () => {
+    const { ctx, session } = makeCtx({ enabled: true, toolName: "absorb", minToolTokens: 1, contextThresholdPct: 0, excludeTools: [] });
+    const out = executeAbsorb({ ref: "m00003", summary: "build passed" }, ctx, "toolu_abs_1");
+    assert.match(out, /absorbed m00003/);
+    assert.match(out, /<absorbed-summary>\nbuild passed\n<\/absorbed-summary>/);
+    assert.equal(session.state.absorbed?.length, 1);
+    assert.equal(session.state.absorbed?.[0]?.toolCallId, "call_1");
+    assert.equal(session.state.absorbed?.[0]?.absorbCallId, "toolu_abs_1");
+
+    const turn2 = ctx.core.processTurn({ messages: ctx.messages, state: session.state, config: ctx.config, tokenCount: 0 });
+    assert.equal(
+        turn2.messages.some((m) => m.contentType === "tool-result" && m.toolCallId === "call_1"),
+        false,
+        "absorbed tool-result must be hidden on the next turn",
+    );
+
+    const again = executeAbsorb({ ref: "m00003", summary: "dup" }, ctx, "toolu_abs_2");
+    assert.match(again, /already absorbed/);
+});
+
+test("executeAbsorb: unknown ref fails with a scoped error", () => {
+    const { ctx } = makeCtx({ enabled: true, toolName: "absorb", minToolTokens: 1, contextThresholdPct: 0, excludeTools: [] });
+    const out = executeAbsorb({ ref: "m00999", summary: "x" }, ctx);
+    assert.match(out, /\[absorb FAILED: .*does not exist/);
+});

--- a/tests/bili-message-roundtrip.test.ts
+++ b/tests/bili-message-roundtrip.test.ts
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { anthropicToCore, coreToAnthropic } from "acp-kernel/wire";
-import { openaiToCore, coreToOpenai } from "acp-kernel/wire";
+import { openaiToCore, coreToOpenai, injectOpenaiSystem } from "acp-kernel/wire";
 import { responsesToCore, coreToResponses } from "acp-kernel/wire";
 import type { AnthropicBlock, AnthropicRequestBody } from "acp-kernel/wire";
 import type { OpenAIRequestBody } from "acp-kernel/wire";
@@ -92,24 +92,31 @@ test("anthropic: tool_result without is_error stays clean", () => {
     assert.equal(tr.is_error, undefined, "no spurious is_error");
 });
 
-// 4. OpenAI developer role round-trips (was collapsed to system).
-test("openai: developer role is restored", () => {
+// 4. OpenAI developer role round-trips (was collapsed to system). Since the
+// kernel's system-hoist (0.0.45) the LEADING system/developer prefix is lifted
+// out of the fold space into systemText; the proxy re-injects it via
+// injectOpenaiSystem and restores the original head role (developer).
+test("openai: leading developer head is hoisted and re-injected", () => {
     const body: OpenAIRequestBody = { messages: [{ role: "developer", content: "you are a dev" }] };
-    const { msgs } = openaiToCore(body);
-    assert.equal(msgs[0]?.role, "system", "kernel sees system");
-    assert.equal(msgs[0]?.originalRole, "developer", "originalRole sidecar stored");
+    const { msgs, systemText } = openaiToCore(body);
+    assert.equal(msgs.length, 0, "leading system/developer is hoisted out of msgs");
+    assert.equal(systemText, "you are a dev");
     const rebuilt = coreToOpenai(msgs);
-    assert.equal(rebuilt[0]?.role, "developer", "developer role reconstructed");
-    assert.equal(rebuilt[0]?.content, "you are a dev");
+    assert.equal(rebuilt.length, 0);
+    const withSystem = injectOpenaiSystem(rebuilt, [systemText]);
+    assert.equal(withSystem[0]?.role, "system");
+    assert.equal(withSystem[0]?.content, "you are a dev");
 });
 
-// 4b. Sanity: a plain system role is NOT promoted to developer.
-test("openai: system role stays system", () => {
+// 4b. Sanity: a plain system head hoists the same way.
+test("openai: leading system head is hoisted and re-injected", () => {
     const body: OpenAIRequestBody = { messages: [{ role: "system", content: "sys" }] };
-    const { msgs } = openaiToCore(body);
-    assert.equal(msgs[0]?.originalRole, "system");
-    const rebuilt = coreToOpenai(msgs);
-    assert.equal(rebuilt[0]?.role, "system");
+    const { msgs, systemText } = openaiToCore(body);
+    assert.equal(msgs.length, 0);
+    assert.equal(systemText, "sys");
+    const withSystem = injectOpenaiSystem(coreToOpenai(msgs), [systemText]);
+    assert.equal(withSystem[0]?.role, "system");
+    assert.equal(withSystem[0]?.content, "sys");
 });
 
 // 5. OpenAI image_url round-trips (image was previously dropped entirely).

--- a/tests/launcher-plugin-mode.test.ts
+++ b/tests/launcher-plugin-mode.test.ts
@@ -280,7 +280,7 @@ test("mcp stdio shell: manifest → tools/list → tools/call forwards to the pl
     const init = byId(1) as { result?: { serverInfo?: { name?: string } } };
     assert.equal(init.result?.serverInfo?.name, "bili");
     const tools = byId(2) as { result?: { tools?: { name: string }[] } };
-    assert.deepEqual(tools.result?.tools?.map((t) => t.name).sort(), ["acp_status", "compress", "decompress", "search_context"]);
+    assert.deepEqual(tools.result?.tools?.map((t) => t.name).sort(), ["absorb", "acp_status", "compress", "decompress", "search_context"]);
     const call = byId(3) as { result?: { content?: { text?: string }[]; isError?: boolean } };
     assert.equal(call.result?.isError, false);
     assert.match(call.result?.content?.[0]?.text ?? "", /CONTEXT BREAKDOWN/, "acp_status result forwarded verbatim");
@@ -348,7 +348,7 @@ test("mcp stdio shell (codex style): BILI_CONVERSATION_ID self-register → head
 
     const byId = (n: number): Record<string, unknown> => JSON.parse(lines.find((l) => (JSON.parse(l) as { id?: number }).id === n) ?? "{}");
     const tools = byId(2) as { result?: { tools?: { name: string }[] } };
-    assert.deepEqual(tools.result?.tools?.map((t) => t.name).sort(), ["acp_status", "compress", "decompress", "search_context"], "tools listed");
+    assert.deepEqual(tools.result?.tools?.map((t) => t.name).sort(), ["absorb", "acp_status", "compress", "decompress", "search_context"], "tools listed");
     const call = byId(3) as { result?: { content?: { text?: string }[]; isError?: boolean } };
     assert.equal(call.result?.isError, false, `tools/call succeeded (self-registered conversation bound)${call.result?.isError ? ": " + (call.result?.content?.[0]?.text ?? "") : ""}`);
     assert.match(call.result?.content?.[0]?.text ?? "", /CONTEXT BREAKDOWN/);

--- a/tests/plugin-protocol.test.ts
+++ b/tests/plugin-protocol.test.ts
@@ -203,11 +203,11 @@ test("plugin manifest serves the exact wire tool schemas, headers and version", 
         assert.equal(manifest.ok, true);
         assert.equal(manifest.protocolVersion, 1);
         assert.ok(/^\d+\.\d+\.\d+/.test(manifest.version), `version looks wrong: ${manifest.version}`);
-        assert.deepEqual([...manifest.toolNames].sort(), ["acp_status", "compress", "decompress", "search_context"]);
+        assert.deepEqual([...manifest.toolNames].sort(), ["absorb", "acp_status", "compress", "decompress", "search_context"]);
         const names = manifest.tools.anthropic!.map((t) => t.name).sort();
-        assert.deepEqual(names, ["acp_status", "compress", "decompress", "search_context"]);
-        assert.equal(manifest.tools.openai!.length, 4);
-        assert.equal(manifest.tools.responses!.length, 4);
+        assert.deepEqual(names, ["absorb", "acp_status", "compress", "decompress", "search_context"]);
+        assert.equal(manifest.tools.openai!.length, 5);
+        assert.equal(manifest.tools.responses!.length, 5);
         assert.equal(manifest.headers.agent, "x-bili-plugin");
         assert.equal(manifest.headers.conversation, "x-bili-plugin-conversation");
         assert.equal(manifest.toolEndpoint, "/__bili/plugin/tool");


### PR DESCRIPTION
Closes #605 — tracking issue for this PR.

## What

Adapts the proxy to acp-kernel 0.0.45's new `absorb` pipeline (kernel PR #139, merged) — closes #14 on the companion billion-context-pi tracker direction: 小上下文场景下, 工具调用后模型立即复述关键结果, 原始工具输出下一轮隐藏.

- **src/absorb.ts (new)**: `absorbEnabled` / `applyAbsorbConfig` (settings → kernel `Config.absorb`, percent parsing for `contextThresholdPct`) and `executeAbsorb`. The wire result carries the model's summary verbatim inside `<absorbed-summary>` — the absorb tool_use is rewritten to text on the wire, so that text is the only durable record of the original output.
- **Injection**: absorb tool + system-prompt section for anthropic / openai / responses (streaming loops included), gated on `absorb` being enabled in compress settings. Plugin manifest and MCP tool list now advertise absorb (5 tools); plugin tool API executes it under the session lock.

## Kernel 0.0.31 → 0.0.45 upgrade fallout (fixed here)

1. `openaiToCore` now hoists the leading system/developer prefix out of the fold space. `prepareOpenai` re-injects `systemText` (restoring a `developer` head role) — without this the host system prompt is **silently dropped** from every rebuilt request.
2. Kernel `KEEP_LAST_ORPHANED=2` (issue #9 fix) keeps the newest two orphaned compress calls visible. In plugin mode the wire echo of an executed compress carries a host id that never matches the block's `plugin_*` call id → permanent orphan → stays visible. `hidePluginEchoCompressCalls` drops the consumed tail pair before the turn.
3. Pinned `acp-kernel` to exact `0.0.45-pr.160.14` (the npm preview of kernel release PR #160). **Follow-up commit flips this to `0.0.45` once the kernel release lands on npm** — merge this PR after that.

## Tests

518/518 pass (`node --import tsx --test`), `tsc --noEmit --project tsconfig.build.json` clean, tsup build clean:
- roundtrip tests adapted to the hoist contract (`systemText` + `injectOpenaiSystem`)
- manifest / MCP tool lists now expect 5 tools
- plugin fold test passes again (echo pair hidden, range folded, summary retrievable via search_context)
- 6 new unit tests for `absorbEnabled` / `applyAbsorbConfig` / `executeAbsorb` (disabled fast-fail, missing-summary guidance, success records + hides + verbatim summary, idempotency, unknown ref)

Merge is human-only per AGENTS.md.