### PR TITLE
release v0.1.49

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.48",
+  "version": "0.1.49",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.48",
+      "version": "0.1.49",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.48",
+  "version": "0.1.49",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
> **Model: qwen3.8-27b (vllm)**

## Highlights since v0.1.48

### Context-window resolution overhaul (#212, PR #219)
- **deepseek**: 64k → 128k (stale built-in value was capping real 128k models → constant emergency compression)
- **MiniMax**: added to the host→provider map (api.minimax.chat / api.minimaxi.com / api.minimax.io) — previously fell through to the 200k default
- **Priority inversion**: warm registry cache now beats the built-in table (a stale table can no longer lock out fresher data); cold start stays non-blocking (sync peek, no fetch)
- **models.dev fetch through the upstream proxy**: Node's global fetch ignores `https_proxy` env vars, so the registry was permanently dead on proxied networks. Now routes through the configured proxy (undici ProxyAgent) with direct fallback.

### The ENTIRE models.dev registry is now bundled (282 KB, 355 models)
- Every field models.dev ships: name / description / family / reasoning / tool_call / modalities / limit.context+output+input / benchmarks / weights / …
- Offline floor: fresh install, no disk cache, unreachable models.dev, no proxy → exact windows from the very first request (`using bundled snapshot (355 models); fetch failed`)
- Today only `limit.context` is consumed; the rest rides along so future features (pricing, modality checks) get the offline floor for free
- Refresh with `npm run registry:snapshot` before a release

### Web UI config guard (#212)
- A hand-edited config (comments/trailing commas) previously made the UI silently render empty + a save rebuilt from `{}`, wiping every other field. Now: GET returns `parseError`, PUT returns **409** and refuses to write.

## Verification
- typecheck ✅ · 545/545 tests ✅ · build ✅ (dist 2.44 MB)
- Offline e2e with real `pi`: deepseek-chat resolved to 128,000 (was 64,000) — evidenced by nudge `usage=0% (0/119808)` (= 128,000 − 8,192 output reserve) under a permanently-offline environment

## Release checklist
- [ ] CI green
- [ ] Merge (human)
- [ ] CI publishes `0.1.49` to npm + tag `v0.1.49` + GitHub Release
- [ ] `npm view billion-context version` → 0.1.49