### PR TITLE
feat(launcher): add hermes to the bili launcher (/bili/ rewrite, no MITM)

### DIFF
--- a/devlog/2026-08-24_hermes-launcher/REQ.md
+++ b/devlog/2026-08-24_hermes-launcher/REQ.md
@@ -1,0 +1,42 @@
+# REQ: `bili hermes` — bring hermes-agent under the proxy with zero config edits
+
+## Date
+2026-08-24
+
+## References
+- Issue #195 (Hermes 完整支持)
+
+## Background
+
+hermes-agent (Nous Research, Python) supports three LLM transports that all map
+onto protocols the proxy already speaks:
+
+| hermes `transport` | wire path |
+|---|---|
+| `openai_chat` (chat_completions) | POST /v1/chat/completions |
+| `codex_responses` | POST /v1/responses |
+| `anthropic_messages` | POST /v1/messages |
+
+The launcher should bring hermes under the proxy with the same promise as every
+other client: **read the client's own config, never edit it, route traffic
+through the proxy, inject the four ACP tools.**
+
+## Requirements
+
+1. `bili hermes [opts --] [args]` spawns a fresh proxy and launches hermes
+   against it; proxy dies with the client.
+2. Zero edits to the user's real `~/.hermes/` — skills, memories, sessions,
+   SOUL.md, `.env` stay shared.
+3. Provider endpoints are discovered from `~/.hermes/config.yaml` (both the
+   v12 `providers:` dict and the legacy `custom_providers:` list).
+4. Every upstream — http AND https — rides the `/bili/` URL form (no cert
+   MITM): hermes's httpx builds its CA bundle from certifi, so MITM would need
+   trust config we cannot inject via env. The proxy terminates TLS upstream
+   itself, so `/bili/https://...` needs no client-side cert at all.
+5. Works with `HERMES_HOME` already set (hermes-native override respected).
+
+## Non-goals
+- No hermes-side plugin (hermes has no extension API; wire-mode tool injection
+  covers it — verified end to end).
+- `hermes acp` (Zed Agent Client Protocol) is unrelated to bili's ACP
+  compression and out of scope.

--- a/devlog/2026-08-24_hermes-launcher/WORKLOG.md
+++ b/devlog/2026-08-24_hermes-launcher/WORKLOG.md
@@ -66,3 +66,21 @@ Revert the single commit; no data migrations, no config-format changes.
 - Upstream forbids wheel/sdist builds (setup.py guard); the supported local
   install is a clone + `uv venv` + editable install (see ~/system/README.md
   "Hermes Agent").
+
+## Follow-up 4: review findings (second tmux review round)
+
+A reviewer session running under `bili hermes` itself flagged two gaps:
+
+1. **Silent bypass when prepare fails**: the launcher only warned when
+   discovery found zero providers. If `httpRewrites` was non-empty but
+   `prepareHermesHome` returned `undefined` (unreadable config.yaml, no
+   matching lines), traffic silently bypassed the proxy. The else branch now
+   warns in both cases with distinct messages.
+2. **CRLF → LF regression**: `lines.join("\n")` destroyed CRLF files
+   (Windows-edited configs). The rewriter now detects the dominant EOL from
+   the source text and preserves it; the split regex already tolerated both.
+
+Tests: CRLF preservation (incl. no-doubled-newlines + rewritten line keeps
+`\r`) and unreadable-config-with-pending-rewrites → undefined.
+
+559/559 pass, typecheck clean.

