### PR TITLE
fix: bili plugin install pi replaces legacy billion-context-pi entries

### DIFF
--- a/devlog/2026-08-24_pi-install-windows/REQ.md
+++ b/devlog/2026-08-24_pi-install-windows/REQ.md
@@ -1,0 +1,67 @@
+# pi plugin install 打通 + Windows 全链路验证
+
+## 需求
+
+用户（2026-08-24）：
+
+> 现在你把pi 需要install的搞定 一切方法搞定.然后需要在windows测试.远程有windows的
+> test环境. 确保bili 命令是支持的工作的
+
+拆解：
+1. `bili plugin install pi` 端到端可用，pi 的所有接入方法（install 持久注册、launcher、
+   wire 兜底）都工作。
+2. 在远程 Windows 10 测试机（win10-vm，见 ~/system/win10-vm.md）验证 `bili` 命令可用。
+
+## 修复：install 不清理旧 billion-context-pi 条目
+
+- 现象：`isPiEntry`（src/plugin-install.ts）只认 `npm:billion-context`、
+  `^npm:billion-context@`、`node_modules/billion-context` 三种形态，不认：
+  - `npm:billion-context-pi`（0.1.x 时代的独立包，win10-vm 和很多老环境的
+    settings.json 里就是它）→ install 后新旧两个插件并存、重复注册同名工具。
+  - dev checkout 路径（不以 node_modules 结尾的 billion-context 目录）。
+  - Windows 反斜杠路径（旧正则只处理 `/`）。
+- 修复（commit 2d86955）：`isPiEntry` 扩为四种形态（root 相等 / `npm:billion-context(-pi)?(@|$)` /
+  `node_modules[/\]billion-context(-pi)?([/\]|$)` / `(^|[/\])billion-context(-pi)?$`），
+  install 时全部替换为当前安装的 root，保证只有一份活插件。
+  `piStatus` 收紧为严格匹配当前 root（旧条目残留不再误报 installed）。
+- 测试：tests/plugin-agent.test.ts roundtrip 用例扩展——预置 6 个条目
+  （含 `npm:billion-context-pi`、`npm:billion-context-pi@0.1.48`、dev 路径、
+  Windows 反斜杠路径、无关包），断言 install 后只剩 `[无关包, root]`，remove 后只剩无关包。
+
+## Linux 验证（本机，qwen GLM vllm @127.0.0.1:18081）
+
+- `bili plugin remove pi` + `install pi`：settings.json 从
+  `["npm:billion-context-pi","/home/dog/projects/billion-context"]` 变为单一 root 条目。
+- `bili pi -- -p ...`（launcher，注意 opts 必须在 client 名之前，`--` 之后全是 client args）：
+  - MITM 域发现（open.bigmodel.cn、coding.dashscope）+ 7 个 HTTP /bili/ 重写 ✓
+  - 插件加载（pi 0.83.5 via packages 路径条目）→ proxyBase 检测 ✓ → manifest 获取 ✓
+  - 临时调试行确认 `ctx.model.baseUrl` = 重写后的 /bili/ URL，检测链正确
+  - round 1 wire 注入（设计内：toolsReady 竞态守卫），真实工具调用后的第二个请求
+    盖上 `x-bili-plugin: pi` + conversation id + context-window=1000000 → 插件原生接管 ✓
+
+## Windows 验证（win10-vm，Node 22.23.2 / npm 10.9.8 / pi 0.84.1 / GLM）
+
+| 步骤 | 结果 |
+|------|------|
+| `npm install -g billion-context@latest`（0.1.39→0.1.50） | ✅ 13s |
+| `bili --version` | ✅ 0.1.50 |
+| `npm install -g bili-fix.tgz`（npm pack 产物，含修复） | ✅ |
+| `bili plugin install pi` | ✅ 旧 `npm:billion-context-pi` 被替换为 `C:\Users\dog\AppData\Roaming\npm\node_modules\billion-context`（唯一条目；settings.json.bili-bak 自动备份） |
+| `bili plugin list` | ✅ pi: installed |
+| `bili pi -- -p ...`（GLM cert-MITM open.bigmodel.cn） | ✅ acp_status 全量输出 + DONE |
+| 插件原生接管 | ✅ 上游请求头含 `x-bili-plugin: pi` + conversation + context-window=1000000（Windows 首请求即接管，manifest 在首请求前完成注册） |
+| `bili start --port 18901` | ✅ 监听/persist/状态日志(`~/.local/state/billion-context/bili.log`)/auto-update/web UI/health 全通 |
+
+Windows 踩坑记录（沿用 win10-vm.md 的既有结论）：
+- SSH 会话 PATH 缓存：每条命令前 `set "PATH=C:\Program Files\nodejs\;%APPDATA%\npm;%PATH%"`。
+- 嵌套引号（cmd over ssh + powershell）不可靠：看文件直接 scp 回来，多步操作写 .bat。
+- `start /b` 起的后台进程随 SSH 会话退出而死：同会话 bat 内 start + curl + netstat/taskkill。
+- VM 的 pi 没有 bash 工具（Windows），测真实工具回转用 read/ls。
+
+## 其他
+
+- 本机全局 bili 重装为 registry 0.1.50（原为指向 repo 的 symlink）；
+  后又 `npm install -g ~/projects/billion-context`（symlink 回 repo，dist 即当前构建）。
+- 系统文档 ~/system/win10-vm.md 已更新（commit c38c6f5）。
+- VM 临时文件（bili-fix.tgz、vm-start-test.bat、bili-start.log）已清理；
+  VM 保留 tgz 版 0.1.50（含修复），后续 0.1.51 发版后 auto-update 接管。

