### PR TITLE
fix: persistent overlay homes for pi/omp/hermes launchers (session history loss)

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,9 +132,9 @@ bili pi -- print "hi"                 # args after the client are passed through
 bili pi-test                          # clean pi (extensions off) — proxy owns compression, no double-compress
 bili codex                            # launch codex through the proxy
 bili claude                           # launch claude through the proxy
-bili omp                              # pi-style: MITM env + isolated temp models.yml
+bili omp                              # pi-style: MITM env + persistent overlay home (~/.omp/agent-bili, real config untouched)
 bili opencode                         # MITM for HTTPS + temp opencode.json (/bili/ for HTTP) + thin /acp plugin
-bili hermes                           # no MITM possible (certifi CA) — isolated HERMES_HOME, all traffic /bili/
+bili hermes                           # no MITM possible (certifi CA) — persistent overlay home (~/.hermes-bili), all traffic /bili/
 bili test pi                          # quick end-to-end smoke test of the pi path
 bili pi --mitm-domain api.foo.com     # add a domain to the MITM whitelist
 ```
@@ -177,7 +177,7 @@ How the client is pointed at the proxy (set automatically in the child env):
 | codex       | `HTTPS_PROXY`       | `SSL_CERT_FILE`         |
 | omp         | `HTTPS_PROXY`       | `NODE_EXTRA_CA_CERTS`   |
 | opencode    | `HTTPS_PROXY`       | `NODE_EXTRA_CA_CERTS`   |
-| hermes      | `HERMES_HOME` (temp `config.yaml`, every upstream `/bili/`) | — (no MITM: httpx builds its own CA bundle) |
+| hermes      | `HERMES_HOME` (persistent overlay `~/.hermes-bili`, every upstream `/bili/`) | — (no MITM: httpx builds its own CA bundle) |
 
 `NODE_EXTRA_CA_CERTS` *appends* to the built-in trust store, so it points at
 the MITM root alone (`root-ca.pem`). `SSL_CERT_FILE` *replaces* the default

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -409,6 +409,105 @@ export function buildCodexMcpArgs(origin: string, conversationId: string): strin
     ];
 }
 
+/**
+ * Shared persistent-overlay machinery for home-dir-based launchers (pi / omp /
+ * hermes). The overlay (`<realHome>-bili`) symlinks every real-home entry
+ * except the launcher-generated file (models.json / models.yml / config.yaml),
+ * which is rewritten in place atomically.
+ *
+ * The overlay is PERSISTENT and never deleted: these agents record absolute
+ * paths derived from their home override into shared state (resume pointers
+ * like omp's `terminal-sessions/<tty>`, fork metadata, session references in
+ * history dbs), so an ephemeral temp home removed on exit leaves dangling
+ * pointers — the agent's history becomes invisible — and any state the agent
+ * created inside the temp home (entries the real home lacks) is destroyed.
+ * A stable overlay keeps every recorded path resolvable forever and lets
+ * overlay-created state survive across runs.
+ *
+ * Refresh semantics on every launch: stale `.file.pid.tmp` drafts are dropped;
+ * dead or mis-targeted symlinks are re-pointed; real files/dirs that shadow a
+ * real-home entry are merged into the real home before being replaced by a
+ * symlink (no data loss); entries the real home lacks are kept as-is.
+ */
+function refreshOverlayHome(realHome: string, overlay: string, generatedFile: string): boolean {
+    try {
+        fs.mkdirSync(overlay, { recursive: true });
+    } catch {
+        return false;
+    }
+    const realEntries = new Set<string>();
+    try {
+        for (const entry of fs.readdirSync(realHome)) realEntries.add(entry);
+    } catch {}
+    try {
+        for (const entry of fs.readdirSync(overlay)) {
+            if (entry === generatedFile) continue;
+            const overlayPath = path.join(overlay, entry);
+            if (entry.startsWith(`.${generatedFile}.`) && entry.endsWith(".tmp")) {
+                try {
+                    fs.unlinkSync(overlayPath);
+                } catch {}
+                continue;
+            }
+            let st: fs.Stats;
+            try {
+                st = fs.lstatSync(overlayPath);
+            } catch {
+                continue;
+            }
+            if (st.isSymbolicLink()) {
+                let target: string | undefined;
+                try {
+                    target = fs.readlinkSync(overlayPath);
+                } catch {}
+                const wanted = realEntries.has(entry) ? path.join(realHome, entry) : undefined;
+                if (!wanted || target !== wanted) {
+                    try {
+                        fs.unlinkSync(overlayPath);
+                    } catch {}
+                }
+            } else if (realEntries.has(entry)) {
+                if (st.isDirectory()) mergeOverlayDir(overlayPath, path.join(realHome, entry));
+                try {
+                    fs.rmSync(overlayPath, { recursive: true, force: true });
+                } catch {}
+            }
+        }
+        for (const entry of realEntries) {
+            if (entry === generatedFile) continue;
+            try {
+                fs.symlinkSync(path.join(realHome, entry), path.join(overlay, entry));
+            } catch {}
+        }
+    } catch {}
+    return true;
+}
+
+function mergeOverlayDir(fromDir: string, toDir: string): void {
+    try {
+        fs.mkdirSync(toDir, { recursive: true });
+        for (const child of fs.readdirSync(fromDir)) {
+            const dst = path.join(toDir, child);
+            if (fs.existsSync(dst)) continue;
+            try {
+                fs.renameSync(path.join(fromDir, child), dst);
+            } catch {}
+        }
+    } catch {}
+}
+
+function writeOverlayFileAtomic(overlay: string, fileName: string, contents: string): void {
+    const draft = path.join(overlay, `.${fileName}.${process.pid}.tmp`);
+    try {
+        fs.writeFileSync(draft, contents);
+        fs.renameSync(draft, path.join(overlay, fileName));
+    } catch {
+        try {
+            fs.rmSync(draft, { force: true });
+        } catch {}
+    }
+}
+
 export function preparePiHttpRewrite(
     piHome: string,
     origin: string,
@@ -450,26 +549,18 @@ export function preparePiHttpRewrite(
             }
         }
     }
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "bili-pi-"));
-    try {
-        for (const entry of fs.readdirSync(piHome)) {
-            if (entry === "models.json") continue;
-            try {
-                fs.symlinkSync(path.join(piHome, entry), path.join(tmp, entry));
-            } catch {}
-        }
-    } catch {}
-    fs.writeFileSync(path.join(tmp, "models.json"), JSON.stringify(root));
-    return tmp;
+    const overlay = `${piHome}-bili`;
+    if (!refreshOverlayHome(piHome, overlay, "models.json")) return undefined;
+    writeOverlayFileAtomic(overlay, "models.json", JSON.stringify(root));
+    return overlay;
 }
 
 /**
- * omp counterpart of preparePiHttpRewrite: build an isolated PI_CODING_AGENT_DIR
- * that symlinks every entry of the real omp home EXCEPT models.yml, and write a
- * models.yml whose target providers' baseUrl is rewritten (HTTP → /bili/ wrap,
- * wrapped-HTTPS → raw https for cert MITM). The real models.yml is never
- * touched. The rewrite is line-based (indentation-tracked) so all other bytes —
- * comments, ordering, formatting — are preserved verbatim.
+ * omp counterpart of preparePiHttpRewrite: line-based (indentation-tracked)
+ * models.yml rewrite (HTTP → /bili/ wrap, wrapped-HTTPS → raw https for cert
+ * MITM) riding the persistent `<ompHome>-bili` overlay from
+ * refreshOverlayHome — comments, ordering and formatting are preserved
+ * verbatim, and the real models.yml is never touched.
  */
 export function prepareOmpHttpRewrite(
     ompHome: string,
@@ -518,27 +609,20 @@ export function prepareOmpHttpRewrite(
             }
         }
     }
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "bili-omp-"));
-    try {
-        for (const entry of fs.readdirSync(ompHome)) {
-            if (entry === "models.yml") continue;
-            try {
-                fs.symlinkSync(path.join(ompHome, entry), path.join(tmp, entry));
-            } catch {}
-        }
-    } catch {}
-    fs.writeFileSync(path.join(tmp, "models.yml"), lines.join("\n"));
-    return tmp;
+    const overlay = `${ompHome}-bili`;
+    if (!refreshOverlayHome(ompHome, overlay, "models.yml")) return undefined;
+    writeOverlayFileAtomic(overlay, "models.yml", lines.join("\n"));
+    return overlay;
 }
 
 /**
- * hermes counterpart of prepareOmpHttpRewrite: an isolated HERMES_HOME (temp
- * dir, every ~/.hermes sibling symlinked so skills/memories/sessions stay
+ * hermes counterpart of prepareOmpHttpRewrite: a persistent `<hermesHome>-bili`
+ * overlay (every ~/.hermes sibling symlinked so skills/memories/sessions stay
  * shared) holding a rewritten copy of config.yaml. Every provider endpoint
  * line (api: / base_url: / url:) is rewrapped as origin + "/bili/" + raw
  * upstream — http AND https alike, since hermes's httpx stack can't consume
  * the MITM CA without extra trust config. The real ~/.hermes is never
- * touched. Returns the temp dir (undefined when nothing is rewritable).
+ * touched. Returns the overlay dir (undefined when nothing is rewritable).
  */
 export function prepareHermesHome(
     hermesHome: string,
@@ -569,17 +653,10 @@ export function prepareHermesHome(
         changed = true;
     }
     if (!changed) return undefined;
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "bili-hermes-"));
-    try {
-        for (const entry of fs.readdirSync(hermesHome)) {
-            if (entry === "config.yaml") continue;
-            try {
-                fs.symlinkSync(path.join(hermesHome, entry), path.join(tmp, entry));
-            } catch {}
-        }
-    } catch {}
-    fs.writeFileSync(path.join(tmp, "config.yaml"), lines.join(eol));
-    return tmp;
+    const overlay = `${hermesHome}-bili`;
+    if (!refreshOverlayHome(hermesHome, overlay, "config.yaml")) return undefined;
+    writeOverlayFileAtomic(overlay, "config.yaml", lines.join(eol));
+    return overlay;
 }
 
 /**
@@ -880,10 +957,10 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
     const ca = resolveCaCertPath(process.env);
     let env: NodeJS.ProcessEnv;
     let clientArgs = params.clientArgs;
-    let piTmpHome: string | undefined;
-    let ompTmpHome: string | undefined;
+    let piOverlayHome: string | undefined;
+    let ompOverlayHome: string | undefined;
     let opencodeTmpFile: string | undefined;
-    let hermesTmpHome: string | undefined;
+    let hermesOverlayHome: string | undefined;
     const tmpFiles: string[] = [];
     const directUrl = launcherDirectUrl(process.env);
     if (directUrl) {
@@ -904,14 +981,15 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
     const origin = handle.origin;
     if (base === "pi") {
         env = buildPiEnv(origin, ca, process.env);
-        piTmpHome = preparePiHttpRewrite(resolvePiHome(process.env), origin, routes.httpRewrites, routes.httpsRewrites);
-        if (piTmpHome) env.PI_CODING_AGENT_DIR = piTmpHome;
+        piOverlayHome = preparePiHttpRewrite(resolvePiHome(process.env), origin, routes.httpRewrites, routes.httpsRewrites);
+        if (piOverlayHome) env.PI_CODING_AGENT_DIR = piOverlayHome;
     } else if (base === "omp") {
         // omp is pi-based: same env as pi (HTTPS_PROXY + CA + BILLION_CONTEXT_PROXY);
-        // the /bili/ rewrite rides an isolated PI_CODING_AGENT_DIR (real models.yml untouched).
+        // the /bili/ rewrite rides a persistent overlay PI_CODING_AGENT_DIR
+        // (~/.omp/agent-bili; real models.yml untouched, session paths stay resolvable).
         env = buildPiEnv(origin, ca, process.env);
-        ompTmpHome = prepareOmpHttpRewrite(resolveOmpHome(process.env), origin, routes.httpRewrites, routes.httpsRewrites);
-        if (ompTmpHome) env.PI_CODING_AGENT_DIR = ompTmpHome;
+        ompOverlayHome = prepareOmpHttpRewrite(resolveOmpHome(process.env), origin, routes.httpRewrites, routes.httpsRewrites);
+        if (ompOverlayHome) env.PI_CODING_AGENT_DIR = ompOverlayHome;
     } else if (base === "opencode") {
         // opencode: HTTPS upstreams ride cert-MITM (HTTPS_PROXY + CA); plaintext
         // HTTP upstreams get a /bili/-rewritten copy of opencode.json via
@@ -924,13 +1002,14 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
         if (opencodeTmpFile) env.OPENCODE_CONFIG = opencodeTmpFile;
     } else if (base === "hermes") {
         // hermes: no plugin, no MITM cert trust (httpx builds its own CA
-        // bundle) — every upstream rides the /bili/ URL form via an isolated
-        // HERMES_HOME whose config.yaml is rewritten. skills/memories/sessions
-        // stay shared through symlinks; the real ~/.hermes is never touched.
+        // bundle) — every upstream rides the /bili/ URL form via a persistent
+        // overlay HERMES_HOME (~/.hermes-bili) whose config.yaml is rewritten.
+        // skills/memories/sessions stay shared through symlinks; the real
+        // ~/.hermes is never touched.
         env = { ...process.env };
-        hermesTmpHome = prepareHermesHome(resolveHermesHome(process.env), origin, routes.httpRewrites);
-        if (hermesTmpHome) {
-            env.HERMES_HOME = hermesTmpHome;
+        hermesOverlayHome = prepareHermesHome(resolveHermesHome(process.env), origin, routes.httpRewrites);
+        if (hermesOverlayHome) {
+            env.HERMES_HOME = hermesOverlayHome;
         } else {
             console.error(
                 routes.httpRewrites.length === 0
@@ -975,21 +1054,6 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
         code = 1;
     } finally {
         stopProxy(handle);
-        if (piTmpHome) {
-            try {
-                fs.rmSync(piTmpHome, { recursive: true, force: true });
-            } catch {}
-        }
-        if (ompTmpHome) {
-            try {
-                fs.rmSync(ompTmpHome, { recursive: true, force: true });
-            } catch {}
-        }
-        if (hermesTmpHome) {
-            try {
-                fs.rmSync(hermesTmpHome, { recursive: true, force: true });
-            } catch {}
-        }
         if (opencodeTmpFile) {
             try {
                 fs.rmSync(path.dirname(opencodeTmpFile), { recursive: true, force: true });

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -426,15 +426,48 @@ export function buildCodexMcpArgs(origin: string, conversationId: string): strin
  *
  * Refresh semantics on every launch: stale `.file.pid.tmp` drafts are dropped;
  * dead or mis-targeted symlinks are re-pointed; real files/dirs that shadow a
- * real-home entry are merged into the real home before being replaced by a
- * symlink (no data loss); entries the real home lacks are kept as-is.
+ * real-home entry are merged into the real home (recursively; mtime-newer-wins
+ * for files, losers preserved as `<name>.bili-conflict`) and only removed from
+ * the overlay when the merge fully succeeded; entries the real home lacks are
+ * kept as-is. A `.bili-launch.pid` marker warns when two launches share the
+ * overlay (each launch rewrites the generated file with its own proxy origin).
  */
+function overlayLockPath(overlay: string): string {
+    return path.join(overlay, ".bili-launch.pid");
+}
+
+function livePidHoldsOverlay(overlay: string): number | undefined {
+    let raw: string | undefined;
+    try {
+        raw = fs.readFileSync(overlayLockPath(overlay), "utf8");
+    } catch {
+        return undefined;
+    }
+    const pid = Number.parseInt(raw.trim(), 10);
+    if (!Number.isInteger(pid) || pid <= 0 || pid === process.pid) return undefined;
+    try {
+        process.kill(pid, 0);
+    } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === "ESRCH") return undefined;
+    }
+    return pid;
+}
+
 function refreshOverlayHome(realHome: string, overlay: string, generatedFile: string): boolean {
     try {
         fs.mkdirSync(overlay, { recursive: true });
     } catch {
         return false;
     }
+    const holder = livePidHoldsOverlay(overlay);
+    if (holder !== undefined) {
+        console.error(
+            `bili: another bili launch (pid ${holder}) is using ${overlay} — concurrent launches share this overlay and the last one's proxy port wins in the generated config.`,
+        );
+    }
+    try {
+        fs.writeFileSync(overlayLockPath(overlay), `${process.pid}\n`);
+    } catch {}
     const realEntries = new Set<string>();
     try {
         for (const entry of fs.readdirSync(realHome)) realEntries.add(entry);
@@ -467,10 +500,13 @@ function refreshOverlayHome(realHome: string, overlay: string, generatedFile: st
                     } catch {}
                 }
             } else if (realEntries.has(entry)) {
-                if (st.isDirectory()) mergeOverlayDir(overlayPath, path.join(realHome, entry));
-                try {
-                    fs.rmSync(overlayPath, { recursive: true, force: true });
-                } catch {}
+                if (mergeOverlayEntry(overlayPath, path.join(realHome, entry))) {
+                    try {
+                        fs.rmSync(overlayPath, { recursive: true, force: true });
+                    } catch {}
+                } else {
+                    console.error(`bili: could not merge ${overlayPath} into ${realHome} — kept in place, resolve manually.`);
+                }
             }
         }
         for (const entry of realEntries) {
@@ -483,17 +519,86 @@ function refreshOverlayHome(realHome: string, overlay: string, generatedFile: st
     return true;
 }
 
-function mergeOverlayDir(fromDir: string, toDir: string): void {
+function mergeOverlayEntry(src: string, dst: string): boolean {
+    let st: fs.Stats;
     try {
-        fs.mkdirSync(toDir, { recursive: true });
-        for (const child of fs.readdirSync(fromDir)) {
-            const dst = path.join(toDir, child);
-            if (fs.existsSync(dst)) continue;
-            try {
-                fs.renameSync(path.join(fromDir, child), dst);
-            } catch {}
-        }
+        st = fs.lstatSync(src);
+    } catch {
+        return true;
+    }
+    let dstStat: fs.Stats | undefined;
+    try {
+        dstStat = fs.lstatSync(dst);
     } catch {}
+    if (st.isDirectory()) {
+        if (dstStat && !dstStat.isDirectory()) {
+            try {
+                fs.renameSync(dst, `${dst}.bili-conflict`);
+                dstStat = undefined;
+            } catch {
+                return false;
+            }
+        }
+        try {
+            fs.mkdirSync(dst, { recursive: true });
+        } catch {
+            return false;
+        }
+        let entries: string[];
+        try {
+            entries = fs.readdirSync(src);
+        } catch {
+            return false;
+        }
+        let ok = true;
+        for (const entry of entries) {
+            if (!mergeOverlayEntry(path.join(src, entry), path.join(dst, entry))) ok = false;
+        }
+        return ok;
+    }
+    if (dstStat && dstStat.isDirectory()) {
+        try {
+            fs.renameSync(src, `${dst}.bili-conflict`);
+            return true;
+        } catch {
+            return false;
+        }
+    }
+    if (st.isSymbolicLink()) {
+        if (dstStat) {
+            try {
+                fs.unlinkSync(src);
+            } catch {}
+            return true;
+        }
+        try {
+            fs.renameSync(src, dst);
+        } catch {
+            return false;
+        }
+        return true;
+    }
+    if (dstStat && dstStat.mtimeMs >= st.mtimeMs) {
+        try {
+            fs.renameSync(src, `${dst}.bili-conflict`);
+            return true;
+        } catch {
+            return false;
+        }
+    }
+    if (dstStat) {
+        try {
+            fs.renameSync(dst, `${dst}.bili-conflict`);
+        } catch {
+            return false;
+        }
+    }
+    try {
+        fs.renameSync(src, dst);
+        return true;
+    } catch {
+        return false;
+    }
 }
 
 function writeOverlayFileAtomic(overlay: string, fileName: string, contents: string): void {

--- a/tests/launcher.test.ts
+++ b/tests/launcher.test.ts
@@ -725,12 +725,69 @@ test("prepareOmpHttpRewrite: rewrites matching provider, leaves others, symlinks
         { key: "a", realUpstream: "http://example.com/v1" },
     ], []);
     try {
-        assert.ok(typeof tmp === "string" && tmp.length > 0);
+        assert.equal(tmp, `${home}-bili`);
         const out = fs.readFileSync(path.join(tmp!, "models.yml"), "utf8");
         assert.ok(out.includes("baseUrl: http://127.0.0.1:8787/bili/http://example.com/v1"), "a rewritten");
         assert.ok(out.includes("baseUrl: https://secure.example.com"), "b unchanged");
         assert.equal(fs.lstatSync(path.join(tmp!, "config.yml")).isSymbolicLink(), true);
         assert.equal(fs.realpathSync(path.join(tmp!, "config.yml")), path.join(home, "config.yml"));
+    } finally {
+        if (tmp) fs.rmSync(tmp, { recursive: true, force: true });
+        fs.rmSync(home, { recursive: true, force: true });
+    }
+});
+
+test("prepareOmpHttpRewrite: overlay is stable, refreshes symlinks, keeps bili-created entries", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "bili-omphome-"));
+    const modelsYml = ["providers:", "  a:", "    baseUrl: http://example.com/v1"].join("\n");
+    fs.writeFileSync(path.join(home, "models.yml"), modelsYml);
+    fs.mkdirSync(path.join(home, "sessions"));
+    const rw = [{ key: "a", realUpstream: "http://example.com/v1" }];
+    let tmp: string | undefined;
+    try {
+        tmp = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", rw, []);
+        assert.equal(tmp, `${home}-bili`);
+        assert.equal(fs.lstatSync(path.join(tmp!, "sessions")).isSymbolicLink(), true);
+        fs.writeFileSync(path.join(tmp!, "agent.db"), "state-created-inside-overlay");
+        const tmp2 = prepareOmpHttpRewrite(home, "http://127.0.0.1:9999", rw, []);
+        assert.equal(tmp2, tmp);
+        assert.equal(fs.readFileSync(path.join(tmp!, "agent.db"), "utf8"), "state-created-inside-overlay");
+        const rewritten = fs.readFileSync(path.join(tmp!, "models.yml"), "utf8");
+        assert.ok(rewritten.includes("baseUrl: http://127.0.0.1:9999/bili/http://example.com/v1"), "port updated");
+        fs.mkdirSync(path.join(home, "memories"));
+        const tmp3 = prepareOmpHttpRewrite(home, "http://127.0.0.1:9999", rw, []);
+        assert.equal(tmp3, tmp);
+        assert.equal(fs.lstatSync(path.join(tmp!, "memories")).isSymbolicLink(), true);
+        const leftovers = fs.readdirSync(tmp!).filter((f) => /^\.models\.yml\.\d+\.tmp$/.test(f));
+        assert.deepEqual(leftovers, [], "no leftover models.yml tmp files");
+    } finally {
+        if (tmp) fs.rmSync(tmp, { recursive: true, force: true });
+        fs.rmSync(home, { recursive: true, force: true });
+    }
+});
+
+test("prepareOmpHttpRewrite: drops dead symlinks and merges shadowed dirs into real home", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "bili-omphome-"));
+    const modelsYml = ["providers:", "  a:", "    baseUrl: http://example.com/v1"].join("\n");
+    fs.writeFileSync(path.join(home, "models.yml"), modelsYml);
+    fs.mkdirSync(path.join(home, "sessions"));
+    const rw = [{ key: "a", realUpstream: "http://example.com/v1" }];
+    const overlay = `${home}-bili`;
+    let tmp: string | undefined;
+    try {
+        tmp = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", rw, []);
+        fs.symlinkSync(path.join(home, "gone-entry"), path.join(overlay, "gone-entry"));
+        fs.rmSync(path.join(overlay, "sessions"));
+        fs.mkdirSync(path.join(overlay, "sessions"));
+        fs.writeFileSync(path.join(overlay, "sessions", "orphaned.jsonl"), "session-created-under-bili");
+        tmp = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", rw, []);
+        assert.equal(fs.existsSync(path.join(overlay, "gone-entry")), false, "dead symlink dropped");
+        assert.equal(fs.lstatSync(path.join(overlay, "sessions")).isSymbolicLink(), true, "shadow dir re-linked");
+        assert.equal(
+            fs.readFileSync(path.join(home, "sessions", "orphaned.jsonl"), "utf8"),
+            "session-created-under-bili",
+            "shadow dir merged into real home",
+        );
     } finally {
         if (tmp) fs.rmSync(tmp, { recursive: true, force: true });
         fs.rmSync(home, { recursive: true, force: true });

--- a/tests/launcher.test.ts
+++ b/tests/launcher.test.ts
@@ -794,6 +794,86 @@ test("prepareOmpHttpRewrite: drops dead symlinks and merges shadowed dirs into r
     }
 });
 
