### PR TITLE
fix(launcher): never reuse a proxy port — always spawn a fresh instance

### DIFF
--- a/devlog/2026-08-24_launcher-no-reuse/REQ.md
+++ b/devlog/2026-08-24_launcher-no-reuse/REQ.md
@@ -1,0 +1,30 @@
+# REQ - Launcher never reuses a proxy port
+
+- Task ID: `2026-08-24_launcher-no-reuse`
+- Home Repo: `billion-context`
+- Created: 2026-08-24
+- Status: Done
+- Priority: P1
+- Owner: bili-agent (qwen3.8-27b)
+- References: user report — `bili claude` broken; tmux repro showed a stale 12h-old detached proxy being reused
+
+## 1. Background & Problem Statement
+
+- **Context**: `ensureProxyRunning` probed the preferred port (default 8787) and, when a healthy listener answered with compatible MITM domains, reused it instead of spawning a new proxy.
+- **Current behavior (symptom)**: a detached `bili start` proxy from an earlier session (12h old, old code) keeps squatting on 8787 forever; every subsequent `bili <client>` silently routes through that stale process. User directive: "bili 命令不应该复用任何端口 应该每次都是新的才对".
+- **Impact**: stale-code proxies shadowing fresh launches; config drift (wrong MITM domains can still be reused when they happen to sit inside the default set); orphaned listeners that nothing ever reclaims.
+
+## 4. Acceptance Criteria
+
+- [x] `bili <client>` ALWAYS spawns a fresh proxy process; no health-probe reuse path.
+- [x] Concurrent launches each get their own port (verified: 8787 + 46257 side by side).
+- [x] Proxy is always killed on client exit (no `reused` short-circuit).
+- [x] typecheck / 531 tests / build green.
+
+## 5. Alternatives Considered
+
+- Keep reuse but only for same-vintage proxies — rejected: requires version handshakes; complexity for no real benefit since spawn cost is ~1s.
+
+## 6. Milestones
+
+- Single commit; done in one pass.

--- a/devlog/2026-08-24_launcher-no-reuse/WORKLOG.md
+++ b/devlog/2026-08-24_launcher-no-reuse/WORKLOG.md
@@ -1,0 +1,42 @@
+# WORKLOG - Launcher never reuses a proxy port
+
+- Task ID: `2026-08-24_launcher-no-reuse`
+- Home Repo: `billion-context`
+- Status: Done
+- Updated: 2026-08-24 13:05
+
+## 1. Summary
+
+- **What was done**: removed the health-probe reuse path from `ensureProxyRunning` — every launch now calls `findFreePort` and spawns a fresh detached proxy; `ProxyHandle.reused` deleted; always stop on exit.
+- **Why**: reused proxies were stale-code orphans (12h old on 8787) shadowing fresh launches; user directive.
+- **Behavior / compatibility changes**: Yes — concurrent `bili <client>` instances no longer share one proxy; each gets its own port. Sessions remain per-conversation so this is safe.
+- **Risk level**: Low
+
+## 2. Change Log
+
+### Commits
+
+| Commit | Description |
+|--------|-------------|
+| this branch, tip | `fix(launcher): never reuse a proxy port — always spawn a fresh instance` |
+
+### Key Files
+
+- `src/launcher.ts` — dropped `reused` field + reuse block + `domainsNeedFreshProxy`/`coveredByDefaultMitm`; `stopProxy` now unconditional in all 4 exit paths; log line always "started proxy at".
+- `src/cli.ts` — help text: "a fresh instance every launch".
+- `tests/launcher.test.ts` — reuse test inverted ("always spawns a fresh proxy"); `reused` assertions removed; stopProxy no-op test now covers missing-pid child.
+
+## 4. Testing & Verification
+
+- typecheck ✅ · 531/531 tests ✅ · build ✅
+- tmux e2e: killed the 12h-old orphan on 8787 → `bili claude` logs `started proxy at http://127.0.0.1:8787` (new pid) → second concurrent launch got port 46257 (no reuse) → both proxies reaped on client exit.
+- Claude Code itself shows "Not logged in" on this machine **with or without bili** (no `~/.claude/.credentials.json`); that is an account/login issue, not a launcher regression. Wire path (proxying + ACP tool injection) was already proven with the fake-upstream harness.
+
+## 5. Rollback Plan
+
+- Revert the single commit.
+
+## 6. Lessons Learned
+
+- "Reuse if healthy" is only safe when the reused process is guaranteed current; for a dev-machine tool with detached children, spawn-per-launch is strictly simpler and self-healing.
+- Detached + unref'd children outlive their owner by design — any reuse heuristic turns them into permanent squatters on the default port.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -79,8 +79,7 @@ Usage:
   bili --help                      show this help
 
 Launcher (bili pi / bili codex / bili claude / bili omp / bili opencode):
