### PR TITLE
release v0.1.48

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.47",
+  "version": "0.1.48",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.47",
+      "version": "0.1.48",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.47",
+  "version": "0.1.48",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
> **Model: qwen3.8-27b (vllm)**

## Release v0.1.48

Pure version bump — no code changes on this branch.

### Highlights since v0.1.47

| PR | Change |
|----|--------|
| #215 | fix(responses): remap round-2 message lifecycle so codex stops dropping text deltas |
| #216 | fix(launcher): never reuse a proxy port — always spawn a fresh instance every launch |
| #217 | fix(plugin): stamp `x-bili-plugin` only after tools are registered (closes the wire/plugin race; graceful degradation to wire mode when the manifest is unreachable) + manifest-failure regression test |

### Pre-flight (same as CI)

- `npm run typecheck` ✅
- `npm test` — 534/534 pass, 0 fail ✅
- `npm run build` ✅

### Notes

- `src/update.ts` untouched since v0.1.47 → no no-op validation release required.
- `acp-kernel` stays pinned at the version in `package.json` (no cross-repo bump).

Merge → CI publishes `0.1.48` to npm, tags `v0.1.48`, creates the GitHub Release.