+test("prepareOmpHttpRewrite: shadow FILE merged newer-wins, loser kept as .bili-conflict", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "bili-omphome-"));
+    const modelsYml = ["providers:", "  a:", "    baseUrl: http://example.com/v1"].join("\n");
+    fs.writeFileSync(path.join(home, "models.yml"), modelsYml);
+    fs.writeFileSync(path.join(home, "settings.json"), "stale-from-real-home");
+    fs.writeFileSync(path.join(home, "older.json"), "real-newer");
+    const rw = [{ key: "a", realUpstream: "http://example.com/v1" }];
+    const overlay = `${home}-bili`;
+    let tmp: string | undefined;
+    try {
+        tmp = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", rw, []);
+        assert.equal(fs.readFileSync(path.join(overlay, ".bili-launch.pid"), "utf8").trim(), `${process.pid}`, "launch pid marker written");
+        fs.rmSync(path.join(overlay, "settings.json"));
+        fs.writeFileSync(path.join(overlay, "settings.json"), "client-newer-write");
+        const now = Date.now();
+        fs.utimesSync(path.join(home, "settings.json"), new Date(now - 4000), new Date(now - 4000));
+        fs.rmSync(path.join(overlay, "older.json"));
+        fs.writeFileSync(path.join(overlay, "older.json"), "overlay-stale");
+        fs.utimesSync(path.join(overlay, "older.json"), new Date(now - 4000), new Date(now - 4000));
+        tmp = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", rw, []);
+        assert.equal(fs.readFileSync(path.join(home, "settings.json"), "utf8"), "client-newer-write", "newer overlay file wins");
+        assert.equal(fs.readFileSync(path.join(home, "settings.json.bili-conflict"), "utf8"), "stale-from-real-home", "loser preserved as conflict copy");
+        assert.equal(fs.lstatSync(path.join(overlay, "settings.json")).isSymbolicLink(), true, "shadow file re-linked");
+        assert.equal(fs.readFileSync(path.join(home, "older.json"), "utf8"), "real-newer", "newer real-home file wins");
+        assert.equal(fs.readFileSync(path.join(home, "older.json.bili-conflict"), "utf8"), "overlay-stale", "stale overlay copy preserved as conflict");
+        assert.equal(fs.lstatSync(path.join(overlay, "older.json")).isSymbolicLink(), true, "re-linked after merge");
+    } finally {
+        if (tmp) fs.rmSync(tmp, { recursive: true, force: true });
+        fs.rmSync(home, { recursive: true, force: true });
+    }
+});
+
+test("prepareOmpHttpRewrite: recursive dir merge keeps deep new files when both sides share a subdir", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "bili-omphome-"));
+    const modelsYml = ["providers:", "  a:", "    baseUrl: http://example.com/v1"].join("\n");
+    fs.writeFileSync(path.join(home, "models.yml"), modelsYml);
+    fs.mkdirSync(path.join(home, "sessions", "sub"), { recursive: true });
+    fs.writeFileSync(path.join(home, "sessions", "sub", "old.jsonl"), "old");
+    const rw = [{ key: "a", realUpstream: "http://example.com/v1" }];
+    const overlay = `${home}-bili`;
+    let tmp: string | undefined;
+    try {
+        tmp = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", rw, []);
+        fs.rmSync(path.join(overlay, "sessions"));
+        fs.mkdirSync(path.join(overlay, "sessions", "sub"), { recursive: true });
+        fs.writeFileSync(path.join(overlay, "sessions", "sub", "new.jsonl"), "deep-new-session");
+        tmp = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", rw, []);
+        assert.equal(fs.readFileSync(path.join(home, "sessions", "sub", "old.jsonl"), "utf8"), "old", "existing deep file untouched");
+        assert.equal(fs.readFileSync(path.join(home, "sessions", "sub", "new.jsonl"), "utf8"), "deep-new-session", "deep new file merged, not destroyed");
+        assert.equal(fs.lstatSync(path.join(overlay, "sessions")).isSymbolicLink(), true, "shadow dir re-linked");
+    } finally {
+        if (tmp) fs.rmSync(tmp, { recursive: true, force: true });
+        fs.rmSync(home, { recursive: true, force: true });
+    }
+});
+
+test("prepareOmpHttpRewrite: file-vs-dir type clash preserves both sides", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "bili-omphome-"));
+    const modelsYml = ["providers:", "  a:", "    baseUrl: http://example.com/v1"].join("\n");
+    fs.writeFileSync(path.join(home, "models.yml"), modelsYml);
+    fs.writeFileSync(path.join(home, "state.bin"), "v1-file");
+    const rw = [{ key: "a", realUpstream: "http://example.com/v1" }];
+    const overlay = `${home}-bili`;
+    let tmp: string | undefined;
+    try {
+        tmp = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", rw, []);
+        fs.rmSync(path.join(overlay, "state.bin"));
+        fs.mkdirSync(path.join(overlay, "state.bin", "x"), { recursive: true });
+        fs.writeFileSync(path.join(overlay, "state.bin", "x", "precious.txt"), "precious");
+        tmp = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", rw, []);
+        assert.equal(fs.statSync(path.join(home, "state.bin")).isDirectory(), true, "merged dir took the canonical name");
+        assert.equal(fs.readFileSync(path.join(home, "state.bin", "x", "precious.txt"), "utf8"), "precious", "overlay subtree preserved, not destroyed");
+        assert.equal(fs.readFileSync(path.join(home, "state.bin.bili-conflict"), "utf8"), "v1-file", "displaced real-home file preserved as conflict copy");
+        assert.equal(fs.lstatSync(path.join(overlay, "state.bin")).isSymbolicLink(), true, "re-linked after merge");
+    } finally {
+        if (tmp) fs.rmSync(tmp, { recursive: true, force: true });
+        fs.rmSync(home, { recursive: true, force: true });
+    }
+});
+
 test("prepareOmpHttpRewrite: returns undefined when no rewrites", () => {
     assert.equal(prepareOmpHttpRewrite("/whatever", "http://127.0.0.1:8787", [], []), undefined);
 });

