### PR TITLE
release v0.1.47

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.46",
+  "version": "0.1.47",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.46",
+      "version": "0.1.47",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.46",
+  "version": "0.1.47",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
> **Model: qwen3.8-27b (vllm)**

Release PR for v0.1.47 — 33 commits since v0.1.46.

## Highlights

### Launcher: five clients, zero-config
- **omp** support (#207): no-config `/bili/` rewrite via isolated `PI_CODING_AGENT_DIR`; cert-MITM for HTTPS upstreams.
- **opencode** support (#211): OPENCODE_CONFIG `/bili/` rewrite + thin `/acp` status plugin (fallback=latest session); self-dist resolution survives global symlink installs.
- **`--bin <name>` flag**: launch non-standard binary names (`bili --bin opencode-stable opencode`).

### Claude Code fixes (#211)
- **claude rides `/bili/` for everything** — its undici fetch ignores HTTPS_PROXY, so cert-MITM could never intercept it. All upstreams (http/https/wrapped) now route via ANTHROPIC_BASE_URL wrapping.
- readClaudeSettings honors a shell-exported ANTHROPIC_BASE_URL (settings.json still wins).
- cli no longer forwards the `--` separator to the client (clap treats it as positional).

### /acp status command + panel (#205)
- New `/acp` slash command in the pi/omp plugin: renders the kernel's buildStatusPanel (billion-context@version, context usage, blocks, nudge).
- Plugin-conversation map persists across proxy restarts; omp sessions bind via prompt_cache_key (OpenAI wire) or `/register` (session_start); new-session register no longer requires stats.requests === 0.
- Session/conversation/log footer.

### OpenAI SSE passthrough (#205 merge)
- Real tool_call events now pass through verbatim in the compress loop — no more reordering / response-ID rewriting that made clients (omp on OpenAI-protocol relays) lose tool results and loop. Fixes the omp infinite-clone loop.

### Other
- dejson parser (#208), kernel persist (#198), round-2 thinking framing (#200), npm artifact check (#202), compress-tools import fix (#203).

## Checklist
- [x] typecheck clean
- [x] 531 tests pass
- [x] build clean
- [x] version bumped only on this branch (release commit touches package.json + package-lock.json only)
- [x] src/update.ts unchanged since v0.1.46 (no no-op validation release needed)
- [x] acp-kernel stays at 0.0.43