### PR TITLE
release v0.1.51

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.50",
+  "version": "0.1.51",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.50",
+      "version": "0.1.51",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.50",
+  "version": "0.1.51",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Model: qwen3.8-27b (vllm)

Version bump only. Changes since v0.1.50 (12 commits):

## Fixes
- **#206 tag-echo loop**: strip model-emitted render tags (d0485a4) + follow-up hardening from review (2cc9e3c)
- **Persistent overlay homes** for pi/omp/hermes launchers — session history was being lost across runs (321b2d6); overlay merge-back hardened, no silent data loss (0db9f62)
- **Legacy `npm:billion-context-pi` entry** no longer wrongly suppresses launcher `-e` injection (#233, 7e47026) — fixes `/acp` disappearing under `bili pi` when an old entry lingers in pi settings

## Features
- `bili pi` injects the native plugin via `-e` when not installed (4caec3a) — native tools + `/acp` out of the box, zero persistent changes

## Docs
- README aligned with the zh edition (f3677f8); usage detail moved into CONFIGURATION en+zh (e0eefad, #232)
- Windows-safe `runLaunch` test (cd8bd8a)

Pre-flight: typecheck ✅ · 592/592 tests ✅ · build ✅