### PR TITLE
fix: stamp type:message on type-less Responses input items (omp wire form)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Versions follow the merge of a `*_release-v*` branch; CI publishes to npm on tag
 
 ## [Unreleased]
 
+### Fixes
+
+- **Responses: stamp `type:"message"` on type-less input items at ingress.** omp (pi-ai) sends user items without the spec-required `type` field; the kernel wire projection switches on `item.type` and silently dropped them, so user prompts never entered the compression state (no refs, never tagged, never compressible, invisible to nudge/preflight — #247 testing caught this).
+
 ### Features
 
 - **Launcher-handed context windows (`BILI_LAUNCHER_MODEL_WINDOWS`)**: `bili <client>` launchers already read the client's own model config when rewriting endpoints — they now also capture each model's declared context window (pi `models.json` `contextWindow`, omp `models.yml` `contextWindow`, opencode `opencode.json` `models.<id>.limit`, codex `config.toml` `model` + `model_context_window`) and hand the map to the spawned proxy via the `BILI_LAUNCHER_MODEL_WINDOWS` env var. The proxy ranks it between the plugin report and the models.dev registry in the native-window chain, so a self-hosted model named like a known family (`qwen3.8-27b` → table guessed 128k) no longer gets the built-in table's denominator — the nudge percent reflects the client's real window (262k in the wild-caught case, where an omp session was being compressed at 29% real usage because the proxy computed 81% against a wrong 95k denominator). No user configuration needed; only the launcher sets the env.

--- a/devlog/2026-08-26_responses-typeless-items/REQ.md
+++ b/devlog/2026-08-26_responses-typeless-items/REQ.md
@@ -1,0 +1,10 @@
+# REQ: Responses type-less input items enter the kernel
+
+Issue #247 A/B testing (model switch overflow) revealed: omp (pi-ai wire) sends
+user items as `{role, content}` WITHOUT the spec-required `type:"message"`.
+`responsesToCore` switches on `item.type` and silently drops them, so user
+prompts never entered compression state — no refs, never tagged, never
+compressible, invisible to nudge and to #254's preflight. With this fix,
+#254's preflight compression works end-to-end for omp (verified: 12 turns ×
+12KB on a 100k-window model, switch to 24k window → preflight compressed 5
+ranges, saved 39166 tokens, payload 20140 < 24000, request passed, no error).

--- a/devlog/2026-08-26_responses-typeless-items/WORKLOG.md
+++ b/devlog/2026-08-26_responses-typeless-items/WORKLOG.md
@@ -1,0 +1,24 @@
+# WORKLOG
+
+- A/B reproduction: mock upstream enforcing per-model windows (mock.js),
+  omp via isolated PI_CODING_AGENT_DIR, control = global bili 0.1.56
+  (switch → upstream 400 "maximum context length" reproduced), fixed =
+  master + #254 (a0b80c7) built in /tmp/bc-pr254-local.
+- First fixed run failed to trigger preflight: kernel saw 13 of 29 items —
+  all 15 type-less user items dropped by the projection (dump analysis,
+  `input items:` counter). Offline probes (probe3/4) confirmed kernel is
+  fine with typed ids.
+- Fix: `normalizeResponsesMessageItems()` in src/loop/adapter-responses.ts,
+  wired in prepareResponses BEFORE sanitizeResponsesInputIds /
+  dropWhitespaceResponsesMessages (canonical form for both).
+- Adversarial small-window scenarios (3 giant turns / 8 notes vs 8744
+  window) still 400: kernel protection (preserveRecentMessages 5 +
+  preserveRecentTokens 5000) dominates tiny windows; preflight compresses
+  one batch then T1 pending hits 0. Accepted as non-representative — real
+  switches target >=262k windows where protection is ~2%.
+- Realistic-ratio e2e PASSED (12×12KB, 100k→24k): see REQ.md.
+- Note: repo-local node_modules carried acp-kernel 0.0.43 vs lockfile 0.0.46
+  (stale); worktree corrected with `npm install --no-save acp-kernel@0.0.46`
+  before building. Local builds from a stale checkout bundle the old kernel.
+- tests/responses-empty-messages.test.ts +1 (normalize matrix). 647/647,
+  typecheck, build green.

