### PR TITLE
release v0.1.56

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.55",
+  "version": "0.1.56",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.55",
+      "version": "0.1.56",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.55",
+  "version": "0.1.56",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## release v0.1.56

Version bump only (package.json + package-lock.json). No code changes.

### Changes since v0.1.55

**Features**
- Launcher-handed context windows (`BILI_LAUNCHER_MODEL_WINDOWS`) — launchers capture each client model's declared context window and hand it to the proxy, ranked between plugin report and models.dev registry (#252)
- `bili omp` zero-config native plugin with native tools (`loadMode: "essential"` + identity register) — omp sessions now get compress/decompress/search_context/acp_status in the main turn with no `bili plugin install` required (#257)
- Customizable compression prompts (#156) — `compress.prompts` overrides, inert until `acknowledgePromptsRisk: true`
- hermes launcher (#223) — `bili hermes` via isolated HERMES_HOME rewrite

**Fixes**
- Strip model-emitted render tags from plugin-mode passthrough responses (omp native-mode tag-echo loop) + non-streaming JSON parity, stream-cut tail flush, multi-line data collapse (#260)
- Preserve SSE event framing in plugin passthrough — done-family events kept their trailing blank line (omp 'JSON Parse error') (#259)
- Drop whitespace-only Responses message items at ingress (flattened-turn artifact) (#258)
- Retry omp identity register after failure instead of wedging the session
- Double compress per turn (stale post-compress usage, #252) — per-turn compress credit
- omp/stateless Responses sessions never compress (prompt_cache_key identity)
- acp-loop replay auto-retry on upstream risk-control rejections (#189)
- Upstream rejection of replayed thinking blocks (#222/#221)
- OpenAI SSE tool-call name-split regression (#224)

### Pre-flight (local, same as CI)
- `npm run typecheck` — clean
- `npm test` — 646/646 pass
- `npm run build` — success

Merging triggers CI: build + test + `npm publish --tag latest` + git tag `v0.1.56` + GitHub Release.
