### PR TITLE
fix: omp chat-completions sessions get pck identity + /acp panel

### DIFF
--- a/src/agent/pi.ts
+++ b/src/agent/pi.ts
@@ -58,6 +58,30 @@ function sessionIdOf(ctx: Ctx): string | undefined {
     }
 }
 
+// omp's chat-completions payloads carry NO conversation signal (no
+// prompt_cache_key / session / user, and no session header — verified by dump),
+// so the proxy's openai identity falls to a content fingerprint that never
+// matches the session id this plugin registered (the identity register is keyed
+// by the omp session uuid). The before_provider_request return value REPLACES
+// the whole outgoing payload (omp onPayload chain, verified in the omp 17.3.8
+// dist), so stamp prompt_cache_key with the omp session id: the proxy binds
+// pluginMode by that identity and /acp finds the session by it. Chat shape only
+// (messages array, no responses `input`, no anthropic `max_tokens`, no native
+// prompt_cache_key); pi is untouched (it stamps x-bili-plugin-conversation in
+// before_provider_headers, which outranks the body field).
+function stampPromptCacheKey(event: unknown, ctx: Ctx, agent: string): Record<string, unknown> | undefined {
+    if (agent !== "omp") return undefined;
+    const payload = (event as { payload?: unknown } | undefined)?.payload;
+    if (payload === null || typeof payload !== "object" || Array.isArray(payload)) return undefined;
+    const p = payload as Record<string, unknown>;
+    if (!Array.isArray(p.messages)) return undefined;
+    if (p.input !== undefined || p.max_tokens !== undefined) return undefined;
+    if (typeof p.prompt_cache_key === "string" && p.prompt_cache_key.trim().length > 0) return undefined;
+    const sid = sessionIdOf(ctx);
+    if (sid === undefined || sid.length === 0) return undefined;
+    return { ...p, prompt_cache_key: sid };
+}
+
 function fmtTok(n: number): string {
     if (n < 1000) return String(n);
     if (n < 1_000_000) return `${(n / 1000).toFixed(1)}K`;
@@ -264,11 +288,12 @@ export function createBiliPlugin(agentOverride?: string, opts?: { retryIntervalM
             }
             void registerTools(pi, ctx, state, agent).catch((err: unknown) => console.error(`bili-plugin(${agent}): ${err instanceof Error ? err.message : String(err)}`));
         });
