### PR TITLE
release v0.1.50

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.49",
+  "version": "0.1.50",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.49",
+      "version": "0.1.50",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.49",
+  "version": "0.1.50",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Model: qwen3.8-27b (vllm)

## release v0.1.50

Version bump only (0.1.49 → 0.1.50). Changes since v0.1.49:

- **#222** — fix: survive upstream rejection of replayed thinking blocks in compress loop (degraded retry without thinking)
- **#224** — fix(openai-sse): settle tool calls at finish, not per-chunk — repairs the tool-name-split regression (SGLang splits `tool_calls.delta.name` across chunks; old per-chunk adjudication lost the name → hermes/omp reported `Unknown tool ''`)
- **#223** — feat(launcher): add `hermes` to the `bili` launcher (HERMES_HOME temp config rewrite, all traffic via /bili/, no MITM) + review fixes (prepare-failure warning, CRLF preservation)

Pre-flight on this branch: typecheck ✅ · tests 565/565 ✅ · build ✅