--- a/devlog/2026-08-24_hermes-launcher/WORKLOG.md
+++ b/devlog/2026-08-24_hermes-launcher/WORKLOG.md
@@ -1,0 +1,68 @@
+# WORKLOG: `bili hermes`
+
+Branch: `2026-08-24_hermes-launcher` (single commit on top of master f391a3e)
+
+## 1. Why `/bili/` for everything (no cert MITM)
+
+Hermes is a Python/httpx client: `httpx` builds its SSL context from
+`certifi` explicitly, so `SSL_CERT_FILE` / `NODE_EXTRA_CA_CERTS` are ignored —
+cert-MITM cannot be trusted via env alone. Wrapping every upstream (http and
+https) in the `/bili/` URL form sidesteps TLS entirely on the client leg; the
+proxy does TLS to the real upstream itself. Same decision as claude (whose
+undici also ignores HTTPS_PROXY).
+
+## 2. Implementation
+
+- `src/client-config.ts`: `HermesProvider`/`HermesConfig`, `resolveHermesHome`
+  (HERMES_HOME → ~/.hermes), `parseHermesYaml` (line-based: v12 `providers:`
+  dict → `api:` per provider; legacy `custom_providers:` list → `- name:` /
+  `base_url:`/`api:`/`url:`; inline keys on dash lines handled),
+  `readHermesConfig`; wired into `loadClientConfig`.
+- `src/launcher.ts`:
+  - `LAUNCH_CLIENTS`/`BaseClientName` += hermes; `launcherInjectMcp` excludes
+    hermes (no MCP injection — wire mode owns the tools).
+  - `discoverRoutes` hermes branch: every provider endpoint → `httpRewrites`
+    (https too), `httpsDomains` stays empty.
+  - `prepareHermesHome(hermesHome, origin, rewrites)`: mkdtemp
+    `bili-hermes-*`, symlink every `~/.hermes` sibling except `config.yaml`
+    (skills/memories/sessions shared), rewrite every
+    `api:`/`base_url:`/`url:` line whose URL matches a discovered upstream to
+    `origin + /bili/ + raw` (comment suffix preserved). Returns temp dir;
+    `HERMES_HOME` is pointed at it.
+  - runLaunch: hermes branch + temp-dir cleanup in `finally`; warns when no
+    providers were found (traffic would bypass the proxy).
+- `src/cli.ts`: usage lines + launcher section + example.
+- `tests/launcher.test.ts`: +4 tests (parse v12+legacy, read+resolve,
+  discoverRoutes wrap-both-schemes/no-MITM, prepareHermesHome rewrite/share/
+  untouched-original/empty-rewrites).
+
+## 3. Verification
+
+- `npx tsc --noEmit` clean; `npm test` 557/557 (was 553, +4); build ok.
+- Real e2e (isolated HERMES_HOME + SGLang qwen3.8-27b on 127.0.0.1:8199), all
+  three transports:
+  - `openai_chat` → `forward POST → /v1/chat/completions`, pong.
+  - `codex_responses` → `forward POST → /v1/responses`, pong.
+  - `anthropic_messages` → `forward POST → /v1/messages`, pong.
+  - In every run the model's tool list ended with
+    `compress, decompress, search_context, acp_status` (28 hermes built-ins +
+    4 injected), `acp-loop round 1` healthy, no tool-call loops.
+  - Hermes's startup model probing (GET /v1/models, /api/tags, /api/show,
+    /api/v1/models) is passed through verbatim by the proxy.
+  - The source config.yaml kept its raw `api: http://127.0.0.1:8199/v1`
+    (untouched); no `bili-hermes-*` temp dirs left behind.
+
+## 4. Rollback
+
+Revert the single commit; no data migrations, no config-format changes.
+
+## 5. Notes / gotchas
+
+- hermes `--provider custom` on the CLI is a placeholder profile that routes
+  to openrouter unless completed by config — irrelevant here because the
+  launcher rewrites the user's real config instead.
+- `HERMES_HOME` env is respected by both sides (hermes + launcher), so e2e
+  could run against a throwaway home without touching `~/.hermes`.
+- Upstream forbids wheel/sdist builds (setup.py guard); the supported local
+  install is a clone + `uv venv` + editable install (see ~/system/README.md
+  "Hermes Agent").

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -64,6 +64,7 @@ Usage:
   bili claude [opts --] [args]     start a proxy + launch claude against it (cert-MITM)
   bili omp [opts --] [args]        start a proxy + launch omp against it (cert-MITM)
   bili opencode [opts --] [args]   start a proxy + launch opencode against it (cert-MITM)
+  bili hermes [opts --] [args]     start a proxy + launch hermes-agent against it (/bili/ rewrite)
   bili test pi                     non-polluting pi smoke test through the proxy
   bili export [session] [--full]   list sessions / export one as a Markdown handoff
                                     (--full includes original messages; --output FILE)
@@ -78,7 +79,7 @@ Usage:
   bili --version                   print version
   bili --help                      show this help
 
-Launcher (bili pi / bili codex / bili claude / bili omp / bili opencode):
+Launcher (bili pi / bili codex / bili claude / bili omp / bili opencode / bili hermes):
   Brings up a proxy on an independent port (a fresh instance every launch), then runs the client pointed at it via HTTPS_PROXY + the proxy's
   MITM CA — no config-file edits. Discovered HTTPS upstream domains are
   auto-whitelisted for MITM so the proxy TLS-terminates exactly the hosts the
@@ -90,6 +91,7 @@ Launcher (bili pi / bili codex / bili claude / bili omp / bili opencode):
     bili codex                            # launch codex through the proxy
     bili claude                           # launch claude through the proxy
     bili omp                              # launch omp through the proxy (pi-based; /bili/ rewrite)
