### PR TITLE
release v0.1.54

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.53",
+  "version": "0.1.54",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.53",
+      "version": "0.1.54",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.53",
+  "version": "0.1.54",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Model: qwen3.8-27b (vllm)

Version bump only. Changes since v0.1.53:

- #239 — surface truncated upstream streams instead of silent end_turn
- #241 — allow remote clients when bound to a non-loopback host (#240)
- #243 — keep proxy-synthesized Responses item ids within the 64-char upstream cap + heal already-poisoned rollouts at ingress (#242)

Pre-flight: typecheck ✅ · 597/597 tests ✅ · build ✅