--- a/tests/launcher.test.ts
+++ b/tests/launcher.test.ts
@@ -262,9 +262,14 @@ import { selfPackageRoot } from "../src/plugin-install.js";
 test("runLaunch pi: native -e plugin injected only when not installed", async () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "bili-pie-"));
     const prevHome = process.env.HOME;
+    const prevUserProfile = process.env.USERPROFILE;
     const prevPiBin = process.env.PI_BIN;
     const prevPiDir = process.env.PI_CODING_AGENT_DIR;
     process.env.HOME = home;
+    // resolvePiHome falls back to os.homedir(), which on Windows reads
+    // USERPROFILE, not HOME — set both or the test reads the runner's real
+    // home and the second assertion fails.
+    if (prevUserProfile !== undefined) process.env.USERPROFILE = home;
     delete process.env.PI_CODING_AGENT_DIR;
     const fakePi = path.join(home, "fake-pi");
     fs.writeFileSync(fakePi, "");
@@ -331,6 +336,8 @@ test("runLaunch pi: native -e plugin injected only when not installed", async ()
     } finally {
         process.exit = prevExit;
         process.env.HOME = prevHome;
+        if (prevUserProfile === undefined) delete process.env.USERPROFILE;
+        else process.env.USERPROFILE = prevUserProfile;
         if (prevPiBin === undefined) delete process.env.PI_BIN;
         else process.env.PI_BIN = prevPiBin;
         if (prevPiDir === undefined) delete process.env.PI_CODING_AGENT_DIR;


### PR DESCRIPTION
Fixes #12 (omp session history invisible via `bili omp`) plus the same bug class in the pi and hermes launchers.

## Root cause

`bili omp` pointed `PI_CODING_AGENT_DIR` at a `mkdtemp` temp home (entries symlinked to `~/.omp/agent`, rewritten `models.yml`) and `rm -rf`'d it in a `finally` when the client exited. Two loss modes:

1. **Dangling resume pointers** — omp persists *absolute* session paths derived from the temp home into shared state. Found on the reporting machine: `~/.omp/agent/terminal-sessions/pts-1` contained `/tmp/bili-omp-*/sessions/.../*.jsonl` — dangling after cleanup, so resume-last-session could not find the session.
2. **Files destroyed with the temp home** — anything the client created *directly inside* the temp home (`agent.db`, `models.db`, ...) ceased to exist on exit.

Also: killed processes skipped the `finally`, leaking `/tmp/bili-omp-*` dirs (3 found; plus 4 `bili-pi-*`, 2 `bili-hermes-*`).

pi (`PI_CODING_AGENT_DIR`) and hermes (`HERMES_HOME`, `terminal-sessions/<id>` last-session pointers) have the identical bug class. opencode/claude/codex launchers are env/temp-file only — unaffected.

## Fix

Replace temp homes with **stable persistent overlays** next to the real home: `~/.omp/agent-bili`, `~/.pi/agent-bili`, `~/.hermes-bili`. Every launch:

- refreshes entry symlinks (drops dead ones; merges overlay-created entries that shadow real-home entries back into the real home, so no data is ever lost)
- rewrites the generated config (`models.yml` / `models.json` / `config.yaml`) atomically
- never deletes the overlay — all paths the client persisted stay resolvable across runs

The real home's config files remain untouched.

## Test plan

- `npm run typecheck` ✓
- `npm test` — 567/567 ✓ (new launcher tests: overlay path is `<home>-bili` and stable across launches; symlink refresh picks up new real-home entries; bili-created state inside the overlay survives; dead symlinks dropped; shadowed dirs merged into the real home)
- `npm run build` ✓