### PR TITLE
fix(openai-sse): settle tool calls at finish, not per-chunk (name-split regression)

### DIFF
--- a/devlog/2026-08-24_openai-tool-name-split/REQ.md
+++ b/devlog/2026-08-24_openai-tool-name-split/REQ.md
@@ -1,0 +1,29 @@
+# REQ: OpenAI SSE tool-name splitting fix
+
+## Source
+
+Found live while validating the hermes launcher (#223): a reviewer session
+running under `bili hermes` against SGLang kept dying with
+`hermes: Unknown tool '' → Max retries (3) exceeded → Stopping as partial`
+while the proxy logged `acp-loop round 1: 0 call(s)`.
+
+## Problem
+
+SGLang/vLLM stream a tool-call name across multiple deltas (name in the
+first fragment, empty names after). The per-chunk proxy-vs-real decision
+from the #205 passthrough fix buffered the name fragment, then an
+empty-name continuation flipped the stream into passthrough mode, and the
+finish-time flush was skipped — the client received the call WITHOUT its
+name and the compress loop never saw it either.
+
+## Requirements
+
+1. A split-name PROXY tool call (e.g. `compress`) must be intercepted
+   server-side exactly like a single-fragment call; nothing may leak to
+   the client.
+2. A split-name REAL tool call must reach the client with its full name,
+   the upstream response id, and the original chunk order.
+3. Mixed rounds (proxy + real calls in one turn): proxy calls executed
+   server-side; the replay must contain only the real fragments.
+4. No duplicated finish/[DONE] after a verbatim replay.
+5. Regression tests for all of the above.

--- a/devlog/2026-08-24_openai-tool-name-split/WORKLOG.md
+++ b/devlog/2026-08-24_openai-tool-name-split/WORKLOG.md
@@ -1,0 +1,75 @@
+# WORKLOG: OpenAI SSE tool-name splitting fix
+
+Branch: `2026-08-24_openai-tool-name-split` (single commit on top of origin/master)
+
+## 1. Bug (found by a REAL review session under `bili hermes`)
+
+SGLang/vLLM stream a tool-call NAME across multiple deltas: the first
+fragment carries the name, continuation fragments carry empty names and
+argument fragments. The previous passthrough fix (#205) decided
+"proxy tool vs real tool" PER CHUNK:
+
+- chunk 1 `function.name = "compress"` → in PROXY_TOOL_SET → buffered
+  (never forwarded)
+- chunk 2 `function.name = ""` → NOT in set → `sawRealToolCall = true` →
+  raw chunk forwarded to the client
+- at finish_reason, `sawRealToolCall` SKIPPED the pending flush → the
+  buffered name chunk was dropped forever
+
+Client accumulated a tool call with an EMPTY name:
+`hermes: ⚠ Unknown tool '' — sending error to model for agent-correction (1/3)
+(2/3) (3/3) ❌ Max retries (3) for invalid tool calls exceeded. Stopping as partial.`
+Meanwhile the proxy logged `acp-loop round 1: 0 call(s)` every round — the
+call was neither intercepted nor correctly delivered.
+
+## 2. Fix
+
+Decide once, at completion, from the ACCUMULATED names — never per chunk.
+
+`src/loop/adapter-openai.ts` `parseStream`:
+- buffer EVERY tool_call fragment into `pending` by index (name now
+  CONCATENATED — spec-correct for split names, no-op for the
+  name-once-then-empty pattern)
+- keep the raw chunks (`rawToolChunks`) in arrival order
+- at finish_reason (or [DONE] when finish never came) `settleToolCalls()`:
+  - all accumulated names ∈ PROXY_TOOL_SET → pure proxy round → structured
+    `tool_call` events (compress loop intercepts, client sees nothing) —
+    same as before
+  - any name ∉ PROXY_TOOL_SET → real round → replay the raw chunks
+    verbatim (original ids + original order) as `meta`, plus
+    `passthrough`-flagged structured events so the loop counts them as
+    real calls (reRequest=false) but does NOT regenerate them; proxy calls
+    in a mixed round still get structured events for server-side execution,
+    and `filterRealToolFragments` strips their fragments out of the replay
+    (mixed chunk → rewritten copy; pure-proxy chunk → dropped)
+
+`src/loop/core.ts`:
+- `done` event gains `suppressCompletion?: boolean`; when set, the loop
+  skips `emitCompletion` (the verbatim replay already carried the
+  upstream's own finish chunk + [DONE]; a regenerated completion would
+  duplicate them)
+
+## 3. Tests (`tests/openai-toolcall-finish-reason.test.ts`, 3 → 6)
+
+- existing passthrough test strengthened: raw replay present,
+  passthrough-flagged structured event, `suppressCompletion` asserted
+- NEW regression: name-split PROXY tool never leaks (accumulates
+  `compress` + args, zero raw fragments reach the client, finish_reason
+  tool_calls, completion NOT suppressed)
+- NEW: name-split REAL tool accumulates and replays verbatim
+- NEW: mixed proxy+real round strips proxy fragments from the replay
+
+## 4. Verification
+
+- `npx tsc --noEmit` clean; `npm test` 559/559; build ok.
+- Real e2e: `bili hermes` TUI review session (SGLang qwen3.8-27b,
+  OpenAI wire). Before the fix the reviewer died on
+  `Unknown tool '' ×3 → Stopping as partial`. After: the reviewer made
+  three `compress` calls (all intercepted: `acp-loop round 1: 1 call(s):
+  compress(...)` + re-request), real `read_file` calls forwarded
+  (`3 real tool call(s) forwarded to client`), no TUI errors, and
+  delivered `VERDICT: OK` after ~20 minutes of continuous work.
+
+## 5. Rollback
+
+Revert the single commit.

--- a/src/loop/adapter-openai.ts
+++ b/src/loop/adapter-openai.ts
@@ -2,16 +2,50 @@ import type { CoreMessage } from "acp-kernel";
 import { coreToOpenai, injectOpenaiSystem } from "acp-kernel/wire";
 import { buildVisibilityMarker } from "../compress-loop.js";
 
-const PROXY_TOOL_SET = new Set([
-    "compress", "decompress", "search_context", "acp_status",
-    "bili_compress", "bili_decompress", "bili_search_context", "bili_status",
-]);
 import type {
     CompressLoopAdapter,
     EmitCompletionOpts,
     ParsedStreamEvent,
     ToolCallEmit,
 } from "./core.js";
+
+const PROXY_TOOL_SET = new Set([
+    "compress", "decompress", "search_context", "acp_status",
+    "bili_compress", "bili_decompress", "bili_search_context", "bili_status",
+]);
+
+// Given a raw SSE chunk that carries tool_call fragments, decide how to
+// replay it for a real-tool round: "keep" = every fragment belongs to a real
+// call (forward verbatim), null = nothing real in it (drop), or a rewritten
+// copy keeping only the real fragments (mixed chunk).
+function filterRealToolFragments(
+    parsed: Record<string, unknown>,
+    realIndexes: Set<number>,
+): "keep" | null | Record<string, unknown> {
+    const choices = parsed.choices as Array<Record<string, unknown>> | undefined;
+    const choice = choices?.[0];
+    const delta = choice?.delta as Record<string, unknown> | undefined;
+    const tcs = delta?.tool_calls as Array<Record<string, unknown>> | undefined;
+    if (!tcs || tcs.length === 0) return "keep";
+    let anyReal = false;
+    let anyProxy = false;
+    for (const tc of tcs) {
+        const idx = typeof tc.index === "number" ? tc.index : 0;
+        if (realIndexes.has(idx)) anyReal = true;
+        else anyProxy = true;
+    }
+    if (!anyProxy) return "keep";
+    if (!anyReal) return null;
+    const filtered: Record<string, unknown> = { ...parsed };
+    const filteredChoices: Array<Record<string, unknown>> = [...(choices as Array<Record<string, unknown>>)];
+    const filteredChoice: Record<string, unknown> = { ...(choice as Record<string, unknown>) };
+    const filteredDelta: Record<string, unknown> = { ...(delta as Record<string, unknown>) };
+    filteredDelta.tool_calls = tcs.filter((tc) => realIndexes.has(typeof tc.index === "number" ? tc.index : 0));
+    filteredChoice.delta = filteredDelta;
+    filteredChoices[0] = filteredChoice;
+    filtered.choices = filteredChoices;
+    return filtered;
+}
 
 interface ToolCallBuffer {
     index: number;
@@ -130,7 +164,73 @@ export function createOpenaiAdapter(requestBody: Record<string, unknown>, client
 
         async *parseStream(upstream, _round) {
             const pending = new Map<number, ToolCallBuffer>();
+            // Raw tool_call chunks in arrival order. Backends (SGLang/vLLM)
+            // stream a tool name across MULTIPLE deltas — the first fragment
+            // carries the name, continuation fragments carry empty names.
+            // Deciding "proxy vs real" per-chunk loses the name entirely (the
+            // name chunk gets buffered while an empty-name continuation flips
+            // the stream into passthrough mode, and the flush is then skipped).
+            // So: buffer EVERYTHING, decide once at finish.
+            const rawToolChunks: { json: string; parsed: Record<string, unknown> }[] = [];
             let sawRealToolCall = false;
+            const flushPendingAsStructured = function* (): Generator<ParsedStreamEvent> {
+                for (const [, tc] of pending) {
+                    if (tc.name.length > 0 || tc.id.length > 0) {
+                        yield {
+                            kind: "tool_call",
+                            name: tc.name,
+                            callId: tc.id,
+                            arguments: tc.arguments,
+                        } as ParsedStreamEvent;
+                    }
+                }
+                pending.clear();
+            };
+            // Decide proxy-vs-real from the ACCUMULATED names and emit events:
+            // real calls → raw replay (verbatim chunks, original ids/order) +
+            // passthrough-flagged structured events so the loop counts them;
+            // proxy calls → structured events (server-side execution).
+            const settleToolCalls = function* (): Generator<ParsedStreamEvent> {
+                const realIndexes = new Set<number>();
+                for (const [idx, tc] of pending) {
+                    if (tc.name.length > 0 && !PROXY_TOOL_SET.has(tc.name)) realIndexes.add(idx);
+                }
+                sawRealToolCall = realIndexes.size > 0;
+                if (!sawRealToolCall) {
+                    yield* flushPendingAsStructured();
+                    return;
+                }
+                for (const [idx, tc] of pending) {
+                    if (realIndexes.has(idx) && (tc.name.length > 0 || tc.id.length > 0)) {
+                        yield {
+                            kind: "tool_call",
+                            name: tc.name,
+                            callId: tc.id,
+                            arguments: tc.arguments,
+                            passthrough: true,
+                        } as ParsedStreamEvent;
+                    }
+                }
+                for (const { json, parsed } of rawToolChunks) {
+                    const filtered = filterRealToolFragments(parsed, realIndexes);
+                    if (filtered === "keep") {
+                        yield { kind: "meta", chunk: Buffer.from("data: " + json + "\n\n", "utf8") } as ParsedStreamEvent;
+                    } else if (filtered !== null) {
+                        yield { kind: "meta", chunk: Buffer.from("data: " + JSON.stringify(filtered) + "\n\n", "utf8") } as ParsedStreamEvent;
+                    }
+                }
+                for (const [idx, tc] of pending) {
+                    if (!realIndexes.has(idx) && tc.name.length > 0) {
+                        yield {
+                            kind: "tool_call",
+                            name: tc.name,
+                            callId: tc.id,
+                            arguments: tc.arguments,
+                        } as ParsedStreamEvent;
+                    }
+                }
+                pending.clear();
+            };
             for await (const eventStr of iterSseChunks(upstream)) {
                 const dataLine = eventStr.split("\n").find((l) => l.startsWith("data:"));
                 if (!dataLine) continue;
@@ -140,18 +240,11 @@ export function createOpenaiAdapter(requestBody: Record<string, unknown>, client
                         yield { kind: "meta", chunk: Buffer.from(eventStr + "\n\n", "utf8") } as ParsedStreamEvent;
                         continue;
                     }
-                    for (const [, tc] of pending) {
-                        if (tc.name.length > 0 || tc.id.length > 0) {
-                            yield {
-                                kind: "tool_call",
-                                name: tc.name,
-                                callId: tc.id,
-                                arguments: tc.arguments,
-                            } as ParsedStreamEvent;
-                        }
+                    yield* settleToolCalls();
+                    if (sawRealToolCall) {
+                        yield { kind: "meta", chunk: Buffer.from(eventStr + "\n\n", "utf8") } as ParsedStreamEvent;
                     }
-                    pending.clear();
-                    yield { kind: "done", finishReason: "stop" } as ParsedStreamEvent;
+                    yield { kind: "done", finishReason: "stop", ...(sawRealToolCall ? { suppressCompletion: true } : {}) } as ParsedStreamEvent;
                     continue;
                 }
                 let parsed: Record<string, unknown>;
@@ -180,32 +273,8 @@ export function createOpenaiAdapter(requestBody: Record<string, unknown>, client
                 const finishReason = typeof choice.finish_reason === "string" ? choice.finish_reason : undefined;
 
                 if (finishReason) {
-                    if (sawRealToolCall) {
-                        const u2 = parsed.usage as Record<string, unknown> | undefined;
-                        const pd2 = u2?.prompt_tokens_details as Record<string, unknown> | undefined;
-                        yield {
-                            kind: "usage",
-                            inputTokens: typeof u2?.prompt_tokens === "number" ? u2.prompt_tokens : undefined,
-                            outputTokens: typeof u2?.completion_tokens === "number" ? u2.completion_tokens : undefined,
-                            cachedTokens: typeof pd2?.cached_tokens === "number" ? pd2.cached_tokens : undefined,
-                        } as ParsedStreamEvent;
-                        yield { kind: "meta", chunk: rawBuf } as ParsedStreamEvent;
-                        yield { kind: "done", finishReason } as ParsedStreamEvent;
-                        continue;
-                    }
-                    let yieldedToolCall = false;
-                    for (const [, tc] of pending) {
-                        if (tc.name.length > 0 || tc.id.length > 0) {
-                            yieldedToolCall = true;
-                            yield {
-                                kind: "tool_call",
-                                name: tc.name,
-                                callId: tc.id,
-                                arguments: tc.arguments,
-                            } as ParsedStreamEvent;
-                        }
-                    }
-                    pending.clear();
+                    const hadToolCalls = [...pending.values()].some((tc) => tc.name.length > 0 || tc.id.length > 0);
+                    yield* settleToolCalls();
                     const u = parsed.usage as Record<string, unknown> | undefined;
                     const pd = u?.prompt_tokens_details as Record<string, unknown> | undefined;
                     yield {
@@ -214,10 +283,15 @@ export function createOpenaiAdapter(requestBody: Record<string, unknown>, client
                         outputTokens: typeof u?.completion_tokens === "number" ? u.completion_tokens : undefined,
                         cachedTokens: typeof pd?.cached_tokens === "number" ? pd.cached_tokens : undefined,
                     } as ParsedStreamEvent;
-                    yield {
-                        kind: "done",
-                        finishReason: yieldedToolCall && finishReason === "stop" ? "tool_calls" : finishReason,
-                    } as ParsedStreamEvent;
+                    if (sawRealToolCall) {
+                        yield { kind: "meta", chunk: rawBuf } as ParsedStreamEvent;
+                        yield { kind: "done", finishReason, suppressCompletion: true } as ParsedStreamEvent;
+                    } else {
+                        yield {
+                            kind: "done",
+                            finishReason: hadToolCalls && finishReason === "stop" ? "tool_calls" : finishReason,
+                        } as ParsedStreamEvent;
+                    }
                 }
 
                 if (!delta) continue;
@@ -228,22 +302,7 @@ export function createOpenaiAdapter(requestBody: Record<string, unknown>, client
 
                 if (delta.tool_calls) {
                     const tcs = delta.tool_calls as Array<Record<string, unknown>>;
-                    let allProxy = true;
-                    for (const tc of tcs) {
-                        const fn = tc.function as Record<string, unknown> | undefined;
-                        const name = typeof fn?.name === "string" ? fn.name : "";
-                        if (!PROXY_TOOL_SET.has(name)) {
-                            allProxy = false;
-                        }
-                    }
-                    if (!allProxy) {
-                        sawRealToolCall = true;
-                        yield { kind: "meta", chunk: rawBuf } as ParsedStreamEvent;
-                        if (typeof delta.content === "string" && delta.content.length > 0) {
-                            yield { kind: "text", delta: delta.content } as ParsedStreamEvent;
-                        }
-                        continue;
-                    }
+                    rawToolChunks.push({ json: jsonStr, parsed });
                     for (const tc of tcs) {
                         const idx = typeof tc.index === "number" ? tc.index : 0;
                         const fn = tc.function as Record<string, unknown> | undefined;
@@ -256,7 +315,7 @@ export function createOpenaiAdapter(requestBody: Record<string, unknown>, client
                             pending.set(idx, buf);
                         } else {
                             if (id) buf.id = id;
-                            if (name) buf.name = name;
+                            buf.name += name;
                             buf.arguments += args;
                         }
                     }

--- a/src/loop/core.ts
+++ b/src/loop/core.ts
@@ -60,7 +60,7 @@ export type ParsedStreamEvent =
     | { kind: "reasoning"; delta: string; raw?: Buffer; signature?: string; blockEnd?: boolean }
     | { kind: "tool_call"; name: string; callId: string; arguments: string; passthrough?: boolean }
     | { kind: "usage"; inputTokens?: number; outputTokens?: number; cachedTokens?: number }
-    | { kind: "done"; finishReason?: string }
+    | { kind: "done"; finishReason?: string; suppressCompletion?: boolean }
     | { kind: "meta"; chunk: Buffer; firstRoundOnly?: boolean };
 
 export interface EmitCompletionOpts {
@@ -209,6 +209,7 @@ export async function* runCompressLoop(
             const calls: ToolCallEmit[] = [];
             let usage: { inputTokens?: number; outputTokens?: number; cachedTokens?: number } = {};
             let finishReason: string | undefined;
+            let suppressCompletion = false;
 
             for await (const ev of adapter.parseStream(currentUpstream, round)) {
                 if (signal?.aborted) break;
@@ -247,6 +248,7 @@ export async function* runCompressLoop(
                     };
                 } else if (ev.kind === "done") {
                     finishReason = ev.finishReason;
+                    suppressCompletion = ev.suppressCompletion === true;
                 } else if (ev.kind === "meta") {
                     if (round === 1 || !ev.firstRoundOnly) {
                         yield ev.chunk;
@@ -391,7 +393,12 @@ export async function* runCompressLoop(
             // blind to why it failed. MAX_LOOP_ROUNDS bounds runaway loops.
             const reRequest = proxyResults.length > 0 && realCalls === 0;
             if (!reRequest) {
-                yield adapter.emitCompletion({ finishReason, usage });
+                // A passthrough round already streamed the upstream's own finish
+                // chunk + [DONE] verbatim (original id + order); re-emitting a
+                // regenerated completion would duplicate them.
+                if (!suppressCompletion) {
+                    yield adapter.emitCompletion({ finishReason, usage });
+                }
                 return;
             }
 

--- a/tests/openai-toolcall-finish-reason.test.ts
+++ b/tests/openai-toolcall-finish-reason.test.ts
@@ -46,9 +46,14 @@ test("openai adapter: real tool_calls passed through verbatim (meta)", async () 
     const events = await collect(stream);
     const metas = events.filter((e) => e.kind === "meta");
     assert.ok(metas.length >= 2, "tool_call + finish_reason chunks passed through as meta");
+    const toolCallMetas = metas.filter((m) => m.kind === "meta" && m.chunk.toString().includes("get_weather"));
+    assert.ok(toolCallMetas.length >= 1, "the raw tool_call chunk itself is replayed verbatim");
+    const passthrough = events.find((e) => e.kind === "tool_call");
+    assert.ok(passthrough?.kind === "tool_call" && passthrough.name === "get_weather" && passthrough.passthrough === true, "structured passthrough event so the loop counts it as a real call");
     const done = events.find((e) => e.kind === "done");
     assert.ok(done && done.kind === "done", "done event present");
     assert.equal(done!.finishReason, "stop", "finish_reason preserved as-is from upstream");
+    assert.equal(done!.suppressCompletion, true, "no regenerated completion after the verbatim replay");
 });
 
 // 2. Compliant upstream: tool_calls + finish_reason="tool_calls" → unchanged.
@@ -73,4 +78,91 @@ test("openai adapter: text-only finish_reason=stop left unchanged", async () => 
     const events = await collect(stream);
     const done = events.find((e) => e.kind === "done");
     assert.equal(done?.kind === "done" && done.finishReason, "stop");
+});
+
+// 4. REGRESSION (SGLang/vLLM name-splitting): the tool NAME arrives in the
+//    first delta and continuation deltas carry EMPTY names. A proxy tool
+//    (compress) split this way must be accumulated and handed to the compress
+//    loop as a structured event — the client must never see an empty-name
+//    fragment (hermes: "Unknown tool ''" → retry loop → partial stop).
+test("openai adapter: name-split proxy tool never leaks to the client", async () => {
+    const stream = mockStream(
+        sseChunk({ role: "assistant" }),
+        sseChunk({
+            tool_calls: [
+                { index: 0, id: "call_c", type: "function", function: { name: "compress", arguments: "" } },
+            ],
+        }),
+        sseChunk({
+            tool_calls: [
+                { index: 0, function: { name: "", arguments: '{"content":[{"startId":"m2"' } },
+            ],
+        }),
+        sseChunk({
+            tool_calls: [
+                { index: 0, function: { name: "", arguments: ',"endId":"m9"}]}' } },
+            ],
+        }),
+        sseChunk({}, "tool_calls"),
+    );
+    const events = await collect(stream);
+    const structured = events.filter((e) => e.kind === "tool_call");
+    assert.equal(structured.length, 1, "exactly one structured tool_call for the compress loop");
+    const tc = structured[0];
+    assert.ok(tc?.kind === "tool_call");
+    assert.equal(tc.name, "compress", "name accumulated across the split deltas");
+    assert.equal(tc.callId, "call_c");
+    assert.equal(tc.arguments, '{"content":[{"startId":"m2","endId":"m9"}]}', "arguments concatenated");
+    const leaked = events.filter((e) => e.kind === "meta" && e.chunk.toString().includes("compress"));
+    assert.equal(leaked.length, 0, "no raw fragment carrying the proxy tool leaks to the client");
+    const done = events.find((e) => e.kind === "done");
+    assert.equal(done?.kind === "done" && done.finishReason, "tool_calls");
+    assert.notEqual(done?.kind === "done" && done.suppressCompletion, true, "proxy round: completion NOT suppressed (loop re-requests)");
+});
+
+// 5. Name-split REAL tool: fragments must accumulate and replay with the
+//    original chunk order/ids, exactly like the single-fragment case.
+test("openai adapter: name-split real tool accumulates and replays verbatim", async () => {
+    const stream = mockStream(
+        sseChunk({ role: "assistant" }),
+        sseChunk({ tool_calls: [{ index: 0, id: "call_r", type: "function", function: { name: "get_wea", arguments: "" } }] }),
+        sseChunk({ tool_calls: [{ index: 0, function: { name: "ther", arguments: "{}" } }] }),
+        sseChunk({}, "tool_calls"),
+    );
+    const events = await collect(stream);
+    const structured = events.filter((e) => e.kind === "tool_call");
+    const tc = structured[0];
+    assert.ok(tc?.kind === "tool_call");
+    assert.equal(tc.name, "get_weather", "name fragments concatenated");
+    assert.equal(tc.passthrough, true);
+    const replay = events.filter((e) => e.kind === "meta" && e.chunk.toString().includes("tool_calls"));
+    assert.ok(replay.length >= 2, "both raw fragments replayed to the client");
+    const done = events.find((e) => e.kind === "done");
+    assert.equal(done?.kind === "done" && done.finishReason, "tool_calls");
+});
+
+// 6. Mixed round (compress + real bash in the same turn): the replay must
+//    contain ONLY the real call's fragments; the compress call goes to the
+//    loop as a structured event for server-side execution.
+test("openai adapter: mixed proxy+real round strips proxy fragments from the replay", async () => {
+    const stream = mockStream(
+        sseChunk({ role: "assistant" }),
+        sseChunk({ tool_calls: [{ index: 0, id: "call_c", type: "function", function: { name: "compress", arguments: "{}" } }] }),
+        sseChunk({ tool_calls: [{ index: 1, id: "call_b", type: "function", function: { name: "bash", arguments: "{\"c\":\"ls\"}" } }] }),
+        sseChunk({}, "tool_calls"),
+    );
+    const events = await collect(stream);
+    const structured = events.filter((e) => e.kind === "tool_call");
+    assert.equal(structured.length, 2);
+    const byName = new Map(structured.map((e) => (e.kind === "tool_call" ? [e.name, e] : ["", e])));
+    const compress = byName.get("compress");
+    const bash = byName.get("bash");
+    assert.ok(compress?.kind === "tool_call" && compress.passthrough !== true, "compress handled server-side (no passthrough)");
+    assert.ok(bash?.kind === "tool_call" && bash.passthrough === true, "bash forwarded to the client");
+    const replayText = events
+        .filter((e) => e.kind === "meta")
+        .map((e) => (e.kind === "meta" ? e.chunk.toString() : ""))
+        .join("");
+    assert.ok(replayText.includes("bash"), "bash fragment replayed");
+    assert.ok(!replayText.includes("compress"), "compress fragment stripped from the replay");
 });


### PR DESCRIPTION
> **Model: qwen3.8-27b (vllm)**

## Summary

Follow-up to the #205 SSE passthrough fix. SGLang/vLLM stream a tool-call **name across multiple deltas** (name in the first fragment, empty names after). The per-chunk proxy-vs-real decision buffered the name fragment, then an empty-name continuation flipped the stream into passthrough mode and the finish-time flush was skipped — the client received the call **without its name** and the compress loop never saw it either.

Live symptom (a reviewer session under `bili hermes`):
```
hermes: ⚠ Unknown tool '' — sending error to model for agent-correction (1/3) (2/3) (3/3)
❌ Max retries (3) for invalid tool calls exceeded. Stopping as partial.
```
while the proxy logged `acp-loop round 1: 0 call(s)` every round.

## Fix

- Buffer EVERY tool_call fragment (name concatenated, spec-correct for split names); decide once at finish from the ACCUMULATED names
- Pure proxy round → structured events (compress loop intercepts; client sees nothing) — as before
- Real round → replay the raw chunks verbatim (original ids + order) + passthrough-flagged structured events; `done.suppressCompletion` stops the loop from emitting a duplicate regenerated completion
- Mixed round → proxy calls still executed server-side; `filterRealToolFragments` strips their fragments from the replay

## Tests

3 → 6 in `tests/openai-toolcall-finish-reason.test.ts`: name-split proxy tool never leaks; name-split real tool accumulates + replays verbatim; mixed round strips proxy fragments. **559/559** pass, typecheck clean.

## E2E

Before: reviewer died on `Unknown tool '' ×3 → partial stop`. After: 20-minute live review — three `compress` calls intercepted (`acp-loop round 1: 1 call(s): compress(...)` + re-request), real `read_file` calls forwarded (`3 real tool call(s) forwarded to client`), TUI clean, `VERDICT: OK`.

Affects all OpenAI-wire clients (omp, hermes, opencode routes through OpenAI upstreams).