### PR TITLE
docs: recover deleted README usage detail into CONFIGURATION (en+zh)

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -344,3 +344,277 @@ Environment variables take precedence over the config file. They are useful for 
 | `ACP_PROVIDERS` | Path to an external `providers.json` (legacy / shared file). |
 | `BILI_REPLAY_RETRY_BASE_MS` | Base backoff delay (ms) for acp-loop replay retries after a transient upstream rejection (default `1500`; set `0` to disable the delay). See #189. |
 | `BILI_REPLAY_RETRY_MAX` | Total attempts for acp-loop replay retries (default `3`; set `1` to disable retries entirely — legacy fail-fast behavior). See #189. |
+| `ACP_SESSION_HEADER` | Conversation-id header name (default `x-acp-session`). |
+| `ACP_REASONING_KEEP` | Responses API only: set `none` to drop all reasoning items. Default routes reasoning through the compression pipeline so it is hidden automatically once its turn is summarized (prevents the unbounded accumulation that broke Codex's prompt-cache prefix). |
+| `ACP_LOG_FILE` | Log file path (default XDG state path; `off` disables the file, keeps stderr). Auto-rotates at 10 MB. |
+| `ACP_DUMP_SSE` | Directory to dump raw SSE frames for debugging. |
+| `BILI_UPSTREAM_PROXY` | Upstream proxy for the proxy's own outbound connections — highest priority, above per-URL/per-provider config. See the README *Upstream proxy* section. |
+| `BILI_PERSIST` | Set `0` to disable session persistence (in-memory only, lost on restart). |
+| `BILI_PERSIST_DEBOUNCE_MS` | Debounce window for persistence writes to disk, in ms (default `500`). |
+| `BILI_MAX_SESSIONS` | Max sessions held in memory (default `256`; LRU eviction — disk is the source of truth). |
+| `BILI_SESSIONS_DIR` | Directory for persisted session state (default XDG data dir). |
+| `BILLION_CONTEXT_PROXY` | Exported by the launcher; client-side bili plugins/extensions detect it and self-disable their own compression (no double compression). |
+| `BILLION_CONTEXT_PLUGIN` | Set `0` to disable plugin mode entirely (wire-level tool injection resumes). |
+| `BILI_LAUNCHER_PLUGIN` | Set `1` to have the launcher inject the bili MCP server for claude/codex (native tools). See [Launcher Reference](#launcher-reference). |
+| `BILI_LAUNCHER_DIRECT` | Set `1` for direct-URL routing in the launcher (drop MITM/CA trust). See [Launcher Reference](#launcher-reference). |
+| `BILI_CLAUDE_UPSTREAM` | claude direct mode: your relay endpoint, when `ANTHROPIC_BASE_URL` already points at a relay the launcher would otherwise bypass. |
+
+---
+
+## CLI Reference
+
+Full command surface (`bili --help` prints an abridged version). Precedence everywhere: **CLI flag > env var > config file > built-in default**.
+
+| Command | What it does |
+|---|---|
+| `bili [start] [options]` | Start the proxy (reads the XDG config file by default) |
+| `bili pi [opts --] [args]` | Start a proxy + launch **pi** against it |
+| `bili pi-test [opts --] [args]` | Like `bili pi`, but adds `--no-extensions` (clean-room test — the proxy owns compression) |
+| `bili codex [opts --] [args]` | Proxy + **codex** |
+| `bili claude [opts --] [args]` | Proxy + **claude** (Claude Code CLI) |
+| `bili omp [opts --] [args]` | Proxy + **omp** (pi-based) |
+| `bili opencode [opts --] [args]` | Proxy + **opencode** |
+| `bili hermes [opts --] [args]` | Proxy + **hermes-agent** (`/bili/` rewrite) |
+| `bili test pi` | Non-polluting end-to-end smoke test of the pi path |
+| `bili export [session] [--full] [--output FILE]` | List persisted sessions / export one as a Markdown handoff — see [Sessions & Migration](#sessions--migration) |
+| `bili update` | Check for & install a newer version now (bypasses the 3-minute throttle) |
+| `bili plugin install <agent>` | Install the native-tool plugin / MCP bridge into a host — see [Plugin Mode](#plugin-mode-native-tools) |
+| `bili plugin remove <agent>` | Remove it again |
+| `bili plugin list` | Show install status for every host |
+| `bili mcp` | Run the bili MCP server standalone on stdio |
+| `bili plugin-register <id> [--origin URL] [--agent name]` | Pre-bind a conversation id to plugin mode (advanced) |
+| `bili --version` / `bili --help` | Print version / help |
+
+Anything after `--` in a launcher command is passed through to the client verbatim (`bili pi -- print "hi"`).
+
+### Options
+
+| Flag | Effect |
+|---|---|
+| `--port <N>` | Listen port (default `8787`) |
+| `--host <ADDR>` | Listen host (default `127.0.0.1`) |
+| `--config <FILE>` | Path to config JSON (default: XDG location) |
+| `--debug` | Verbose logging |
+| `--passthrough` | Forward without compression |
+| `--no-passthrough` | Force compression on (overrides config) |
+| `--no-auto-update` | Disable background self-update for this run |
+| `--mitm-domain <domain>` | Extra MITM whitelist entry (repeatable; launcher only) |
+
+---
+
+## Client Integration
+
+Two ways to point a client at the proxy without the launcher: the **`/bili/` prefix** (API-key clients) and **MITM transparent mode** (login clients with hardcoded endpoints).
+
+### `/bili/` prefix (API-key clients)
+
+Clients you configure with an **API key** (not a login) let you change the upstream URL. Prepend the proxy origin + `/bili/` to it — that's the only change. The API key stays in the client config and is passed through untouched.
+
+**OpenCode** — edit `~/.config/opencode/opencode.json`, change the provider's `baseURL`:
+
+```jsonc
+// before:
+"baseURL": "https://open.bigmodel.cn/api/coding/paas/v4"
+// after (prepend the proxy origin + /bili/):
+"baseURL": "http://localhost:8787/bili/https://open.bigmodel.cn/api/coding/paas/v4"
+```
+
+**Codex (API key)** — edit `~/.codex/config.toml`, change the provider's `base_url`:
+
+```toml
+# before:
+base_url = "https://api.openai.com/v1"
+# after:
+base_url = "http://localhost:8787/bili/https://api.openai.com/v1"
+```
+
+**Codex (ChatGPT login)** — set the top-level `openai_base_url` field (keeps `model_provider = "openai"` and OAuth login intact):
+
+```toml
+# ~/.codex/config.toml (top-level field, not a section)
+model_provider = "openai"
+openai_base_url = "http://localhost:8787/bili/https://chatgpt.com/backend-api/codex"
+```
+
+Run `codex login` as usual; the OAuth token travels in the `Authorization` header, which the proxy forwards untouched.
+
+**Pi** — edit `~/.pi/agent/models.json`, change the provider's `baseUrl`:
+
+```jsonc
+// before:
+"baseUrl": "https://api.anthropic.com"
+// after:
+"baseUrl": "http://localhost:8787/bili/https://api.anthropic.com"
+```
+
+**Other API-key clients** (Cursor / Aider / Continue …) — wherever the upstream URL is configured, prepend `http://localhost:8787/bili/`. Nothing else changes.
+
+The `/bili/` prefix doubles as a **self-detection signal**: billion-context client extensions (billion-context-pi / opencode-acp) recognize it in their own baseUrl and self-disable, so you never get double compression.
+
+### MITM transparent proxy (login clients)
+
+Clients you sign **into an account** (ChatGPT Plus/Pro, Claude, ZCode coding plan, …) authenticate via OAuth and often **hardcode the endpoint** — if you can't change the baseURL, the prefix trick doesn't work. These use MITM mode instead.
+
+How it works: the client only offers an **HTTP proxy** setting, so it sends `CONNECT <host>:443`; billion-context terminates the TLS locally (with a locally-generated root CA), injects compression into the cleartext, re-encrypts and forwards. The OAuth token travels in the client's `Authorization` header, which is forwarded untouched — so the subscription discount is preserved.
+
+Supported MITM clients:
+
+| Client | Login | Endpoint hardcoded | Status |
+|---|---|---|---|
+| **ZCode** | bigmodel coding plan (OAuth) | `open.bigmodel.cn` (builtin provider) | ✅ tested |
+| **Claude Code** | Claude subscription (OAuth) | `api.anthropic.com` | ❓ untested (may not work — needs verification) |
+
+> **Codex exception:** Codex exposes a top-level `openai_base_url` config field, so the ChatGPT login version CAN use the `/bili/` prefix (see above). MITM is not needed for Codex.
+
+MITM is scoped to a **whitelist** of model hosts (`open.bigmodel.cn`, `api.anthropic.com`, `api.openai.com`, `chatgpt.com`). All other HTTPS hosts are blind-tunnelled — billion-context never decrypts non-model traffic.
+
+One-time setup (trust the root CA in the client):
+
+1. Start the proxy once to generate the root CA:
+
+   ```bash
+   bili start
+   ls ~/.local/share/billion-context/ca/root-ca.pem   # exists now
+   ```
+
+2. In the client's **Settings → Network / Proxy** set:
+   - **HTTP Proxy**: `http://127.0.0.1:8787`
+   - **Proxy CA certificate path**: `~/.local/share/billion-context/ca/root-ca.pem`
+   - (optional) **No-proxy list**: `localhost,127.0.0.1`
+   - (For ZCode specifically: **Settings → Network**. For Claude Code, set the `HTTPS_PROXY` env var and `NODE_EXTRA_CA_CERTS` to the CA path.)
+
+3. Restart the client. Its model traffic now flows through billion-context with compression injected. Send a message and check the proxy log (`~/.local/state/billion-context/bili.log`) for `mitm <host>:443 tunnel established`.
+
+> The root CA is generated locally and lives only on this machine; it is **not** a system-wide install. Only the client you configure (via its CA-path setting) trusts it, so no other app is affected. Deleting the CA files and restarting the proxy regenerates them.
+
+To give a MITM login client its **own upstream proxy** (firewall/GFW) without affecting API-key clients on the same host, use the `mitm://` scheme key — see the README's *Upstream proxy* section.
+
+---
+
+## Launcher Reference
+
+`bili <client>` brings up a proxy on an independent port (a **fresh instance every launch** — an already-running `bili start` is never reused, #216), then runs the client pointed at it. **No config-file edits**: the client's own config is **read** (never edited) to discover which upstream hosts it talks to; those hosts are auto-whitelisted for MITM so the proxy TLS-terminates exactly the hosts the client uses. When the client exits, a proxy the launcher started is stopped.
+
+Both upstream schemes are covered automatically, with no config edits:
+
+- **HTTPS upstreams → cert MITM.** The client is pointed at the proxy via `HTTPS_PROXY` and trusts the proxy's MITM root CA (`~/.local/share/billion-context/ca/root-ca.pem`, generated lazily). Compression is injected on the intercepted TLS stream.
+- **HTTP / localhost upstreams → `/bili/` baseURL rewrite** (plaintext can't be MITM'd). The launcher rewrites the client's base URL through the client's own mechanism, via an isolated temp copy of its config — the real config files are never touched (details below).
+
+How each client is pointed at the proxy (set automatically in the child env):
+
+| Client | Redirect | CA trust |
+|---|---|---|
+| pi | `HTTPS_PROXY` + isolated `PI_CODING_AGENT_DIR` | `NODE_EXTRA_CA_CERTS` |
+| omp | `HTTPS_PROXY` + isolated `PI_CODING_AGENT_DIR` | `NODE_EXTRA_CA_CERTS` |
+| codex | `HTTPS_PROXY` + `-c key=value` overrides | `SSL_CERT_FILE` → `combined-ca.pem` |
+| claude | `ANTHROPIC_BASE_URL` = `/bili/` URL | none needed |
+| opencode | `HTTPS_PROXY` + isolated `OPENCODE_CONFIG` | `NODE_EXTRA_CA_CERTS` |
+| hermes | isolated `HERMES_HOME`; **all** upstreams `/bili/` | none (certifi ignores `SSL_CERT_FILE`) |
+
+`NODE_EXTRA_CA_CERTS` *appends* to the built-in trust store, so it points at the MITM root alone (`root-ca.pem`). `SSL_CERT_FILE` *replaces* the default CA bundle, so for codex it points at `combined-ca.pem` — a bundle containing the MITM root **plus** the system/Node public roots — keeping pip/git/curl style TLS (blind-tunnelled, real certificates) working inside the child env (#152).
+
+Claude Code's undici fetch ignores `HTTPS_PROXY`, so cert MITM cannot intercept it. Every claude upstream — including a pre-configured `ANTHROPIC_BASE_URL` relay — is routed through the `/bili/` URL form via `ANTHROPIC_BASE_URL` instead; no CA trust is required.
+
+Where upstreams are discovered from (read-only):
+
+| Client | Read from |
+|---|---|
+| Pi | `~/.pi/agent/models.json` — each provider's `baseUrl` |
+| omp | `~/.omp/agent/models.yml` — each provider's `baseUrl` |
+| Codex | `~/.codex/config.toml` — each `[model_providers.<name>]` `base_url` (+ top-level `openai_base_url`) |
+| Claude Code | `ANTHROPIC_BASE_URL` env var, else hardcoded `api.anthropic.com` |
+| OpenCode | `~/.config/opencode/opencode.json` — each provider's `baseURL` |
+| hermes | `~/.hermes/config.yaml` — each provider's endpoint lines |
+
+### Isolated temp config (what gets written)
+
+The `/bili/` rewrite modes write a **temp copy** — the real config is never edited — and the temp dir is removed when the client exits:
+
+- **pi / omp** — an isolated `PI_CODING_AGENT_DIR` (under `/tmp`) containing only a rewritten `models.json` / `models.yml` with the `/bili/`-wrapped plaintext baseUrls. Everything else (`settings.json`, `sessions/`, `auth.json`, extensions…) is **symlinked** to the real pi/omp home, so sessions and logins are shared: a conversation started under the launcher continues seamlessly in a bare client, and vice versa.
+- **opencode** — a temp `opencode.json` pointed at by `OPENCODE_CONFIG`, with `/bili/`-rewritten baseURLs **plus the thin `/acp` plugin appended** (native tools out of the box; the standalone `opencode-acp` plugin self-disables via `BILLION_CONTEXT_PROXY`).
+- **hermes** — an isolated `HERMES_HOME` with a rewritten `config.yaml` routing **every** upstream (HTTP and HTTPS) through `/bili/` (httpx builds its own CA bundle and ignores `SSL_CERT_FILE`, so cert MITM is impossible). `skills/`, `memories/`, `sessions/` are symlinked through. If no providers are configured — or `config.yaml` can't be rewritten — the launcher prints a warning and hermes runs **unproxied** (compression off).
+
+### Native tools in the launcher
+
+- **pi** — if the plugin is NOT installed, the launcher rides pi's `-e <file>` flag to load `dist/agent/pi.js` for that run only (nothing is written): native tools + the `/acp` command out of the box. If it IS installed, the symlinked `settings.json` already loads it — no `-e` is added.
+- **omp** — ships with the plugin built in; nothing to do.
+- **opencode** — the temp config appends the thin plugin automatically.
+- **claude / codex** — opt-in via `BILI_LAUNCHER_PLUGIN=1`: the launcher additionally injects a single `bili` MCP server (`--mcp-config` for claude, `-c mcp_servers.bili.*` for codex — both ephemeral, nothing written to host config). The default stays wire mode while host-flag compatibility soaks (verified with claude 2.1.227 / codex 0.147.0). `BILI_LAUNCHER_PLUGIN=0` forces plain wire mode.
+- **hermes** — no plugin API; always wire mode.
+
+Launcher-mode matrix:
+
+| Mode | Tools surface | Setup |
+|---|---|---|
+| Launcher + MCP (`BILI_LAUNCHER_PLUGIN=1`, claude/codex) | native MCP tools | one env var |
+| Launcher wire mode (default for claude/codex) | proxy-injected wire tools | none — just `bili claude` / `bili codex` |
+| Launcher `-e` / auto-plugin (pi, opencode; omp built-in) | native plugin tools | none |
+| Manual plugin (`bili plugin install`) | agent-side plugin | run install |
+| Manual baseURL (`/bili/` prefix) | proxy-injected wire tools | edit client config |
+
+### Direct-URL mode (opt-in)
+
+`BILI_LAUNCHER_DIRECT=1` drops MITM/CA trust entirely — claude's `ANTHROPIC_BASE_URL` / codex's provider `base_url` point at the `/bili/` prefix directly. Warnings:
+
+- **codex direct mode**: the LLM traffic does **not** go through the proxy, so compression is not applied — only the bili MCP tool calls do. For full compression use the default MITM mode (unset `BILI_LAUNCHER_DIRECT`).
+- **claude direct mode**: `ANTHROPIC_BASE_URL` is overridden to the proxy; a pre-configured relay is bypassed unless `BILI_CLAUDE_UPSTREAM=<relay>` is set. OAuth-subscription traffic requires the default MITM mode.
+
+`--mitm-domain <domain>` (repeatable) adds extra domains to the MITM whitelist beyond what auto-discovery finds — useful for hosts the client fetches at runtime rather than from its config file. The launcher picks a free port automatically if the default is taken; `--passthrough` / `--debug` / `--no-auto-update` work like plain `bili`.
+
+---
+
+## Plugin Mode (native tools)
+
+For a native-plugin experience, an agent can run a small cooperative plugin alongside the proxy: the plugin registers the four ACP tools (`compress` / `decompress` / `search_context` / `acp_status`) natively with the agent and drives the agent's own tool loop, while the proxy stays the compression authority (state, history folding, philosophy prompt, nudges). Tool schemas are served by the proxy itself (`GET /__bili/plugin/manifest`), so plugin and proxy can never drift. Protocol spec: [PLUGIN.md](PLUGIN.md).
+
+Plugin-equipped sessions are detected automatically via request headers — wire-level tool injection is then suppressed for them (no double compression, native tool UX). Works in both proxy modes: the `/bili/` prefix baseURL **and** MITM transparent mode. The plugin can also report the agent's own model context window (`x-bili-plugin-context-window`) and read live context usage via `GET /__bili/plugin/status`.
+
+### install / remove / list
+
+```bash
+bili plugin install pi      # add this billion-context install to pi's settings.json (packages)
+bili plugin install omp     # same for omp (config.yml extensions)
+bili plugin install claude  # register the bili MCP server (claude mcp add, user scope)
+bili plugin install codex   # append [mcp_servers.bili] to ~/.codex/config.toml
+bili plugin install opencode  # add mcp.bili to ~/.config/opencode/opencode.json
+bili plugin list            # install status for every supported host
+bili plugin remove pi       # undo (original files backed up to *.bili-bak once)
+```
+
+`install pi` also replaces any **legacy** billion-context entries (old `npm:billion-context-pi` references, stale `npm:billion-context@x.y.z`, leftover dev-checkout paths) so exactly one bili plugin stays live.
+
+The installed plugin is a **thin** one (~5 KB, zero runtime deps): it detects the proxy (from the `/bili/` baseURL or `BILLION_CONTEXT_PROXY`), fetches tool schemas from the proxy, registers native tools, and forwards executions — the proxy remains the single compression authority, so plugin and proxy always match versions. Hosts without a plugin API (claude, codex, opencode) install the MCP bridge (`dist/mcp.js`) instead — same protocol underneath, though MCP has no slash-commands (no `/acp` panel command).
+
+Kill switch: `BILLION_CONTEXT_PLUGIN=0` disables plugin mode entirely (wire-level injection resumes).
+
+**When do you need `plugin install` at all?** Launcher users mostly don't (see [Launcher Reference](#launcher-reference) — pi gets `-e`, opencode auto-injects, omp ships with it, claude/codex opt in via `BILI_LAUNCHER_PLUGIN=1`, hermes is wire-only). It's for a manually-configured client (`/bili/` prefix or MITM) where you want the native panel: pi/omp/opencode get native tools + `/acp`; claude/codex get native MCP tools (no `/acp`); hermes can't (wire only). Without any plugin everything still works — compression runs via wire-injected tools, and the model can be asked to call `acp_status` to check live usage.
+
+---
+
+## Sessions & Migration
+
+### Compression state lives in the proxy (#151)
+
+Compression state (blocks, summaries, original message cache) lives **in the proxy**, not in the client. The client's own local history is the full uncompressed view. Two consequences:
+
+- If you point the client back at the real upstream (or stop the proxy), the client replays its **full local history** every turn. After a long compressed session this can exceed the model's context window (`context_window_exceeded`).
+- There is no way to "unpack" a compression block into the client's local history — the client never saw the compressed form.
+
+### Migrating off the proxy
+
+Export the session and paste it into a fresh conversation as a handoff:
+
+```bash
+bili export                      # list persisted sessions (id, label, blocks)
+bili export <id|label>           # print a Markdown handoff (block summaries)
+bili export <id> --full          # include the original messages per block
+bili export <id> --full --output handoff.md
+```
+
+Then start a new conversation in the client (direct to upstream) and paste the handoff doc as the opening context.
+
+### Codex subagents get their own compression namespace (#150)
+
+Codex subagents (e.g. the `guardian_subagent` approval reviewer) reuse the main conversation's `session_id`, so on the wire they look like the same session. Without care their requests inherit the main conversation's compression state — a subagent turn can get its context folded (losing the verbatim user authorization it must read back) and the two roles' usage estimates pollute each other.
+
+billion-context detects this via the `instructions` field: subagent requests carry their own role prompt. The **first** instructions seen for a conversation anchor the main namespace (stable even if the main prompt drifts); any other instructions value maps to a separate `|sub:` namespace with its own empty compression state. Subagent requests are self-contained replays, so the fresh namespace is lossless — and the web UI's session list shows the two namespaces as separate sessions sharing the same client label.

--- a/CONFIGURATION.zh-CN.md
+++ b/CONFIGURATION.zh-CN.md
@@ -342,3 +342,279 @@
 | `ACP_LOG` | 设为 `0` 关闭请求日志。 |
 | `ACP_AUTO_UPDATE` | 设为 `0` 禁用自动更新检查。 |
 | `ACP_PROVIDERS` | 指向外部 `providers.json` 的路径（旧版 / 共享文件）。 |
+| `BILI_REPLAY_RETRY_BASE_MS` | acp-loop 回放重试的基础退避延迟（毫秒）：上游瞬时拒绝后重试（默认 `1500`；设 `0` 关闭延迟）。见 #189。 |
+| `BILI_REPLAY_RETRY_MAX` | acp-loop 回放重试的总次数（默认 `3`；设 `1` 彻底关闭重试 —— 旧版 fail-fast 行为）。见 #189。 |
+| `ACP_SESSION_HEADER` | 会话 id 请求头名称（默认 `x-acp-session`）。 |
+| `ACP_REASONING_KEEP` | 仅 Responses API：设 `none` 丢弃全部 reasoning 项。默认让 reasoning 走压缩管道，其轮次被摘要后自动隐藏（避免无限累积破坏 Codex 的 prompt-cache 前缀）。 |
+| `ACP_LOG_FILE` | 日志文件路径（默认 XDG state 路径；`off` 关闭文件只保留 stderr）。10 MB 自动轮转。 |
+| `ACP_DUMP_SSE` | 调试用：转储原始 SSE 帧的目录。 |
+| `BILI_UPSTREAM_PROXY` | 代理自身出站连接的上游代理 —— 优先级最高，高于 per-URL/per-provider 配置。见 README「上游代理」一节。 |
+| `BILI_PERSIST` | 设 `0` 关闭会话持久化（仅内存，重启即丢）。 |
+| `BILI_PERSIST_DEBOUNCE_MS` | 持久化写盘的防抖窗口（毫秒，默认 `500`）。 |
+| `BILI_MAX_SESSIONS` | 内存中最多保留的会话数（默认 `256`；LRU 淘汰 —— 磁盘是事实源）。 |
+| `BILI_SESSIONS_DIR` | 会话持久化目录（默认 XDG data 目录）。 |
+| `BILLION_CONTEXT_PROXY` | launcher 会导出它；客户端侧 bili 插件/扩展检测到后自禁用自身压缩（避免双重压缩）。 |
+| `BILLION_CONTEXT_PLUGIN` | 设 `0` 彻底关闭插件模式（恢复 wire 层工具注入）。 |
+| `BILI_LAUNCHER_PLUGIN` | 设 `1` 让 launcher 为 claude/codex 注入 bili MCP 服务器（原生工具）。见[启动器参考](#启动器参考)。 |
+| `BILI_LAUNCHER_DIRECT` | 设 `1` 启用 launcher 直连 URL 路由（放弃 MITM/CA 信任）。见[启动器参考](#启动器参考)。 |
+| `BILI_CLAUDE_UPSTREAM` | claude 直连模式：当 `ANTHROPIC_BASE_URL` 已指向某个 relay 时，用它指定你的 relay 端点（否则会被旁路）。 |
+
+---
+
+## CLI 参考
+
+完整命令面（`bili --help` 打印的是精简版）。优先级处处一致：**CLI 参数 > 环境变量 > 配置文件 > 内置默认值**。
+
+| 命令 | 作用 |
+|---|---|
+| `bili [start] [options]` | 启动代理（默认读取 XDG 配置文件） |
+| `bili pi [opts --] [args]` | 启动代理 + 拉起 **pi** 接入它 |
+| `bili pi-test [opts --] [args]` | 类似 `bili pi`，但追加 `--no-extensions`（干净测试 —— 压缩完全由代理负责） |
+| `bili codex [opts --] [args]` | 代理 + **codex** |
+| `bili claude [opts --] [args]` | 代理 + **claude**（Claude Code CLI） |
+| `bili omp [opts --] [args]` | 代理 + **omp**（pi 内核） |
+| `bili opencode [opts --] [args]` | 代理 + **opencode** |
+| `bili hermes [opts --] [args]` | 代理 + **hermes-agent**（`/bili/` 重写） |
+| `bili test pi` | 无污染的 pi 链路端到端冒烟测试 |
+| `bili export [session] [--full] [--output FILE]` | 列出持久化会话 / 把一个会话导出为 Markdown 交接文档 —— 见[会话与迁移](#会话与迁移) |
+| `bili update` | 立即检查并安装新版本（绕过 3 分钟节流） |
+| `bili plugin install <agent>` | 把原生工具插件 / MCP 桥装进宿主 —— 见[插件模式（原生工具）](#插件模式原生工具) |
+| `bili plugin remove <agent>` | 卸载 |
+| `bili plugin list` | 显示每个宿主的安装状态 |
+| `bili mcp` | 独立运行 bili MCP 服务器（stdio） |
+| `bili plugin-register <id> [--origin URL] [--agent name]` | 预绑定会话 id 到插件模式（高级用法） |
+| `bili --version` / `bili --help` | 打印版本 / 帮助 |
+
+launcher 命令里 `--` 之后的参数原样透传给客户端（`bili pi -- print "hi"`）。
+
+### 参数
+
+| 参数 | 作用 |
+|---|---|
+| `--port <N>` | 监听端口（默认 `8787`） |
+| `--host <ADDR>` | 监听主机（默认 `127.0.0.1`） |
+| `--config <FILE>` | 配置 JSON 路径（默认： XDG 位置） |
+| `--debug` | 详细日志 |
+| `--passthrough` | 不经压缩直接转发 |
+| `--no-passthrough` | 强制开启压缩（覆盖配置文件） |
+| `--no-auto-update` | 本次运行禁用后台自动更新 |
+| `--mitm-domain <domain>` | 追加 MITM 白名单域名（可重复；仅 launcher） |
+
+---
+
+## 客户端接入
+
+不用 launcher 时，把客户端指向代理有两种方式：**`/bili/` 前缀**（API-key 客户端）和 **MITM 透明代理**（端点硬编码的登录客户端）。
+
+### `/bili/` 前缀（API-key 客户端）
+
+用 **API key** 配置（不是登录账号）的客户端允许你改上游 URL。只需在前面加上代理地址 + `/bili/`，其他都不用改。API key 仍留在客户端配置里，代理原样透传。
+
+**OpenCode** —— 编辑 `~/.config/opencode/opencode.json`，改 provider 的 `baseURL`：
+
+```jsonc
+// 之前：
+"baseURL": "https://open.bigmodel.cn/api/coding/paas/v4"
+// 之后（前面加上代理地址 + /bili/）：
+"baseURL": "http://localhost:8787/bili/https://open.bigmodel.cn/api/coding/paas/v4"
+```
+
+**Codex（API key 模式）** —— 编辑 `~/.codex/config.toml`，改 provider 的 `base_url`：
+
+```toml
+# 之前：
+base_url = "https://api.openai.com/v1"
+# 之后：
+base_url = "http://localhost:8787/bili/https://api.openai.com/v1"
+```
+
+**Codex（ChatGPT 登录）** —— 设顶层 `openai_base_url` 字段（保持 `model_provider = "openai"` 和 OAuth 登录不变）：
+
+```toml
+# ~/.codex/config.toml（顶层字段，不是 section）
+model_provider = "openai"
+openai_base_url = "http://localhost:8787/bili/https://chatgpt.com/backend-api/codex"
+```
+
+照常运行 `codex login`；OAuth token 随 `Authorization` 头传输，代理原样转发给上游。
+
+**Pi** —— 编辑 `~/.pi/agent/models.json`，改 provider 的 `baseUrl`：
+
+```jsonc
+// 之前：
+"baseUrl": "https://api.anthropic.com"
+// 之后：
+"baseUrl": "http://localhost:8787/bili/https://api.anthropic.com"
+```
+
+**其他 API-key 客户端（Cursor / Aider / Continue ……）** —— 只要配置了上游 URL，前面加 `http://localhost:8787/bili/` 就行，其他都不用改。
+
+`/bili/` 前缀还是个**自检测信号**：billion-context 的客户端扩展（billion-context-pi / opencode-acp）能在自己的 baseUrl 里认出它并自禁用，避免双层压缩。
+
+### MITM 透明代理（登录/订阅客户端）
+
+用**账号登录**的客户端（ChatGPT Plus/Pro、Claude、ZCode coding plan ……）走 OAuth 认证，且通常**硬编码端点** —— 改不了 baseURL 就没法用前缀方式，这类客户端要用 MITM 模式。
+
+原理：这类客户端只提供 **HTTP 代理**设置，所以它发送 `CONNECT <host>:443`；billion-context 在本地终结 TLS（用本地生成的根 CA），把压缩注入明文，再重新加密转发。OAuth token 随客户端的 `Authorization` 头传输、原样转发 —— 订阅折扣得以保留。
+
+支持的 MITM 客户端：
+
+| 客户端 | 登录方式 | 硬编码端点 | 状态 |
+|---|---|---|---|
+| **ZCode** | bigmodel coding plan（OAuth） | `open.bigmodel.cn`（内置 provider） | ✅ 已测试 |
+| **Claude Code** | Claude 订阅（OAuth） | `api.anthropic.com` | ❓ 未测试（可能不可用 —— 待验证） |
+
+> **Codex 例外：** Codex 暴露顶层 `openai_base_url` 配置字段，所以 ChatGPT 登录版**可以**用 `/bili/` 前缀（见上文）。Codex 不需要 MITM。
+
+MITM 只对一份**白名单**中的模型域名生效（`open.bigmodel.cn`、`api.anthropic.com`、`api.openai.com`、`chatgpt.com`）。其余 HTTPS 主机全部盲转发 —— billion-context 绝不解密非模型流量。
+
+一次性设置（在客户端里信任根 CA）：
+
+1. 启动一次代理以生成根 CA：
+
+   ```bash
+   bili start
+   ls ~/.local/share/billion-context/ca/root-ca.pem   # 现在存在了
+   ```
+
+2. 在客户端的 **设置 → 网络 / 代理** 里设：
+   - **HTTP 代理**： `http://127.0.0.1:8787`
+   - **代理 CA 证书路径**： `~/.local/share/billion-context/ca/root-ca.pem`
+   - （可选）**No-proxy 列表**： `localhost,127.0.0.1`
+   - （ZCode 具体位置：**Settings → Network**。Claude Code 则设 `HTTPS_PROXY` 环境变量、`NODE_EXTRA_CA_CERTS` 指向 CA 路径。）
+
+3. 重启客户端。它的模型流量从此流经 billion-context 并注入压缩。发一条消息，在代理日志（`~/.local/state/billion-context/bili.log`）里找 `mitm <host>:443 tunnel established`。
+
+> 根 CA 在本地生成、只存在于本机 —— **不是**系统级安装。只有你配置的那个客户端（通过它的 CA 路径设置）信任它，其他应用不受影响。删掉 CA 文件并重启代理会重新生成。
+
+要给 MITM 登录客户端配**专属上游代理**（防火墙/GFW）而不影响同一域名上的 API-key 客户端，用 `mitm://` scheme 键 —— 见 README「上游代理」一节。
+
+---
+
+## 启动器参考
+
+`bili <client>` 在一个独立端口拉起代理（**每次启动都是全新实例** —— 不会复用已在运行的 `bili start`，#216），然后把客户端指向它。**不改动任何配置文件**：启动器只**读取**（绝不编辑）客户端自己的配置来发现它访问哪些上游主机；这些主机自动加入 MITM 白名单。客户端退出时，启动器拉起的代理随之停止。
+
+两种上游方案全自动覆盖，无需配置：
+
+- **HTTPS 上游 → 证书 MITM。** 通过 `HTTPS_PROXY` 把客户端指向代理，并让它信任代理的 MITM 根 CA（`~/.local/share/billion-context/ca/root-ca.pem`，惰性生成）。压缩注入在被拦截的 TLS 流上。
+- **HTTP / localhost 上游 → `/bili/` baseURL 重写**（明文没法 MITM）。启动器通过客户端自己的机制重写 base URL，走的是配置的隔离临时副本 —— 真实配置文件一个字节都不碰（见下文）。
+
+各客户端如何被指向代理（自动设置在子进程环境里）：
+
+| 客户端 | 重定向方式 | CA 信任 |
+|---|---|---|
+| pi | `HTTPS_PROXY` + 隔离 `PI_CODING_AGENT_DIR` | `NODE_EXTRA_CA_CERTS` |
+| omp | `HTTPS_PROXY` + 隔离 `PI_CODING_AGENT_DIR` | `NODE_EXTRA_CA_CERTS` |
+| codex | `HTTPS_PROXY` + `-c key=value` 覆盖 | `SSL_CERT_FILE` → `combined-ca.pem` |
+| claude | `ANTHROPIC_BASE_URL` = `/bili/` URL | 无需 |
+| opencode | `HTTPS_PROXY` + 隔离 `OPENCODE_CONFIG` | `NODE_EXTRA_CA_CERTS` |
+| hermes | 隔离 `HERMES_HOME`；**全部**上游走 `/bili/` | 无（certifi 忽略 `SSL_CERT_FILE`） |
+
+`NODE_EXTRA_CA_CERTS` 是**追加**到内置信任库，所以只指向 MITM 根证书（`root-ca.pem`）即可。`SSL_CERT_FILE` 会**替换**默认 CA bundle，所以 codex 指向 `combined-ca.pem` —— 包含 MITM 根证书**加上**系统/Node 公共根 —— 保证子进程环境里 pip/git/curl 类 TLS（盲转发、真证书）不受影响（#152）。
+
+Claude Code 的 undici fetch 忽略 `HTTPS_PROXY`，所以证书 MITM 拦不到它。claude 的所有上游 —— 包括预先配置的 `ANTHROPIC_BASE_URL` relay —— 一律改走 `/bili/` URL 形式的 `ANTHROPIC_BASE_URL`；无需任何 CA 信任。
+
+上游从哪里发现（只读）：
+
+| 客户端 | 读取位置 |
+|---|---|
+| Pi | `~/.pi/agent/models.json` —— 各 provider 的 `baseUrl` |
+| omp | `~/.omp/agent/models.yml` —— 各 provider 的 `baseUrl` |
+| Codex | `~/.codex/config.toml` —— 各 `[model_providers.<name>]` 的 `base_url`（+ 顶层 `openai_base_url`） |
+| Claude Code | `ANTHROPIC_BASE_URL` 环境变量，否则硬编码 `api.anthropic.com` |
+| OpenCode | `~/.config/opencode/opencode.json` —— 各 provider 的 `baseURL` |
+| hermes | `~/.hermes/config.yaml` —— 各 provider 的端点行 |
+
+### 隔离临时配置（写了什么）
+
+`/bili/` 重写模式写的是**临时副本** —— 真实配置绝不编辑 —— 客户端退出时临时目录一并删除：
+
+- **pi / omp** —— 隔离的 `PI_CODING_AGENT_DIR`（在 `/tmp` 下），里面只有一份重写后的 `models.json` / `models.yml`（明文 baseUrl 包上 `/bili/`）。其余一切（`settings.json`、`sessions/`、`auth.json`、扩展……）都**符号链接**到真实 pi/omp 主目录，所以会话与登录互通：launcher 里开的会话在裸客户端里无缝继续，反之亦然。
+- **opencode** —— 临时 `opencode.json`（由 `OPENCODE_CONFIG` 指向），`baseURL` 重写为 `/bili/` 形式，**并追加了薄 `/acp` 插件**（开箱即原生工具；独立的 `opencode-acp` 插件检测到 `BILLION_CONTEXT_PROXY` 后自禁用）。
+- **hermes** —— 隔离的 `HERMES_HOME`，重写后的 `config.yaml` 让**所有**上游（HTTP 和 HTTPS）都走 `/bili/`（httpx 自建 CA bundle 且忽略 `SSL_CERT_FILE`，证书 MITM 不可行）。`skills/`、`memories/`、`sessions/` 符号链接共享。若没配置任何 provider —— 或 `config.yaml` 无法重写 —— 启动器打印警告，hermes 将**不经代理**运行（无压缩）。
+
+### 启动器里的原生工具
+
+- **pi** —— 未安装插件时，启动器借用 pi 的 `-e <file>` 参数为本次运行加载 `dist/agent/pi.js`（不写任何东西）：开箱即原生工具 + `/acp` 命令。已安装则符号链接的 `settings.json` 已加载它 —— 不再加 `-e`。
+- **omp** —— 发行版自带插件；无需任何操作。
+- **opencode** —— 临时配置自动追加薄插件。
+- **claude / codex** —— 通过 `BILI_LAUNCHER_PLUGIN=1` 选择启用：启动器额外注入单个 `bili` MCP 服务器（claude 用 `--mcp-config`，codex 用 `-c mcp_servers.bili.*` —— 都是临时生效，不写宿主配置）。默认仍是 wire 模式，待宿主参数兼容性充分验证后翻转（已在 claude 2.1.227 / codex 0.147.0 验证）。`BILI_LAUNCHER_PLUGIN=0` 强制 wire 模式。
+- **hermes** —— 无插件 API；永远 wire 模式。
+
+启动器模式矩阵：
+
+| 模式 | 工具形态 | 设置 |
+|---|---|---|
+| 启动器 + MCP（`BILI_LAUNCHER_PLUGIN=1`，claude/codex） | 原生 MCP 工具 | 一个环境变量 |
+| 启动器 wire 模式（claude/codex 默认） | 代理注入的 wire 工具 | 无 —— `bili claude` / `bili codex` 即可 |
+| 启动器 `-e` / 自动插件（pi、opencode；omp 自带） | 原生插件工具 | 无 |
+| 手动插件（`bili plugin install`） | 客户端侧插件 | 执行 install |
+| 手动 baseURL（`/bili/` 前缀） | 代理注入的 wire 工具 | 改客户端配置 |
+
+### 直连 URL 模式（可选）
+
+`BILI_LAUNCHER_DIRECT=1` 彻底放弃 MITM/CA 信任 —— claude 的 `ANTHROPIC_BASE_URL` / codex 的 provider `base_url` 直接指向 `/bili/` 前缀。警告：
+
+- **codex 直连模式**：LLM 流量**不**经过代理，压缩不生效 —— 只有 bili MCP 工具调用经过。要完整压缩请用默认 MITM 模式（不设 `BILI_LAUNCHER_DIRECT`）。
+- **claude 直连模式**：`ANTHROPIC_BASE_URL` 被覆盖指向代理；预先配置的 relay 被旁路，除非设 `BILI_CLAUDE_UPSTREAM=<relay>`。OAuth 订阅流量需要默认 MITM 模式。
+
+`--mitm-domain <domain>`（可重复）在自动发现之外追加 MITM 白名单域名 —— 适用于客户端在运行时才获取、不写进配置文件的主机。默认端口被占用时启动器自动换空闲端口；`--passthrough` / `--debug` / `--no-auto-update` 与普通 `bili` 用法相同。
+
+---
+
+## 插件模式（原生工具）
+
+想要原生插件体验，可以在客户端里装一个配合代理的插件：插件把四个 ACP 工具（`compress` / `decompress` / `search_context` / `acp_status`）原生注册进客户端、由客户端自己的工具循环驱动，而代理仍然是压缩引擎（状态、历史折叠、压缩哲学 prompt、nudge 全归代理）。工具 schema 由代理统一下发（`GET /__bili/plugin/manifest`），插件与代理永远不会版本漂移。协议规范见 [PLUGIN.md](PLUGIN.md)。
+
+带插件的会话通过请求头自动识别 —— 该会话的 wire 层工具注入自动关闭（不会双重压缩，工具体验原生）。两种代理模式都支持：`/bili/` 前缀 baseURL **和** MITM 透明模式。插件还可以上报客户端自己的模型上下文窗口（`x-bili-plugin-context-window`），并通过 `GET /__bili/plugin/status` 读取实时上下文水位。
+
+### install / remove / list
+
+```bash
+bili plugin install pi      # 把本 billion-context 安装加入 pi 的 settings.json（packages）
+bili plugin install omp     # omp 同理（config.yml extensions）
+bili plugin install claude  # 注册 bili MCP 服务器（claude mcp add，user 作用域）
+bili plugin install codex   # 向 ~/.codex/config.toml 追加 [mcp_servers.bili]
+bili plugin install opencode  # 向 ~/.config/opencode/opencode.json 加 mcp.bili
+bili plugin list            # 所有受支持宿主的安装状态
+bili plugin remove pi       # 撤销（原文件一次性备份为 *.bili-bak）
+```
+
+`install pi` 还会替换**遗留的** billion-context 条目（旧的 `npm:billion-context-pi` 引用、过期的 `npm:billion-context@x.y.z`、残留的 dev 目录路径），确保只有恰好一个 bili 插件在生效。
+
+安装的插件是**薄**插件（约 5 KB，零运行时依赖）：它检测代理（从 `/bili/` baseURL 或 `BILLION_CONTEXT_PROXY`）、从代理拉取工具 schema、注册原生工具、转发执行 —— 代理始终是唯一的压缩引擎，所以插件与代理永远版本一致。没有插件 API 的宿主（claude、codex、opencode）改装 MCP 桥（`dist/mcp.js`）—— 底层协议相同，但 MCP 没有斜杠命令（没有 `/acp`）。
+
+总开关：`BILLION_CONTEXT_PLUGIN=0` 彻底关闭插件模式（恢复 wire 层注入）。
+
+**到底什么时候需要 `plugin install`？** 用启动器的基本都不需要（见[启动器参考](#启动器参考) —— pi 自动 `-e`、opencode 自动注入、omp 自带、claude/codex 用 `BILI_LAUNCHER_PLUGIN=1`、hermes 只能 wire）。它适用于手动配置客户端（`/bili/` 前缀或 MITM）又想要原生面板的场景：pi/omp/opencode 装后获得原生工具 + `/acp`；claude/codex 获得原生 MCP 工具（无 `/acp`）；hermes 装不了（只能 wire）。不装任何插件一切照常工作 —— 压缩走 wire 注入的工具，让模型调 `acp_status` 即可查看实时用量。
+
+---
+
+## 会话与迁移
+
+### 压缩状态存在代理里（#151）
+
+压缩状态（块、摘要、原始消息缓存）存在**代理**里，不在客户端。客户端自己的本地历史是完整的未压缩视图。两个后果：
+
+- 把客户端指回真实上游（或停掉代理）后，客户端每轮重放**完整本地历史**。长压缩会话之后这很容易超出模型上下文窗口（`context_window_exceeded`）。
+- 没有办法把压缩块「解包」回客户端本地历史 —— 客户端从未见过压缩形态。
+
+### 从代理迁移出去
+
+导出会话，粘贴到新会话里作为交接：
+
+```bash
+bili export                      # 列出持久化会话（id、标签、块数）
+bili export <id|label>           # 打印 Markdown 交接文档（块摘要）
+bili export <id> --full          # 附上每个块的原始消息
+bili export <id> --full --output handoff.md
+```
+
+然后在客户端里开一个新会话（直连上游），把交接文档粘贴为开场上下文。
+
+### Codex 子代理有独立压缩命名空间（#150）
+
+Codex 子代理（如 `guardian_subagent` 审批 reviewer）复用主会话的 `session_id`，在线路上看起来是同一个会话。若不处理，子代理请求会继承主会话的压缩状态 —— 子代理轮次的上下文可能被折叠（丢失它必须逐字读取的用户授权），两个角色的用量估算也会互相污染。
+
+billion-context 通过 `instructions` 字段识别：子代理请求带自己的角色 prompt。会话**首次**看到的 instructions 锚定主命名空间（即使主 prompt 后来漂移也稳定）；任何其他 instructions 值映射到独立的 `|sub:` 命名空间，拥有自己的空白压缩状态。子代理请求是自包含重放，所以新命名空间无损 —— Web UI 的会话列表会把两个命名空间显示为共享同一客户端标签的独立会话。

--- a/devlog/2026-08-25_configuration-usage-docs/REQ.md
+++ b/devlog/2026-08-25_configuration-usage-docs/REQ.md
@@ -1,0 +1,7 @@
+# 需求
+
+用户合并 PR #231（README 对齐中文版）后指出：README 删掉了大量细节用法，要求把这些细节转移到 CONFIGURATION.md / CONFIGURATION.zh-CN.md（中英文同步），并补上 `--help` 有而文档缺的内容。
+
+- 素材：`git diff 7d958b1..master -- README*.md` 的被删行（插件模式、MITM 手动设置、逐客户端 baseURL 示例、launcher 表格、Codex subagents、sessions/export 等）。
+- 事实核对：launcher 表格按当前 src/launcher.ts 重写（claude 走 ANTHROPIC_BASE_URL 而非 cert-MITM；pi 未装插件自动 -e；hermes 无 MITM；omp/opencode 隔离配置）——旧 README 表格已过时的部分不再照搬。
+- 环境变量表补齐 17 行（ACP_SESSION_HEADER/ACP_REASONING_KEEP/ACP_LOG_FILE/ACP_DUMP_SSE/BILI_UPSTREAM_PROXY/BILI_PERSIST*/BILI_MAX_SESSIONS/BILI_SESSIONS_DIR/BILLION_CONTEXT_PROXY/BILLION_CONTEXT_PLUGIN/BILI_LAUNCHER_PLUGIN/BILI_LAUNCHER_DIRECT/BILI_CLAUDE_UPSTREAM；zh 侧另补 BILI_REPLAY_*）。

--- a/devlog/2026-08-25_configuration-usage-docs/WORKLOG.md
+++ b/devlog/2026-08-25_configuration-usage-docs/WORKLOG.md
@@ -1,0 +1,8 @@
+# 工作日志
+
+- branch 2026-08-25_configuration-usage-docs（自 master e551506）。
+- git diff 7d958b1..master 导出 README 删行 → /tmp/en-deleted.txt、/tmp/zh-deleted.txt 作为素材。
+- 核对 src/launcher.ts（claude ANTHROPIC_BASE_URL 路由 :236-246、各 client env :920-975、BILI_LAUNCHER_PLUGIN :358、direct 警告 :907/:911）后重写表格，不照搬过时内容。
+- CONFIGURATION.md：环境变量表 +16 行；追加 5 节（CLI Reference / Client Integration / Launcher Reference / Plugin Mode / Sessions & Migration），346→620 行。
+- CONFIGURATION.zh-CN.md：环境变量表 +18 行（含补齐 BILI_REPLAY_*）；追加对应 5 节，344→620 行，与英文逐节对应。
+- 纯文档改动，不涉及代码/版本号。


### PR DESCRIPTION
Model: qwen3.8-27b (vllm)

PR #231 slimmed the READMEs down; the deleted usage detail now lives here, in both CONFIGURATION.md and CONFIGURATION.zh-CN.md (symmetric 620/620 lines).

**Added sections (both languages):**
- **CLI Reference** — full command surface incl. what `--help` omits detail on (`bili export --output`, `plugin-register --origin/--agent`, `test pi`, `mcp`), options table, precedence rule.
- **Client Integration** — per-client `/bili/` baseURL examples (OpenCode / Codex API-key / Codex ChatGPT login / Pi / others), MITM transparent-proxy setup for login clients (ZCode/Claude Code, whitelist, one-time root-CA steps).
- **Launcher Reference** — redirect/CA table for all six clients, upstream-discovery table, isolated temp config (PI_CODING_AGENT_DIR / OPENCODE_CONFIG / HERMES_HOME), native-tools-per-client (incl. the new pi `-e` auto-injection from #227), mode matrix, direct-URL mode warnings.
- **Plugin Mode** — concept, install/remove/list, thin plugin vs MCP bridge, kill switch, "when do you need install" guidance.
- **Sessions & Migration** — state lives in the proxy (#151), `bili export` handoff flow, Codex subagent namespaces (#150).

**Tables rewritten against current code** (not copied from the stale README text): claude routes via `ANTHROPIC_BASE_URL` (undici ignores HTTPS_PROXY, no cert-MITM), hermes has no MITM (certifi), pi gets `-e` when uninstalled.

**Env var tables:** +16 rows en / +18 rows zh (BILI_LAUNCHER_*, BILLION_CONTEXT_*, BILI_PERSIST*, ACP_REASONING_KEEP, ACP_LOG_FILE, ACP_DUMP_SSE, BILI_UPSTREAM_PROXY, …).

Docs only — no code or version changes.