### PR TITLE
fix: legacy billion-context-pi entry wrongly suppressed launcher -e injection

### DIFF
--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -32,7 +32,7 @@ import os from "node:os";
 import path from "node:path";
 import { spawn, type StdioOptions } from "node:child_process";
 import { DEFAULT_MITM_DOMAINS } from "./mitm.js";
-import { selfPackageRoot, isPiEntry } from "./plugin-install.js";
+import { selfPackageRoot, isBiliPiEntry } from "./plugin-install.js";
 
 /** Absolute path of a file inside our dist/, resolved via the package root
  * (import.meta.url-based) so it survives global-installed symlink bins
@@ -610,7 +610,7 @@ function piPluginInstalled(piHome: string): boolean {
     try {
         const parsed = JSON.parse(fs.readFileSync(path.join(piHome, "settings.json"), "utf8")) as { packages?: unknown };
         const list = Array.isArray(parsed.packages) ? parsed.packages.map(String) : [];
-        return list.some((p) => isPiEntry(p, root));
+        return list.some((p) => isBiliPiEntry(p, root));
     } catch {
         return false;
     }

--- a/src/plugin-install.ts
+++ b/src/plugin-install.ts
@@ -91,6 +91,18 @@ export function isPiEntry(entry: string, root: string): boolean {
         || /(^|[/\\])billion-context(-pi)?$/.test(entry);
 }
 
+// Entries that load THIS package's pi plugin (billion-context proper).
+// Legacy `billion-context-pi` entries are deliberately excluded: that is a
+// separate older package — usually not installed, and it self-disables under
+// BILLION_CONTEXT_PROXY — so treating it as "installed" wrongly suppressed
+// the launcher's `-e` fallback and left pi with no plugin at all.
+export function isBiliPiEntry(entry: string, root: string): boolean {
+    return entry === root
+        || /^npm:billion-context(@|$)/.test(entry)
+        || /(^|[/\\])node_modules[/\\]billion-context([\/\\]|$)/.test(entry)
+        || /(^|[/\\])billion-context$/.test(entry);
+}
+
 function piInstall(): string {
     const root = selfPackageRoot();
     const file = piSettingsFile();

--- a/tests/launcher.test.ts
+++ b/tests/launcher.test.ts
@@ -333,6 +333,28 @@ test("runLaunch pi: native -e plugin injected only when not installed", async ()
         assert.equal(clientArgsSeen.length, 1);
         assert.ok(!clientArgsSeen[0].includes("-e"));
         assert.deepEqual(exitCalls, [0, 0]);
+
+        // legacy billion-context-pi entry is a DIFFERENT (usually absent) package
+        // that self-disables under BILLION_CONTEXT_PROXY — it must NOT suppress -e
+        fs.writeFileSync(path.join(piHome, "settings.json"), JSON.stringify({ packages: ["npm:billion-context-pi"] }));
+        clientArgsSeen.length = 0;
+        await runLaunch(
+            { client: "pi", clientArgs: [], overrides: {} },
+            { fetchImpl, spawnImpl, sleep: () => Promise.resolve() },
+        );
+        assert.equal(clientArgsSeen.length, 1);
+        assert.deepEqual(clientArgsSeen[0].slice(0, 2), ["-e", distAgent]);
+
+        // a registry npm:billion-context entry DOES load this package's plugin → no -e
+        fs.writeFileSync(path.join(piHome, "settings.json"), JSON.stringify({ packages: ["npm:billion-context"] }));
+        clientArgsSeen.length = 0;
+        await runLaunch(
+            { client: "pi", clientArgs: [], overrides: {} },
+            { fetchImpl, spawnImpl, sleep: () => Promise.resolve() },
+        );
+        assert.equal(clientArgsSeen.length, 1);
+        assert.ok(!clientArgsSeen[0].includes("-e"));
+        assert.deepEqual(exitCalls, [0, 0, 0, 0]);
     } finally {
         process.exit = prevExit;
         process.env.HOME = prevHome;


### PR DESCRIPTION
Model: qwen3.8-27b (vllm)

## Problem

After PR #227, a user who had the **legacy** `npm:billion-context-pi` entry in pi's `settings.json` (left over from the old separate package) lost `/acp` under `bili pi`:

- `isPiEntry()` (broadened in #227 for install cleanup) matched `npm:billion-context-pi` as "installed"
- → `piPluginInstalled()` returned `true` → launcher skipped `-e` injection
- → but the legacy package is usually **not installed** → pi had NO plugin at all

Removing the settings entry (or `bili plugin remove pi`, which restores an old backup) made it reproduce on a clean setup.

## Fix

- `src/plugin-install.ts`: new exported `isBiliPiEntry(entry, root)` — matches only **billion-context itself** (root path, `npm:billion-context`/`@version`, node_modules paths, bare dir name). No `-pi` suffix.
- `src/launcher.ts`: `piPluginInstalled()` now uses `isBiliPiEntry` — legacy entries no longer suppress `-e`.
- `install/remove` keep the broad `isPiEntry` for legacy-entry cleanup (that direction is still correct).

## Tests

- `tests/launcher.test.ts`: the `-e` injection test now covers three settings states: no entry → `-e`; `packages:["npm:billion-context-pi"]` (legacy) → **must** `-e`; `packages:["npm:billion-context"]` → no `-e`.
- Full suite 537/537, typecheck, build all green.

## E2E (real machine, legacy settings live)

With the user's actual `settings.json` (`packages:["npm:billion-context-pi"]`):
- launcher passed `-e …/dist/agent/pi.js` to pi ✓
- first request carried `x-bili-plugin: pi`, `x-bili-plugin-context-window: 262144`, conversation id ✓
- tool round-trip + reply OK, exit 0 — `/acp` restored