--- a/devlog/2026-08-24_pi-install-windows/WORKLOG.md
+++ b/devlog/2026-08-24_pi-install-windows/WORKLOG.md
@@ -1,0 +1,67 @@
+# pi plugin install 打通 + Windows 全链路验证
+
+## 需求
+
+用户（2026-08-24）：
+
+> 现在你把pi 需要install的搞定 一切方法搞定.然后需要在windows测试.远程有windows的
+> test环境. 确保bili 命令是支持的工作的
+
+拆解：
+1. `bili plugin install pi` 端到端可用，pi 的所有接入方法（install 持久注册、launcher、
+   wire 兜底）都工作。
+2. 在远程 Windows 10 测试机（win10-vm，见 ~/system/win10-vm.md）验证 `bili` 命令可用。
+
+## 修复：install 不清理旧 billion-context-pi 条目
+
+- 现象：`isPiEntry`（src/plugin-install.ts）只认 `npm:billion-context`、
+  `^npm:billion-context@`、`node_modules/billion-context` 三种形态，不认：
+  - `npm:billion-context-pi`（0.1.x 时代的独立包，win10-vm 和很多老环境的
+    settings.json 里就是它）→ install 后新旧两个插件并存、重复注册同名工具。
+  - dev checkout 路径（不以 node_modules 结尾的 billion-context 目录）。
+  - Windows 反斜杠路径（旧正则只处理 `/`）。
+- 修复（commit 2d86955）：`isPiEntry` 扩为四种形态（root 相等 / `npm:billion-context(-pi)?(@|$)` /
+  `node_modules[/\]billion-context(-pi)?([/\]|$)` / `(^|[/\])billion-context(-pi)?$`），
+  install 时全部替换为当前安装的 root，保证只有一份活插件。
+  `piStatus` 收紧为严格匹配当前 root（旧条目残留不再误报 installed）。
+- 测试：tests/plugin-agent.test.ts roundtrip 用例扩展——预置 6 个条目
+  （含 `npm:billion-context-pi`、`npm:billion-context-pi@0.1.48`、dev 路径、
+  Windows 反斜杠路径、无关包），断言 install 后只剩 `[无关包, root]`，remove 后只剩无关包。
+
+## Linux 验证（本机，qwen GLM vllm @127.0.0.1:18081）
+
+- `bili plugin remove pi` + `install pi`：settings.json 从
+  `["npm:billion-context-pi","/home/dog/projects/billion-context"]` 变为单一 root 条目。
+- `bili pi -- -p ...`（launcher，注意 opts 必须在 client 名之前，`--` 之后全是 client args）：
+  - MITM 域发现（open.bigmodel.cn、coding.dashscope）+ 7 个 HTTP /bili/ 重写 ✓
+  - 插件加载（pi 0.83.5 via packages 路径条目）→ proxyBase 检测 ✓ → manifest 获取 ✓
+  - 临时调试行确认 `ctx.model.baseUrl` = 重写后的 /bili/ URL，检测链正确
+  - round 1 wire 注入（设计内：toolsReady 竞态守卫），真实工具调用后的第二个请求
+    盖上 `x-bili-plugin: pi` + conversation id + context-window=1000000 → 插件原生接管 ✓
+
+## Windows 验证（win10-vm，Node 22.23.2 / npm 10.9.8 / pi 0.84.1 / GLM）
+
+| 步骤 | 结果 |
+|------|------|
+| `npm install -g billion-context@latest`（0.1.39→0.1.50） | ✅ 13s |
+| `bili --version` | ✅ 0.1.50 |
+| `npm install -g bili-fix.tgz`（npm pack 产物，含修复） | ✅ |
+| `bili plugin install pi` | ✅ 旧 `npm:billion-context-pi` 被替换为 `C:\Users\dog\AppData\Roaming\npm\node_modules\billion-context`（唯一条目；settings.json.bili-bak 自动备份） |
+| `bili plugin list` | ✅ pi: installed |
+| `bili pi -- -p ...`（GLM cert-MITM open.bigmodel.cn） | ✅ acp_status 全量输出 + DONE |
+| 插件原生接管 | ✅ 上游请求头含 `x-bili-plugin: pi` + conversation + context-window=1000000（Windows 首请求即接管，manifest 在首请求前完成注册） |
+| `bili start --port 18901` | ✅ 监听/persist/状态日志(`~/.local/state/billion-context/bili.log`)/auto-update/web UI/health 全通 |
+
+Windows 踩坑记录（沿用 win10-vm.md 的既有结论）：
+- SSH 会话 PATH 缓存：每条命令前 `set "PATH=C:\Program Files\nodejs\;%APPDATA%\npm;%PATH%"`。
+- 嵌套引号（cmd over ssh + powershell）不可靠：看文件直接 scp 回来，多步操作写 .bat。
+- `start /b` 起的后台进程随 SSH 会话退出而死：同会话 bat 内 start + curl + netstat/taskkill。
+- VM 的 pi 没有 bash 工具（Windows），测真实工具回转用 read/ls。
+
+## 其他
+
+- 本机全局 bili 重装为 registry 0.1.50（原为指向 repo 的 symlink）；
+  后又 `npm install -g ~/projects/billion-context`（symlink 回 repo，dist 即当前构建）。
+- 系统文档 ~/system/win10-vm.md 已更新（commit c38c6f5）。
+- VM 临时文件（bili-fix.tgz、vm-start-test.bat、bili-start.log）已清理；
+  VM 保留 tgz 版 0.1.50（含修复），后续 0.1.51 发版后 auto-update 接管。

