### PR TITLE
release v0.1.52

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.51",
+  "version": "0.1.52",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.51",
+      "version": "0.1.52",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.51",
+  "version": "0.1.52",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Model: qwen3.8-27b (vllm)

Version bump only. Changes since v0.1.51:

- **#235** — `/acp` before the first model request now shows an armed/idle info notice (`billion-context@X — proxy connected, compression armed…`) instead of a scary warning, in both the pi and opencode plugins. Pre-flight: typecheck ✅ · 593/593 ✅ · build ✅