### PR TITLE
release v0.1.55

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.54",
+  "version": "0.1.55",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.54",
+      "version": "0.1.55",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.54",
+  "version": "0.1.55",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Model: qwen3.8-27b (vllm)

Version bump only (package.json + lockfile). Changes since v0.1.54:

## Features
- **`bili dsh` launcher** (deepseek-harness): DSH_HOME persistent overlay (~/.dsh-bili) rewriting settings.yaml upstreams to /bili/, built-in deepseek-official route via DEEPSEEK_BASE_URL (user relay wrapped idempotently), native /acp command via --patch loader injection (works on web/tui profiles), zero writes to the real ~/.dsh (#250)
- **omp zero-config native plugin**: `bili omp` now splices `-e dist/agent/omp.js` when no live plugin entry exists — native /acp command with zero config writes; ompPluginLoadedFrom only trusts entries whose target file exists (#248/#250)

## Fixes
- **omp 92% no-compression incident**: Responses sessions now derive identity from prompt_cache_key when the kernel would fall to a per-request content fingerprint — omp (headless full-replay, stable pck per conversation) kept hashing every turn into a NEW session, so nudge always saw 0% usage (#248/#250)
- Gate isPromotableCacheKey (≤128 printable ASCII): malformed pck can no longer poison upstream headers
- /acp panel Breakdown/Nudge/Sent-to-LLM sections now recorded for wire sessions too (was plugin-mode only)
- adapter-openai: missing usage fields serialize as 0 instead of vanishing (dsh mapUsage NaN crash)
- misleading injectTool log flag now prints the effective value (wire injection suppressed marker in plugin mode)
- review hardening: dsh patch-file dist guard + stale-draft cleanup + network-error absorption in /acp