-        pi.on("before_provider_request", (_event, ctx) => {
+        pi.on("before_provider_request", (event, ctx) => {
             // omp emits this per model request (but never before_provider_headers);
             // it doubles as the retry driver when the session_start manifest
             // fetch raced the proxy startup. Cached by sid, throttled by retryAt.
             void registerTools(pi, ctx, state, agent).catch((err: unknown) => console.error(`bili-plugin(${agent}): ${err instanceof Error ? err.message : String(err)}`));
+            return stampPromptCacheKey(event, ctx, agent);
         });
         pi.on("session_start", (_event, ctx) => {
             state.sid = undefined;

--- a/src/server.ts
+++ b/src/server.ts
@@ -729,10 +729,29 @@ async function handle(
                   parsed as ResponsesRequestBody,
               )
             : undefined;
+        // OpenAI chat mirrors the responses pck promotion: clients that replay
+        // full history statelessly (omp chat-completions via a relay) send NO
+        // conversation headers, so the kernel's openai signal falls to a hash of
+        // the first user message that never matches the session id the agent
+        // plugin registered (identity register is keyed by the omp session
+        // uuid). prompt_cache_key (stamped by the omp plugin, or sent natively)
+        // is the client's own stable per-conversation id — promote it over the
+        // fingerprint only; a real conversation header stays stronger.
+        const openaiSignal = protocol === "openai"
+            ? conversationSignalOpenai(parsed as OpenAIRequestBody, convHeader)
+            : "";
+        const openaiIdentity = protocol === "openai"
+            ? preferPromptCacheKeyIdentity(
+                  convHeader
+                    ? { value: openaiSignal, source: "header" as const, clientProvided: true }
+                    : { value: openaiSignal, source: "content-fingerprint" as const, clientProvided: false },
+                  parsed as { prompt_cache_key?: unknown },
+              )
+            : undefined;
         const conversation = protocol === "anthropic"
             ? conversationSignalAnthropic(parsed as AnthropicRequestBody, convHeader)
             : protocol === "openai"
-              ? conversationSignalOpenai(parsed as OpenAIRequestBody, convHeader)
+              ? openaiIdentity?.value ?? openaiSignal
               : subagentNamespace(
                   responsesIdentity?.value ?? conversationSignalResponses(parsed as ResponsesRequestBody, convHeader),
                   (parsed as ResponsesRequestBody).instructions,
@@ -747,13 +766,14 @@ async function handle(
         //    body.session_id) — never the synthetic one — so a user can tell
         //    at a glance which client owns a session. pi sends nothing, so its
         //    label stays empty (shown as "—" in the UI).
-        const affinity = affinityToken(responsesIdentity ?? {
+        const bodyIdentity = responsesIdentity ?? openaiIdentity;
+        const affinity = affinityToken(bodyIdentity ?? {
             value: clientConv ?? conversation,
             source: clientConv ? "header" : "generated",
             clientProvided: !!clientConv,
         });
-        const clientLabel = responsesIdentity?.clientProvided
-            ? responsesIdentity.value
+        const clientLabel = bodyIdentity?.clientProvided
+            ? bodyIdentity.value
             : clientConversationHeader(req.headers);
         const session = getSession(sessionId, { protocol, upstreamOrigin, label: clientLabel ?? undefined });
         // Launcher-mode binding (#162): prefer identity — claude code sends
@@ -782,16 +802,17 @@ async function handle(
             session.metadata.effectiveContextLimit = reqConfig.modelContextLimit;
             recordPluginSession(pluginConversation ?? conversation, session.id);
         }
-        // Responses clients that send their own session id as `prompt_cache_key`
-        // (omp) get that conversation recorded even WITHOUT the x-bili-plugin
-        // header, so the /acp command — which looks the session up by the
-        // client's session id — can find it. The session id itself now ALSO
-        // derives from prompt_cache_key (preferPromptCacheKeyIdentity above,
-        // which only kicks in when the kernel would have fallen to a
-        // per-request content fingerprint) — this lookup binding remains for
-        // clients that send a real conversation header or session_id.
-        if (protocol === "responses") {
-            const pck = (parsed as ResponsesRequestBody).prompt_cache_key;
+        // Responses AND OpenAI-chat clients that send their own session id as
+        // `prompt_cache_key` (omp) get that conversation recorded even WITHOUT
+        // the x-bili-plugin header, so the /acp command — which looks the
+        // session up by the client's session id — can find it. The session id
+        // itself now ALSO derives from prompt_cache_key (the
+        // preferPromptCacheKeyIdentity calls above, which only kick in when the
+        // kernel would have fallen to a per-request content fingerprint) — this
+        // lookup binding remains for clients that send a real conversation
+        // header or session_id.
+        if (protocol === "responses" || protocol === "openai") {
+            const pck = (parsed as { prompt_cache_key?: unknown }).prompt_cache_key;
             if (typeof pck === "string" && pck.trim().length > 0) {
                 recordPluginSession(pck.trim(), session.id);
             }

--- a/tests/openai-pck-identity.test.ts
+++ b/tests/openai-pck-identity.test.ts
@@ -1,0 +1,148 @@
+import assert from "node:assert";
+import http from "node:http";
+import { once } from "node:events";
+import test from "node:test";
+
+process.env.NODE_ENV = "test";
+
+import { defaultConfig } from "acp-kernel";
+import { startServer, type ProxyOptions } from "../src/server.ts";
+import { SessionStore, _setStoreForTest } from "../src/persist.ts";
+import { _setForTest as setRegistryForTest } from "../src/registry.ts";
+import { _resetPluginStateForTest } from "../src/plugin.ts";
+
+// #266 proxy-side half: omp's chat-completions payloads carry NO conversation
+// signal, so the omp plugin stamps prompt_cache_key with the omp session id.
+// The proxy's openai path must mirror the responses pck promotion: (a) bind
+// pluginMode when an identity register matches the pck (wire injection
+// suppressed), and (b) record the session by pck so /acp (status?conversationId
+// = the client session id) finds it instead of 404-ing to the armed fallback.
+
+function openaiSse(): string {
+    const chunk = (choices: unknown): string =>
+        `data: ${JSON.stringify({ id: "c1", object: "chat.completion.chunk", created: 1, model: "gpt", choices })}\n\n`;
+    return (
+        chunk([{ index: 0, delta: { role: "assistant" }, finish_reason: null }]) +
+        chunk([{ index: 0, delta: { content: "ok" }, finish_reason: null }]) +
+        chunk([{ index: 0, delta: {}, finish_reason: "stop" }]) +
+        "data: [DONE]\n\n"
+    );
+}
+
+interface Rig {
+    proxyUrl: (path: string) => string;
+    chatUrl: () => string;
+    upstreamBodies: string[];
+    closeAll(): Promise<void>;
+}
+
+async function startRig(): Promise<Rig> {
+    const upstreamBodies: string[] = [];
+    const upstream = http.createServer((req, res) => {
+        const chunks: Buffer[] = [];
+        req.on("data", (c: Buffer) => chunks.push(c));
+        req.on("end", () => {
+            upstreamBodies.push(Buffer.concat(chunks).toString("utf8"));
+            res.writeHead(200, { "content-type": "text/event-stream" });
+            res.end(openaiSse());
+        });
+    });
+    upstream.listen(0, "127.0.0.1");
+    await once(upstream, "listening");
+    const upstreamPort = (upstream.address() as { port: number }).port;
+
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    setRegistryForTest({});
+    _resetPluginStateForTest();
+
+    const opts: ProxyOptions = {
+        port: 0,
+        host: "127.0.0.1",
+        upstream: "http://127.0.0.1",
+        routes: { [`http://127.0.0.1:${upstreamPort}`]: { models: { "glm-test": { context: 100_000 } } } },
+        modelContextLimit: 100_000,
+        kernelConfig: defaultConfig(100_000),
+        compress: { injectTool: true, injectNudge: true },
+        promptCache: { routing: "auto" },
+        log: false,
+        sessionHeader: "x-acp-session",
+        debug: false,
+        passthrough: false,
+        autoUpdate: false,
+        mitm: { enabled: false, domains: [] },
+    };
+    const proxy = await startServer(opts);
+    await once(proxy, "listening");
+    const proxyPort = (proxy.address() as { port: number }).port;
+    const closeOne = (s: http.Server): Promise<void> =>
+        new Promise((resolve, reject) => s.close((e) => (e ? reject(e) : resolve())));
+    return {
+        proxyUrl: (path) => `http://127.0.0.1:${proxyPort}${path}`,
+        chatUrl: () => `http://127.0.0.1:${proxyPort}/bili/http://127.0.0.1:${upstreamPort}/v1/chat/completions`,
+        upstreamBodies,
+        closeAll: async () => {
+            await closeOne(proxy);
+            await closeOne(upstream);
+        },
+    };
+}
+
+function postChat(rig: Rig, pck: string): Promise<Response> {
+    return fetch(rig.chatUrl(), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ model: "glm-test", messages: [{ role: "user", content: "hello" }], prompt_cache_key: pck }),
+    });
+}
+
+async function register(rig: Rig, conversationId: string, agent: string, identity: boolean): Promise<void> {
+    const res = await fetch(rig.proxyUrl("/__bili/plugin/register"), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ conversationId, agent, identity }),
+    });
+    assert.equal(res.status, 200, "register accepted");
+}
+
+async function status(rig: Rig, conversationId: string): Promise<{ ok: boolean; pluginAgent?: string | null; panel?: string }> {
+    const res = await fetch(rig.proxyUrl(`/__bili/plugin/status?conversationId=${encodeURIComponent(conversationId)}`));
+    return (await res.json()) as { ok: boolean; pluginAgent?: string | null; panel?: string };
+}
+
+test("openai pck: the session is recorded by prompt_cache_key so /acp (status by pck) finds it — the /acp panel fix", async () => {
+    const rig = await startRig();
+    try {
+        // No register at all — just an openai chat request carrying the pck the
+        // omp plugin stamped. Before the fix openai sessions were never
+        // recorded (recordPluginSession lived only in the responses branch), so
+        // status?conversationId=<pck> 404'd and /acp showed the armed fallback
+        // forever.
+        await postChat(rig, "omp-uuid-record");
+        const s = await status(rig, "omp-uuid-record");
+        assert.equal(s.ok, true, "session found by prompt_cache_key");
+        assert.ok(typeof s.panel === "string" && s.panel.length > 0, "panel rendered, not the armed fallback");
+    } finally {
+        await rig.closeAll();
+    }
+});
+
+test("openai pck: identity register + matching pck binds pluginMode (wire injection suppressed)", async () => {
+    const rig = await startRig();
+    try {
+        // Control: an unregistered openai session rides wire mode — the
+        // compress tool IS injected into the outgoing tools array.
+        await postChat(rig, "omp-uuid-wire");
+        assert.ok(rig.upstreamBodies[0]!.includes('"compress"'), "unregistered openai session is wire mode (compress tool injected)");
+
+        // The omp plugin identity-registers its session uuid; the next request
+        // carrying that uuid as prompt_cache_key must bind pluginMode.
+        await register(rig, "omp-uuid-bind", "omp", true);
+        await postChat(rig, "omp-uuid-bind");
+        assert.ok(!rig.upstreamBodies[1]!.includes('"compress"'), "wire tool injection suppressed after identity binding");
+        const s = await status(rig, "omp-uuid-bind");
+        assert.equal(s.ok, true, "bound conversation is found");
+        assert.equal(s.pluginAgent, "omp", "pluginAgent recorded as omp");
+    } finally {
+        await rig.closeAll();
+    }
+});

--- a/tests/plugin-agent.test.ts
+++ b/tests/plugin-agent.test.ts
@@ -786,3 +786,74 @@ test("omp identity register failure throttles and retries later", async () => {
         await proxy.close();
     }
 });
+
+// #266: omp's chat-completions payloads carry NO conversation signal, so the
+// plugin stamps prompt_cache_key with the omp session id. The
+// before_provider_request return value REPLACES the whole outgoing payload
+// (omp onPayload chain), so the matrix below drives the real handler and
+// asserts exactly which payload shapes get stamped. fakeCtx(undefined) keeps
+// registerTools a no-op (no proxy) so the test is pure.
+test("omp before_provider_request stamps prompt_cache_key only for chat-completions payloads (injection matrix)", async () => {
+    const sid = "omp-uuid-abc";
+    const mk = (): FakePi => {
+        const pi = makeFakePi();
+        createBiliPlugin("omp")(pi as never);
+        return pi;
+    };
+    const handler = (pi: FakePi, payload: unknown) =>
+        pi.events.get("before_provider_request")!({ type: "before_provider_request", payload }, fakeCtx(undefined, sid));
+
+    // chat payload (messages, no input, no max_tokens, no native pck) → stamped
+    {
+        const pi = mk();
+        const payload = { model: "glm-4", messages: [{ role: "user", content: "hi" }] };
+        const out = handler(pi, payload) as Record<string, unknown>;
+        assert.equal(out.prompt_cache_key, sid, "chat payload stamped with the omp session id");
+        assert.deepEqual(out.messages, payload.messages, "rest of the payload preserved");
+        assert.equal(payload.prompt_cache_key, undefined, "original payload not mutated");
+    }
+    // native prompt_cache_key already present → not overridden
+    {
+        const pi = mk();
+        const out = handler(pi, { messages: [{ role: "user", content: "hi" }], prompt_cache_key: "native-pck" });
+        assert.equal(out, undefined, "native pck is not overridden");
+    }
+    // responses payload (input array) → untouched
+    {
+        const pi = mk();
+        const out = handler(pi, { input: [{ role: "user", content: "hi" }] });
+        assert.equal(out, undefined, "responses payload (input) untouched");
+    }
+    // anthropic wire (max_tokens) → untouched
+    {
+        const pi = mk();
+        const out = handler(pi, { messages: [{ role: "user", content: "hi" }], max_tokens: 1024, system: "s" });
+        assert.equal(out, undefined, "anthropic wire (max_tokens) untouched");
+    }
+    // no session id → untouched
+    {
+        const pi = mk();
+        const out = pi.events.get("before_provider_request")!({ type: "before_provider_request", payload: { messages: [{ role: "user", content: "hi" }] } }, fakeCtx(undefined, ""));
+        assert.equal(out, undefined, "no session id → untouched");
+    }
+    // non-object payload → untouched
+    {
+        const pi = mk();
+        assert.equal(handler(pi, "not an object"), undefined, "non-object payload untouched");
+        assert.equal(handler(pi, null), undefined, "null payload untouched");
+        assert.equal(handler(pi, [1, 2, 3]), undefined, "array payload untouched");
+    }
+    // no messages array → untouched
+    {
+        const pi = mk();
+        assert.equal(handler(pi, { model: "x" }), undefined, "no messages → untouched");
+        assert.equal(handler(pi, { messages: "nope" }), undefined, "non-array messages → untouched");
+    }
+});
+
+test("pi agent never stamps prompt_cache_key (it stamps headers instead)", async () => {
+    const pi = makeFakePi();
+    createBiliPlugin("pi")(pi as never);
+    const out = pi.events.get("before_provider_request")!({ type: "before_provider_request", payload: { messages: [{ role: "user", content: "hi" }] } }, fakeCtx(undefined, "pi-uuid"));
+    assert.equal(out, undefined, "pi agent never stamps the body");
+});


### PR DESCRIPTION
## Problem

omp 会话使用 chat-completions 协议 provider(如 GLM relay)时:
- `/acp` 面板永远显示 armed 兜底文案("No model request in this conversation yet"), 跑多久都不出数据
- 原生模式永不绑定(全程 wire 注入)

## Root cause (三层)

1. omp 的 chat-completions payload **不带任何会话标识**(无 `prompt_cache_key`/`session`/`user`, 请求头也无 session header)
2. bc 的 openai 路径会话键 = `hashId(首条 user 消息)`(kernel `conversationSignalOpenai`), 与 omp 会话 uuid 永不相等 → 插件 identity register(以 omp session uuid 为 key)永不命中 → pluginMode 永不绑定
3. `recordPluginSession(pck)` 只在 responses 分支 → openai 会话从不记录 → `/acp` 按 uuid 查 404 → armed 兜底文案

## Fix

- **omp 插件**(`src/agent/pi.ts`): 新增 `stampPromptCacheKey()` — `before_provider_request` 的返回值会**替换整个出站 payload**(omp `onPayload` 链)。chat 形态 payload(`messages` 数组 + 无 `input` + 无 `max_tokens` + 无原生 pck)注入 `prompt_cache_key: <omp session id>`。responses payload 原生已带不动; anthropic wire(`max_tokens`)不动; pi agent 不动(有 `before_provider_headers`)。
- **代理**(`src/server.ts`): openai 协议镜像 responses 路径 — `openaiIdentity = preferPromptCacheKeyIdentity(...)` 用于 conversation/affinity/label; `recordPluginSession(pck)` 扩到 openai。

## Verification

- 单测: plugin-agent 26/26(新增注入矩阵 + pi 不注入), 新增 `tests/openai-pck-identity.test.ts`(openai pck 记录 + pluginMode 绑定端到端), 全量 650/650, typecheck, build
- e2e(真 omp 17.3.8 + chat mock): mock 收到带 pck 的 payload ✓; `status?conversationId=<uuid>` → 200 + `pluginAgent: "omp"` + panel ✓; 决定性探针(手工 register + 同 pck 请求 → mock 收到 `tools: []`)证明 wire 注入抑制/pluginMode 绑定 ✓
- one-shot 单请求时 register 可能竞速落后(manifest 往返)— 该请求走 wire(压缩照常), TUI 长会话从请求 1-2 起绑定, 与 responses 路径既有行为一致

Closes #266
