### PR TITLE
fix(agent): /acp shows armed/idle info instead of warning before first request

### DIFF
--- a/devlog/2026-08-25_acp-first-launch/REQ.md
+++ b/devlog/2026-08-25_acp-first-launch/REQ.md
@@ -1,0 +1,19 @@
+# Request
+
+User (2026-08-25): "再修复首次启动后 Warning: bili: no ACP session yet (send a model request first, then run /acp) 这个问题" — right after `bili pi` starts, running `/acp` before any model request showed a scary warning instead of useful status.
+
+## Root cause
+
+Not a data bug: before the first model request the proxy legitimately has no compression session for the conversation, so `GET /__bili/plugin/status` answers 404 and the plugin rendered it as `Warning: bili: no ACP session yet …`. After one request the panel worked fine (verified both states in a real TUI).
+
+## Fix (UX)
+
+- `src/agent/shared.ts`: new `fetchProxyVersion(proxyBase)` — manifest probe returning the proxy version (liveness check).
+- `src/agent/pi.ts` `/acp` handler: on status 404, probe the manifest; if alive show an **info** notice: `billion-context@X — proxy connected, compression armed. No model request in this conversation yet; send one, then run /acp again.` Only fall back to the old warning when the manifest is unreachable too.
+- `src/agent/opencode.ts`: same treatment for its `/acp` (status.ok === false path).
+
+## Validation
+
+- tests/plugin-agent.test.ts: new test — mock server 404s status but serves manifest v9.9.9 → expects type `info`, msg matches `billion-context@9.9.9` + `compression armed`. Old test (both 404) still passes (warning fallback).
+- typecheck, full suite 593/593, build green.
+- Real TUI e2e (tmux + dist): `/acp` before first message → info notice; after one message → full ACP panel (billion-context@0.1.51).

--- a/src/agent/opencode.ts
+++ b/src/agent/opencode.ts
@@ -8,6 +8,8 @@
 //     pending-register queue (POST /__bili/plugin/register on session.created)
 //   - renders the proxy's buildStatusPanel via an ignored chat message
 
+import { fetchProxyVersion } from "./shared.js";
+
 interface OpencodeCommandConfig {
     template: string;
     description?: string;
@@ -102,7 +104,16 @@ const server = async (ctx: OpencodePluginContext): Promise<OpencodeHooks> => {
                 if (typeof status.panel === "string" && status.panel.length > 0) {
                     text = status.panel;
                 } else if (status.ok === false) {
-                    text = "bili: no ACP session yet (send a model request first, then run /acp)";
+                    // zero sessions on the proxy (fresh launch) — friendly idle notice
+                    let version: string | undefined;
+                    try {
+                        version = await fetchProxyVersion(proxyBase);
+                    } catch {
+                        version = undefined;
+                    }
+                    text = version !== undefined
+                        ? `billion-context@${version} — proxy connected, no ACP session yet. Send a model request, then run /acp again.`
+                        : "bili: no ACP session yet (send a model request first, then run /acp)";
                 } else {
                     text = "bili: proxy returned no status panel";
                 }

--- a/src/agent/pi.ts
+++ b/src/agent/pi.ts
@@ -5,7 +5,7 @@
 // minimal structural declarations — the bundled artifact imports NOTHING
 // from the host at runtime (the host duck-types us in).
 
-import { detectProxyBase, fetchManifest, forwardTool, fetchStatus, type ManifestTool } from "./shared.js";
+import { detectProxyBase, fetchManifest, forwardTool, fetchStatus, fetchProxyVersion, type ManifestTool } from "./shared.js";
 
 type Ctx = {
     sessionManager?: { getSessionId?: () => string } | undefined;
@@ -169,7 +169,24 @@ export function createBiliPlugin(agentOverride?: string): (pi: ExtensionAPI) => 
                         return;
                     }
                     if (status === undefined) {
-                        notify("bili: no ACP session yet (send a model request first, then run /acp)", "warning");
+                        // 404 from a live proxy = this conversation has sent no
+                        // model request yet (e.g. /acp right after startup).
+                        // Probe the manifest to confirm liveness + version and
+                        // show an armed/idle notice instead of a scary warning.
+                        let version: string | undefined;
+                        try {
+                            version = await fetchProxyVersion(proxyBase);
+                        } catch {
+                            version = undefined;
+                        }
+                        if (version !== undefined) {
+                            notify(
+                                `billion-context@${version} — proxy connected, compression armed. No model request in this conversation yet; send one, then run /acp again.`,
+                                "info",
+                            );
+                        } else {
+                            notify("bili: no ACP session yet (send a model request first, then run /acp)", "warning");
+                        }
                         return;
                     }
                     const panel = typeof status.panel === "string" ? status.panel : undefined;

--- a/src/agent/shared.ts
+++ b/src/agent/shared.ts
@@ -113,3 +113,13 @@ export async function fetchStatus(proxyBase: string, conversationId: string): Pr
     if (!ok || !json || typeof json !== "object") return undefined;
     return json as Record<string, unknown>;
 }
+
+/** Liveness + version probe for status UIs: same loopback origin as the
+ *  status endpoint, so a 404 status + a live manifest means "proxy up,
+ *  conversation not seen yet" — an armed-but-idle state, not an error. */
+export async function fetchProxyVersion(proxyBase: string): Promise<string | undefined> {
+    const { ok, json } = await fetchJson(`${proxyBase}/__bili/plugin/manifest`, undefined, STATUS_TIMEOUT_MS);
+    if (!ok || !json || typeof json !== "object") return undefined;
+    const version = (json as { version?: unknown }).version;
+    return typeof version === "string" && version.length > 0 ? version : undefined;
+}

--- a/tests/plugin-agent.test.ts
+++ b/tests/plugin-agent.test.ts
@@ -400,6 +400,44 @@ test("/acp command warns when the session is unknown", async () => {
     }
 });
 