--- a/src/loop/adapter-responses.ts
+++ b/src/loop/adapter-responses.ts
@@ -30,6 +30,26 @@ const RESPONSES_ITEM_ID_MAX = 64;
  * request otherwise). Rewrites in place, deterministically, so repeated
  * requests keep referencing the same replacement id (#242).
  */
+export function normalizeResponsesMessageItems(input: unknown): number {
+    if (!Array.isArray(input)) return 0;
+    let typed = 0;
+    for (const item of input) {
+        if (typeof item !== "object" || item === null) continue;
+        const rec = item as Record<string, unknown>;
+        if (rec["type"] !== undefined) continue;
+        if (rec["role"] !== "user" && rec["role"] !== "assistant") continue;
+        if (rec["content"] === undefined) continue;
+        // omp (pi-ai) sends user items without the spec-required "type" field;
+        // responsesToCore switches on item.type and silently drops type-less
+        // items, so user prompts never enter the kernel (no refs, never
+        // compressible, invisible to nudge/preflight). Stamp the standard
+        // type at ingress.
+        rec["type"] = "message";
+        typed++;
+    }
+    return typed;
+}
+
 export function sanitizeResponsesInputIds(input: unknown): void {
     if (!Array.isArray(input)) return;
     for (const item of input) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -49,7 +49,7 @@ import { log as loggerLog, configureLogger, getLogPath, closeLogger } from "./lo
 import { defaultLogFile, stateDir, proxyOriginFile } from "./paths.js";
 import { compressLoopResponsesJson } from "./compress-loop-responses.js";
 import { runCompressLoop, pickAdapter } from "./loop/index.js";
-import { sanitizeResponsesInputIds, dropWhitespaceResponsesMessages } from "./loop/adapter-responses.js";
+import { sanitizeResponsesInputIds, dropWhitespaceResponsesMessages, normalizeResponsesMessageItems } from "./loop/adapter-responses.js";
 import { rewriteOpenaiJsonResponse } from "./stream-openai.js";
 import { rewriteResponsesJsonResponse } from "./stream-responses.js";
 import { emitStreamError } from "./stream-error.js";
@@ -1133,7 +1133,15 @@ function prepareResponses(
     // #242: over-long input item ids (poisoned rollouts) 400 upstream on every
     // request; rewrite them to short deterministic ids before anything reads
     // or replays the input.
+    // omp-style type-less user items must be typed before the projection
+    // drops them (see normalizeResponsesMessageItems) — before id sanitize and
+    // whitespace drop so those see the canonical form.
+    const typedItems = normalizeResponsesMessageItems(parsed.input);
+    if (typedItems > 0) {
+        log("info", `[${sessionId}] stamped type:"message" on ${typedItems} type-less input item(s) before projection (omp wire form)`);
+    }
     sanitizeResponsesInputIds(parsed.input);
+
     const droppedEmpty = dropWhitespaceResponsesMessages(parsed.input);
     if (droppedEmpty > 0) {
         log("info", `[${sessionId}] dropped ${droppedEmpty} whitespace-only message item(s) before projection (flattened-turn artifact)`);

--- a/tests/responses-empty-messages.test.ts
+++ b/tests/responses-empty-messages.test.ts
@@ -3,7 +3,7 @@ import test from "node:test";
 
 process.env.NODE_ENV = "test";
 
-import { dropWhitespaceResponsesMessages } from "../src/loop/adapter-responses.ts";
+import { dropWhitespaceResponsesMessages, normalizeResponsesMessageItems } from "../src/loop/adapter-responses.ts";
 
 function msg(role: string, text: string, extra: Record<string, unknown> = {}): Record<string, unknown> {
     return { type: "message", role, content: [{ type: "output_text", text }], ...extra };
@@ -82,4 +82,27 @@ test("dropWhitespaceResponsesMessages preserves items with malformed non-object 
     const dropped = dropWhitespaceResponsesMessages(input);
     assert.equal(dropped, 0, "malformed part makes emptiness unknowable — item preserved");
     assert.equal(input.length, 2, "nothing removed");
+});
+
+// #247 test companion: omp sends user items without the spec-required "type"
+// field; the kernel projection switches on item.type and silently drops them.
+test("normalizeResponsesMessageItems stamps type:message on type-less role items", () => {
+    const input: any[] = [
+        { role: "user", content: [{ type: "input_text", text: "hello" }] },
+        { type: "message", role: "user", content: [{ type: "input_text", text: "typed" }] },
+        { role: "assistant", content: [{ type: "output_text", text: "reply" }] },
+        { role: "system", content: "no content field" },
+        { type: "function_call", call_id: "c1", name: "f", arguments: "{}" },
+        "plain string",
+    ];
+    const typed = normalizeResponsesMessageItems(input);
+    assert.equal(typed, 2);
+    assert.equal(input[0].type, "message");
+    assert.equal(input[1].type, "message");
+    assert.equal(input[2].type, "message");
+    assert.equal(input[3].type, undefined);
+    assert.equal(input[4].type, "function_call");
+    assert.equal(typeof input[5], "string");
+    // non-array tolerated
+    assert.equal(normalizeResponsesMessageItems(null), 0);
 });


### PR DESCRIPTION
Model: qwen3.8-27b (vllm)

Found while A/B-testing #254 against issue #247 (model switch → context overflow).

## Root cause

omp (pi-ai wire) sends user input items as `{role, content:[...]}` **without** the spec-required `"type"` field. The kernel wire projection (`responsesToCore`) switches on `item.type` and **silently drops every type-less item** — verified on a real omp session dump: 15 user items, all dropped, kernel saw only assistant messages.

Consequences (independent of #247, affects all omp Responses traffic):
- user prompts never get refs/tags — permanently invisible to the compression state
- never compressible → nudge/preflight cannot shrink them

This alone makes #254's preflight ineffective for omp: the overflow payload is mostly user messages the kernel cannot see.

## Fix

`normalizeResponsesMessageItems()` in `src/loop/adapter-responses.ts`, wired in `prepareResponses` **before** `sanitizeResponsesInputIds` / `dropWhitespaceResponsesMessages` so every downstream consumer sees the canonical form. Stamps `type:"message"` on `{role: user|assistant, content}` items lacking `type`. Logged when it fires.

## Verification

- A/B e2e with a window-enforcing mock upstream + real omp (isolated `PI_CODING_AGENT_DIR`):
  - **Control (v0.1.56)**: switch 100k→24k window → upstream 400 "maximum context length", session stuck (bug reproduced)
  - **Fixed (master + #254 + this PR)**: 12 turns × 12KB on the 100k model, switch to 24k → preflight compressed 5 ranges (~39166 tokens saved), rebuilt payload 20140 < 24000 → request passed, conversation continued, exit 0
- Known non-goal: tiny windows where kernel protection (`preserveRecentMessages 5` + `preserveRecentTokens 5000`) dominates (e.g. 8.7k window) — preflight stops early by design; real switches target ≥262k windows where protection ≈2%.
- tests/responses-empty-messages.test.ts +1 (normalize matrix); 647/647, typecheck, build green.

Companion to #254 — merging both fixes the #247 scenario for omp.