### PR TITLE
fix(loop): strip model-emitted render tags to break #206 echo feedback loop

### DIFF
--- a/src/compress-loop-responses.ts
+++ b/src/compress-loop-responses.ts
@@ -12,6 +12,7 @@ import { applyRanges } from "./stream.js";
 import { resolveDecompress } from "./decompress-shared.js";
 import { buildVisibilityMarker } from "./compress-loop.js";
 import { MAX_LOOP_ROUNDS } from "./loop/index.js";
+import { stripResponsesText } from "./loop/tag-echo-filter.js";
 import { fetchWithRetry, UpstreamHttpError } from "./fetch-util.js";
 import { proxyDispatcher } from "./upstream-proxy.js";
 
@@ -182,6 +183,7 @@ export async function compressLoopResponsesJson(
 ): Promise<Record<string, unknown>> {
     let current = initialResponse;
     for (let loopCount = 1; loopCount <= MAX_LOOP_ROUNDS; loopCount++) {
+        current = stripResponsesText(current);
         const output = responsesJsonOutput(current);
         const extracted = extractTextTriggers(output.text);
         const allCalls = [...output.calls, ...extracted.calls].filter((call) => call.name.length > 0);

--- a/src/loop/adapter-anthropic.ts
+++ b/src/loop/adapter-anthropic.ts
@@ -235,7 +235,8 @@ export function createAnthropicAdapter(requestBody: Record<string, unknown>, ori
                         lastTextIndex = ci;
                         const clean = tagFilter.push(delta.text);
                         if (clean.length > 0) {
-                            yield { kind: "text", delta: clean, raw: rewriteTextDeltaEvent(eventStr, ci, clean) } as ParsedStreamEvent;
+                            const raw = clean === delta.text ? remapIndexInEvent(eventStr, ci) : rewriteTextDeltaEvent(eventStr, ci, clean);
+                            yield { kind: "text", delta: clean, raw } as ParsedStreamEvent;
                         }
                     } else if (delta.type === "thinking_delta" && typeof delta.thinking === "string" && delta.thinking.length > 0) {
                         const ci = indexMap.get(upstreamIndex) ?? upstreamIndex;

--- a/src/loop/adapter-anthropic.ts
+++ b/src/loop/adapter-anthropic.ts
@@ -1,6 +1,8 @@
 import type { CoreMessage } from "acp-kernel";
 import { coreToAnthropic, extractSystem, buildSystem, type AnthropicRequestBody } from "acp-kernel/wire";
 import { buildVisibilityMarker } from "../compress-loop.js";
+import { createTagEchoFilter } from "./tag-echo-filter.js";
+import { log as loggerLog } from "../logger.js";
 import type {
     CompressLoopAdapter,
     EmitCompletionOpts,
@@ -83,6 +85,37 @@ function remapIndexInEvent(eventStr: string, newIndex: number): Buffer {
     return Buffer.from(rebuilt.join("\n") + "\n\n", "utf8");
 }
 
+function rewriteTextDeltaEvent(eventStr: string, newIndex: number, newText: string): Buffer {
+    const lines = eventStr.split("\n");
+    const rebuilt: string[] = [];
+    for (const l of lines) {
+        if (l.startsWith("data:")) {
+            const jsonStr = l.slice(5).replace(/^ /, "");
+            try {
+                const obj = JSON.parse(jsonStr) as Record<string, unknown>;
+                if (typeof obj === "object" && obj !== null && typeof obj.index === "number") {
+                    obj.index = newIndex;
+                    const d = obj.delta as Record<string, unknown> | undefined;
+                    if (d && typeof d.text === "string") d.text = newText;
+                    rebuilt.push(`data: ${JSON.stringify(obj)}`);
+                    continue;
+                }
+            } catch {
+            }
+        }
+        rebuilt.push(l);
+    }
+    return Buffer.from(rebuilt.join("\n") + "\n\n", "utf8");
+}
+
+function buildTextDeltaEvent(index: number, text: string): Buffer {
+    return Buffer.from(
+        `event: content_block_delta\n` +
+        `data: ${JSON.stringify({ type: "content_block_delta", index, delta: { type: "text_delta", text } })}\n\n`,
+        "utf8",
+    );
+}
+
 export function createAnthropicAdapter(requestBody: Record<string, unknown>, originalSystem?: AnthropicRequestBody["system"]): CompressLoopAdapter {
     const model = (requestBody.model as string) ?? undefined;
     let messageId: string | undefined;
@@ -151,6 +184,14 @@ export function createAnthropicAdapter(requestBody: Record<string, unknown>, ori
             let usageYielded = false;
             const indexMap = new Map<number, number>();
             const thinkingIndexes = new Set<number>();
+            // #206: strip model-imitated render tags from text deltas before
+            // they reach the client (and before coreText accumulates them for
+            // re-request rounds). Flush at the owning block's stop so held-back
+            // fragments still emit while the block is open.
+            const tagFilter = createTagEchoFilter((snippet) => {
+                loggerLog("warn", `[tag-echo] stripped model-emitted render tag: ${snippet.slice(0, 80).replace(/\n/g, " ")}`);
+            });
+            let lastTextIndex: number | null = null;
 
             for await (const eventStr of iterSseEvents(upstream)) {
                 const parsed = parseAnthropicSse(eventStr);
@@ -191,7 +232,11 @@ export function createAnthropicAdapter(requestBody: Record<string, unknown>, ori
                         }
                     } else if (delta.type === "text_delta" && typeof delta.text === "string") {
                         const ci = indexMap.get(upstreamIndex) ?? upstreamIndex;
-                        yield { kind: "text", delta: delta.text, raw: remapIndexInEvent(eventStr, ci) } as ParsedStreamEvent;
+                        lastTextIndex = ci;
+                        const clean = tagFilter.push(delta.text);
+                        if (clean.length > 0) {
+                            yield { kind: "text", delta: clean, raw: rewriteTextDeltaEvent(eventStr, ci, clean) } as ParsedStreamEvent;
+                        }
                     } else if (delta.type === "thinking_delta" && typeof delta.thinking === "string" && delta.thinking.length > 0) {
                         const ci = indexMap.get(upstreamIndex) ?? upstreamIndex;
                         yield {
@@ -230,6 +275,13 @@ export function createAnthropicAdapter(requestBody: Record<string, unknown>, ori
                         yield { kind: "reasoning", delta: "", blockEnd: true } as ParsedStreamEvent;
                     } else {
                         const ci = indexMap.get(upstreamIndex) ?? upstreamIndex;
+                        if (lastTextIndex !== null) {
+                            const tail = tagFilter.flush();
+                            if (tail.length > 0) {
+                                yield { kind: "text", delta: tail, raw: buildTextDeltaEvent(lastTextIndex, tail) } as ParsedStreamEvent;
+                            }
+                            lastTextIndex = null;
+                        }
                         yield { kind: "meta", chunk: remapIndexInEvent(eventStr, ci), firstRoundOnly: round === 1 } as ParsedStreamEvent;
                     }
                 } else if (type === "message_delta") {
@@ -257,6 +309,13 @@ export function createAnthropicAdapter(requestBody: Record<string, unknown>, ori
                     }
                     yield { kind: "done", finishReason: stopReason } as ParsedStreamEvent;
                 } else if (type === "message_stop") {
+                    if (lastTextIndex !== null) {
+                        const tail = tagFilter.flush();
+                        if (tail.length > 0) {
+                            yield { kind: "text", delta: tail, raw: buildTextDeltaEvent(lastTextIndex, tail) } as ParsedStreamEvent;
+                        }
+                        lastTextIndex = null;
+                    }
                     if (!usageYielded) {
                         usageYielded = true;
                         yield {

--- a/src/loop/adapter-openai.ts
+++ b/src/loop/adapter-openai.ts
@@ -91,7 +91,7 @@ function rewriteContentChunk(parsed: Record<string, unknown>, content: string): 
         const delta = { ...(choice.delta as Record<string, unknown>) };
         delta.content = content;
         choice.delta = delta;
-        clone.choices = [choice];
+        clone.choices = [choice, ...clone.choices.slice(1)];
     }
     return Buffer.from(`data: ${JSON.stringify(clone)}\n\n`, "utf8");
 }
@@ -357,10 +357,11 @@ export function createOpenaiAdapter(requestBody: Record<string, unknown>, client
 
                 const hasReasoning = typeof delta.reasoning_content === "string" && delta.reasoning_content.length > 0;
                 if (typeof delta.content === "string" && delta.content.length > 0) {
-                    const clean = tagFilter.push(delta.content);
-                    if (clean.length > 0) {
-                        yield { kind: "text", delta: clean, ...(hasReasoning ? {} : { raw: rewriteContentChunk(parsed, clean) }) } as ParsedStreamEvent;
-                    }
+                        const clean = tagFilter.push(delta.content);
+                        if (clean.length > 0) {
+                            const raw = clean === delta.content ? rawBuf : rewriteContentChunk(parsed, clean);
+                            yield { kind: "text", delta: clean, ...(hasReasoning ? {} : { raw }) } as ParsedStreamEvent;
+                        }
                 } else if (!hasReasoning && (delta.role || (Object.keys(delta).length === 0 && !finishReason))) {
                     yield { kind: "meta", chunk: rawBuf, firstRoundOnly: true } as ParsedStreamEvent;
                 }

--- a/src/loop/adapter-openai.ts
+++ b/src/loop/adapter-openai.ts
@@ -1,6 +1,8 @@
 import type { CoreMessage } from "acp-kernel";
 import { coreToOpenai, injectOpenaiSystem } from "acp-kernel/wire";
 import { buildVisibilityMarker } from "../compress-loop.js";
+import { createTagEchoFilter } from "./tag-echo-filter.js";
+import { log as loggerLog } from "../logger.js";
 
 import type {
     CompressLoopAdapter,
@@ -80,6 +82,18 @@ async function* iterSseChunks(stream: ReadableStream<Uint8Array>): AsyncGenerato
     } finally {
         reader.releaseLock();
     }
+}
+
+function rewriteContentChunk(parsed: Record<string, unknown>, content: string): Buffer {
+    const clone = { ...parsed } as { choices?: Array<Record<string, unknown>> };
+    if (clone.choices && clone.choices.length > 0) {
+        const choice = { ...(clone.choices[0] as Record<string, unknown>) };
+        const delta = { ...(choice.delta as Record<string, unknown>) };
+        delta.content = content;
+        choice.delta = delta;
+        clone.choices = [choice];
+    }
+    return Buffer.from(`data: ${JSON.stringify(clone)}\n\n`, "utf8");
 }
 
 export function createOpenaiAdapter(requestBody: Record<string, unknown>, clientSystem?: string): CompressLoopAdapter {
@@ -164,6 +178,17 @@ export function createOpenaiAdapter(requestBody: Record<string, unknown>, client
 
         async *parseStream(upstream, _round) {
             const pending = new Map<number, ToolCallBuffer>();
+            // #206: strip model-imitated render tags from content deltas; the
+            // filter may hold back a short tail, flushed at finish/[DONE].
+            const tagFilter = createTagEchoFilter((snippet) => {
+                loggerLog("warn", `[tag-echo] stripped model-emitted render tag: ${snippet.slice(0, 80).replace(/\n/g, " ")}`);
+            });
+            const flushFilter = function* (): Generator<ParsedStreamEvent> {
+                const tail = tagFilter.flush();
+                if (tail.length > 0) {
+                    yield { kind: "text", delta: tail, raw: buildContent(tail) } as ParsedStreamEvent;
+                }
+            };
             // Raw tool_call chunks in arrival order. Backends (SGLang/vLLM)
             // stream a tool name across MULTIPLE deltas — the first fragment
             // carries the name, continuation fragments carry empty names.
@@ -236,6 +261,7 @@ export function createOpenaiAdapter(requestBody: Record<string, unknown>, client
                 if (!dataLine) continue;
                 const jsonStr = dataLine.slice(5).trim();
                 if (jsonStr === "[DONE]") {
+                    yield* flushFilter();
                     if (sawRealToolCall) {
                         yield { kind: "meta", chunk: Buffer.from(eventStr + "\n\n", "utf8") } as ParsedStreamEvent;
                         continue;
@@ -273,6 +299,7 @@ export function createOpenaiAdapter(requestBody: Record<string, unknown>, client
                 const finishReason = typeof choice.finish_reason === "string" ? choice.finish_reason : undefined;
 
                 if (finishReason) {
+                    yield* flushFilter();
                     const hadToolCalls = [...pending.values()].some((tc) => tc.name.length > 0 || tc.id.length > 0);
                     yield* settleToolCalls();
                     const u = parsed.usage as Record<string, unknown> | undefined;
@@ -320,14 +347,20 @@ export function createOpenaiAdapter(requestBody: Record<string, unknown>, client
                         }
                     }
                     if (typeof delta.content === "string" && delta.content.length > 0) {
-                        yield { kind: "text", delta: delta.content } as ParsedStreamEvent;
+                        const clean = tagFilter.push(delta.content);
+                        if (clean.length > 0) {
+                            yield { kind: "text", delta: clean } as ParsedStreamEvent;
+                        }
                     }
                     continue;
                 }
 
                 const hasReasoning = typeof delta.reasoning_content === "string" && delta.reasoning_content.length > 0;
                 if (typeof delta.content === "string" && delta.content.length > 0) {
-                    yield { kind: "text", delta: delta.content, ...(hasReasoning ? {} : { raw: rawBuf }) } as ParsedStreamEvent;
+                    const clean = tagFilter.push(delta.content);
+                    if (clean.length > 0) {
+                        yield { kind: "text", delta: clean, ...(hasReasoning ? {} : { raw: rewriteContentChunk(parsed, clean) }) } as ParsedStreamEvent;
+                    }
                 } else if (!hasReasoning && (delta.role || (Object.keys(delta).length === 0 && !finishReason))) {
                     yield { kind: "meta", chunk: rawBuf, firstRoundOnly: true } as ParsedStreamEvent;
                 }

--- a/src/loop/adapter-responses.ts
+++ b/src/loop/adapter-responses.ts
@@ -1,7 +1,7 @@
 import type { CoreMessage } from "acp-kernel";
 import { coreToResponses, injectResponsesDeveloperMessage, patchResponsesInput, type ResponseInputItem, type ResponsesProjection } from "acp-kernel/wire";
 import { buildVisibilityMarker } from "../compress-loop.js";
-import { createTagEchoFilter, stripResponsesText } from "./tag-echo-filter.js";
+import { createTagEchoFilter, stripResponsesText, containsRenderTagText } from "./tag-echo-filter.js";
 import { log as loggerLog } from "../logger.js";
 import { ACP_TEXT_OPEN, ACP_TEXT_CLOSE, ACP_STATUS_OPEN, ACP_STATUS_CLOSE, ACP_SEARCH_OPEN, ACP_SEARCH_CLOSE, ACP_DECOMPRESS_OPEN, ACP_DECOMPRESS_CLOSE, COMPRESS_TOOL_NAME, PROXY_TOOL_NAMES } from "../compress-tool.js";
 import type { BiliMessage } from "acp-kernel/wire";
@@ -250,7 +250,8 @@ export function createResponsesAdapter(textProtocol?: boolean, projection?: Resp
                     if (mapped) {
                         yield { kind: "meta", chunk: rewriteRefEvent(type, stripResponsesText(obj), mapped), firstRoundOnly: false } as ParsedStreamEvent;
                     } else if (!suppressTextLifecycle) {
-                        yield { kind: "meta", chunk: rebuildResponsesEvent(type, stripResponsesText(obj)), firstRoundOnly: true } as ParsedStreamEvent;
+                        const chunk = containsRenderTagText(eventStr) ? rebuildResponsesEvent(type, stripResponsesText(obj)) : rawBuf;
+                        yield { kind: "meta", chunk, firstRoundOnly: true } as ParsedStreamEvent;
                     }
                 } else if (type === "response.output_text.delta") {
                     const delta = typeof obj.delta === "string" ? obj.delta : "";
@@ -264,7 +265,8 @@ export function createResponsesAdapter(textProtocol?: boolean, projection?: Resp
                             if (mapped) {
                                 yield { kind: "text", delta: clean, raw: rewriteRefEvent(type, { ...obj, delta: clean }, mapped) } as ParsedStreamEvent;
                             } else if (round === 1) {
-                                yield { kind: "text", delta: clean, raw: rebuildResponsesEvent(type, { ...obj, delta: clean }) } as ParsedStreamEvent;
+                                const raw = clean === delta ? rawBuf : rebuildResponsesEvent(type, { ...obj, delta: clean });
+                                yield { kind: "text", delta: clean, raw } as ParsedStreamEvent;
                             } else {
                                 yield { kind: "text", delta: clean } as ParsedStreamEvent;
                             }
@@ -315,7 +317,8 @@ export function createResponsesAdapter(textProtocol?: boolean, projection?: Resp
                             remapped.delete(origId);
                             yield { kind: "meta", chunk: rewriteItemEvent(type, stripResponsesText(obj), mapped), firstRoundOnly: false } as ParsedStreamEvent;
                         } else if (!suppressTextLifecycle) {
-                            yield { kind: "meta", chunk: rebuildResponsesEvent(type, stripResponsesText(obj)), firstRoundOnly: true } as ParsedStreamEvent;
+                            const chunk = containsRenderTagText(eventStr) ? rebuildResponsesEvent(type, stripResponsesText(obj)) : rawBuf;
+                            yield { kind: "meta", chunk, firstRoundOnly: true } as ParsedStreamEvent;
                         }
                     } else if (item?.type !== "message" || !suppressTextLifecycle) {
                         yield { kind: "meta", chunk: rawBuf, firstRoundOnly: true } as ParsedStreamEvent;

--- a/src/loop/adapter-responses.ts
+++ b/src/loop/adapter-responses.ts
@@ -1,6 +1,8 @@
 import type { CoreMessage } from "acp-kernel";
 import { coreToResponses, injectResponsesDeveloperMessage, patchResponsesInput, type ResponseInputItem, type ResponsesProjection } from "acp-kernel/wire";
 import { buildVisibilityMarker } from "../compress-loop.js";
+import { createTagEchoFilter, stripResponsesText } from "./tag-echo-filter.js";
+import { log as loggerLog } from "../logger.js";
 import { ACP_TEXT_OPEN, ACP_TEXT_CLOSE, ACP_STATUS_OPEN, ACP_STATUS_CLOSE, ACP_SEARCH_OPEN, ACP_SEARCH_CLOSE, ACP_DECOMPRESS_OPEN, ACP_DECOMPRESS_CLOSE, COMPRESS_TOOL_NAME, PROXY_TOOL_NAMES } from "../compress-tool.js";
 import type { BiliMessage } from "acp-kernel/wire";
 import type {
@@ -30,6 +32,10 @@ function rewriteItemEvent(type: string, obj: Record<string, unknown>, mapped: Ma
 
 function rewriteRefEvent(type: string, obj: Record<string, unknown>, mapped: MappedItem): Buffer {
     return Buffer.from(`event: ${type}\ndata: ${JSON.stringify({ ...obj, item_id: mapped.id, output_index: mapped.index })}\n\n`, "utf8");
+}
+
+function rebuildResponsesEvent(type: string, obj: Record<string, unknown>): Buffer {
+    return Buffer.from(`event: ${type}\ndata: ${JSON.stringify(obj)}\n\n`, "utf8");
 }
 
 async function* iterSseEvents(stream: ReadableStream<Uint8Array>): AsyncGenerator<string> {
@@ -177,6 +183,22 @@ export function createResponsesAdapter(textProtocol?: boolean, projection?: Resp
         async *parseStream(upstream, round) {
             const pending = new Map<string, FunctionCallBuffer>();
             const remapped = new Map<string, MappedItem>();
+            // #206: render-tag echo filter — deltas stream through the filter;
+            // full-text events (.done / output_item.done / completed response)
+            // are stripped wholesale via stripResponsesText.
+            const tagFilter = createTagEchoFilter((snippet) => {
+                loggerLog("warn", `[tag-echo] stripped model-emitted render tag: ${snippet.slice(0, 80).replace(/\n/g, " ")}`);
+            });
+            let lastTextRef: { itemId: string; outputIndex: number } | null = null;
+            const flushFilter = function* (): Generator<ParsedStreamEvent> {
+                const tail = tagFilter.flush();
+                if (tail.length > 0) {
+                    const raw = lastTextRef
+                        ? rebuildResponsesEvent("response.output_text.delta", { type: "response.output_text.delta", item_id: lastTextRef.itemId, output_index: lastTextRef.outputIndex, delta: tail })
+                        : undefined;
+                    yield { kind: "text", delta: tail, ...(raw ? { raw } : {}) } as ParsedStreamEvent;
+                }
+            };
             for await (const eventStr of iterSseEvents(upstream)) {
                 const type = extractEventType(eventStr);
                 const dataLine = extractDataLine(eventStr);
@@ -226,20 +248,26 @@ export function createResponsesAdapter(textProtocol?: boolean, projection?: Resp
                 ) {
                     const mapped = remapped.get(typeof obj.item_id === "string" ? obj.item_id : "");
                     if (mapped) {
-                        yield { kind: "meta", chunk: rewriteRefEvent(type, obj, mapped), firstRoundOnly: false } as ParsedStreamEvent;
+                        yield { kind: "meta", chunk: rewriteRefEvent(type, stripResponsesText(obj), mapped), firstRoundOnly: false } as ParsedStreamEvent;
                     } else if (!suppressTextLifecycle) {
-                        yield { kind: "meta", chunk: rawBuf, firstRoundOnly: true } as ParsedStreamEvent;
+                        yield { kind: "meta", chunk: rebuildResponsesEvent(type, stripResponsesText(obj)), firstRoundOnly: true } as ParsedStreamEvent;
                     }
                 } else if (type === "response.output_text.delta") {
                     const delta = typeof obj.delta === "string" ? obj.delta : "";
                     if (delta.length > 0) {
-                        const mapped = remapped.get(typeof obj.item_id === "string" ? obj.item_id : "");
-                        if (mapped) {
-                            yield { kind: "text", delta, raw: rewriteRefEvent(type, obj, mapped) } as ParsedStreamEvent;
-                        } else if (round === 1) {
-                            yield { kind: "text", delta, raw: rawBuf } as ParsedStreamEvent;
-                        } else {
-                            yield { kind: "text", delta } as ParsedStreamEvent;
+                        const itemId = typeof obj.item_id === "string" ? obj.item_id : "";
+                        const outputIndex = typeof obj.output_index === "number" ? obj.output_index : 0;
+                        const mapped = remapped.get(itemId);
+                        lastTextRef = { itemId: mapped ? mapped.id : itemId, outputIndex: mapped ? mapped.index : outputIndex };
+                        const clean = tagFilter.push(delta);
+                        if (clean.length > 0) {
+                            if (mapped) {
+                                yield { kind: "text", delta: clean, raw: rewriteRefEvent(type, { ...obj, delta: clean }, mapped) } as ParsedStreamEvent;
+                            } else if (round === 1) {
+                                yield { kind: "text", delta: clean, raw: rebuildResponsesEvent(type, { ...obj, delta: clean }) } as ParsedStreamEvent;
+                            } else {
+                                yield { kind: "text", delta: clean } as ParsedStreamEvent;
+                            }
                         }
                     }
                 } else if (type === "response.function_call_arguments.delta") {
@@ -285,15 +313,16 @@ export function createResponsesAdapter(textProtocol?: boolean, projection?: Resp
                         const mapped = remapped.get(origId);
                         if (mapped) {
                             remapped.delete(origId);
-                            yield { kind: "meta", chunk: rewriteItemEvent(type, obj, mapped), firstRoundOnly: false } as ParsedStreamEvent;
+                            yield { kind: "meta", chunk: rewriteItemEvent(type, stripResponsesText(obj), mapped), firstRoundOnly: false } as ParsedStreamEvent;
                         } else if (!suppressTextLifecycle) {
-                            yield { kind: "meta", chunk: rawBuf, firstRoundOnly: true } as ParsedStreamEvent;
+                            yield { kind: "meta", chunk: rebuildResponsesEvent(type, stripResponsesText(obj)), firstRoundOnly: true } as ParsedStreamEvent;
                         }
                     } else if (item?.type !== "message" || !suppressTextLifecycle) {
                         yield { kind: "meta", chunk: rawBuf, firstRoundOnly: true } as ParsedStreamEvent;
                     }
                 } else if (type === "response.completed") {
-                    responseObj = (obj.response as Record<string, unknown>) ?? null;
+                    yield* flushFilter();
+                    responseObj = stripResponsesText((obj.response as Record<string, unknown>) ?? null);
                     terminalKind = "completed";
                     terminalRaw = null;
                     const respUsage = (responseObj as Record<string, unknown> | null)?.usage as
@@ -308,10 +337,12 @@ export function createResponsesAdapter(textProtocol?: boolean, projection?: Resp
                     } as ParsedStreamEvent;
                     yield { kind: "done", finishReason: "completed" } as ParsedStreamEvent;
                 } else if (type === "response.incomplete") {
+                    yield* flushFilter();
                     terminalKind = "incomplete";
                     terminalRaw = rawBuf;
                     yield { kind: "done", finishReason: "incomplete" } as ParsedStreamEvent;
                 } else if (type === "response.failed" || type === "response.error") {
+                    yield* flushFilter();
                     terminalKind = "failed";
                     terminalRaw = rawBuf;
                     yield { kind: "done", finishReason: "failed" } as ParsedStreamEvent;

--- a/src/loop/tag-echo-filter.ts
+++ b/src/loop/tag-echo-filter.ts
@@ -3,20 +3,20 @@
 // imitate them in visible output ("tag echo"), the client replays the echoed
 // tags on later turns, and the imitation amplifies into unbounded repetition.
 // Stripping render tags from outgoing text breaks the loop at the source.
-// ONLY the render form (`<acp attrs…>` / exact `</acp>`) is stripped — the
-// underscore-namespaced text-protocol triggers (`<acp_compress>` etc.) and
+// ONLY the render form (`\x3cacp attrs…>` / exact `\x3c/acp>`) is stripped — the
+// underscore-namespaced text-protocol triggers (`\x3cacp_compress>` etc.) and
 // ordinary prose containing `<` pass through untouched.
 
-const PAIRED = /<acp\s[^<>]*>([^<>]{0,64})<\/acp>/;
+const PAIRED = /\x3cacp\s[^<>]*>([^<>]{0,64})<\/acp>/;
 const LONE = /<\/?acp(?=[\s>])[^<>]*>/;
 // A suffix of the buffer that could still grow into a render tag: either an
-// unterminated `<acp …` opening (attrs so far, no `>` yet) or a short
+// unterminated `\x3cacp …` opening (attrs so far, no `>` yet) or a short
 // ambiguous prefix like `<`, `<a`, `</ac`, …
-const PARTIAL_TAIL = /(<acp\s[^<>]*|<\/?a?c?p?)$/;
+const PARTIAL_TAIL = /(\x3cacp\s[^<>]*|<\/?a?c?p?)$/;
 // An unterminated render-tag opening that already shows a quoted tokens=
 // attribute — always an imitation truncated mid-tag, never prose.
-const TRUNCATED_TAG = /<acp\s[^<>]*tokens\s*=\s*"[^<>"]*"[^<>]*$/;
-const CLOSE_TAG = "</acp";
+const TRUNCATED_TAG = /\x3cacp\s[^<>]*tokens\s*=\s*"[^<>"]*"[^<>]*$/;
+const CLOSE_TAG = "\x3c/acp";
 const HOLD_LIMIT = 128;
 const SWALLOW_CAP = 80;
 
@@ -31,6 +31,14 @@ export function stripAcpTags(text: string): string {
         .replace(new RegExp(PAIRED.source, "g"), "")
         .replace(new RegExp(LONE.source, "g"), "")
         .replace(new RegExp(TRUNCATED_TAG.source), "");
+}
+
+// Cheap pre-check on a raw wire string (SSE event or JSON body): does it
+// contain anything that looks like a render tag (literal or JSON-escaped
+// `\u003c` form)? Callers use this to skip re-serializing chunks that need
+// no stripping, preserving byte-identical passthrough.
+export function containsRenderTagText(s: string): boolean {
+    return /\x3c\/?acp(?=[\s>])/.test(s) || /\\u003c\/?acp(?=[\s>\\])/.test(s);
 }
 
 export function createTagEchoFilter(onDrop?: (snippet: string) => void): TagEchoFilter {
@@ -88,8 +96,11 @@ export function createTagEchoFilter(onDrop?: (snippet: string) => void): TagEcho
             drop(m[0]);
             out += buf.slice(0, m.index);
             buf = buf.slice(m.index + m[0].length);
-            const wasPaired = m === p && m[0].endsWith(CLOSE_TAG);
-            if (!wasPaired && /^<acp\s/.test(m[0])) {
+            // A PAIRED match is by definition a complete open+content+close
+            // span — only a LONE opening tag leaves the stream mid-tag and
+            // needs to swallow until its close arrives.
+            const wasPaired = m === p;
+            if (!wasPaired && /^\x3cacp\s/.test(m[0])) {
                 swallowUntilClose = true;
                 swallowed = "";
             }

--- a/src/loop/tag-echo-filter.ts
+++ b/src/loop/tag-echo-filter.ts
@@ -1,0 +1,168 @@
+// Streaming-safe stripper for model-emitted literal ACP render tags (#206).
+// Compressed history is rendered to the model as render tags; models sometimes
+// imitate them in visible output ("tag echo"), the client replays the echoed
+// tags on later turns, and the imitation amplifies into unbounded repetition.
+// Stripping render tags from outgoing text breaks the loop at the source.
+// ONLY the render form (`<acp attrs…>` / exact `</acp>`) is stripped — the
+// underscore-namespaced text-protocol triggers (`<acp_compress>` etc.) and
+// ordinary prose containing `<` pass through untouched.
+
+const PAIRED = /<acp\s[^<>]*>([^<>]{0,64})<\/acp>/;
+const LONE = /<\/?acp(?=[\s>])[^<>]*>/;
+// A suffix of the buffer that could still grow into a render tag: either an
+// unterminated `<acp …` opening (attrs so far, no `>` yet) or a short
+// ambiguous prefix like `<`, `<a`, `</ac`, …
+const PARTIAL_TAIL = /(<acp\s[^<>]*|<\/?a?c?p?)$/;
+// An unterminated render-tag opening that already shows a quoted tokens=
+// attribute — always an imitation truncated mid-tag, never prose.
+const TRUNCATED_TAG = /<acp\s[^<>]*tokens\s*=\s*"[^<>"]*"[^<>]*$/;
+const CLOSE_TAG = "</acp";
+const HOLD_LIMIT = 128;
+const SWALLOW_CAP = 80;
+
+export interface TagEchoFilter {
+    push(delta: string): string;
+    flush(): string;
+    dropped(): boolean;
+}
+
+export function stripAcpTags(text: string): string {
+    return text
+        .replace(new RegExp(PAIRED.source, "g"), "")
+        .replace(new RegExp(LONE.source, "g"), "")
+        .replace(new RegExp(TRUNCATED_TAG.source), "");
+}
+
+export function createTagEchoFilter(onDrop?: (snippet: string) => void): TagEchoFilter {
+    let held = "";
+    let swallowUntilClose = false;
+    let swallowed = "";
+    let droppedAny = false;
+    let notified = false;
+    const drop = (snippet: string) => {
+        droppedAny = true;
+        if (onDrop && !notified) {
+            notified = true;
+            onDrop(snippet);
+        }
+    };
+    const process = (input: string): string => {
+        let buf = input;
+        let out = "";
+        for (;;) {
+            if (swallowUntilClose) {
+                const combined = swallowed + buf;
+                const closeIdx = combined.indexOf(CLOSE_TAG);
+                if (closeIdx >= 0 && combined[closeIdx + CLOSE_TAG.length] === ">") {
+                    const end = closeIdx + CLOSE_TAG.length + 1;
+                    drop(swallowed + combined.slice(0, end));
+                    swallowed = "";
+                    swallowUntilClose = false;
+                    buf = combined.slice(end);
+                    continue;
+                }
+                if (combined.length > SWALLOW_CAP) {
+                    swallowed = "";
+                    swallowUntilClose = false;
+                    buf = combined;
+                    continue;
+                }
+                swallowed = combined;
+                return out;
+            }
+            const p = PAIRED.exec(buf);
+            const l = LONE.exec(buf);
+            let m: RegExpExecArray | null;
+            if (p && l) m = p.index <= l.index ? p : l;
+            else m = p ?? l;
+            if (!m) {
+                const t = PARTIAL_TAIL.exec(buf);
+                if (t && t[0].length <= HOLD_LIMIT) {
+                    held = t[0];
+                    out += buf.slice(0, buf.length - t[0].length);
+                } else {
+                    out += buf;
+                }
+                break;
+            }
+            drop(m[0]);
+            out += buf.slice(0, m.index);
+            buf = buf.slice(m.index + m[0].length);
+            const wasPaired = m === p && m[0].endsWith(CLOSE_TAG);
+            if (!wasPaired && /^<acp\s/.test(m[0])) {
+                swallowUntilClose = true;
+                swallowed = "";
+            }
+        }
+        return out;
+    };
+    return {
+        push(delta: string): string {
+            const chunk = held + delta;
+            held = "";
+            return process(chunk);
+        },
+        flush(): string {
+            let rest = swallowed + held;
+            swallowed = "";
+            held = "";
+            swallowUntilClose = false;
+            const t = new RegExp(TRUNCATED_TAG.source).exec(rest);
+            if (t) {
+                drop(t[0]);
+                rest = rest.slice(0, t.index);
+            }
+            return rest;
+        },
+        dropped(): boolean {
+            return droppedAny;
+        },
+    };
+}
+
+function stripParts(content: unknown): unknown {
+    if (!Array.isArray(content)) return content;
+    return content.map((part) => {
+        if (part && typeof part === "object" && typeof (part as Record<string, unknown>).text === "string") {
+            return { ...(part as Record<string, unknown>), text: stripAcpTags((part as Record<string, unknown>).text as string) };
+        }
+        return part;
+    });
+}
+
+function stripItemContent(it: unknown): unknown {
+    if (it && typeof it === "object" && Array.isArray((it as Record<string, unknown>).content)) {
+        return { ...(it as Record<string, unknown>), content: stripParts((it as Record<string, unknown>).content) };
+    }
+    return it;
+}
+
+// Strip render tags from the text fields of a Responses-API event/response
+// object (mutates in place). Handles the shapes that carry literal text:
+// output_text.done `.text`, content_part.done `.part.text`,
+// output_item.done `.item.content[].text`, and `.response.output[].content[]`
+// on response.completed.
+export function stripResponsesText<T>(obj: T): T {
+    if (!obj || typeof obj !== "object") return obj;
+    const o = obj as Record<string, unknown>;
+    if (typeof o.text === "string") o.text = stripAcpTags(o.text);
+    if (o.part && typeof o.part === "object" && typeof (o.part as Record<string, unknown>).text === "string") {
+        o.part = { ...(o.part as Record<string, unknown>), text: stripAcpTags((o.part as Record<string, unknown>).text as string) };
+    }
+    if (o.item && typeof o.item === "object") {
+        const item = { ...(o.item as Record<string, unknown>) };
+        if (Array.isArray(item.content)) item.content = stripParts(item.content);
+        o.item = item;
+    }
+    if (o.response && typeof o.response === "object") {
+        const resp = { ...(o.response as Record<string, unknown>) };
+        if (Array.isArray(resp.output)) {
+            resp.output = resp.output.map(stripItemContent);
+        }
+        o.response = resp;
+    }
+    if (Array.isArray(o.output)) {
+        o.output = o.output.map(stripItemContent);
+    }
+    return obj;
+}

--- a/src/stream-openai.ts
+++ b/src/stream-openai.ts
@@ -3,6 +3,7 @@ import type { Session } from "./session.js";
 import { COMPRESS_TOOL_NAME, parseCompressInput } from "./compress-tool.js";
 import { applyRanges, type RewriteCtx } from "./stream.js";
 import { normalizeSseLineEndings } from "./sse-util.js";
+import { stripAcpTags } from "./loop/tag-echo-filter.js";
 
 type StreamState = {
     compressIndices: Set<number>;
@@ -191,7 +192,7 @@ export function rewriteOpenaiJsonResponse(body: unknown, ctx: RewriteCtx): unkno
     let sawReal = false;
     const noteParts: string[] = [];
     const keepToolCalls: unknown[] = [];
-    const existingText = typeof msg.content === "string" ? msg.content : "";
+    let existingText = typeof msg.content === "string" ? msg.content : "";
     const toolCalls = msg.tool_calls as Array<{ function?: { name?: string; arguments?: string } }> | undefined;
     if (Array.isArray(toolCalls)) {
         for (const tc of toolCalls) {
@@ -206,6 +207,8 @@ export function rewriteOpenaiJsonResponse(body: unknown, ctx: RewriteCtx): unkno
     }
     if (existingText && (existingText.includes("\x3cacp ") || existingText.includes("\x3c/acp"))) {
         ctx.log(`[warn: tag echo] non-stream openai output contains <acp tag: ${existingText.slice(0, 120).replace(/\n/g, " ")}`);
+        existingText = stripAcpTags(existingText);
+        msg.content = existingText;
     }
     if (!converted) return body;
     const note = noteParts.join("\n");

--- a/src/stream-openai.ts
+++ b/src/stream-openai.ts
@@ -3,7 +3,7 @@ import type { Session } from "./session.js";
 import { COMPRESS_TOOL_NAME, parseCompressInput } from "./compress-tool.js";
 import { applyRanges, type RewriteCtx } from "./stream.js";
 import { normalizeSseLineEndings } from "./sse-util.js";
-import { stripAcpTags } from "./loop/tag-echo-filter.js";
+import { containsRenderTagText, stripAcpTags } from "./loop/tag-echo-filter.js";
 
 type StreamState = {
     compressIndices: Set<number>;
@@ -205,7 +205,7 @@ export function rewriteOpenaiJsonResponse(body: unknown, ctx: RewriteCtx): unkno
             }
         }
     }
-    if (existingText && (existingText.includes("\x3cacp ") || existingText.includes("\x3c/acp"))) {
+    if (existingText && containsRenderTagText(existingText)) {
         ctx.log(`[warn: tag echo] non-stream openai output contains <acp tag: ${existingText.slice(0, 120).replace(/\n/g, " ")}`);
         existingText = stripAcpTags(existingText);
         msg.content = existingText;

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -3,7 +3,7 @@ import { type Session, cacheBlockContent } from "./session.js";
 import { COMPRESS_TOOL_NAME, parseCompressInput, PROXY_TOOL_NAMES } from "./compress-tool.js";
 import { resolveDecompress } from "./decompress-shared.js";
 import { normalizeSseLineEndings } from "./sse-util.js";
-import { stripAcpTags } from "./loop/tag-echo-filter.js";
+import { containsRenderTagText, stripAcpTags } from "./loop/tag-echo-filter.js";
 
 export type RewriteCtx = {
     core: CompressionCore;
@@ -105,7 +105,7 @@ function routeEvent(
             return NOOP;
         }
         const dt = (d as { delta?: { text?: string } }).delta;
-        if (dt?.text && (dt.text.includes("\x3cacp ") || dt.text.includes("\x3c/acp"))) {
+        if (dt?.text && containsRenderTagText(dt.text)) {
             ctx.log(`[warn: tag echo] model emitted <acp tag in text delta: ${dt.text.slice(0, 120).replace(/\n/g, " ")}`);
         }
         return emitEvent(ev);
@@ -332,7 +332,7 @@ export function rewriteJsonResponse(body: unknown, ctx: RewriteCtx): unknown {
     if (converted && !sawRealToolUse) b.stop_reason = "end_turn";
     for (const blk of newContent) {
         const t = (blk as { type?: string; text?: string }).text;
-        if (typeof t === "string" && (t.includes("\x3cacp ") || t.includes("\x3c/acp"))) {
+        if (typeof t === "string" && containsRenderTagText(t)) {
             ctx.log(`[warn: tag echo] non-stream model output contains <acp tag: ${t.slice(0, 120).replace(/\n/g, " ")}`);
             (blk as { text?: string }).text = stripAcpTags(t);
         }

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -3,6 +3,7 @@ import { type Session, cacheBlockContent } from "./session.js";
 import { COMPRESS_TOOL_NAME, parseCompressInput, PROXY_TOOL_NAMES } from "./compress-tool.js";
 import { resolveDecompress } from "./decompress-shared.js";
 import { normalizeSseLineEndings } from "./sse-util.js";
+import { stripAcpTags } from "./loop/tag-echo-filter.js";
 
 export type RewriteCtx = {
     core: CompressionCore;
@@ -333,6 +334,7 @@ export function rewriteJsonResponse(body: unknown, ctx: RewriteCtx): unknown {
         const t = (blk as { type?: string; text?: string }).text;
         if (typeof t === "string" && (t.includes("\x3cacp ") || t.includes("\x3c/acp"))) {
             ctx.log(`[warn: tag echo] non-stream model output contains <acp tag: ${t.slice(0, 120).replace(/\n/g, " ")}`);
+            (blk as { text?: string }).text = stripAcpTags(t);
         }
     }
     return body;

--- a/tests/e2e-tag-echo.test.ts
+++ b/tests/e2e-tag-echo.test.ts
@@ -1,0 +1,180 @@
+import assert from "node:assert";
+import http from "node:http";
+import { once } from "node:events";
+import test from "node:test";
+
+process.env.NODE_ENV = "test";
+
+import { defaultConfig } from "acp-kernel";
+import { startServer, type ProxyOptions } from "../src/server.ts";
+import { SessionStore, _setStoreForTest } from "../src/persist.ts";
+import { _setForTest as setRegistryForTest } from "../src/registry.ts";
+
+// Render-tag pieces are assembled from hex escapes so no literal tag sequence
+// appears in this file's source.
+const LT = "\x3c";
+const GT = "\x3e";
+const TAG = (id: string, tokens = 177) => `${LT}acp tokens="${tokens}" type="text"${GT}${id}${LT}/acp${GT}`;
+const OPEN_MARK = `${LT}acp `;
+const CLOSE_MARK = `${LT}/acp${GT}`;
+
+interface Harness {
+    proxyPort: number;
+    upstreamPort: number;
+    captured: { body: string }[];
+    close(): Promise<void>;
+}
+
+function anthropicSse(event: string, data: unknown): string {
+    return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+function startHarness(scripts: string[][]): Promise<Harness> {
+    const captured: { body: string }[] = [];
+    let call = 0;
+    const upstream = http.createServer((req, res) => {
+        const chunks: Buffer[] = [];
+        req.on("data", (c: Buffer) => chunks.push(c));
+        req.on("end", () => {
+            captured.push({ body: Buffer.concat(chunks).toString() });
+            res.writeHead(200, { "content-type": "text/event-stream" });
+            const script = scripts[Math.min(call, scripts.length - 1)]!;
+            call += 1;
+            for (const line of script) res.write(line);
+            res.end();
+        });
+    });
+    upstream.listen(0, "127.0.0.1");
+    return (async () => {
+        await once(upstream, "listening");
+        const upstreamPort = upstream.address().port;
+        _setStoreForTest(new SessionStore({ enabled: false }));
+        setRegistryForTest({});
+        const proxy = await startServer({
+            port: 0,
+            host: "127.0.0.1",
+            upstream: "http://127.0.0.1",
+            routes: { [`http://127.0.0.1:${upstreamPort}`]: { models: { "claude-test": { context: 400_000 } } } },
+            modelContextLimit: 400_000,
+            kernelConfig: defaultConfig(400_000),
+            compress: { injectTool: true, injectNudge: true },
+            sessionHeader: "x-acp-session",
+            log: false,
+            debug: false,
+            passthrough: false,
+            autoUpdate: false,
+            mitm: { enabled: false, domains: [] },
+        } as ProxyOptions);
+        await once(proxy, "listening");
+        const proxyPort = proxy.address().port;
+        return {
+            proxyPort,
+            upstreamPort,
+            captured,
+            close: async () => {
+                proxy.close();
+                await once(proxy, "close");
+                upstream.close();
+                await once(upstream, "close");
+            },
+        };
+    })();
+}
+
+async function callAnthropic(h: Harness, session: string, messages: Array<{ role: string; content: string }>): Promise<string> {
+    const resp = await fetch(`http://127.0.0.1:${h.proxyPort}/bili/http://127.0.0.1:${h.upstreamPort}/v1/messages`, {
+        method: "POST",
+        headers: { "content-type": "application/json", "x-acp-session": session },
+        body: JSON.stringify({ model: "claude-test", max_tokens: 1024, stream: true, system: "You are a test assistant.", messages }),
+    });
+    assert.equal(resp.status, 200);
+    let raw = "";
+    for await (const chunk of resp.body) raw += Buffer.from(chunk).toString("utf8");
+    return raw;
+}
+
+function clientText(raw: string): string {
+    return [...raw.matchAll(/"type":"text_delta","text":"((?:[^"\\]|\\.)*)"/g)]
+        .map((m) => JSON.parse(`"${m[1]}"`) as string)
+        .join("");
+}
+
+function compressRound1Script(): string[] {
+    const compressArgs = JSON.stringify({ startId: "m00001", endId: "m00002", topic: "e2e 206", summary: "tag echo e2e compress round trip covering twelve historical detail messages about fruit" });
+    return [
+        anthropicSse("message_start", { type: "message_start", message: { id: "msg_206_1", role: "assistant", usage: { input_tokens: 55 } } }),
+        anthropicSse("content_block_start", { type: "content_block_start", index: 0, content_block: { type: "tool_use", id: "toolu_206_1", name: "compress", input: {} } }),
+        anthropicSse("content_block_delta", { type: "content_block_delta", index: 0, delta: { type: "input_json_delta", partial_json: compressArgs.slice(0, 20) } }),
+        anthropicSse("content_block_delta", { type: "content_block_delta", index: 0, delta: { type: "input_json_delta", partial_json: compressArgs.slice(20) } }),
+        anthropicSse("content_block_stop", { type: "content_block_stop", index: 0 }),
+        anthropicSse("message_delta", { type: "message_delta", delta: { stop_reason: "tool_use", stop_sequence: null }, usage: { output_tokens: 12 } }),
+        anthropicSse("message_stop", { type: "message_stop" }),
+    ];
+}
+
+// The "deliberately misbehaving model": after compression the upstream sees
+// render tags in its prompt, so it imitates them in visible output — split
+// across deltas at awkward boundaries, exactly like the #206 reports.
+function tagEchoScript(): string[] {
+    const full = `好的，总结如下 ${TAG("m00155")}${TAG("m00155", 44)}${TAG("m00156", 33)}另外 5 < 6 成立${TAG("m00157")}完毕`;
+    const splitAt = [7, 20, 26, 41, 48, 60];
+    const parts: string[] = [];
+    let prev = 0;
+    for (const s of splitAt) {
+        parts.push(full.slice(prev, s));
+        prev = s;
+    }
+    parts.push(full.slice(prev));
+    return [
+        anthropicSse("message_start", { type: "message_start", message: { id: "msg_206_2", role: "assistant", usage: { input_tokens: 20, cache_read_input_tokens: 5 } } }),
+        anthropicSse("content_block_start", { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } }),
+        ...parts.map((p) => anthropicSse("content_block_delta", { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: p } })),
+        anthropicSse("content_block_stop", { type: "content_block_stop", index: 0 }),
+        anthropicSse("message_delta", { type: "message_delta", delta: { stop_reason: "end_turn", stop_sequence: null }, usage: { output_tokens: 9 } }),
+        anthropicSse("message_stop", { type: "message_stop" }),
+    ];
+}
+
+test("e2e #206: round-2 text after compress deliberately echoes render tags — client stream stays clean", async () => {
+    const h = await startHarness([compressRound1Script(), tagEchoScript()]);
+    try {
+        const raw = await callAnthropic(h, "e2e-206-round2", [
+            ...Array.from({ length: 12 }, (_, i) => ({ role: i % 2 === 0 ? "user" : "assistant", content: `historical detail ${i}. ${"x".repeat(6000)}` })),
+            { role: "user", content: "please compress the conversation now" },
+        ]);
+        assert.ok(h.captured.length >= 2, `expected >= 2 upstream requests, got ${h.captured.length}`);
+        assert.ok(clientText(raw).includes("Compressed m00001–m00002"), "compress did not succeed in round 1");
+        assert.equal(raw.includes(OPEN_MARK), false, "client stream leaked a render open tag");
+        assert.equal(raw.includes(CLOSE_MARK), false, "client stream leaked a render close tag");
+        assert.ok(clientText(raw).endsWith("好的，总结如下 另外 5 < 6 成立完毕"), `unexpected client text: ${JSON.stringify(clientText(raw))}`);
+        assert.ok(raw.includes("message_stop"));
+    } finally {
+        await h.close();
+    }
+});
+
+test("e2e #206: next-turn replay in same session — echoed tags stripped, prose intact", async () => {
+    const done = [
+        anthropicSse("message_start", { type: "message_start", message: { id: "msg_206_3", role: "assistant", usage: { input_tokens: 20 } } }),
+        anthropicSse("content_block_start", { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } }),
+        anthropicSse("content_block_delta", { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "Done after compress" } }),
+        anthropicSse("content_block_stop", { type: "content_block_stop", index: 0 }),
+        anthropicSse("message_delta", { type: "message_delta", delta: { stop_reason: "end_turn", stop_sequence: null }, usage: { output_tokens: 4 } }),
+        anthropicSse("message_stop", { type: "message_stop" }),
+    ];
+    const h = await startHarness([compressRound1Script(), done, tagEchoScript()]);
+    try {
+        await callAnthropic(h, "e2e-206-turn2", [
+            ...Array.from({ length: 12 }, (_, i) => ({ role: i % 2 === 0 ? "user" : "assistant", content: `historical detail ${i}. ${"x".repeat(6000)}` })),
+            { role: "user", content: "please compress the conversation now" },
+        ]);
+        const callsAfterTurn1 = h.captured.length;
+        const raw = await callAnthropic(h, "e2e-206-turn2", [{ role: "user", content: "continue" }]);
+        assert.ok(h.captured.length > callsAfterTurn1, "turn-2 request never reached upstream");
+        assert.equal(raw.includes(OPEN_MARK), false, "turn-2 client stream leaked a render open tag");
+        assert.equal(raw.includes(CLOSE_MARK), false, "turn-2 client stream leaked a render close tag");
+        assert.ok(clientText(raw).endsWith("好的，总结如下 另外 5 < 6 成立完毕"), `unexpected turn-2 client text: ${JSON.stringify(clientText(raw))}`);
+    } finally {
+        await h.close();
+    }
+});

--- a/tests/tag-echo.test.ts
+++ b/tests/tag-echo.test.ts
@@ -1,0 +1,199 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { Config, CoreMessage } from "acp-kernel";
+import { createCore, createInitialState } from "acp-kernel";
+import type { Session } from "../src/session.ts";
+import { runCompressLoop, createOpenaiAdapter, createAnthropicAdapter, createResponsesAdapter } from "../src/loop/index.ts";
+import { stripAcpTags, createTagEchoFilter } from "../src/loop/tag-echo-filter.ts";
+import { buildCompressSystemPrompt } from "../src/compress-tool.ts";
+
+const TAG = (ref: string, tokens = 177) => `\x3cacp tokens="${tokens}" type="text">${ref}\x3c/acp>`;
+const LT = "\x3c";
+const OPEN = `${LT}acp `;
+const CLOSE = `${LT}/acp>`;
+
+function makeCtx(id: string): {
+    core: ReturnType<typeof createCore>;
+    config: Config;
+    messages: CoreMessage[];
+    session: Session;
+    log: (m: string) => void;
+    proxyUrl?: string;
+    textProtocol?: boolean;
+} {
+    return {
+        core: createCore(),
+        config: { modelContextLimit: 200000 } as Config,
+        messages: [],
+        session: {
+            id,
+            meta: {},
+            stats: { requests: 0, tokensSaved: 0, inputTokens: 0, cachedTokens: 0, outputTokens: 0, cacheSamples: 0, lastInputTokens: 0, contextTokens: 0 },
+            metadata: {},
+            state: createInitialState(),
+            createdAt: Date.now(),
+            lastSeen: Date.now(),
+            blockContents: new Map(),
+            inFlight: 0,
+            persisted: false,
+        },
+        log: () => {},
+    };
+}
+
+function sseFromStrings(parts: string[]): ReadableStream<Uint8Array> {
+    const encoder = new TextEncoder();
+    let i = 0;
+    return new ReadableStream<Uint8Array>({
+        pull(controller) {
+            if (i >= parts.length) {
+                controller.close();
+                return;
+            }
+            controller.enqueue(encoder.encode(parts[i++]));
+        },
+    });
+}
+
+async function drain(stream: ReadableStream<Uint8Array>, adapter: Parameters<typeof runCompressLoop>[4], textProtocol = false): Promise<string> {
+    const ctx = makeCtx("tag-echo-test");
+    if (textProtocol) ctx.textProtocol = true;
+    const chunks: Buffer[] = [];
+    for await (const chunk of runCompressLoop(stream, ctx, {}, { url: "http://mock", headers: {} }, adapter, buildCompressSystemPrompt())) {
+        chunks.push(chunk);
+    }
+    return Buffer.concat(chunks).toString("utf8");
+}
+
+test("stripAcpTags removes paired render tags with their ref", () => {
+    assert.equal(stripAcpTags(`before ${TAG("m00155")} after`), "before  after");
+});
+
+test("stripAcpTags removes lone open/close tags", () => {
+    assert.equal(stripAcpTags(`a ${OPEN}tokens="1"> tail`), "a  tail");
+    assert.equal(stripAcpTags(`x ${CLOSE} y`), "x  y");
+});
+
+test("stripAcpTags leaves underscore trigger tags intact", () => {
+    const s = `${LT}acp_compress${LT}/acp_compress${OPEN}x="">ref${CLOSE}`;
+    assert.equal(stripAcpTags(s), `${LT}acp_compress${LT}/acp_compress`);
+});
+
+test("stripAcpTags leaves ordinary angle brackets alone", () => {
+    assert.equal(stripAcpTags("a < b and </abcd> and <acpx>"), "a < b and </abcd> and <acpx>");
+});
+
+test("stripAcpTags: long paired content keeps content, strips tags", () => {
+    const long = "x".repeat(80);
+    assert.equal(stripAcpTags(`${OPEN}t="1">${long}${CLOSE}`), long);
+});
+
+test("streaming filter matches stripAcpTags for every split position", () => {
+    const cases = [
+        `answer ${TAG("m00155")}${TAG("m00155", 44)} done`,
+        TAG("m00155").repeat(21),
+        `edge ${OPEN}tok`,
+        `half ${CLOSE} tail`,
+        `trigger ${LT}acp_compress${LT}/acp_compress end`,
+        `plain < <a </a <ac text`,
+        `${TAG("m1")}${TAG("m2")}`,
+    ];
+    for (const full of cases) {
+        const expected = stripAcpTags(full);
+        for (let split = 0; split <= full.length; split++) {
+            const f = createTagEchoFilter();
+            const out = f.push(full.slice(0, split)) + f.push(full.slice(split)) + f.flush();
+            assert.equal(out, expected, `split=${split} full=${JSON.stringify(full)}`);
+        }
+        for (let seed = 1; seed < 8; seed++) {
+            const f = createTagEchoFilter();
+            let out = "";
+            let rest = full;
+            while (rest.length > 0) {
+                const take = (seed * 7 + rest.length) % (rest.length) + 1;
+                out += f.push(rest.slice(0, take));
+                rest = rest.slice(take);
+            }
+            out += f.flush();
+            assert.equal(out, expected, `seed=${seed} full=${JSON.stringify(full)}`);
+        }
+    }
+});
+
+test("streaming filter: unterminated open tag at flush is dropped", () => {
+    const f = createTagEchoFilter();
+    const out = f.push(`text ${OPEN}tokens="9"`);
+    assert.equal(out, "text ");
+    assert.equal(f.flush(), "");
+});
+
+test("anthropic adapter strips echoed tags across split deltas", async () => {
+    const full = `好的 ${TAG("m00155")}${TAG("m00156", 33)}结论`;
+    const splitAt = [6, 19, 25, 40, 47];
+    const parts: string[] = [];
+    let prev = 0;
+    for (const s of splitAt) {
+        parts.push(full.slice(prev, s));
+        prev = s;
+    }
+    parts.push(full.slice(prev));
+    const sseParts: string[] = [
+        `event: message_start\ndata: ${JSON.stringify({ type: "message_start", message: { id: "msg_1", usage: { input_tokens: 100 } } })}\n\n`,
+        `event: content_block_start\ndata: ${JSON.stringify({ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } })}\n\n`,
+        ...parts.map((p) => `event: content_block_delta\ndata: ${JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: p } })}\n\n`),
+        `event: content_block_stop\ndata: ${JSON.stringify({ type: "content_block_stop", index: 0 })}\n\n`,
+        `event: message_delta\ndata: ${JSON.stringify({ type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 5 } })}\n\n`,
+        `event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`,
+    ];
+    const out = await drain(sseFromStrings(sseParts), createAnthropicAdapter({ model: "test" }));
+    assert.equal(out.includes(OPEN), false);
+    assert.equal(out.includes(CLOSE), false);
+    const texts = [...out.matchAll(/"text_delta","text":"((?:[^"\\]|\\.)*)"/g)].map((m) => JSON.parse(`"${m[1]}"`) as string);
+    assert.equal(texts.join(""), "好的 结论");
+    const stopIdx = out.indexOf("content_block_stop");
+    const lastDeltaIdx = out.lastIndexOf("content_block_delta");
+    assert.ok(lastDeltaIdx < stopIdx, "flushed tail must precede block stop");
+});
+
+test("openai adapter strips echoed tags", async () => {
+    const sseParts: string[] = [
+        `data: ${JSON.stringify({ id: "c1", object: "chat.completion.chunk", created: 1, model: "gpt", choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }] })}\n\n`,
+        `data: ${JSON.stringify({ id: "c1", object: "chat.completion.chunk", created: 1, model: "gpt", choices: [{ index: 0, delta: { content: `repeat ${TAG("m00155")}` }, finish_reason: null }] })}\n\n`,
+        `data: ${JSON.stringify({ id: "c1", object: "chat.completion.chunk", created: 1, model: "gpt", choices: [{ index: 0, delta: { content: `${TAG("m00155", 44)}end` }, finish_reason: null }] })}\n\n`,
+        `data: ${JSON.stringify({ id: "c1", object: "chat.completion.chunk", created: 1, model: "gpt", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] })}\n\n`,
+        `data: [DONE]\n\n`,
+    ];
+    const out = await drain(sseFromStrings(sseParts), createOpenaiAdapter({ model: "gpt" }));
+    assert.equal(out.includes(OPEN), false);
+    assert.equal(out.includes(CLOSE), false);
+    const contents = [...out.matchAll(/"content":"((?:[^"\\]|\\.)*)"/g)].map((m) => JSON.parse(`"${m[1]}"`) as string);
+    assert.equal(contents.join(""), "repeat end");
+});
+
+test("openai adapter: tag split across deltas is fully stripped", async () => {
+    const sseParts: string[] = [
+        `data: ${JSON.stringify({ id: "c1", object: "chat.completion.chunk", created: 1, model: "gpt", choices: [{ index: 0, delta: { content: `${OPEN}tokens="2"` }, finish_reason: null }] })}\n\n`,
+        `data: ${JSON.stringify({ id: "c1", object: "chat.completion.chunk", created: 1, model: "gpt", choices: [{ index: 0, delta: { content: ` type="text">m00001${CLOSE}ok` }, finish_reason: null }] })}\n\n`,
+        `data: ${JSON.stringify({ id: "c1", object: "chat.completion.chunk", created: 1, model: "gpt", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] })}\n\n`,
+        `data: [DONE]\n\n`,
+    ];
+    const out = await drain(sseFromStrings(sseParts), createOpenaiAdapter({ model: "gpt" }));
+    assert.equal(out.includes(OPEN), false);
+    assert.equal(out.includes(CLOSE), false);
+});
+
+test("responses adapter strips echoed tags from deltas and full-text events", async () => {
+    const echoed = `repeat ${TAG("m00155")}${TAG("m00156", 33)}done`;
+    const sseParts: string[] = [
+        `event: response.created\ndata: ${JSON.stringify({ type: "response.created", response: { id: "resp_1" } })}\n\n`,
+        `event: response.output_item.added\ndata: ${JSON.stringify({ type: "response.output_item.added", output_index: 0, item: { type: "message", id: "msg_1", role: "assistant", content: [] } })}\n\n`,
+        `event: response.output_text.delta\ndata: ${JSON.stringify({ type: "response.output_text.delta", item_id: "msg_1", output_index: 0, delta: `repeat ${TAG("m00155")}` })}\n\n`,
+        `event: response.output_text.delta\ndata: ${JSON.stringify({ type: "response.output_text.delta", item_id: "msg_1", output_index: 0, delta: `${TAG("m00156", 33)}done` })}\n\n`,
+        `event: response.output_text.done\ndata: ${JSON.stringify({ type: "response.output_text.done", item_id: "msg_1", output_index: 0, text: echoed })}\n\n`,
+        `event: response.output_item.done\ndata: ${JSON.stringify({ type: "response.output_item.done", output_index: 0, item: { type: "message", id: "msg_1", role: "assistant", content: [{ type: "output_text", text: echoed }] } })}\n\n`,
+        `event: response.completed\ndata: ${JSON.stringify({ type: "response.completed", response: { id: "resp_1", status: "completed", output: [{ type: "message", id: "msg_1", role: "assistant", content: [{ type: "output_text", text: echoed }] }], usage: { input_tokens: 10, output_tokens: 3 } } })}\n\n`,
+    ];
+    const out = await drain(sseFromStrings(sseParts), createResponsesAdapter());
+    assert.equal(out.includes(OPEN), false);
+    assert.equal(out.includes(CLOSE), false);
+});

--- a/tests/tag-echo.test.ts
+++ b/tests/tag-echo.test.ts
@@ -4,7 +4,9 @@ import type { Config, CoreMessage } from "acp-kernel";
 import { createCore, createInitialState } from "acp-kernel";
 import type { Session } from "../src/session.ts";
 import { runCompressLoop, createOpenaiAdapter, createAnthropicAdapter, createResponsesAdapter } from "../src/loop/index.ts";
-import { stripAcpTags, createTagEchoFilter } from "../src/loop/tag-echo-filter.ts";
+import { stripAcpTags, createTagEchoFilter, containsRenderTagText } from "../src/loop/tag-echo-filter.ts";
+import { rewriteJsonResponse } from "../src/stream.ts";
+import { rewriteOpenaiJsonResponse } from "../src/stream-openai.ts";
 import { buildCompressSystemPrompt } from "../src/compress-tool.ts";
 
 const TAG = (ref: string, tokens = 177) => `\x3cacp tokens="${tokens}" type="text">${ref}\x3c/acp>`;
@@ -97,6 +99,8 @@ test("streaming filter matches stripAcpTags for every split position", () => {
         `trigger ${LT}acp_compress${LT}/acp_compress end`,
         `plain < <a </a <ac text`,
         `${TAG("m1")}${TAG("m2")}`,
+        `first ${TAG("m1")} mid prose ${TAG("m2")} last`,
+        `好的 ${TAG("m00155")}${TAG("m00155", 44)}${TAG("m00156", 33)} 另外 5 < 6 成立${TAG("m00157")}完毕`,
     ];
     for (const full of cases) {
         const expected = stripAcpTags(full);
@@ -125,6 +129,15 @@ test("streaming filter: unterminated open tag at flush is dropped", () => {
     const out = f.push(`text ${OPEN}tokens="9"`);
     assert.equal(out, "text ");
     assert.equal(f.flush(), "");
+});
+
+test("streaming filter keeps prose between tags across chunk boundaries", () => {
+    const parts = [`good ${TAG("m00155")}`, `${TAG("m00155", 44)}${TAG("m00156", 33)}`, `mid 5 < 6 tail${TAG("m00157")}END`];
+    const f = createTagEchoFilter();
+    let out = "";
+    for (const p of parts) out += f.push(p);
+    out += f.flush();
+    assert.equal(out, stripAcpTags(parts.join("")));
 });
 
 test("anthropic adapter strips echoed tags across split deltas", async () => {
@@ -196,4 +209,98 @@ test("responses adapter strips echoed tags from deltas and full-text events", as
     const out = await drain(sseFromStrings(sseParts), createResponsesAdapter());
     assert.equal(out.includes(OPEN), false);
     assert.equal(out.includes(CLOSE), false);
+});
+
+test("tag-free anthropic deltas pass through byte-identical (no re-serialization drift)", async () => {
+    const evt = { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "plain 5 < 6 text" } };
+    const line = `event: content_block_delta\ndata: ${JSON.stringify(evt)}\n\n`;
+    const sseParts: string[] = [
+        `event: message_start\ndata: ${JSON.stringify({ type: "message_start", message: { id: "msg_1", usage: { input_tokens: 100 } } })}\n\n`,
+        `event: content_block_start\ndata: ${JSON.stringify({ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } })}\n\n`,
+        line,
+        `event: content_block_stop\ndata: ${JSON.stringify({ type: "content_block_stop", index: 0 })}\n\n`,
+        `event: message_delta\ndata: ${JSON.stringify({ type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 5 } })}\n\n`,
+        `event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`,
+    ];
+    const out = await drain(sseFromStrings(sseParts), createAnthropicAdapter({ model: "test" }));
+    assert.ok(out.includes(`data: ${JSON.stringify(evt)}\n\n`), "raw delta must be the canonical remapIndexInEvent serialization");
+});
+
+test("tag-free openai chunks pass through with original raw bytes", async () => {
+    const chunk = { id: "c1", object: "chat.completion.chunk", created: 1, model: "gpt", choices: [{ index: 0, delta: { content: "hello plain text" }, finish_reason: null }] };
+    const raw = `data: ${JSON.stringify(chunk)}\n\n`;
+    const sseParts: string[] = [
+        `data: ${JSON.stringify({ id: "c1", object: "chat.completion.chunk", created: 1, model: "gpt", choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }] })}\n\n`,
+        raw,
+        `data: ${JSON.stringify({ id: "c1", object: "chat.completion.chunk", created: 1, model: "gpt", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] })}\n\n`,
+        `data: [DONE]\n\n`,
+    ];
+    const out = await drain(sseFromStrings(sseParts), createOpenaiAdapter({ model: "gpt" }));
+    assert.ok(out.includes(raw), "tag-free chunk must pass through as the original rawBuf");
+});
+
+test("tag-free responses deltas and done events pass through with original raw bytes", async () => {
+    const deltaEvt = { type: "response.output_text.delta", item_id: "msg_1", output_index: 0, delta: "plain delta text" };
+    const doneEvt = { type: "response.output_text.done", item_id: "msg_1", output_index: 0, text: "plain delta text" };
+    const deltaRaw = `event: response.output_text.delta\ndata: ${JSON.stringify(deltaEvt)}\n\n`;
+    const doneRaw = `event: response.output_text.done\ndata: ${JSON.stringify(doneEvt)}\n\n`;
+    const sseParts: string[] = [
+        `event: response.created\ndata: ${JSON.stringify({ type: "response.created", response: { id: "resp_1" } })}\n\n`,
+        `event: response.output_item.added\ndata: ${JSON.stringify({ type: "response.output_item.added", output_index: 0, item: { type: "message", id: "msg_1", role: "assistant", content: [] } })}\n\n`,
+        deltaRaw,
+        doneRaw,
+        `event: response.output_item.done\ndata: ${JSON.stringify({ type: "response.output_item.done", output_index: 0, item: { type: "message", id: "msg_1", role: "assistant", content: [{ type: "output_text", text: "plain delta text" }] } })}\n\n`,
+        `event: response.completed\ndata: ${JSON.stringify({ type: "response.completed", response: { id: "resp_1", status: "completed", output: [{ type: "message", id: "msg_1", role: "assistant", content: [{ type: "output_text", text: "plain delta text" }] }], usage: { input_tokens: 10, output_tokens: 3 } } })}\n\n`,
+    ];
+    const out = await drain(sseFromStrings(sseParts), createResponsesAdapter());
+    assert.ok(out.includes(deltaRaw), "tag-free delta must pass through as original rawBuf");
+    assert.ok(out.includes(doneRaw), "tag-free done event must pass through as original rawBuf");
+});
+
+test("containsRenderTagText detects literal and JSON-escaped render tags", () => {
+    const esc = JSON.stringify("x \x3cacp tokens=\"1\" type=\"text\"\x3em00155\x3c/acp\x3e y").slice(1, -1);
+    assert.ok(containsRenderTagText(`a ${TAG("m1")} b`));
+    assert.ok(containsRenderTagText(`a ${OPEN}x="">b`));
+    assert.ok(containsRenderTagText(`a ${CLOSE} b`));
+    assert.ok(containsRenderTagText(`escaped ${esc}`));
+    assert.ok(containsRenderTagText(`escaped open only \\u003cacp tokens="1"\\u003e ref \\u003c/acp\\u003e`));
+    assert.equal(containsRenderTagText("plain text with < b and </br> tags"), false);
+    assert.equal(containsRenderTagText(`trigger ${LT}acp_compress${LT}/acp_compress`), false);
+});
+
+test("non-stream anthropic rewriteJsonResponse strips echoed tags", async () => {
+    const body = {
+        id: "msg_1",
+        content: [
+            { type: "text", text: `answer ${TAG("m00155")} done` },
+            { type: "text", text: `second ${TAG("m00156", 44)}` },
+        ],
+        usage: { input_tokens: 10, output_tokens: 5 },
+    };
+    const c = makeCtx("ns-anthropic");
+    const rewritten = rewriteJsonResponse(structuredClone(body), { core: c.core, config: c.config, messages: c.messages, session: c.session, log: () => {} });
+    const parsed = rewritten as { content: Array<{ text: string }> };
+    assert.equal(parsed.content[0].text, "answer  done");
+    assert.equal(parsed.content[1].text, "second ");
+});
+
+test("non-stream openai rewriteOpenaiJsonResponse strips echoed tags", () => {
+    const body = {
+        id: "chatcmpl-1",
+        choices: [{ index: 0, message: { role: "assistant", content: `answer ${TAG("m00155")} done` }, finish_reason: "stop" }],
+        usage: { prompt_tokens: 10, completion_tokens: 5 },
+    };
+    const rewritten = rewriteOpenaiJsonResponse(structuredClone(body), { core: createCore(), config: { modelContextLimit: 200000 } as Config, messages: [], session: makeCtx("ns-openai").session, log: () => {} });
+    const parsed = rewritten as { choices: Array<{ message: { content: string } }> };
+    assert.equal(parsed.choices[0].message.content, "answer  done");
+});
+
+test("non-stream rewriters leave tag-free text untouched", async () => {
+    const anthropicBody = { id: "m", content: [{ type: "text", text: "clean 5 < 6 text" }], usage: { input_tokens: 1, output_tokens: 1 } };
+    const cc = makeCtx("ns-clean");
+    const rewritten = rewriteJsonResponse(structuredClone(anthropicBody), { core: cc.core, config: cc.config, messages: cc.messages, session: cc.session, log: () => {} });
+    assert.equal((rewritten as { content: Array<{ text: string }> }).content[0].text, "clean 5 < 6 text");
+    const openaiBody = { id: "c", choices: [{ index: 0, message: { role: "assistant", content: "clean 5 < 6 text" }, finish_reason: "stop" }] };
+    const rewrittenOpenai = rewriteOpenaiJsonResponse(structuredClone(openaiBody), { core: createCore(), config: { modelContextLimit: 200000 } as Config, messages: [], session: makeCtx("ns-openai-clean").session, log: () => {} });
+    assert.equal((rewrittenOpenai as { choices: Array<{ message: { content: string } }> }).choices[0].message.content, "clean 5 < 6 text");
 });


### PR DESCRIPTION
## Problem (#206)

Models sometimes imitate the \`<acp tokens=... type=...>mNNNNN</acp>\` render tags that compressed history is rendered into, emitting them in **visible output** ("tag echo"). The client stores the echoed tags in its local history and replays them next turn; the model then sees its own echoes and repeats further — feedback amplification, occasionally unbounded repetition.

The proxy already **logged** tag echoes (3 warn sites) but never mitigated them.

## Fix

Strip render tags from **outgoing model text** at the wire adapters, breaking the loop at the source:

- **new \`src/loop/tag-echo-filter.ts\`** — streaming-safe filter (hold/partial-tag handling, swallow-until-close, truncated-tag flush) + one-shot \`stripAcpTags\` + Responses-object \`stripResponsesText\`.
- \`adapter-anthropic.ts\` / \`adapter-openai.ts\` / \`adapter-responses.ts\`: filter text deltas in \`parseStream\`, flush tails at stream end, strip full-text fields on \`output_text.done\` / \`output_item.done\` / \`response.completed\`; raw SSE chunks are rewritten so round-1 passthrough is clean too.
- Non-streaming paths: \`rewriteJsonResponse\` (anthropic), \`rewriteOpenaiJsonResponse\` (openai), \`compress-loop-responses.ts\` (responses JSON).
- One \`[warn] [tag-echo]\` log per response (not per delta).

## Safety

- Only the render form is stripped (\`<acp \`…\`>\` / exact \`</acp>\`); underscore-namespaced **text-protocol triggers** (\`<acp_compress>\` etc.) and ordinary prose containing \`<\` pass through untouched.
- Long (>64 chars) paired content keeps its content, only tags are removed.

## Tests

\`tests/tag-echo.test.ts\` — 11 tests: unit stripping semantics, exhaustive streaming-vs-batch equivalence (every split position + pseudo-random chunkings, incl. the 21×-repeated-tag shape from the #206 report), and end-to-end adapter tests for all three protocols across split deltas. Full suite: 576/576 pass; typecheck + build clean.