+test("/acp shows armed info when the proxy is live but the session is unknown", async () => {
+    const server = http.createServer((req, res) => {
+        if (req.url?.startsWith("/__bili/plugin/status")) {
+            res.writeHead(404, { "content-type": "application/json" });
+            res.end(JSON.stringify({ ok: false, error: "unknown plugin conversation" }));
+            return;
+        }
+        if (req.url?.startsWith("/__bili/plugin/manifest")) {
+            res.writeHead(200, { "content-type": "application/json" });
+            res.end(JSON.stringify({ ok: true, version: "9.9.9", toolNames: [] }));
+            return;
+        }
+        res.writeHead(404);
+        res.end("{}");
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const origin = `http://127.0.0.1:${(server.address() as { port: number }).port}`;
+    try {
+        const pi = makeFakePi();
+        biliPlugin(pi as never);
+        const cmd = pi.commands.get("acp")!;
+        const notes: Array<{ msg: string; type?: string }> = [];
+        const ctx = {
+            sessionManager: { getSessionId: () => "sess-fresh" },
+            model: { baseUrl: `${origin}/bili/https://api.example.com/v1` },
+            ui: { notify: (msg: string, type?: string) => notes.push({ msg, type }) },
+        };
+        await cmd.handler("", ctx);
+        assert.equal(notes.length, 1);
+        assert.equal(notes[0]!.type, "info");
+        assert.match(notes[0]!.msg, /billion-context@9\.9\.9/);
+        assert.match(notes[0]!.msg, /compression armed/);
+    } finally {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+});
+
 test("omp entry reports x-bili-plugin: omp without env vars", async () => {
     const proxy = await startFakeProxy();
     try {


### PR DESCRIPTION
Model: qwen3.8-27b (vllm)

## Problem

Right after `bili pi` starts, running `/acp` before sending any model request showed:

```
Warning: bili: no ACP session yet (send a model request first, then run /acp)
```

Not a data bug — before the first request the proxy legitimately has no session, so the status endpoint 404s — but the rendering as a scary **warning** was poor UX for the normal "just started" state.

## Fix

- `src/agent/shared.ts`: new `fetchProxyVersion(proxyBase)` — cheap manifest probe (liveness + version).
- `src/agent/pi.ts`: `/acp` on status 404 probes the manifest; if the proxy is alive it shows an **info** notice instead:
  ```
  billion-context@0.1.51 — proxy connected, compression armed. No model request in this conversation yet; send one, then run /acp again.
  ```
  The old warning remains only when the manifest is unreachable too (proxy actually down).
- `src/agent/opencode.ts`: same treatment for its `/acp` command.

## Tests

- New test: status 404 + manifest 200 (v9.9.9) → type `info`, matches `billion-context@9.9.9` / `compression armed`.
- Existing both-404 test still passes (warning fallback).
- typecheck · 593/593 · build all green.

## E2E (real TUI, tmux + dist)

- `/acp` before first message → friendly info notice ✓
- send one message, `/acp` → full ACP panel (billion-context@0.1.51, usage/blocks/nudge) ✓