### PR TITLE
fix: survive upstream rejection of replayed thinking blocks in compress loop

### DIFF
--- a/src/loop/core.ts
+++ b/src/loop/core.ts
@@ -24,6 +24,14 @@ import type { WireProtocol } from "../util.js";
 
 export const MAX_LOOP_ROUNDS = 10;
 
+function isLoopThinking(m: CoreMessage): boolean {
+    return m.contentType === "reasoning" && typeof m.id === "string" && m.id.startsWith("acp_loop_");
+}
+
+function stripLoopThinking(messages: CoreMessage[]): CoreMessage[] {
+    return messages.filter((m) => !isLoopThinking(m));
+}
+
 export interface LoopCtx {
     core: CompressionCore;
     config: Config;
@@ -189,6 +197,7 @@ export async function* runCompressLoop(
     let activeClearTimer: (() => void) | null = null;
     let currentUpstream = upstream;
     const coreMessages: CoreMessage[] = [...ctx.messages];
+    let degradedRetried = false;
 
     try {
         for (let round = 1; round <= MAX_LOOP_ROUNDS; round++) {
@@ -308,7 +317,7 @@ export async function* runCompressLoop(
                 if (reasoningSegments.length > 0) {
                     for (let i = 0; i < reasoningSegments.length; i++) {
                         const seg = reasoningSegments[i];
-                        if (seg.text.length === 0 && seg.signature.length === 0) continue;
+                        if (seg.text.length === 0 || seg.signature.length === 0) continue;
                         const reasoningMsg: BiliMessage = {
                             id: i === 0 ? `acp_loop_r${round}_reasoning` : `acp_loop_r${round}_reasoning_${i + 1}`,
                             role: "assistant",
@@ -399,7 +408,20 @@ export async function* runCompressLoop(
 
             if (signal?.aborted) break;
 
-            const newBody = adapter.buildRequest(coreMessages, systemPrompt, requestBody);
+            const fetchUpstream = (body: Record<string, unknown>) =>
+                fetchWithTimeout(
+                    requestOptions.url,
+                    {
+                        method: "POST",
+                        headers: requestOptions.headers,
+                        body: JSON.stringify(body),
+                        ...(ctx.proxyUrl ? { dispatcher: proxyDispatcher(ctx.proxyUrl) } : {}),
+                    },
+                    undefined,
+                    signal,
+                );
+
+            let newBody = adapter.buildRequest(coreMessages, systemPrompt, requestBody);
             if (process.env.ACP_DUMP_REQ !== "0" && ctx.debug) {
                 try {
                     const fs = await import("node:fs");
@@ -409,20 +431,30 @@ export async function* runCompressLoop(
                     fs.writeFileSync(`${dumpDir}/req-${Date.now()}-${sid}-REREQUEST.json`, JSON.stringify(newBody, null, 2));
                 } catch { /* best-effort */ }
             }
-            const { response: resp, clearTimer } = await fetchWithTimeout(
-                requestOptions.url,
-                {
-                    method: "POST",
-                    headers: requestOptions.headers,
-                    body: JSON.stringify(newBody),
-                    ...(ctx.proxyUrl ? { dispatcher: proxyDispatcher(ctx.proxyUrl) } : {}),
-                },
-                undefined,
-                signal,
-            );
+            let fetched = await fetchUpstream(newBody);
 
+            if (
+                !fetched.response.ok &&
+                fetched.response.status >= 400 &&
+                fetched.response.status < 500 &&
+                !degradedRetried &&
+                coreMessages.some(isLoopThinking)
+            ) {
+                const errText = await fetched.response.text().catch(() => "upstream error");
+                fetched.clearTimer();
+                degradedRetried = true;
+                const stripped = stripLoopThinking(coreMessages);
+                coreMessages.length = 0;
+                coreMessages.push(...stripped);
+                ctx.log(`[acp-loop] round ${round}: re-request rejected (${fetched.response.status}: ${errText.slice(0, 200)}); retrying without replayed thinking blocks`);
+                loggerLog("warn", `[acp-loop] re-request rejected (${fetched.response.status}); retrying without thinking replay: ${errText.slice(0, 200)}`);
+                newBody = adapter.buildRequest(coreMessages, systemPrompt, requestBody);
+                fetched = await fetchUpstream(newBody);
+            }
+
+            const resp = fetched.response;
             if (!resp.ok || !resp.body) {
-                clearTimer();
+                fetched.clearTimer();
                 const errText = await resp.text().catch(() => "upstream error");
                 ctx.log(`[acp-proxy: compress loop upstream error ${resp.status}: ${errText.slice(0, 200)}]`);
                 loggerLog("error", `[acp-loop] upstream error ${resp.status}: ${errText.slice(0, 200)}`);
@@ -432,7 +464,7 @@ export async function* runCompressLoop(
 
             currentUpstream = resp.body as ReadableStream<Uint8Array>;
             if (activeClearTimer) activeClearTimer();
-            activeClearTimer = clearTimer;
+            activeClearTimer = fetched.clearTimer;
         }
     } finally {
         if (activeClearTimer) {

--- a/tests/anthropic-thinking-replay.test.ts
+++ b/tests/anthropic-thinking-replay.test.ts
@@ -1,0 +1,179 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { Config, CoreMessage } from "acp-kernel";
+import { createCore, createInitialState } from "acp-kernel";
+import type { Session } from "../src/session.ts";
+import { runCompressLoop } from "../src/loop/core.ts";
+import { createAnthropicAdapter } from "../src/loop/adapter-anthropic.ts";
+import { buildCompressSystemPrompt } from "../src/compress-tool.ts";
+
+function makeCtx(messages: CoreMessage[] = []) {
+    return {
+        core: createCore(),
+        config: { modelContextLimit: 200000 } as Config,
+        messages,
+        session: {
+            id: "thinking-replay-test",
+            meta: {},
+            stats: { requests: 0, tokensSaved: 0, inputTokens: 0, cachedTokens: 0, outputTokens: 0, cacheSamples: 0, lastInputTokens: 0, contextTokens: 0 },
+            metadata: {},
+            state: createInitialState(),
+            createdAt: Date.now(),
+            lastSeen: Date.now(),
+            blockContents: new Map(),
+            inFlight: 0,
+            persisted: false,
+        } as unknown as Session,
+        log: () => {},
+    };
+}
+
+function sse(type: string, data: unknown): string {
+    return `event: ${type}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+const COMPRESS_ARGS = JSON.stringify({ content: [{ startId: "m00001", endId: "m00002", summary: "s" }] });
+
+function round1Thinking(withSignature: boolean): string {
+    const events = [
+        sse("message_start", { type: "message_start", message: { id: "msg_1", usage: { input_tokens: 10 } } }),
+        sse("content_block_start", { type: "content_block_start", index: 0, content_block: { type: "thinking", thinking: "" } }),
+        sse("content_block_delta", { type: "content_block_delta", index: 0, delta: { type: "thinking_delta", thinking: "I should compress first." } }),
+    ];
+    if (withSignature) {
+        events.push(sse("content_block_delta", { type: "content_block_delta", index: 0, delta: { type: "signature_delta", signature: "sig-abc" } }));
+    }
+    events.push(
+        sse("content_block_stop", { type: "content_block_stop", index: 0 }),
+        sse("content_block_start", { type: "content_block_start", index: 1, content_block: { type: "tool_use", id: "toolu_1", name: "compress", input: {} } }),
+        sse("content_block_delta", { type: "content_block_delta", index: 1, delta: { type: "input_json_delta", partial_json: COMPRESS_ARGS } }),
+        sse("content_block_stop", { type: "content_block_stop", index: 1 }),
+        sse("message_delta", { type: "message_delta", delta: { stop_reason: "tool_use" }, usage: { output_tokens: 7 } }),
+        sse("message_stop", { type: "message_stop" }),
+    );
+    return events.join("");
+}
+
+const ROUND2_TEXT = [
+    sse("message_start", { type: "message_start", message: { id: "msg_2", usage: { input_tokens: 20 } } }),
+    sse("content_block_start", { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } }),
+    sse("content_block_delta", { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "Continued after compression." } }),
+    sse("content_block_stop", { type: "content_block_stop", index: 0 }),
+    sse("message_delta", { type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 5 } }),
+    sse("message_stop", { type: "message_stop" }),
+].join("");
+
+interface CapturedRequest {
+    body: Record<string, unknown>;
+}
+
+async function drain(
+    stream: ReadableStream<Uint8Array>,
+    ctx: ReturnType<typeof makeCtx>,
+    captured: CapturedRequest[],
+): Promise<string> {
+    const chunks: Buffer[] = [];
+    const adapter = createAnthropicAdapter({ model: "claude-test", stream: true, messages: [] });
+    for await (const chunk of runCompressLoop(
+        stream,
+        ctx as never,
+        { model: "claude-test", stream: true, messages: [] },
+        { url: "http://mock", headers: {} },
+        adapter,
+        buildCompressSystemPrompt(),
+    )) {
+        chunks.push(chunk);
+    }
+    return Buffer.concat(chunks).toString("utf8");
+}
+
+function assistantThinkingBlocks(body: Record<string, unknown>): unknown[] {
+    const messages = body.messages as { role: string; content: { type: string }[] }[];
+    const blocks: unknown[] = [];
+    for (const m of messages ?? []) {
+        if (m.role !== "assistant" || !Array.isArray(m.content)) continue;
+        for (const block of m.content) {
+            if (block.type === "thinking") blocks.push(block);
+        }
+    }
+    return blocks;
+}
+
+test("issue #221: re-request rejected 400 → degraded retry without thinking replay succeeds (agent continues, no silent halt)", async () => {
+    const captured: CapturedRequest[] = [];
+    let fetchCalls = 0;
+    const orig = globalThis.fetch;
+    globalThis.fetch = (async (_input: unknown, init?: RequestInit) => {
+        fetchCalls++;
+        captured.push({ body: JSON.parse(String(init?.body)) });
+        if (fetchCalls === 1) {
+            return new Response("invalid thinking block signature", { status: 400 });
+        }
+        return new Response(ROUND2_TEXT, { status: 200 });
+    }) as typeof fetch;
+    try {
+        const out = await drain(
+            new Response(round1Thinking(true), { status: 200 }).body!,
+            makeCtx(),
+            captured,
+        );
+        assert.equal(fetchCalls, 2, "first re-request 400s, degraded retry follows");
+        assert.equal(assistantThinkingBlocks(captured[0].body).length, 1, "first re-request replays the signed thinking block");
+        assert.equal(assistantThinkingBlocks(captured[1].body).length, 0, "degraded retry strips thinking blocks");
+        assert.ok(JSON.stringify(captured[1].body).includes('"compress"'), "degraded retry keeps the compress tool_use + tool_result continuation");
+        assert.ok(out.includes("[ACP]"), "marker surfaced to client");
+        assert.ok(out.includes("Continued after compression."), "round-2 text reaches the client");
+        assert.ok(!out.includes("upstream error"), "no error surfaced to the client");
+        assert.ok(/"stop_reason":"end_turn"/.test(out), "turn ends with end_turn after real content (not a silent stop right after the marker)");
+    } finally {
+        globalThis.fetch = orig;
+    }
+});
+
+test("issue #221: signature-less thinking (relay never sent signature_delta) is proactively dropped from the replay", async () => {
+    const captured: CapturedRequest[] = [];
+    let fetchCalls = 0;
+    const orig = globalThis.fetch;
+    globalThis.fetch = (async (_input: unknown, init?: RequestInit) => {
+        fetchCalls++;
+        captured.push({ body: JSON.parse(String(init?.body)) });
+        return new Response(ROUND2_TEXT, { status: 200 });
+    }) as typeof fetch;
+    try {
+        const out = await drain(
+            new Response(round1Thinking(false), { status: 200 }).body!,
+            makeCtx(),
+            captured,
+        );
+        assert.equal(fetchCalls, 1, "single re-request, accepted on first try");
+        assert.equal(assistantThinkingBlocks(captured[0].body).length, 0, "signature-less thinking is never replayed (it 400s on Anthropic-protocol validation)");
+        assert.ok(JSON.stringify(captured[0].body).includes('"compress"'), "compress continuation intact");
+        assert.ok(out.includes("[ACP]"), "marker surfaced to client");
+        assert.ok(out.includes("Continued after compression."), "round-2 text reaches the client");
+    } finally {
+        globalThis.fetch = orig;
+    }
+});
+
+test("issue #221: degraded retry also rejected → error surfaced (visible failure, not a silent stop)", async () => {
+    const captured: CapturedRequest[] = [];
+    let fetchCalls = 0;
+    const orig = globalThis.fetch;
+    globalThis.fetch = (async (_input: unknown, init?: RequestInit) => {
+        fetchCalls++;
+        captured.push({ body: JSON.parse(String(init?.body)) });
+        return new Response("bad request", { status: 400 });
+    }) as typeof fetch;
+    try {
+        const out = await drain(
+            new Response(round1Thinking(true), { status: 200 }).body!,
+            makeCtx(),
+            captured,
+        );
+        assert.equal(fetchCalls, 2, "one full attempt + one degraded attempt, then give up");
+        assert.ok(out.includes("upstream error 400"), "error is visible to the client");
+        assert.ok(/"stop_reason":"end_turn"/.test(out), "stream still terminates cleanly");
+    } finally {
+        globalThis.fetch = orig;
+    }
+});


### PR DESCRIPTION
## Problem (upstream #221)

Occasionally the model stops executing right after an ACP tool result (reported with MiniMax M3 via an Anthropic-protocol relay; `/v1/messages?beta=true`).

## Root cause

After a proxy-tool round (compress / decompress / acp_status / search_context), the compress loop rebuilds the conversation and re-requests upstream so the model sees the tool result. The rebuilt assistant message replays the **thinking blocks** collected from the intercepted turn:

1. If the relay never sends `signature_delta`, the replayed thinking block has no signature — invalid for Anthropic-protocol endpoints that validate.
2. Even signed thinking replay is rejected by some relay/converter backends.

In both cases the re-request gets a 4xx, the loop emits an error + `end_turn`, and the **agent halts right after the ACP marker** — exactly the reported symptom.

## Fix (`src/loop/core.ts`)

- **Proactive**: signature-less thinking segments are no longer replayed (they were already streamed to the client verbatim in round 1).
- **Resilient**: if a re-request is rejected with 4xx, retry once with all loop-injected thinking blocks stripped (degraded retry, at most once per turn). Only if that also fails is the upstream error surfaced.

## Tests

New `tests/anthropic-thinking-replay.test.ts` (3 tests):
- 400 → degraded retry without thinking → model continues, client gets marker + round-2 content, no error
- signature-less thinking → replay body contains no thinking blocks, accepted first try
- degraded retry also 400 → visible error + clean `end_turn` (no silent stop)

Full suite: **548 pass**, typecheck + build clean.

Fixes #221