### PR TITLE
release v0.1.53

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.52",
+  "version": "0.1.53",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.52",
+      "version": "0.1.53",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@types/node": "^22.0.0",
         "@types/node-forge": "^1.3.14",
-        "acp-kernel": "0.0.43",
+        "acp-kernel": "0.0.46",
         "fzstd": "0.1.1",
         "node-forge": "^1.4.0",
         "tar": "^7.5.22",
@@ -988,9 +988,9 @@
       }
     },
     "node_modules/acp-kernel": {
-      "version": "0.0.43",
-      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.43.tgz",
-      "integrity": "sha512-w5vSovgdj/IpHiuwwOJvXDNwQfVE6Qe+raucvdPt61b19g7jDV+o6wxhkowe5m69gr+/X5+tE00BCEHSuGtuvw==",
+      "version": "0.0.46",
+      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.46.tgz",
+      "integrity": "sha512-LE0qif1XmfGHVF39vNIIaRVzi+W/ZPaxmIo+rtGxgT//U03dJhgI8CfzF9thUlHVqM8NSw5uRrTYwWrAgDVcoQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.52",
+  "version": "0.1.53",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/node-forge": "^1.3.14",
-    "acp-kernel": "0.0.43",
+    "acp-kernel": "0.0.46",
     "fzstd": "0.1.1",
     "node-forge": "^1.4.0",
     "tar": "^7.5.22",


### PR DESCRIPTION
Release v0.1.53 — bumps `acp-kernel` 0.0.43 → **0.0.46** (exact pin), picking up the tier-2/3 count-trigger fix (ranxianglei/acp-kernel#162, "T2 永不触发") plus the intermediate 0.0.44/0.0.45 changes.

## What changes for users
Tier-2 distillation nudges now fire once ≥ 5 active tier-1 blocks exist (block COUNT) instead of the unreachable token-mass gate. Downstream review confirmed the proxy passes kernel-rendered nudge text through unchanged (src/server.ts: anthropic/openai/responses injection sites) — no adapter code change needed.

## Pre-flight
- `npm install` refreshed lockfile (kernel 0.0.46 from npm, no overlay) ✅
- `npm run typecheck` ✅
- `npm test` ✅ 593/593
- `npm run build` ✅

Merge → CI publishes `billion-context@0.1.53`.