### PR TITLE
fix(plugin): stamp x-bili-plugin only after tools are registered

### DIFF
--- a/devlog/2026-08-24_plugin-header-gating/REQ.md
+++ b/devlog/2026-08-24_plugin-header-gating/REQ.md
@@ -1,0 +1,47 @@
+# REQ - Plugin header gating (register before claiming ownership)
+
+- Task ID: `2026-08-24_plugin-header-gating`
+- Home Repo: `billion-context`
+- Status: Accepted
+- Created: 2026-08-24 17:20
+
+## 1. One-liner
+
+The pi/omp plugin must not stamp `x-bili-plugin` headers until its tools are
+actually registered, otherwise the first provider request goes out with no ACP
+tools at all.
+
+## 2. Background
+
+After the three-protocol matrix test on the local SGLang backend, a race was
+observed in one-shot runs (`bili pi -p ...`):
+
+- round 1 `tools=[read,bash,edit,write]` — no ACP tools
+- round 2 `tools=[read,bash,edit,write,compress,decompress,search_context,acp_status]`
+
+Root cause: `before_provider_headers` stamps `x-bili-plugin` synchronously but
+fires `void registerTools(...)` without awaiting it. The header is what tells
+the proxy "the client owns the ACP tools natively — skip wire injection". The
+first request therefore left with neither native tools (manifest fetch still
+in flight) nor wire-injected tools.
+
+## 3. Requested Change
+
+1. `src/agent/pi.ts` — only stamp the `x-bili-plugin*` headers when
+   `registerTools()` has completed (a `toolsReady` flag on `RegisterState`).
+2. Consequence (desired): before registration the request rides the proxy's
+   wire mode — tools injected + native compress loop. After registration the
+   session switches to pure plugin mode. A permanently failing manifest fetch
+   degrades gracefully to permanent wire mode instead of a tool-less session.
+3. Tests: a regression test asserting headers are NOT stamped before
+   registration; existing tests reordered to register before asserting.
+
+## 4. Acceptance Criteria
+
+- One-shot `bili pi -p "..."` logs round 1 with the 4 ACP tools present.
+- All existing tests pass; no new `as any` / `@ts-ignore`.
+
+## 5. Out of Scope
+
+- Any proxy-side changes (the fallback wire injection already exists).
+- MCP bridge (`src/mcp.ts`) — tools/list is synchronous there, no race.