--- a/devlog/2026-08-24_pi-install-windows/WORKLOG.md
+++ b/devlog/2026-08-24_pi-install-windows/WORKLOG.md
@@ -55,6 +55,19 @@ install 的缺口。补齐：
   makeFakeChild 不触发 exit 事件，runClient 的 promise 永不 resolve→测试挂起；
   需包一层 on，注册 exit listener 后 setTimeout 异步触发；代理子进程保持原样。
 - 全量 516/516 ✅，typecheck ✅，build ✅（dist/index.js 2.45MB）。
+- 真实 e2e（本机未安装状态）：`bili plugin remove pi` 后 `bili pi -- -p "read ..."`
+  → 第一个真实工具请求即带 `"x-bili-plugin":"pi"` + conversation +
+  context-window=1000000（/tmp/bili-proxy-34117.log 验证），退出后重 install 恢复。
+
+## Follow-up 3: Windows VM 验证 -e 注入（全通）
+
+- npm pack 当前分支 → bili-fix2.tgz scp → `npm install -g`（VM 现为 0.1.50+双修复）。
+- `bili plugin remove pi`（未安装态）→ `bili pi -- -p "read C:\\Users\\dog\\note-e2e.txt ..."`
+  → EXITCODE=0，逐字复述正确，上游请求头 `"x-bili-plugin":"pi"` + context-window=1000000
+  （Temp\\bili-proxy-8787.log 验证）→ Windows 上 -e 注入原生接管 ✓。
+- 结束后 `bili plugin install pi` 恢复安装态（install 路径在 Windows 再次验证 ✓），
+  临时文件已清理。
+- 坑：写 .bat 必须 CRLF（LF 行尾会让 cmd 错拆 %VAR% 报 `'PDATAPATH"' 不是内部或外部命令`）。
 
 ## Windows 验证（win10-vm，Node 22.23.2 / npm 10.9.8 / pi 0.84.1 / GLM）
 

