### PR TITLE
fix(responses): remap round-2 message lifecycle so codex stops dropping text deltas

### DIFF
--- a/src/loop/adapter-responses.ts
+++ b/src/loop/adapter-responses.ts
@@ -18,6 +18,20 @@ interface FunctionCallBuffer {
     arguments: string;
 }
 
+interface MappedItem {
+    id: string;
+    index: number;
+}
+
+function rewriteItemEvent(type: string, obj: Record<string, unknown>, mapped: MappedItem): Buffer {
+    const item = { ...((obj.item as Record<string, unknown>) ?? {}), id: mapped.id };
+    return Buffer.from(`event: ${type}\ndata: ${JSON.stringify({ ...obj, output_index: mapped.index, item })}\n\n`, "utf8");
+}
+
+function rewriteRefEvent(type: string, obj: Record<string, unknown>, mapped: MappedItem): Buffer {
+    return Buffer.from(`event: ${type}\ndata: ${JSON.stringify({ ...obj, item_id: mapped.id, output_index: mapped.index })}\n\n`, "utf8");
+}
+
 async function* iterSseEvents(stream: ReadableStream<Uint8Array>): AsyncGenerator<string> {
     const reader = stream.getReader();
     let buf = "";
@@ -162,6 +176,7 @@ export function createResponsesAdapter(textProtocol?: boolean, projection?: Resp
 
         async *parseStream(upstream, round) {
             const pending = new Map<string, FunctionCallBuffer>();
+            const remapped = new Map<string, MappedItem>();
             for await (const eventStr of iterSseEvents(upstream)) {
                 const type = extractEventType(eventStr);
                 const dataLine = extractDataLine(eventStr);
@@ -196,6 +211,11 @@ export function createResponsesAdapter(textProtocol?: boolean, projection?: Resp
                         }
                     } else if (item?.type === "custom_tool_call") {
                         yield { kind: "meta", chunk: rawBuf, firstRoundOnly: false } as ParsedStreamEvent;
+                    } else if (item?.type === "message" && round > 1 && !suppressTextLifecycle) {
+                        const origId = typeof item.id === "string" ? item.id : "";
+                        const mapped = { id: `msg-proxy-${round}-${origId || outputIndex}`, index: outputIndex++ };
+                        if (origId) remapped.set(origId, mapped);
+                        yield { kind: "meta", chunk: rewriteItemEvent(type, obj, mapped), firstRoundOnly: false } as ParsedStreamEvent;
                     } else if (item?.type !== "message" || !suppressTextLifecycle) {
                         yield { kind: "meta", chunk: rawBuf, firstRoundOnly: true } as ParsedStreamEvent;
                     }
@@ -204,13 +224,23 @@ export function createResponsesAdapter(textProtocol?: boolean, projection?: Resp
                     type === "response.content_part.done" ||
                     type === "response.output_text.done"
                 ) {
-                    if (!suppressTextLifecycle) {
+                    const mapped = remapped.get(typeof obj.item_id === "string" ? obj.item_id : "");
+                    if (mapped) {
+                        yield { kind: "meta", chunk: rewriteRefEvent(type, obj, mapped), firstRoundOnly: false } as ParsedStreamEvent;
+                    } else if (!suppressTextLifecycle) {
                         yield { kind: "meta", chunk: rawBuf, firstRoundOnly: true } as ParsedStreamEvent;
                     }
                 } else if (type === "response.output_text.delta") {
                     const delta = typeof obj.delta === "string" ? obj.delta : "";
                     if (delta.length > 0) {
-                        yield { kind: "text", delta, raw: rawBuf } as ParsedStreamEvent;
+                        const mapped = remapped.get(typeof obj.item_id === "string" ? obj.item_id : "");
+                        if (mapped) {
+                            yield { kind: "text", delta, raw: rewriteRefEvent(type, obj, mapped) } as ParsedStreamEvent;
+                        } else if (round === 1) {
+                            yield { kind: "text", delta, raw: rawBuf } as ParsedStreamEvent;
+                        } else {
+                            yield { kind: "text", delta } as ParsedStreamEvent;
+                        }
                     }
                 } else if (type === "response.function_call_arguments.delta") {
                     const itemId = typeof obj.item_id === "string" ? obj.item_id : "";
@@ -250,6 +280,15 @@ export function createResponsesAdapter(textProtocol?: boolean, projection?: Resp
                         }
                     } else if (item?.type === "custom_tool_call") {
                         yield { kind: "meta", chunk: rawBuf, firstRoundOnly: false } as ParsedStreamEvent;
+                    } else if (item?.type === "message") {
+                        const origId = typeof item.id === "string" ? item.id : "";
+                        const mapped = remapped.get(origId);
+                        if (mapped) {
+                            remapped.delete(origId);
+                            yield { kind: "meta", chunk: rewriteItemEvent(type, obj, mapped), firstRoundOnly: false } as ParsedStreamEvent;
+                        } else if (!suppressTextLifecycle) {
+                            yield { kind: "meta", chunk: rawBuf, firstRoundOnly: true } as ParsedStreamEvent;
+                        }
                     } else if (item?.type !== "message" || !suppressTextLifecycle) {
                         yield { kind: "meta", chunk: rawBuf, firstRoundOnly: true } as ParsedStreamEvent;
                     }

--- a/tests/responses-round2-lifecycle.test.ts
+++ b/tests/responses-round2-lifecycle.test.ts
@@ -1,0 +1,128 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { Config, CoreMessage } from "acp-kernel";
+import { createCore, createInitialState } from "acp-kernel";
+import type { Session } from "../src/session.ts";
+import { runCompressLoop, createResponsesAdapter } from "../src/loop/index.ts";
+import { buildCompressSystemPrompt } from "../src/compress-tool.ts";
+
+function sse(event: string, obj: Record<string, unknown>): string {
+    return `event: ${event}\ndata: ${JSON.stringify({ type: event, ...obj })}\n\n`;
+}
+
+function makeCtx(id: string) {
+    return {
+        core: createCore(),
+        config: { modelContextLimit: 200000 } as Config,
+        messages: [] as CoreMessage[],
+        session: {
+            id,
+            meta: {},
+            stats: { requests: 0, tokensSaved: 0, inputTokens: 0, cachedTokens: 0, outputTokens: 0, cacheSamples: 0, lastInputTokens: 0, contextTokens: 0 },
+            metadata: {},
+            state: createInitialState(),
+            createdAt: Date.now(),
+            lastSeen: Date.now(),
+            blockContents: new Map(),
+            inFlight: 0,
+            persisted: false,
+        } as unknown as Session,
+        log: () => {},
+        protocol: "responses" as const,
+    };
+}
+
+interface OutEvent { event: string; data: Record<string, unknown> }
+
+function parseOut(out: string): OutEvent[] {
+    const events: OutEvent[] = [];
+    for (const block of out.split("\n\n")) {
+        let event = "";
+        const dataLines: string[] = [];
+        for (const line of block.split("\n")) {
+            if (line.startsWith("event:")) event = line.slice(6).trim();
+            else if (line.startsWith("data:")) dataLines.push(line.slice(5).replace(/^ /, ""));
+        }
+        if (!event || dataLines.length === 0) continue;
+        try {
+            events.push({ event, data: JSON.parse(dataLines.join("\n")) as Record<string, unknown> });
+        } catch { }
+    }
+    return events;
+}
+
+test("responses wire round-2: every output_text.delta must reference an item the client saw added (codex #212)", async () => {
+    const round1 = [
+        sse("response.created", { response: { id: "resp_1", status: "in_progress" } }),
+        sse("response.output_item.added", { output_index: 0, item: { type: "function_call", id: "fc_1", call_id: "call_1", name: "acp_status", arguments: "" } }),
+        sse("response.function_call_arguments.delta", { item_id: "fc_1", output_index: 0, delta: "{}" }),
+        sse("response.function_call_arguments.done", { item_id: "fc_1", output_index: 0, arguments: "{}" }),
+        sse("response.output_item.done", { output_index: 0, item: { type: "function_call", id: "fc_1", call_id: "call_1", name: "acp_status", arguments: "{}" } }),
+        sse("response.completed", { response: { id: "resp_1", status: "completed", output: [] } }),
+    ].join("");
+
+    const round2 = [
+        sse("response.created", { response: { id: "resp_2", status: "in_progress" } }),
+        sse("response.output_item.added", { output_index: 0, item: { type: "message", id: "msg_2", role: "assistant", content: [] } }),
+        sse("response.content_part.added", { item_id: "msg_2", output_index: 0, part: { type: "output_text", text: "" } }),
+        sse("response.output_text.delta", { item_id: "msg_2", output_index: 0, delta: "after " }),
+        sse("response.output_text.delta", { item_id: "msg_2", output_index: 0, delta: "compress" }),
+        sse("response.output_text.done", { item_id: "msg_2", output_index: 0, text: "after compress" }),
+        sse("response.content_part.done", { item_id: "msg_2", output_index: 0, part: { type: "output_text", text: "after compress" } }),
+        sse("response.output_item.done", { output_index: 0, item: { type: "message", id: "msg_2", role: "assistant", content: [{ type: "output_text", text: "after compress" }] } }),
+        sse("response.completed", { response: { id: "resp_2", status: "completed", output: [] } }),
+    ].join("");
+
+    let fetchCalls = 0;
+    const orig = globalThis.fetch;
+    globalThis.fetch = (async () => {
+        fetchCalls++;
+        return new Response(round2, { status: 200 });
+    }) as typeof fetch;
+
+    const chunks: Buffer[] = [];
+    try {
+        const ctx = makeCtx("resp-round2");
+        for await (const chunk of runCompressLoop(
+            new Response(round1, { status: 200 }).body!,
+            ctx,
+            { model: "gpt-5", input: [], stream: true },
+            { url: "http://mock", headers: {} },
+            createResponsesAdapter(),
+            buildCompressSystemPrompt(),
+        )) {
+            chunks.push(chunk);
+        }
+    } finally {
+        globalThis.fetch = orig;
+    }
+    assert.equal(fetchCalls, 1, "re-request after proxy tool");
+    const out = Buffer.concat(chunks).toString("utf8");
+    const events = parseOut(out);
+
+    const deltas = events.filter((e) => e.event === "response.output_text.delta");
+    assert.ok(deltas.length >= 3, "text streamed (marker + round-2 text)");
+    const addedIds = new Set(
+        events
+            .filter((e) => e.event === "response.output_item.added")
+            .map((e) => (e.data.item as Record<string, unknown> | undefined)?.id),
+    );
+    const orphans = deltas.filter((e) => !addedIds.has(e.data.item_id));
+    assert.equal(
+        orphans.length,
+        0,
+        `every output_text.delta.item_id must have been introduced by a forwarded output_item.added first; orphan deltas: ${JSON.stringify(orphans.map((e) => e.data.item_id))} (codex logs "OutputTextDelta without active item" for each)`,
+    );
+
+    const round2Item = events.find(
+        (e) => e.event === "response.output_item.added" && typeof e.data.item?.id === "string" && String(e.data.item.id).startsWith("msg-proxy-2-"),
+    );
+    assert.ok(round2Item, "round-2 message item forwarded with remapped id (native streaming, not buffered)");
+    const round2Id = String((round2Item.data.item as Record<string, unknown>).id);
+    const round2Deltas = deltas.filter((e) => e.data.item_id === round2Id);
+    assert.equal(round2Deltas.map((e) => e.data.delta).join(""), "after compress", "round-2 text content streamed in order");
+    assert.ok(
+        events.some((e) => e.event === "response.output_item.done" && (e.data.item as Record<string, unknown>)?.id === round2Id),
+        "round-2 message item closed with output_item.done",
+    );
+});


### PR DESCRIPTION
## Problem (issue #212)

After a compression, codex logs a flood of `ERROR codex_core::util: OutputTextDelta without active item` and the turn aborts.

## Root cause

Codex uses the Responses API in wire (function-calling) mode. When the proxy executes a compress/acp_status tool it re-requests upstream (round 2+). In round ≥ 2 the responses adapter **suppresses** `response.output_item.added` / `response.content_part.added` for message items (`firstRoundOnly: true`) but still **forwards raw** `response.output_text.delta` events carrying the new upstream `item_id`s (core.ts forwards `ev.raw` unconditionally in wire mode). Codex never saw the `output_item.added` for those ids → every delta is dropped with the error above.

Introduced in v0.1.37 by 4deb563 (anthropic round-2 framing fix removed the `round === 1` guard on raw forwarding; the anthropic adapter got matching lifecycle forwarding, the responses adapter did not). Affected: v0.1.37 – v0.1.47 (latest). v0.1.36 is fine.

## Fix

Mirror the anthropic adapter's approach for round ≥ 2 in wire mode:

- `output_item.added` (message) in round ≥ 2 is forwarded with a **remapped proxy id and client-side output_index**, and the full lifecycle (`content_part.added`, `output_text.delta`, `output_text.done`, `content_part.done`, `output_item.done`) is rewritten to the same id/index — real-time streaming preserved, SSE sequence coherent.
- Round ≥ 2 deltas for items with no forwarded `added` no longer forward raw; they fall back to the synthesized `emitText` lifecycle (protocol-safe).
- Round 1 and textProtocol paths unchanged.

## Test

New regression test `tests/responses-round2-lifecycle.test.ts` (fails on master: `orphan deltas: ["msg_2","msg_2"]`, passes with the fix): asserts every forwarded `output_text.delta.item_id` was introduced by a forwarded `output_item.added`, the round-2 item streams natively with remapped id, content order is preserved, and the item is closed with `output_item.done`.

Full suite: 532/532 pass, typecheck + build clean.