--- a/devlog/2026-08-24_plugin-header-gating/WORKLOG.md
+++ b/devlog/2026-08-24_plugin-header-gating/WORKLOG.md
@@ -1,0 +1,55 @@
+# WORKLOG - Plugin header gating
+
+- Task ID: `2026-08-24_plugin-header-gating`
+- Home Repo: `billion-context`
+- Status: Done
+- Updated: 2026-08-24 17:25
+
+## 1. Summary
+
+- **What was done**: `before_provider_headers` now stamps `x-bili-plugin*`
+  only after `registerTools()` has completed (`toolsReady` on `RegisterState`).
+- **Why**: the stamped header claims plugin ownership; stamping it before the
+  tools exist sent round 1 out with no ACP tools (one-shot `-p` runs never
+  recovered until round 2 in interactive sessions).
+- **Behavior / compatibility changes**: Yes — a request that races tool
+  registration now rides wire mode (proxy injects tools) instead of arriving
+  tool-less. Sessions switch to pure plugin mode from the first request after
+  registration. A dead manifest endpoint degrades to permanent wire mode.
+- **Risk level**: Low
+
+## 2. Change Log
+
+### Key Files
+
+- `src/agent/pi.ts` — `RegisterState.toolsReady`; set in `registerTools()`
+  after `pi.registerTool()` for every manifest tool; the stamping block in
+  `before_provider_headers` is guarded by `if (state.toolsReady === true)`.
+- `tests/plugin-agent.test.ts` — new regression test
+  ("before_provider_headers does not claim plugin mode until tools are
+  registered": empty headers before, full headers after registration); main
+  test reordered (session_start + waitForTools before header assertions); omp
+  entry test now drives registration against a real fake proxy instead of
+  asserting on an unregistered plugin.
+
+## 4. Testing & Verification
+
+- typecheck ✅ · **533/533** tests ✅ (+2 net) · build ✅
+- Real e2e (local SGLang 8199, anthropic protocol): one-shot
+  `bili pi --model sglang-anthropic/qwen3.8-27b -p "reply with exactly: pong"`
+  → round 1 `tools=[read,bash,edit,write,compress,decompress,search_context,acp_status]`
+  (previously round 1 lacked the 4 ACP tools) → output `pong`, exit 0.
+- Verified across all three protocols earlier in the session (openai chat /
+  responses / anthropic), each on a fresh proxy port.
+
+## 5. Rollback Plan
+
+- Revert the single commit.
+
+## 6. Lessons Learned
+
+- A header that flips server behavior is an ownership claim — never make the
+  claim before the resource it advertises exists. Async registration + sync
+  stamping = classic lie-by-timing.
+- The proxy's wire mode doubles as a natural fallback: deferring the claim
+  converts a hard failure (tool-less session) into a seamless mode switch.

--- a/src/agent/pi.ts
+++ b/src/agent/pi.ts
@@ -101,7 +101,7 @@ function manifestToTool(proxyBase: string, tool: ManifestTool, agent: string): T
 
 const RETRY_INTERVAL_MS = 10000;
 
-type RegisterState = { sid?: string; pending?: Promise<void>; retryAt?: number };
+type RegisterState = { sid?: string; toolsReady?: boolean; pending?: Promise<void>; retryAt?: number };
 
 async function registerTools(pi: ExtensionAPI, ctx: Ctx, state: RegisterState, agent: string): Promise<void> {
     const proxyBase = proxyBaseForCtx(ctx);
@@ -125,6 +125,7 @@ async function registerTools(pi: ExtensionAPI, ctx: Ctx, state: RegisterState, a
         try {
             for (const t of tools) pi.registerTool(manifestToTool(proxyBase, t, agent));
             state.sid = sid;
+            state.toolsReady = true;
             state.retryAt = undefined;
         } catch (err) {
             state.sid = undefined;
@@ -181,12 +182,22 @@ export function createBiliPlugin(agentOverride?: string): (pi: ExtensionAPI) => 
                 if (proxyBaseForCtx(ctx) === undefined) return;
                 const headers = (event as unknown as { headers?: Record<string, string> }).headers;
                 if (headers === undefined || typeof headers !== "object" || Array.isArray(headers)) return;
-                const sid = sessionIdOf(ctx);
-                if (sid !== undefined) headers["x-bili-plugin-conversation"] = sid;
-                headers["x-bili-plugin"] = agent;
-                const window = ctx.model?.contextWindow;
-                if (typeof window === "number" && Number.isFinite(window) && window > 0) {
-                    headers["x-bili-plugin-context-window"] = String(Math.floor(window));
+                // The x-bili-plugin marker tells the proxy "the client owns the
+                // ACP tools natively — skip wire-level injection". Stamping it
+                // before registerTools() finishes would send round 1 out with
+                // NO ACP tools (the first provider request races the manifest
+                // fetch). Claim ownership only once tools are registered;
+                // until then the request rides the proxy's wire mode. A
+                // permanently failing manifest fetch keeps us in wire mode —
+                // a graceful fallback rather than a tool-less session.
+                if (state.toolsReady === true) {
+                    const sid = sessionIdOf(ctx);
+                    if (sid !== undefined) headers["x-bili-plugin-conversation"] = sid;
+                    headers["x-bili-plugin"] = agent;
+                    const window = ctx.model?.contextWindow;
+                    if (typeof window === "number" && Number.isFinite(window) && window > 0) {
+                        headers["x-bili-plugin-context-window"] = String(Math.floor(window));
+                    }
                 }
             } catch (err) {
                 console.error(`bili-plugin(${agent}): header stamp skipped (${err instanceof Error ? err.message : String(err)})`);

--- a/tests/plugin-agent.test.ts
+++ b/tests/plugin-agent.test.ts
@@ -188,13 +188,16 @@ test("pi extension registers manifest tools and stamps headers when proxied", as
     try {
         const pi = makeFakePi();
         biliPlugin(pi as never);
+        // The header is only stamped once tools are registered, so register
+        // first (a real session does this via session_start before the first
+        // provider request; a one-shot -p run races it and rides wire mode).
+        await pi.events.get("session_start")!({}, fakeCtx(proxy));
+        await waitForTools(pi, 2);
         const headers: Record<string, string> = {};
         pi.events.get("before_provider_headers")!({ headers }, fakeCtx(proxy));
         assert.equal(headers["x-bili-plugin"], "pi");
         assert.equal(headers["x-bili-plugin-conversation"], "sess-42");
         assert.equal(headers["x-bili-plugin-context-window"], "1000000");
-        await pi.events.get("session_start")!({}, fakeCtx(proxy));
-        await waitForTools(pi, 2);
         assert.equal(pi.tools.length, 2);
         assert.equal(pi.tools[0]!.name, "compress");
         assert.deepEqual(pi.tools[0]!.parameters, { type: "object", properties: { content: { type: "array" } }, required: ["content"] });
@@ -205,6 +208,25 @@ test("pi extension registers manifest tools and stamps headers when proxied", as
         const errOut = await pi.tools[1]!.execute("call-2", {}, undefined, undefined, fakeCtx(proxy));
         assert.match(errOut.content[0]!.text, /bili tool error:.*boom/);
         assert.equal(errOut.isError, true);
+    } finally {
+        await proxy.close();
+    }
+});
+
+test("before_provider_headers does not claim plugin mode until tools are registered", async () => {
+    const proxy = await startFakeProxy();
+    try {
+        const pi = makeFakePi();
+        biliPlugin(pi as never);
+        const early: Record<string, string> = {};
+        pi.events.get("before_provider_headers")!({ headers: early }, fakeCtx(proxy));
+        assert.deepEqual(early, {});
+        await pi.events.get("session_start")!({}, fakeCtx(proxy));
+        await waitForTools(pi, 2);
+        const late: Record<string, string> = {};
+        pi.events.get("before_provider_headers")!({ headers: late }, fakeCtx(proxy));
+        assert.equal(late["x-bili-plugin"], "pi");
+        assert.equal(late["x-bili-plugin-conversation"], "sess-42");
     } finally {
         await proxy.close();
     }
@@ -354,27 +376,39 @@ test("/acp command warns when the session is unknown", async () => {
 });
 
 test("omp entry reports x-bili-plugin: omp without env vars", async () => {
-    await withEnv({ BILLION_CONTEXT_PLUGIN_AGENT: undefined, BILLION_CONTEXT_PROXY: "http://127.0.0.1:8799" }, () => {
-        const pi = makeFakePi();
-        ompPlugin(pi as never);
-        const headers: Record<string, string> = {};
-        pi.events.get("before_provider_headers")!({ headers }, fakeCtx(undefined));
-        assert.equal(headers["x-bili-plugin"], "omp");
-    });
-    await withEnv({ BILLION_CONTEXT_PLUGIN_AGENT: "omp", BILLION_CONTEXT_PROXY: "http://127.0.0.1:8799" }, () => {
-        const pi = makeFakePi();
-        biliPlugin(pi as never);
-        const headers: Record<string, string> = {};
-        pi.events.get("before_provider_headers")!({ headers }, fakeCtx(undefined));
-        assert.equal(headers["x-bili-plugin"], "omp");
-    });
-    await withEnv({ BILLION_CONTEXT_PLUGIN_AGENT: undefined }, () => {
-        const pi = makeFakePi();
-        createBiliPlugin("dsh")(pi as never);
-        const headers: Record<string, string> = {};
-        pi.events.get("before_provider_headers")!({ headers }, { sessionManager: { getSessionId: () => "s" }, model: { baseUrl: "http://127.0.0.1:8799/bili/https://x" } });
-        assert.equal(headers["x-bili-plugin"], "dsh");
-    });
+    const proxy = await startFakeProxy();
+    try {
+        await withEnv({ BILLION_CONTEXT_PLUGIN_AGENT: undefined, BILLION_CONTEXT_PROXY: proxy.origin }, async () => {
+            const pi = makeFakePi();
+            ompPlugin(pi as never);
+            await pi.events.get("session_start")!({}, fakeCtx(undefined));
+            await waitForTools(pi, 2);
+            const headers: Record<string, string> = {};
+            pi.events.get("before_provider_headers")!({ headers }, fakeCtx(undefined));
+            assert.equal(headers["x-bili-plugin"], "omp");
+        });
+        await withEnv({ BILLION_CONTEXT_PLUGIN_AGENT: "omp", BILLION_CONTEXT_PROXY: proxy.origin }, async () => {
+            const pi = makeFakePi();
+            biliPlugin(pi as never);
+            await pi.events.get("session_start")!({}, fakeCtx(undefined));
+            await waitForTools(pi, 2);
+            const headers: Record<string, string> = {};
+            pi.events.get("before_provider_headers")!({ headers }, fakeCtx(undefined));
+            assert.equal(headers["x-bili-plugin"], "omp");
+        });
+        await withEnv({ BILLION_CONTEXT_PLUGIN_AGENT: undefined }, async () => {
+            const pi = makeFakePi();
+            createBiliPlugin("dsh")(pi as never);
+            const ctx = { sessionManager: { getSessionId: () => "s" }, model: { baseUrl: `${proxy.origin}/bili/https://x` } };
+            await pi.events.get("session_start")!({}, ctx);
+            await waitForTools(pi, 2);
+            const headers: Record<string, string> = {};
+            pi.events.get("before_provider_headers")!({ headers }, ctx);
+            assert.equal(headers["x-bili-plugin"], "dsh");
+        });
+    } finally {
+        await proxy.close();
+    }
 });
 
 function hintEnv(home: string, piAgentDir: string): Record<string, string> {

--- a/tests/plugin-agent.test.ts
+++ b/tests/plugin-agent.test.ts
@@ -232,6 +232,31 @@ test("before_provider_headers does not claim plugin mode until tools are registe
     }
 });
 
+test("before_provider_headers stays silent when the manifest fetch keeps failing", async () => {
+    // Graceful degradation: a dead manifest endpoint means the plugin never
+    // claims ownership, so the session rides the proxy's wire mode forever.
+    const server = http.createServer((req, res) => {
+        res.writeHead(404);
+        res.end("{}");
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const origin = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+    try {
+        const pi = makeFakePi();
+        biliPlugin(pi as never);
+        await pi.events.get("session_start")!({}, fakeCtx(origin));
+        await flush();
+        await flush();
+        assert.equal(pi.tools.length, 0);
+        const headers: Record<string, string> = {};
+        pi.events.get("before_provider_headers")!({ headers }, fakeCtx(origin));
+        assert.deepEqual(headers, {});
+    } finally {
+        server.close();
+    }
+});
+
 test("pi extension survives hostile host shapes without throwing", async () => {
     const proxy = await startFakeProxy();
     try {


### PR DESCRIPTION
> **Model: qwen3.8-27b (vllm)**

## Problem

One-shot runs (`bili pi -p ...`) sent their first provider request with **no ACP tools**:

```
round 1: tools=[read,bash,edit,write]                                  ← missing
round 2: tools=[read,bash,edit,write,compress,decompress,search_context,acp_status]
```

Root cause: `before_provider_headers` stamps `x-bili-plugin` synchronously (the header tells the proxy *"client owns the ACP tools — skip wire injection"*) but fires `void registerTools(...)` unawaited. Round 1 therefore had neither native tools (manifest fetch still in flight) nor wire-injected ones.

## Fix

Gate the header stamp on a `toolsReady` flag set after `registerTools()` completes:

- Before registration → no header → request rides the proxy's **wire mode** (tools injected + native compress loop — a battle-tested path)
- After registration → header stamped → pure **plugin mode**
- Dead manifest endpoint → never claims ownership → permanent wire mode (graceful degradation instead of a tool-less session)

## Verification

- typecheck ✅ · **533/533 tests** (+2) · build ✅
- Real e2e (local SGLang, anthropic protocol): one-shot `bili pi -p` now logs
  `round 1: tools=[read,bash,edit,write,compress,decompress,search_context,acp_status]` → `pong`, exit 0
- Found via the three-protocol matrix test (openai chat / responses / anthropic all pass)