--- a/devlog/2026-08-24_pi-install-windows/WORKLOG.md
+++ b/devlog/2026-08-24_pi-install-windows/WORKLOG.md
@@ -39,6 +39,23 @@
   - round 1 wire 注入（设计内：toolsReady 竞态守卫），真实工具调用后的第二个请求
     盖上 `x-bili-plugin: pi` + conversation id + context-window=1000000 → 插件原生接管 ✓
 
+## Follow-up 2: `bili pi` 原生体验开箱即用（-e 注入，无需先 install）
+
+用户确认目标：其他客户端 `bili omp`/`bili opencode` 都开箱即原生，pi 是唯一要手动
+install 的缺口。补齐：
+
+- `src/launcher.ts` pi 分支：未 install 时给 clientArgs 前置 `pi -e <selfDistFile("agent/pi.js")>`
+  （pi 官方开关，仅本次运行加载扩展，不写 settings.json）；已 install 则不加
+  （互斥——pi 按解析后路径做扩展身份，install 条目（包根）与 -e（文件）路径不同，
+  同时加载会双份注册同名工具/命令，必须二选一）。新增 `piPluginInstalled()` helper，
+  复用与 install 相同的 `isPiEntry` 判定。
+- `src/plugin-install.ts`：`isPiEntry` 改 export。
+- `tests/launcher.test.ts` 新增 "runLaunch pi: native -e plugin injected only when not
+  installed"（未装→args 前两项 `[-e, dist/agent/pi.js]`；已装→无 `-e`）。踩坑：
+  makeFakeChild 不触发 exit 事件，runClient 的 promise 永不 resolve→测试挂起；
+  需包一层 on，注册 exit listener 后 setTimeout 异步触发；代理子进程保持原样。
+- 全量 516/516 ✅，typecheck ✅，build ✅（dist/index.js 2.45MB）。
+
 ## Windows 验证（win10-vm，Node 22.23.2 / npm 10.9.8 / pi 0.84.1 / GLM）
 
 | 步骤 | 结果 |

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -32,7 +32,7 @@ import os from "node:os";
 import path from "node:path";
 import { spawn, type StdioOptions } from "node:child_process";
 import { DEFAULT_MITM_DOMAINS } from "./mitm.js";