-  Brings up a proxy on an independent port (reusing one already running on
-  that port), then runs the client pointed at it via HTTPS_PROXY + the proxy's
+  Brings up a proxy on an independent port (a fresh instance every launch), then runs the client pointed at it via HTTPS_PROXY + the proxy's
   MITM CA — no config-file edits. Discovered HTTPS upstream domains are
   auto-whitelisted for MITM so the proxy TLS-terminates exactly the hosts the
   client uses; HTTP / localhost providers go direct. pi/claude trust the CA

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -83,14 +83,6 @@ const SPAWN_WAIT_MS = 20000;
 const PROBE_TIMEOUT_MS = 1500;
 
 const DEFAULT_MITM_DOMAIN_SET = new Set(DEFAULT_MITM_DOMAINS.map((d) => d.toLowerCase()));
-function coveredByDefaultMitm(host: string): boolean {
-    const h = host.toLowerCase();
-    return DEFAULT_MITM_DOMAINS.some((d) => h === d || h.endsWith("." + d));
-}
-function domainsNeedFreshProxy(domains: string[] | undefined): boolean {
-    if (!domains || domains.length === 0) return false;
-    return domains.some((d) => !coveredByDefaultMitm(d));
-}
 
 export interface SpawnChild {
     pid: number;
@@ -116,8 +108,7 @@ export interface LaunchOptions {
 export interface ProxyHandle {
     origin: string;
     port: number;
-    reused: boolean;
-    child: SpawnChild | null;
+    child: SpawnChild;
     logPath?: string;
 }
 
@@ -656,11 +647,6 @@ export async function ensureProxyRunning(
     const now = deps.now ?? Date.now;
     const sleepImpl = deps.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
 
-    const preferredOrigin = proxyOrigin(opts.host, opts.port);
-    if (!domainsNeedFreshProxy(opts.mitmDomains) && (await probeHealth(preferredOrigin, fetchImpl))) {
-        return { origin: preferredOrigin, port: opts.port, reused: true, child: null };
-    }
-
     const port = await findFreePort(opts.port, opts.host);
     const spawnedOrigin = proxyOrigin(opts.host, port);
 
@@ -697,7 +683,7 @@ export async function ensureProxyRunning(
     while (now() < deadline) {
         await sleepImpl(HEALTH_POLL_INTERVAL_MS);
         if (await probeHealth(spawnedOrigin, fetchImpl)) {
-            return { origin: spawnedOrigin, port, reused: false, child, logPath };
+            return { origin: spawnedOrigin, port, child, logPath };
         }
     }
     throw new Error(`bili: proxy did not become healthy at ${spawnedOrigin} within ${SPAWN_WAIT_MS}ms`);
@@ -809,7 +795,7 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
     const domains = dedupeInOrder([...routes.httpsDomains, ...(params.mitmDomains ?? [])]);
     const handle = await ensureProxyRunning({ host, port, passthrough, debug, mitmDomains: domains }, deps);
     console.error(
-        `bili: ${handle.reused ? "reusing existing" : "started"} proxy at ${handle.origin} (MITM domains: ${domains.length ? domains.join(", ") : "defaults"})` +
+        `bili: started proxy at ${handle.origin} (MITM domains: ${domains.length ? domains.join(", ") : "defaults"})` +
             (routes.httpRewrites.length > 0 ? ` (HTTP /bili/ rewrites: ${routes.httpRewrites.length})` : "") +
             (routes.httpsRewrites.length > 0 ? ` (HTTPS cert rewrites: ${routes.httpsRewrites.length})` : "") +
             (params.client === "pi-test" ? " (no extensions)" : ""),
@@ -898,7 +884,7 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
         console.error(`bili: failed to launch ${params.client}: ${err instanceof Error ? err.message : String(err)}`);
         code = 1;
     } finally {
-        if (!handle.reused) stopProxy(handle);
+        stopProxy(handle);
         if (piTmpHome) {
             try {
                 fs.rmSync(piTmpHome, { recursive: true, force: true });
@@ -941,7 +927,7 @@ export async function runTestPi(params: RunTestPiParams, deps: LauncherDeps = {}
     ]);
     const handle = await ensureProxyRunning({ host, port, passthrough, debug, mitmDomains: domains }, deps);
     console.error(
-        `bili: ${handle.reused ? "reusing existing" : "started"} proxy at ${handle.origin} (MITM domains: ${domains.length ? domains.join(", ") : "defaults"})`,
+        `bili: started proxy at ${handle.origin} (MITM domains: ${domains.length ? domains.join(", ") : "defaults"})`,
     );
     if (handle.logPath) {
         console.error(`bili: proxy log: ${handle.logPath}`);
@@ -972,7 +958,7 @@ export async function runTestPi(params: RunTestPiParams, deps: LauncherDeps = {}
         console.error(`bili: pi test failed: ${err instanceof Error ? err.message : String(err)}`);
         code = 1;
     } finally {
-        if (!handle.reused) stopProxy(handle);
+        stopProxy(handle);
     }
     process.exit(code ?? 0);
 }

--- a/tests/launcher.test.ts
+++ b/tests/launcher.test.ts
@@ -267,7 +267,7 @@ function makeFakeChild(pid: number): SpawnChild {
     };
 }
 
-test("ensureProxyRunning: reuses an already-healthy proxy without spawning", async () => {
+test("ensureProxyRunning: always spawns a fresh proxy, never reuses a listener", async () => {
     let spawnCalls = 0;
     const spawnImpl: SpawnFn = () => {
         spawnCalls++;
@@ -278,10 +278,10 @@ test("ensureProxyRunning: reuses an already-healthy proxy without spawning", asy
         { host: "127.0.0.1", port: 8787, passthrough: false, debug: false },
         { fetchImpl, spawnImpl },
     );
-    assert.equal(handle.reused, true);
-    assert.equal(handle.child, null);
-    assert.equal(handle.origin, "http://127.0.0.1:8787");
-    assert.equal(spawnCalls, 0);
+    assert.equal(spawnCalls, 1);
+    assert.ok(handle.child);
+    assert.equal(handle.origin, `http://127.0.0.1:${handle.port}`);
+    assert.notEqual(handle.child, null);
 });
 
 test("ensureProxyRunning: spawns when not healthy, polls until healthy", async () => {
@@ -299,7 +299,6 @@ test("ensureProxyRunning: spawns when not healthy, polls until healthy", async (
         { host: "127.0.0.1", port: 8787, passthrough: false, debug: false },
         { fetchImpl, spawnImpl, sleep: () => Promise.resolve() },
     );
-    assert.equal(handle.reused, false);
     assert.equal(handle.child?.pid, 42421);
     assert.ok(spawnedArgs !== null);
     assert.ok(spawnedArgs.includes("start"));
@@ -328,9 +327,9 @@ test("ensureProxyRunning: throws when never healthy within deadline", async () =
     );
 });
 
-test("stopProxy: no-op when reused (child null)", () => {
+test("stopProxy: no-op when child missing pid", () => {
     assert.doesNotThrow(() =>
-        stopProxy({ origin: "http://127.0.0.1:8787", port: 8787, reused: true, child: null }),
+        stopProxy({ origin: "http://127.0.0.1:8787", port: 8787, child: { pid: 0 } }),
     );
 });
 


### PR DESCRIPTION
> **Model: qwen3.8-27b (vllm)**

## Problem
`ensureProxyRunning` health-probed the preferred port and reused any healthy listener. A detached proxy from an earlier session (12h old, old code) squats 8787 forever and silently shadows every later `bili <client>` launch. User directive: launcher must never reuse a port — fresh instance every time.

## Fix
- Removed the reuse path entirely: every launch runs `findFreePort` + spawns a fresh detached proxy (~1s).
- `ProxyHandle.reused` deleted; `stopProxy` unconditional on all 4 exit paths (finally / SIGINT / SIGTERM / exit).
- Dropped now-dead `domainsNeedFreshProxy` / `coveredByDefaultMitm`.
- Help text updated: "a fresh instance every launch".

## Verification
- typecheck ✅ · 531/531 tests ✅ · build ✅
- tmux e2e: first `bili claude` → fresh proxy on 8787 (new pid); second concurrent launch → port 46257, no reuse; both reaped on exit.
- Note: "Not logged in" seen in Claude Code on this machine reproduces with bare `claude` too (no credentials file) — account state, not a launcher issue.

Merge base: master @ 0.1.47.