### PR TITLE
fix: keep proxy-synthesized Responses item ids within the 64-char upstream cap (#242)

### DIFF
--- a/devlog/2026-08-25_responses-id-length/REQ.md
+++ b/devlog/2026-08-25_responses-id-length/REQ.md
@@ -1,0 +1,32 @@
+# Issue #242: round-2 Responses message id > 64 chars → permanent 400
+
+Model: qwen3.8-27b (vllm)
+
+## Request
+
+https://github.com/ranxianglei/billion-context/issues/242 — round-2+ remapped
+message ids embedded the full upstream id (`msg-proxy-${round}-${origId}`),
+producing 66-char ids. Codex persists them into its rollout; every later
+request replays them as input and upstream 400s
+(`Invalid 'input[N].id': string too long … maximum length 64`), bricking the
+conversation.
+
+## Fix
+
+1. **Root cause** — `src/loop/adapter-responses.ts` round-2 mapping now uses a
+   deterministic FNV-1a 32-bit base36 digest: `msg-proxy-${round}-${shortItemHash(...)}`,
+   ≤ ~21 chars regardless of upstream id length. Same-turn lifecycle events
+   (added/deltas/parts/done) continue to share the remapped id via the
+   existing `remapped` map.
+2. **Healing** — `sanitizeResponsesInputIds()` (new export) rewrites any input
+   item id > 64 chars to `msg-fix-${shortItemHash(id)}` (deterministic ⇒ stable
+   across requests), called at the top of `prepareResponses` so poisoned
+   rollouts recover on the next request without any user action.
+
+## Verification
+
+- tests/responses-round2-lifecycle.test.ts +2: round-2 with the exact 54-char
+  id from the bug report (asserts ≤64 + lifecycle consistency), and
+  sanitizeResponsesInputIds unit test (short ids untouched, deterministic,
+  call_id untouched, idempotent).
+- Full suite 595/595, typecheck, build green.

--- a/devlog/2026-08-25_responses-id-length/WORKLOG.md
+++ b/devlog/2026-08-25_responses-id-length/WORKLOG.md
@@ -1,0 +1,20 @@
+# WORKLOG — responses id length (#242)
+
+Model: qwen3.8-27b (vllm)
+
+1. Reproduced the arithmetic: `msg-proxy-2-` (12) + real OpenAI message id (54)
+   = 66 > 64-char upstream cap. Only the round-2 remap site embeds origId;
+   emitText/emitToolCall/emitMarker use `Date.now()` ids (~27 chars, safe).
+2. Confirmed replay path: Codex rollout → next request `input[].id` →
+   upstream 400 before any compression logic runs, so healing must sit at
+   request ingress (`prepareResponses`), before `responsesToCore`/rebuild.
+3. Added `shortItemHash` (FNV-1a 32-bit → base36) + `sanitizeResponsesInputIds`
+   in adapter-responses.ts; server.ts imports and applies at ingress.
+4. Branch off master after PR #241 merged (7b70419).
+
+## Scope decisions
+
+- `/responses/compact` ingress left untouched: a poisoned rollout 400s on its
+  first regular request (compact never runs), and no new long ids are created
+  after this fix.
+- `call_id` fields untouched — the upstream error is specific to `input[].id`.

--- a/src/loop/adapter-responses.ts
+++ b/src/loop/adapter-responses.ts
@@ -20,6 +20,36 @@ interface FunctionCallBuffer {
     arguments: string;
 }
 
+// Deterministic short digest: FNV-1a 32-bit in base36 (≤7 chars) (#242).
+export function shortItemHash(input: string): string {
+    let h = 0x811c9dc5;
+    for (let i = 0; i < input.length; i++) {
+        h ^= input.charCodeAt(i);
+        h = Math.imul(h, 0x01000193);
+    }
+    return (h >>> 0).toString(36);
+}
+
+// Upstream rejects Responses input item ids longer than 64 chars. Round-2+
+// remapped ids used to embed the full upstream id and could exceed that
+// (#242). All proxy-synthesized ids stay ≤ this cap.
+const RESPONSES_ITEM_ID_MAX = 64;
+
+/**
+ * Heal client rollouts already poisoned with over-long ids (they 400 every
+ * request otherwise). Rewrites in place, deterministically, so repeated
+ * requests keep referencing the same replacement id (#242).
+ */
+export function sanitizeResponsesInputIds(input: unknown): void {
+    if (!Array.isArray(input)) return;
+    for (const item of input) {
+        const rec = item as Record<string, unknown>;
+        if (typeof rec?.id === "string" && rec.id.length > RESPONSES_ITEM_ID_MAX) {
+            rec.id = `msg-fix-${shortItemHash(rec.id)}`;
+        }
+    }
+}
+
 interface MappedItem {
     id: string;
     index: number;
@@ -235,7 +265,7 @@ export function createResponsesAdapter(textProtocol?: boolean, projection?: Resp
                         yield { kind: "meta", chunk: rawBuf, firstRoundOnly: false } as ParsedStreamEvent;
                     } else if (item?.type === "message" && round > 1 && !suppressTextLifecycle) {
                         const origId = typeof item.id === "string" ? item.id : "";
-                        const mapped = { id: `msg-proxy-${round}-${origId || outputIndex}`, index: outputIndex++ };
+                        const mapped = { id: `msg-proxy-${round}-${shortItemHash(origId || String(outputIndex))}`, index: outputIndex++ };
                         if (origId) remapped.set(origId, mapped);
                         yield { kind: "meta", chunk: rewriteItemEvent(type, obj, mapped), firstRoundOnly: false } as ParsedStreamEvent;
                     } else if (item?.type !== "message" || !suppressTextLifecycle) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -49,6 +49,7 @@ import { log as loggerLog, configureLogger, getLogPath, closeLogger } from "./lo
 import { defaultLogFile, stateDir, proxyOriginFile } from "./paths.js";
 import { compressLoopResponsesJson } from "./compress-loop-responses.js";
 import { runCompressLoop, pickAdapter } from "./loop/index.js";
+import { sanitizeResponsesInputIds } from "./loop/adapter-responses.js";
 import { rewriteOpenaiJsonResponse } from "./stream-openai.js";
 import { rewriteResponsesJsonResponse } from "./stream-responses.js";
 import { emitStreamError } from "./stream-error.js";
@@ -1081,6 +1082,11 @@ function prepareResponses(
     let responsesProjection: ResponsesProjection | undefined;
     let rebuiltInput: ResponseInputItem[] | string = parsed.input;
     let toolsOut = parsed.tools;
+
+    // #242: over-long input item ids (poisoned rollouts) 400 upstream on every
+    // request; rewrite them to short deterministic ids before anything reads
+    // or replays the input.
+    sanitizeResponsesInputIds(parsed.input);
 
     const shouldInject = opts.compress.injectTool;
     const injectTools = shouldInject && !pluginMode;

--- a/tests/responses-round2-lifecycle.test.ts
+++ b/tests/responses-round2-lifecycle.test.ts
@@ -126,3 +126,100 @@ test("responses wire round-2: every output_text.delta must reference an item the
         "round-2 message item closed with output_item.done",
     );
 });
+
+test("responses wire round-2: remapped message id stays <= 64 chars with a real 54-char upstream id (#242)", async () => {
+    // Exactly the shape from the bug report: 54-char upstream message id that
+    // used to be embedded verbatim into `msg-proxy-2-<origId>` (66 chars) and
+    // then 400'd upstream ("input[N].id: string too long") on every replay.
+    const longId = "msg_083f5e89ab47276e016a8d80c2a5c4819780d41a8c32999fc8";
+    assert.equal(longId.length, 54);
+
+    const round1 = [
+        sse("response.created", { response: { id: "resp_1", status: "in_progress" } }),
+        sse("response.output_item.added", { output_index: 0, item: { type: "function_call", id: "fc_1", call_id: "call_1", name: "acp_status", arguments: "" } }),
+        sse("response.function_call_arguments.delta", { item_id: "fc_1", output_index: 0, delta: "{}" }),
+        sse("response.function_call_arguments.done", { item_id: "fc_1", output_index: 0, arguments: "{}" }),
+        sse("response.output_item.done", { output_index: 0, item: { type: "function_call", id: "fc_1", call_id: "call_1", name: "acp_status", arguments: "{}" } }),
+        sse("response.completed", { response: { id: "resp_1", status: "completed", output: [] } }),
+    ].join("");
+
+    const round2 = [
+        sse("response.created", { response: { id: "resp_2", status: "in_progress" } }),
+        sse("response.output_item.added", { output_index: 0, item: { type: "message", id: longId, role: "assistant", content: [] } }),
+        sse("response.content_part.added", { item_id: longId, output_index: 0, part: { type: "output_text", text: "" } }),
+        sse("response.output_text.delta", { item_id: longId, output_index: 0, delta: "healed" }),
+        sse("response.output_text.done", { item_id: longId, output_index: 0, text: "healed" }),
+        sse("response.content_part.done", { item_id: longId, output_index: 0, part: { type: "output_text", text: "healed" } }),
+        sse("response.output_item.done", { output_index: 0, item: { type: "message", id: longId, role: "assistant", content: [{ type: "output_text", text: "healed" }] } }),
+        sse("response.completed", { response: { id: "resp_2", status: "completed", output: [] } }),
+    ].join("");
+
+    const orig = globalThis.fetch;
+    globalThis.fetch = (async () => new Response(round2, { status: 200 })) as typeof fetch;
+
+    const chunks: Buffer[] = [];
+    try {
+        const ctx = makeCtx("resp-round2-idlen");
+        for await (const chunk of runCompressLoop(
+            new Response(round1, { status: 200 }).body!,
+            ctx,
+            { model: "gpt-5", input: [], stream: true },
+            { url: "http://mock", headers: {} },
+            createResponsesAdapter(),
+            buildCompressSystemPrompt(),
+        )) {
+            chunks.push(chunk);
+        }
+    } finally {
+        globalThis.fetch = orig;
+    }
+    const events = parseOut(Buffer.concat(chunks).toString("utf8"));
+
+    const added = events.find(
+        (e) => e.event === "response.output_item.added" && String((e.data.item as Record<string, unknown>)?.id ?? "").startsWith("msg-proxy-2-"),
+    );
+    assert.ok(added, "round-2 message item forwarded with remapped id");
+    const mappedId = String((added.data.item as Record<string, unknown>).id);
+    assert.ok(mappedId.length <= 64, `remapped id must stay <= 64 chars, got ${mappedId.length}: ${mappedId}`);
+    assert.notEqual(mappedId, `msg-proxy-2-${longId}`, "full upstream id must not be embedded");
+    for (const e of events) {
+        const id = e.event === "response.output_item.added" || e.event === "response.output_item.done"
+            ? (e.data.item as Record<string, unknown> | undefined)?.id
+            : e.data.item_id;
+        if (typeof id === "string" && id.startsWith("msg-proxy-2-")) {
+            assert.ok(id.length <= 64, `event ${e.event} references over-long id ${id}`);
+        }
+    }
+    assert.ok(
+        events.some((e) => e.event === "response.output_text.delta" && e.data.item_id === mappedId && e.data.delta === "healed"),
+        "deltas reference the same remapped id",
+    );
+    assert.ok(
+        events.some((e) => e.event === "response.output_item.done" && (e.data.item as Record<string, unknown>)?.id === mappedId),
+        "item closed with the same remapped id",
+    );
+});
+
+test("sanitizeResponsesInputIds: over-long rollout ids are shortened deterministically (#242)", async () => {
+    const { sanitizeResponsesInputIds } = await import("../src/loop/adapter-responses.ts");
+    const longId = `msg-proxy-2-msg_083f5e89ab47276e016a8d80c2a5c4819780d41a8c32999fc8`;
+    assert.equal(longId.length, 66);
+    const input = [
+        { type: "message", id: "msg_short", role: "user", content: [] },
+        { type: "message", id: longId, role: "assistant", content: [] },
+        { type: "function_call", id: longId, call_id: "call_1", name: "shell", arguments: "{}" },
+    ];
+    sanitizeResponsesInputIds(input);
+    assert.equal(input[0].id, "msg_short", "short ids untouched");
+    assert.ok(input[1].id!.length <= 64, `shortened id <= 64 chars, got ${input[1].id!.length}`);
+    assert.ok(input[1].id!.startsWith("msg-fix-"), `healed id uses msg-fix- prefix, got ${input[1].id}`);
+    assert.equal(input[1].id, input[2].id, "deterministic: same source id maps to same replacement");
+    assert.equal(input[2].call_id, "call_1", "call_id untouched");
+    // idempotent across requests
+    sanitizeResponsesInputIds(input);
+    assert.equal(input[1].id!.startsWith("msg-fix-"), true);
+    assert.ok(input[1].id!.length <= 64);
+    // non-array / string input tolerated
+    sanitizeResponsesInputIds(undefined);
+    sanitizeResponsesInputIds("plain string input");
+});


### PR DESCRIPTION
Model: qwen3.8-27b (vllm)

Fixes #242.

## Root cause

When the Responses-API compress loop runs round 2+, `src/loop/adapter-responses.ts` remapped upstream items with:

```ts
const mapped = { id: `msg-proxy-${round}-${origId || outputIndex}`, ... }
```

`origId` is the **full upstream message id** (e.g. 54 chars from Codex/OpenAI). With the `msg-proxy-2-` prefix that is 66 chars — over the upstream 64-char limit for `input[].id`. Codex Desktop persists that id into its rollout; on every subsequent request the rollout replays it and upstream rejects:

```
Invalid 'input[42].id': string too long. Expected a string with maximum length 64, but got a string with length 66 instead.
```

`--passthrough` does not help (the poisoned id is already persisted client-side). Affected: v0.1.53, Responses path (Codex).

## Fix (two parts)

**1. Stop minting over-long ids** — the round-2+ mapping now uses a deterministic FNV-1a base36 digest instead of embedding the upstream id:

```ts
const mapped = { id: `msg-proxy-${round}-${shortItemHash(origId || String(outputIndex))}`, ... }
```

≤ ~21 chars. All lifecycle events (output_item.added / output_text.delta / output_item.done) share the same mapped id, so references stay intact.

**2. Heal already-poisoned rollouts** — `prepareResponses` now runs `sanitizeResponsesInputIds(parsed.input)` (new export) before the projection reads the input: any `input[].id` longer than 64 chars is rewritten in place to `msg-fix-${shortItemHash(id)}` — deterministic and idempotent, so repeated requests keep referencing the same replacement id. Conversations that were permanently 400-ing recover on their next request.

Not changed: `/responses/compact` (native compaction never carries these ids — a poisoned rollout 400s on its first regular request before compact could run), `call_id` values, and the ~27-char `msg-proxy-${Date.now()}-…` ids used by text/tool/marker emission (already within the cap).

## Tests

- New round-2 lifecycle test using the exact 54-char upstream id from the issue: asserts the mapped id is ≤ 64 chars and that deltas + done events reference the same mapped id.
- New unit tests for `sanitizeResponsesInputIds`: short ids untouched, deterministic (same source → same replacement), `call_id` untouched, idempotent on re-run, non-array tolerated.
- Existing round-2 lifecycle test (`msg-proxy-2-` prefix assertion) still passes.

```
typecheck ✅  tests 595/595 ✅  build ✅
```