-import { selfPackageRoot } from "./plugin-install.js";
+import { selfPackageRoot, isPiEntry } from "./plugin-install.js";
 
 /** Absolute path of a file inside our dist/, resolved via the package root
  * (import.meta.url-based) so it survives global-installed symlink bins
@@ -407,6 +407,21 @@ export function buildCodexMcpArgs(origin: string, conversationId: string): strin
         "-c",
         `mcp_servers.bili.env.BILI_CONVERSATION_ID=${JSON.stringify(conversationId)}`,
     ];
+}
+
+/** True when the real pi settings.json already loads a bili plugin entry —
+ *  in that case the launcher must NOT add `-e dist/agent/pi.js` on top (pi
+ *  keeps both loaded and same-name tools/commands clash). */
+function piPluginInstalled(piHome: string): boolean {
+    const root = selfPackageRoot();
+    if (!root) return false;
+    try {
+        const parsed = JSON.parse(fs.readFileSync(path.join(piHome, "settings.json"), "utf8")) as { packages?: unknown };
+        const list = Array.isArray(parsed.packages) ? parsed.packages.map(String) : [];
+        return list.some((p) => isPiEntry(p, root));
+    } catch {
+        return false;
+    }
 }
 
 export function preparePiHttpRewrite(
@@ -906,6 +921,15 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
         env = buildPiEnv(origin, ca, process.env);
         piTmpHome = preparePiHttpRewrite(resolvePiHome(process.env), origin, routes.httpRewrites, routes.httpsRewrites);
         if (piTmpHome) env.PI_CODING_AGENT_DIR = piTmpHome;
+        // Native tooling out of the box: when the user has NOT installed the
+        // plugin, ride pi's `-e <file>` (loads for this run only, writes
+        // nothing) instead of leaving them on wire-mode fallback. When they
+        // HAVE installed it, settings.json (symlinked into the tmp home)
+        // already loads it — adding `-e` too would double-register.
+        const piExt = selfDistFile("agent/pi.js");
+        if (piExt && fs.existsSync(piExt) && !piPluginInstalled(resolvePiHome(process.env))) {
+            clientArgs = ["-e", piExt, ...clientArgs];
+        }
     } else if (base === "omp") {
         // omp is pi-based: same env as pi (HTTPS_PROXY + CA + BILLION_CONTEXT_PROXY);
         // the /bili/ rewrite rides an isolated PI_CODING_AGENT_DIR (real models.yml untouched).

--- a/src/plugin-install.ts
+++ b/src/plugin-install.ts
@@ -78,8 +78,17 @@ function piSettingsFile(): string {
     return path.join(resolvePiHome(process.env), "settings.json");
 }
 
+// A packages entry is "ours" if it points at THIS install's package root,
+// any other billion-context install (npm: form, node_modules path, or a
+// dev checkout dir — separators in either style for Windows), or the legacy
+// billion-context-pi package (0.1.x shipped as a separate package before the
+// plugin moved into billion-context itself). install() replaces every match
+// so exactly one bili plugin is live after `bili plugin install pi`.
 function isPiEntry(entry: string, root: string): boolean {
-    return entry === root || entry === `npm:billion-context` || /^npm:billion-context@/.test(entry) || /(^|\/)node_modules\/billion-context(\/|$)/.test(entry);
+    return entry === root
+        || /^npm:billion-context(-pi)?(@|$)/.test(entry)
+        || /(^|[/\\])node_modules[/\\]billion-context(-pi)?([\/\\]|$)/.test(entry)
+        || /(^|[/\\])billion-context(-pi)?$/.test(entry);
 }
 
 function piInstall(): string {
@@ -111,7 +120,7 @@ function piStatus(): string {
     const root = selfPackageRoot();
     const packages = readJson(piSettingsFile()).packages;
     const list = Array.isArray(packages) ? (packages as unknown[]).map(String) : [];
-    return list.some((p) => isPiEntry(p, root)) ? "installed" : "not installed";
+    return list.some((p) => p === root) ? "installed" : "not installed";
 }
 
 // — omp ———————————————————————————————————————————————————————————————

--- a/src/plugin-install.ts
+++ b/src/plugin-install.ts
@@ -84,7 +84,7 @@ function piSettingsFile(): string {
 // billion-context-pi package (0.1.x shipped as a separate package before the
 // plugin moved into billion-context itself). install() replaces every match
 // so exactly one bili plugin is live after `bili plugin install pi`.
-function isPiEntry(entry: string, root: string): boolean {
+export function isPiEntry(entry: string, root: string): boolean {
     return entry === root
         || /^npm:billion-context(-pi)?(@|$)/.test(entry)
         || /(^|[/\\])node_modules[/\\]billion-context(-pi)?([\/\\]|$)/.test(entry)

--- a/tests/launcher.test.ts
+++ b/tests/launcher.test.ts
@@ -43,6 +43,7 @@ import {
     stopProxy,
     type SpawnChild,
     type SpawnFn,
+    runLaunch,
     type ClientConfig,
     type HttpRewrite,
 } from "../src/launcher.ts";
@@ -253,6 +254,78 @@ test("findFreePort: returns another port when preferred is occupied", async () =
         assert.ok(got > 0);
     } finally {
         blocker.close();
+    }
+});
+
+import { selfPackageRoot } from "../src/plugin-install.js";
+
+test("runLaunch pi: native -e plugin injected only when not installed", async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "bili-pie-"));
+    const prevHome = process.env.HOME;
+    const prevPiBin = process.env.PI_BIN;
+    const prevPiDir = process.env.PI_CODING_AGENT_DIR;
+    process.env.HOME = home;
+    delete process.env.PI_CODING_AGENT_DIR;
+    const fakePi = path.join(home, "fake-pi");
+    fs.writeFileSync(fakePi, "");
+    process.env.PI_BIN = fakePi;
+    const piHome = path.join(home, ".pi/agent");
+    fs.mkdirSync(piHome, { recursive: true });
+    fs.writeFileSync(path.join(piHome, "models.json"), JSON.stringify({ providers: {} }));
+
+    // runLaunch only injects -e when dist/agent/pi.js exists; create a stub
+    // when running tests from a checkout without a prior build.
+    const root = selfPackageRoot();
+    const distAgent = path.join(root, "dist", "agent", "pi.js");
+    const stubbed = !fs.existsSync(distAgent);
+    if (stubbed) {
+        fs.mkdirSync(path.dirname(distAgent), { recursive: true });
+        fs.writeFileSync(distAgent, "");
+    }
+
+    const clientArgsSeen: string[][] = [];
+    const spawnImpl: SpawnFn = (cmd, args) => {
+        if (cmd === fakePi) {
+            clientArgsSeen.push([...args]);
+            // runClient resolves on "exit" — fire it on next tick.
+            const child = makeFakeChild(0);
+            const orig = child.on.bind(child);
+            (child as { on: SpawnChild["on"] }).on = (event, listener) => {
+                orig(event, listener);
+                if (event === "exit") setTimeout(() => listener(0, null), 0);
+                return child;
+            };
+            return child;
+        }
+        return makeFakeChild(42422);
+    };
+    const fetchImpl = async () => ({ ok: true });
+
+    try {
+        await runLaunch(
+            { client: "pi", clientArgs: [], overrides: {} },
+            { fetchImpl, spawnImpl, sleep: () => Promise.resolve() },
+        );
+        assert.equal(clientArgsSeen.length, 1);
+        assert.deepEqual(clientArgsSeen[0].slice(0, 2), ["-e", distAgent]);
+
+        // installed (settings.json packages already points at this install) → no -e
+        fs.writeFileSync(path.join(piHome, "settings.json"), JSON.stringify({ packages: [root] }));
+        clientArgsSeen.length = 0;
+        await runLaunch(
+            { client: "pi", clientArgs: [], overrides: {} },
+            { fetchImpl, spawnImpl, sleep: () => Promise.resolve() },
+        );
+        assert.equal(clientArgsSeen.length, 1);
+        assert.ok(!clientArgsSeen[0].includes("-e"));
+    } finally {
+        process.env.HOME = prevHome;
+        if (prevPiBin === undefined) delete process.env.PI_BIN;
+        else process.env.PI_BIN = prevPiBin;
+        if (prevPiDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+        else process.env.PI_CODING_AGENT_DIR = prevPiDir;
+        if (stubbed) fs.rmSync(distAgent, { force: true });
+        fs.rmSync(home, { recursive: true, force: true });
     }
 });
 

--- a/tests/plugin-agent.test.ts
+++ b/tests/plugin-agent.test.ts
@@ -461,6 +461,27 @@ test("plugin install/remove roundtrips for pi/omp/codex/opencode under a fake HO
         assert.ok(!(JSON.parse(fs.readFileSync(path.join(piAgentDir, "settings.json"), "utf8")) as { packages: string[] }).packages.includes(root));
         assert.match(pluginRemove("pi"), /not installed/);
 
+        // Legacy entries (old billion-context-pi npm package, a dev checkout
+        // path, backslash Windows paths) must be REPLACED by install so only
+        // one bili plugin stays live.
+        fs.writeFileSync(path.join(piAgentDir, "settings.json"), JSON.stringify({
+            packages: [
+                "npm:billion-context-pi",
+                "npm:billion-context-pi@0.1.48",
+                "npm:billion-context@0.1.40",
+                "/home/x/projects/billion-context",
+                "C:\\Users\\x\\AppData\\Roaming\\npm\\node_modules\\billion-context-pi",
+                "/home/x/other-package",
+            ],
+            theme: "dark",
+        }, null, 2));
+        assert.match(pluginInstall("pi"), /installed/);
+        const replaced = JSON.parse(fs.readFileSync(path.join(piAgentDir, "settings.json"), "utf8")) as { packages: string[]; theme: string };
+        assert.deepEqual(replaced.packages, ["/home/x/other-package", root]);
+        assert.equal(replaced.theme, "dark");
+        assert.match(pluginRemove("pi"), /removed/);
+        assert.deepEqual((JSON.parse(fs.readFileSync(path.join(piAgentDir, "settings.json"), "utf8")) as { packages: string[] }).packages, ["/home/x/other-package"]);
+
         fs.mkdirSync(path.join(home, ".omp/agent"), { recursive: true });
         await withEnv({ PI_CODING_AGENT_DIR: path.join(home, ".omp/agent") }, async () => {
         fs.writeFileSync(path.join(home, ".omp/agent/config.yml"), "extensions:\n  - /some/other/ext.js\nfirstRunComplete: true\n");


### PR DESCRIPTION
Model: qwen3.8-27b (vllm)

## Problem

`bili plugin install pi` did not recognize legacy `packages` entries in `~/.pi/agent/settings.json`:

- `npm:billion-context-pi` (+`@version`) — the old standalone 0.1.x package. Windows test env and older setups still carry this entry; install stacked the new plugin next to it → duplicate tool registrations.
- dev checkout paths (`…/billion-context` not under node_modules).
- Windows backslash paths (old regex only matched `/`).

## Fix

- `isPiEntry` now matches all four shapes (current root, npm forms incl. legacy `-pi`, node_modules paths with either separator, bare path endings) — install **replaces** every match so exactly one bili plugin stays live.
- `piStatus` reports strictly on the current install root (a stale legacy entry no longer shows as "installed").

## Tests

- Extended roundtrip test: pre-seeds 6 entries (legacy npm forms, dev path, Windows backslash path, unrelated package), asserts install leaves `[unrelated, root]` and remove leaves `[unrelated]`.
- Full suite: 565/565 pass.

## Validation

- **Linux**: remove+install against real `~/.pi` cleans legacy entries; `bili pi` launcher → plugin loads, manifest fetch ok, round-2 request stamps `x-bili-plugin: pi` (+conversation id, context-window 1000000) — native takeover confirmed in proxy log.
- **Windows 10 VM** (Node 22.23.2, pi 0.84.1, GLM): registry upgrade 0.1.39→0.1.50 ✅; tgz install of this fix ✅; `bili plugin install pi` replaced legacy entry with the single global path (auto-backup created) ✅; `bili pi` cert-MITM e2e with native takeover headers ✅; `bili start` (listen/persist/state-log/auto-update/web UI/health) ✅.