+    bili hermes                           # launch hermes-agent through the proxy (/bili/ rewrite of ~/.hermes/config.yaml)
     bili test pi                          # quick end-to-end check of the pi path
     bili pi --mitm-domain api.foo.com     # add a domain to the MITM whitelist
 

--- a/src/client-config.ts
+++ b/src/client-config.ts
@@ -52,6 +52,14 @@ export interface OpencodeConfig {
     providers: Record<string, OpencodeProvider>;
 }
 
+export interface HermesProvider {
+    api?: string;
+}
+
+export interface HermesConfig {
+    providers: Record<string, HermesProvider>;
+}
+
 export interface ClientConfig {
     claude?: ClaudeSettings;
     codex?: CodexConfig;
@@ -59,6 +67,7 @@ export interface ClientConfig {
     zcode?: ZcodeConfig;
     omp?: OmpConfig;
     opencode?: OpencodeConfig;
+    hermes?: HermesConfig;
 }
 
 export function nonEmpty(s: unknown): s is string {
@@ -90,6 +99,14 @@ export function resolveOmpHome(env: NodeJS.ProcessEnv): string {
     const h = os.homedir();
     return nonEmpty(env.PI_CODING_AGENT_DIR) ? env.PI_CODING_AGENT_DIR!
         : path.join(h, ".omp", "agent");
+}
+
+/** hermes-agent (Nous Research) keeps everything under HERMES_HOME
+ *  (default ~/.hermes): config.yaml, .env, skills, memories, sessions. */
+export function resolveHermesHome(env: NodeJS.ProcessEnv): string {
+    const h = os.homedir();
+    return nonEmpty(env.HERMES_HOME) ? env.HERMES_HOME!
+        : path.join(h, ".hermes");
 }
 
 export function readClaudeSettings(homeDir: string, cwd: string, env: NodeJS.ProcessEnv = process.env): ClaudeSettings {
@@ -224,6 +241,92 @@ export function readOmpConfig(ompHome: string): OmpConfig {
     return parseOmpYaml(text);
 }
 
+/** Minimal line-based YAML reader for hermes config.yaml: collects provider
+ *  entries from the v12 `providers:` dict (provider key -> `api:` url) and the
+ *  legacy `custom_providers:` list (- name: ... / base_url: ...). Anything
+ *  else in the file is ignored — only name -> endpoint URL pairs matter for
+ *  launcher route discovery. */
+export function parseHermesYaml(text: string): HermesConfig {
+    const result: HermesConfig = { providers: {} };
+    type Mode = "none" | "dict" | "list";
+    let mode: Mode = "none";
+    let sectionIndent = -1;
+    let entryIndent = -1;
+    let current: string | null = null;
+    let anonCount = 0;
+    for (const rawLine of text.split(/\r?\n/)) {
+        const trimmed = rawLine.trim();
+        if (!trimmed || trimmed.startsWith("#")) continue;
+        const indent = rawLine.length - rawLine.trimStart().length;
+        if (mode === "none") {
+            if (/^providers:\s*(#.*)?$/.test(trimmed)) {
+                mode = "dict";
+                sectionIndent = indent;
+                entryIndent = -1;
+                current = null;
+            } else if (/^custom_providers:\s*(#.*)?$/.test(trimmed)) {
+                mode = "list";
+                sectionIndent = indent;
+                entryIndent = -1;
+                current = null;
+            }
+            continue;
+        }
+        if (indent <= sectionIndent) {
+            // Left the section — re-evaluate this line for a new section start.
+            mode = "none";
+            sectionIndent = -1;
+            entryIndent = -1;
+            current = null;
+            if (/^providers:\s*(#.*)?$/.test(trimmed)) {
+                mode = "dict";
+                sectionIndent = indent;
+            } else if (/^custom_providers:\s*(#.*)?$/.test(trimmed)) {
+                mode = "list";
+                sectionIndent = indent;
+            }
+            continue;
+        }
+        if (mode === "dict") {
+            if (entryIndent === -1) entryIndent = indent;
+            if (indent === entryIndent) {
+                const m = /^([A-Za-z0-9_.-]+):/.exec(trimmed);
+                current = m ? m[1] : null;
+                if (current && !result.providers[current]) result.providers[current] = {};
+            } else if (indent > entryIndent && current) {
+                const apiMatch = /^api:\s*(\S+)/.exec(trimmed);
+                if (apiMatch) result.providers[current].api = apiMatch[1];
+            }
+        } else {
+            // Legacy list: "- name: x" opens an entry; nested base_url/api/url lines.
+            const dashMatch = /^-\s+(.*)$/.exec(trimmed);
+            if (dashMatch) {
+                entryIndent = indent;
+                const nameMatch = /name:\s*([A-Za-z0-9_.-]+)/.exec(dashMatch[1]);
+                current = nameMatch ? nameMatch[1] : `custom-${++anonCount}`;
+                if (!result.providers[current]) result.providers[current] = {};
+                const inlineUrl = /^(?:base_url|api|url):\s*(\S+)/.exec(dashMatch[1]);
+                if (inlineUrl) result.providers[current].api = inlineUrl[1];
+            } else if (current) {
+                const urlMatch = /^(?:base_url|api|url):\s*(\S+)/.exec(trimmed);
+                if (urlMatch) result.providers[current].api = urlMatch[1];
+            }
+        }
+    }
+    return result;
+}
+
+export function readHermesConfig(hermesHome: string): HermesConfig {
+    const cfgPath = path.join(hermesHome, "config.yaml");
+    let text: string;
+    try {
+        text = fs.readFileSync(cfgPath, "utf8");
+    } catch {
+        return { providers: {} };
+    }
+    return parseHermesYaml(text);
+}
+
 export function resolveOpencodeConfigFile(env: NodeJS.ProcessEnv): string {
     if (nonEmpty(env.OPENCODE_CONFIG)) return env.OPENCODE_CONFIG;
     const xdg = nonEmpty(env.XDG_CONFIG_HOME) ? env.XDG_CONFIG_HOME : path.join(os.homedir(), ".config");
@@ -306,5 +409,6 @@ export function loadClientConfig(env: NodeJS.ProcessEnv, cwd: string): ClientCon
     config.zcode = readZcodeConfig(zcodeHome);
     config.omp = readOmpConfig(resolveOmpHome(env));
     config.opencode = readOpencodeConfig(resolveOpencodeConfigFile(env));
+    config.hermes = readHermesConfig(resolveHermesHome(env));
     return config;
 }

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -554,6 +554,7 @@ export function prepareHermesHome(
         return undefined;
     }
     const wrapSet = new Set(rewrites.map((r) => r.realUpstream));
+    const eol = txt.includes("\r\n") ? "\r\n" : "\n";
     const lines = txt.split(/\r?\n/);
     let changed = false;
     for (let i = 0; i < lines.length; i++) {
@@ -577,7 +578,7 @@ export function prepareHermesHome(
             } catch {}
         }
     } catch {}
-    fs.writeFileSync(path.join(tmp, "config.yaml"), lines.join("\n"));
+    fs.writeFileSync(path.join(tmp, "config.yaml"), lines.join(eol));
     return tmp;
 }
 
@@ -930,8 +931,12 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
         hermesTmpHome = prepareHermesHome(resolveHermesHome(process.env), origin, routes.httpRewrites);
         if (hermesTmpHome) {
             env.HERMES_HOME = hermesTmpHome;
-        } else if (routes.httpRewrites.length === 0) {
-            console.error("bili: no hermes providers found in ~/.hermes/config.yaml — traffic will NOT go through the proxy (configure a provider first)." );
+        } else {
+            console.error(
+                routes.httpRewrites.length === 0
+                    ? "bili: no hermes providers found in ~/.hermes/config.yaml — traffic will NOT go through the proxy (configure a provider first)."
+                    : "bili: hermes config.yaml could not be rewritten (unreadable or no matching provider endpoints) — traffic will NOT go through the proxy.",
+            );
         }
     } else if (base === "codex") {
         // Per-spawn conversation id for the MCP shell's headless

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -41,7 +41,7 @@ import { selfPackageRoot } from "./plugin-install.js";
 function selfDistFile(name: string): string {
     return path.join(selfPackageRoot(), "dist", name);
 }
-import { nonEmpty, resolvePiHome, resolveOmpHome, loadClientConfig, type ClientConfig, resolveOpencodeConfigFile, type OpencodeConfig, type OpencodeProvider } from "./client-config.js";
+import { nonEmpty, resolvePiHome, resolveOmpHome, resolveHermesHome, loadClientConfig, type ClientConfig, resolveOpencodeConfigFile, type OpencodeConfig, type OpencodeProvider, type HermesConfig, type HermesProvider } from "./client-config.js";
 
 export {
     type ClaudeSettings,
@@ -65,6 +65,9 @@ export {
     readOmpConfig,
     parseOmpYaml,
     resolveOmpHome,
+    readHermesConfig,
+    parseHermesYaml,
+    resolveHermesHome,
     resolveOpencodeConfigFile,
     readOpencodeConfig,
     type OpencodeConfig,
@@ -73,9 +76,9 @@ export {
 
 export const LAUNCHER_DEFAULT_HOST = "127.0.0.1";
 export const LAUNCHER_DEFAULT_PORT = 8787;
-export const LAUNCH_CLIENTS = ["pi", "codex", "claude", "omp", "opencode", "pi-test"] as const;
+export const LAUNCH_CLIENTS = ["pi", "codex", "claude", "omp", "opencode", "hermes", "pi-test"] as const;
 export type ClientName = (typeof LAUNCH_CLIENTS)[number];
-export type BaseClientName = "claude" | "codex" | "pi" | "omp" | "opencode";
+export type BaseClientName = "claude" | "codex" | "pi" | "omp" | "opencode" | "hermes";
 
 const HEALTH_PATH = "/__bili/health";
 const HEALTH_POLL_INTERVAL_MS = 200;
@@ -258,6 +261,25 @@ export function discoverRoutes(client: ClientName, config: ClientConfig): Discov
         for (const [name, prov] of Object.entries(config.opencode?.providers ?? {})) {
             classify(prov.baseURL, name);
         }
+    } else if (client === "hermes") {
+        // hermes rides /bili/ for EVERY upstream (http AND https): its httpx
+        // client builds its own CA bundle from certifi, so cert-MITM would
+        // need extra trust config. Wrapping the URL form needs no cert at all.
+        const hermesSeen = new Set<string>();
+        for (const [name, prov] of Object.entries(config.hermes?.providers ?? {})) {
+            if (!nonEmpty(prov.api)) continue;
+            const real = unwrapUpstream(prov.api!);
+            try {
+                const url = new URL(real);
+                if (url.protocol !== "http:" && url.protocol !== "https:") continue;
+                if (hermesSeen.has(name)) continue;
+                hermesSeen.add(name);
+                rewriteKeys.add(name);
+                httpRewrites.push({ key: name, realUpstream: real });
+            } catch {
+                // Unparseable endpoint: skip.
+            }
+        }
     } else {
         for (const [name, prov] of Object.entries(config.codex?.providers ?? {})) {
             classify(prov.baseUrl, `model_providers.${name}.base_url`);
@@ -333,7 +355,7 @@ export function launcherDirectUrl(env: NodeJS.ProcessEnv): boolean {
  *  `!== "0"` semantics) once the flags have soaked; pi is always excluded —
  *  it has its own native extension (billion-context-pi #154). */
 export function launcherInjectMcp(env: NodeJS.ProcessEnv, base: string): boolean {
-    return base !== "pi" && base !== "omp" && base !== "opencode" && env.BILI_LAUNCHER_PLUGIN === "1";
+    return base !== "pi" && base !== "omp" && base !== "opencode" && base !== "hermes" && env.BILI_LAUNCHER_PLUGIN === "1";
 }
 
 /** Ephemeral MCP config for --mcp-config / -c mcp_servers.bili.*: a single
@@ -506,6 +528,56 @@ export function prepareOmpHttpRewrite(
         }
     } catch {}
     fs.writeFileSync(path.join(tmp, "models.yml"), lines.join("\n"));
+    return tmp;
+}
+
+/**
+ * hermes counterpart of prepareOmpHttpRewrite: an isolated HERMES_HOME (temp
+ * dir, every ~/.hermes sibling symlinked so skills/memories/sessions stay
+ * shared) holding a rewritten copy of config.yaml. Every provider endpoint
+ * line (api: / base_url: / url:) is rewrapped as origin + "/bili/" + raw
+ * upstream — http AND https alike, since hermes's httpx stack can't consume
+ * the MITM CA without extra trust config. The real ~/.hermes is never
+ * touched. Returns the temp dir (undefined when nothing is rewritable).
+ */
+export function prepareHermesHome(
+    hermesHome: string,
+    origin: string,
+    rewrites: HttpRewrite[],
+): string | undefined {
+    if (rewrites.length === 0) return undefined;
+    const cfgPath = path.join(hermesHome, "config.yaml");
+    let txt: string;
+    try {
+        txt = fs.readFileSync(cfgPath, "utf8");
+    } catch {
+        return undefined;
+    }
+    const wrapSet = new Set(rewrites.map((r) => r.realUpstream));
+    const lines = txt.split(/\r?\n/);
+    let changed = false;
+    for (let i = 0; i < lines.length; i++) {
+        const rawLine = lines[i];
+        const m = /^(\s*(?:api|base_url|url):\s*)(\S+)(\s+#.*)?$/.exec(rawLine);
+        if (!m) continue;
+        const rawUrl = m[2];
+        if (!/^https?:\/\//i.test(rawUrl)) continue;
+        const real = unwrapUpstream(rawUrl);
+        if (!wrapSet.has(real)) continue;
+        lines[i] = `${m[1]}${wrapUpstream(origin, real)}${m[3] ?? ""}`;
+        changed = true;
+    }
+    if (!changed) return undefined;
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "bili-hermes-"));
+    try {
+        for (const entry of fs.readdirSync(hermesHome)) {
+            if (entry === "config.yaml") continue;
+            try {
+                fs.symlinkSync(path.join(hermesHome, entry), path.join(tmp, entry));
+            } catch {}
+        }
+    } catch {}
+    fs.writeFileSync(path.join(tmp, "config.yaml"), lines.join("\n"));
     return tmp;
 }
 
@@ -810,6 +882,7 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
     let piTmpHome: string | undefined;
     let ompTmpHome: string | undefined;
     let opencodeTmpFile: string | undefined;
+    let hermesTmpHome: string | undefined;
     const tmpFiles: string[] = [];
     const directUrl = launcherDirectUrl(process.env);
     if (directUrl) {
@@ -848,6 +921,18 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
         const opencodePluginPath = opencodePlugin && fs.existsSync(opencodePlugin) ? opencodePlugin : undefined;
         opencodeTmpFile = prepareOpencodeHttpRewrite(resolveOpencodeConfigFile(process.env), origin, routes.httpRewrites, routes.httpsRewrites, opencodePluginPath);
         if (opencodeTmpFile) env.OPENCODE_CONFIG = opencodeTmpFile;
+    } else if (base === "hermes") {
+        // hermes: no plugin, no MITM cert trust (httpx builds its own CA
+        // bundle) — every upstream rides the /bili/ URL form via an isolated
+        // HERMES_HOME whose config.yaml is rewritten. skills/memories/sessions
+        // stay shared through symlinks; the real ~/.hermes is never touched.
+        env = { ...process.env };
+        hermesTmpHome = prepareHermesHome(resolveHermesHome(process.env), origin, routes.httpRewrites);
+        if (hermesTmpHome) {
+            env.HERMES_HOME = hermesTmpHome;
+        } else if (routes.httpRewrites.length === 0) {
+            console.error("bili: no hermes providers found in ~/.hermes/config.yaml — traffic will NOT go through the proxy (configure a provider first)." );
+        }
     } else if (base === "codex") {
         // Per-spawn conversation id for the MCP shell's headless
         // self-registration (codex provides no session id of its own).
@@ -893,6 +978,11 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
         if (ompTmpHome) {
             try {
                 fs.rmSync(ompTmpHome, { recursive: true, force: true });
+            } catch {}
+        }
+        if (hermesTmpHome) {
+            try {
+                fs.rmSync(hermesTmpHome, { recursive: true, force: true });
             } catch {}
         }
         if (opencodeTmpFile) {

--- a/tests/launcher.test.ts
+++ b/tests/launcher.test.ts
@@ -32,6 +32,10 @@ import {
     parseCodexToml,
     parseOmpYaml,
     readOmpConfig,
+    parseHermesYaml,
+    readHermesConfig,
+    resolveHermesHome,
+    prepareHermesHome,
     readOpencodeConfig,
     resolveOpencodeConfigFile,
     findFreePort,
@@ -49,6 +53,7 @@ test("isLaunchClient: pi/claude/codex/omp/opencode/pi-test true, others false", 
     assert.equal(isLaunchClient("codex"), true);
     assert.equal(isLaunchClient("omp"), true);
     assert.equal(isLaunchClient("opencode"), true);
+    assert.equal(isLaunchClient("hermes"), true);
     assert.equal(isLaunchClient("pi-test"), true);
     assert.equal(isLaunchClient("start"), false);
     assert.equal(isLaunchClient(""), false);
@@ -824,4 +829,106 @@ test("resolveOpencodeConfigFile: OPENCODE_CONFIG wins, XDG fallback", () => {
     assert.equal(resolveOpencodeConfigFile({ OPENCODE_CONFIG: "/tmp/x.json" }), "/tmp/x.json");
     const p = resolveOpencodeConfigFile({ XDG_CONFIG_HOME: "/tmp/xdg" });
     assert.ok(p.endsWith(path.join("opencode", "opencode.json")));
+});
+
+test("parseHermesYaml: v12 providers dict + legacy custom_providers list", () => {
+    const v12 = parseHermesYaml([
+        "model:",
+        "  default: qwen3.8-27b",
+        "  provider: bili",
+        "providers:",
+        "  bili:",
+        "    name: bili",
+        "    api: http://127.0.0.1:8199/v1",
+        "    transport: openai_chat",
+        "  glm:",
+        "    api: https://open.bigmodel.cn/api/paas/v4",
+    ].join("\n"));
+    assert.equal(v12.providers.bili?.api, "http://127.0.0.1:8199/v1");
+    assert.equal(v12.providers.glm?.api, "https://open.bigmodel.cn/api/paas/v4");
+    assert.deepEqual(v12.providers.bili ?? {}, { api: "http://127.0.0.1:8199/v1" });
+
+    const legacy = parseHermesYaml([
+        "custom_providers:",
+        "  - name: sglang",
+        "    base_url: http://127.0.0.1:8199/v1",
+        "    api_key: sk-x",
+        "  - base_url: http://other:1/v1",
+    ].join("\n"));
+    assert.equal(legacy.providers.sglang?.api, "http://127.0.0.1:8199/v1");
+    assert.equal(legacy.providers["custom-1"]?.api, "http://other:1/v1");
+});
+
+test("readHermesConfig + resolveHermesHome", () => {
+    assert.equal(resolveHermesHome({ HERMES_HOME: "/tmp/hh" }), "/tmp/hh");
+    assert.ok(resolveHermesHome({}).endsWith(path.join(".hermes")));
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "hermes-cfg-"));
+    try {
+        assert.deepEqual(readHermesConfig(path.join(dir, "nope")).providers, {});
+        fs.writeFileSync(path.join(dir, "config.yaml"), "providers:\n  x:\n    api: http://1.2.3.4:9/v1\n");
+        const cfg = readHermesConfig(dir);
+        assert.equal(cfg.providers.x?.api, "http://1.2.3.4:9/v1");
+    } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test("discoverRoutes: hermes wraps http AND https via /bili/ (no MITM domains)", () => {
+    const config: ClientConfig = {};
+    (config as Record<string, unknown>).hermes = {
+        providers: {
+            sglang: { api: "http://127.0.0.1:8199/v1" },
+            glm: { api: "https://open.bigmodel.cn/api/paas/v4" },
+            wrapped: { api: "http://127.0.0.1:8787/bili/https://api.foo.io/v1" },
+            broken: { api: "::::" },
+        },
+    };
+    const routes = discoverRoutes("hermes", config);
+    assert.deepEqual(routes.httpsDomains, []);
+    assert.deepEqual(routes.httpRewrites.map((r) => r.key).sort(), ["glm", "sglang", "wrapped"]);
+    const glm = routes.httpRewrites.find((r) => r.key === "glm");
+    assert.equal(glm?.realUpstream, "https://open.bigmodel.cn/api/paas/v4");
+    const wrapped = routes.httpRewrites.find((r) => r.key === "wrapped");
+    assert.equal(wrapped?.realUpstream, "https://api.foo.io/v1");
+});
+
+test("prepareHermesHome: rewrites api lines, shares siblings, never touches the real home", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "hermes-home-"));
+    try {
+        fs.writeFileSync(path.join(dir, "config.yaml"), [
+            "model:",
+            "  default: qwen3.8-27b",
+            "providers:",
+            "  bili:",
+            "    api: http://127.0.0.1:8199/v1  # local sglang",
+            "  glm:",
+            "    api: https://open.bigmodel.cn/api/paas/v4",
+            "custom_providers:",
+            "  - name: legacy",
+            "    base_url: http://10.0.0.5:1234/v1",
+        ].join("\n"));
+        fs.writeFileSync(path.join(dir, "SOUL.md"), "soul");
+        fs.mkdirSync(path.join(dir, "skills"));
+        const original = fs.readFileSync(path.join(dir, "config.yaml"), "utf8");
+
+        const rewrites: HttpRewrite[] = [
+            { key: "bili", realUpstream: "http://127.0.0.1:8199/v1" },
+            { key: "glm", realUpstream: "https://open.bigmodel.cn/api/paas/v4" },
+            { key: "legacy", realUpstream: "http://10.0.0.5:1234/v1" },
+        ];
+        const tmp = prepareHermesHome(dir, "http://127.0.0.1:8787", rewrites);
+        assert.ok(tmp);
+        const txt = fs.readFileSync(path.join(tmp, "config.yaml"), "utf8");
+        assert.ok(txt.includes("api: http://127.0.0.1:8787/bili/http://127.0.0.1:8199/v1  # local sglang"));
+        assert.ok(txt.includes("api: http://127.0.0.1:8787/bili/https://open.bigmodel.cn/api/paas/v4"));
+        assert.ok(txt.includes("base_url: http://127.0.0.1:8787/bili/http://10.0.0.5:1234/v1"));
+        assert.equal(fs.readFileSync(path.join(dir, "config.yaml"), "utf8"), original);
+        assert.equal(fs.readFileSync(path.join(tmp, "SOUL.md"), "utf8"), "soul");
+        assert.ok(fs.lstatSync(path.join(tmp, "skills")).isSymbolicLink());
+        fs.rmSync(tmp, { recursive: true, force: true });
+
+        assert.equal(prepareHermesHome(dir, "http://127.0.0.1:8787", []), undefined);
+    } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+    }
 });

--- a/tests/launcher.test.ts
+++ b/tests/launcher.test.ts
@@ -932,3 +932,33 @@ test("prepareHermesHome: rewrites api lines, shares siblings, never touches the 
         fs.rmSync(dir, { recursive: true, force: true });
     }
 });
+
+test("prepareHermesHome: preserves CRLF line endings when rewriting", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "hermes-home-"));
+    try {
+        fs.writeFileSync(
+            path.join(dir, "config.yaml"),
+            ["model:", "  default: qwen3.8-27b", "providers:", "  bili:", "    api: http://127.0.0.1:8199/v1"].join("\r\n") + "\r\n",
+        );
+        const rewrites: HttpRewrite[] = [{ key: "bili", realUpstream: "http://127.0.0.1:8199/v1" }];
+        const tmp = prepareHermesHome(dir, "http://127.0.0.1:8787", rewrites);
+        assert.ok(tmp);
+        const txt = fs.readFileSync(path.join(tmp, "config.yaml"), "utf8");
+        assert.ok(txt.includes("\r\n"), "CRLF preserved");
+        assert.ok(!/\r\n\r\n/.test(txt), "no doubled newlines");
+        assert.ok(txt.includes("api: http://127.0.0.1:8787/bili/http://127.0.0.1:8199/v1\r"));
+        fs.rmSync(tmp, { recursive: true, force: true });
+    } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test("prepareHermesHome: returns undefined for unreadable config even with rewrites pending", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "hermes-home-"));
+    try {
+        const rewrites: HttpRewrite[] = [{ key: "bili", realUpstream: "http://127.0.0.1:8199/v1" }];
+        assert.equal(prepareHermesHome(dir, "http://127.0.0.1:8787", rewrites), undefined);
+    } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+    }
+});


### PR DESCRIPTION
> **Model: qwen3.8-27b (vllm)**

Closes #195

## What

`bili hermes` — bring hermes-agent (Nous Research, Python) under the proxy with zero config edits, same promise as pi/omp/opencode/codex/claude.

- **Route discovery**: reads `~/.hermes/config.yaml` (v12 `providers:` dict **and** legacy `custom_providers:` list), respects `HERMES_HOME`.
- **All upstreams ride `/bili/`** (http AND https, no cert MITM): hermes's httpx builds its CA bundle from certifi, so `SSL_CERT_FILE` is ignored — MITM can't be trusted via env. The wrapped URL form needs no client cert at all; the proxy does TLS upstream itself. Same reasoning as claude's ride-the-`/bili/` switch.
- **Isolated HERMES_HOME**: mkdtemp `bili-hermes-*`, every `~/.hermes` sibling (skills, memories, sessions, SOUL.md, `.env`) symlinked — state stays shared — only `config.yaml` is rewritten (`api:`/`base_url:`/`url:` lines, comments preserved). The real `~/.hermes` is never touched. Temp dir cleaned on exit.
- No MCP injection (hermes has no extension API); wire-mode owns the four ACP tools.

## Verified (real e2e, SGLang qwen3.8-27b, isolated HERMES_HOME)

| transport | proxy log | result |
|---|---|---|
| `openai_chat` | `forward POST → /v1/chat/completions` | pong, no loops |
| `codex_responses` | `forward POST → /v1/responses` | pong |
| `anthropic_messages` | `forward POST → /v1/messages` | pong |

Every run: model tool list = 28 hermes built-ins + `compress, decompress, search_context, acp_status` injected; `acp-loop round 1` healthy. Hermes startup model probing (`/v1/models`, `/api/tags`, `/api/show`) passes through verbatim. Source config untouched; no leftover temp dirs.

## Tests

557/557 (was 553; +4: parseHermesYaml v12+legacy, readHermesConfig/resolveHermesHome, discoverRoutes wrap-both-schemes, prepareHermesHome rewrite/share/untouched). typecheck clean, build ok.

## Notes

- `hermes acp` (Zed Agent Client Protocol) is unrelated to bili's ACP compression — documented in the devlog.
- Upstream forbids wheel/sdist; local install = clone + `uv venv` + editable (recorded in ~/system/README.md).

Agent did NOT merge this PR (human-only per AGENTS.md).