### PR TITLE
fix: identity plugin binding survives model switches across sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Versions follow the merge of a `*_release-v*` branch; CI publishes to npm on tag
 
 ## [Unreleased]
 
+### Fixes
+
+- **Identity plugin binding survives model switches (one conversation, many sessions)**: an identity registration (`POST /__bili/plugin/register` with `identity: true` — the omp/claude-code path) was consumed one-shot: the first request that carried the conversation id ate the registration and bound ITS session into plugin mode. Switching models or upstreams mid-conversation resolves a NEW session (session key = protocol|upstream|apiKey|conversation) — the registration was already gone, so the omp TUI flow "chat model → responses model" silently dropped back to wire injection (native tools gone, model roleplaying `acp_status` output). Identity registrations are now sticky for the conversation: every request carrying the id binds, LRU-refreshed and bounded by the same 64-entry cap. Wild-caught as "原生模式消失了" after a GLM-chat → qwen-responses model switch.
+
 ### Features
 
 - **Launcher-handed context windows (`BILI_LAUNCHER_MODEL_WINDOWS`)**: `bili <client>` launchers already read the client's own model config when rewriting endpoints — they now also capture each model's declared context window (pi `models.json` `contextWindow`, omp `models.yml` `contextWindow`, opencode `opencode.json` `models.<id>.limit`, codex `config.toml` `model` + `model_context_window`) and hand the map to the spawned proxy via the `BILI_LAUNCHER_MODEL_WINDOWS` env var. The proxy ranks it between the plugin report and the models.dev registry in the native-window chain, so a self-hosted model named like a known family (`qwen3.8-27b` → table guessed 128k) no longer gets the built-in table's denominator — the nudge percent reflects the client's real window (262k in the wild-caught case, where an omp session was being compressed at 29% real usage because the proxy computed 81% against a wrong 95k denominator). No user configuration needed; only the launcher sets the env.

--- a/devlog/2026-08-26_plugin-identity-sticky/REQ.md
+++ b/devlog/2026-08-26_plugin-identity-sticky/REQ.md
@@ -1,0 +1,17 @@
+# 需求: omp TUI 切换模型后原生模式消失
+
+用户报告: bili omp TUI 会话中切换模型(GLM chat → qwen responses)后, 模型退回 wire 模式
+(模型在对话里贴原始 acp_status 输出, "原生模式消失了")。
+
+## 复现(全保真 launcher TUI + 双协议 mock)
+- 新会话 chat 协议发消息: identity register 被消费, plugin mode ✓
+- 切 responses 模型(同 conversation, 新 session): injectTool=true —— wire ✗
+
+## 根因
+consumePluginRegisterFor 对 identity 注册 delete-on-read: 第一个请求消费后注册即删。
+模型切换 → session key(protocol|upstream|apiKey|conversation) 变化 → 新 session →
+队列已空 → wire。#162 语义本应是"该 conversation 的任何请求随到随绑"。
+
+## 修复
+identity 注册对 conversation 粘性: consume 保留条目并刷新 LRU 顺序, 沿用
+MAX_PENDING_REGISTERS=64 容量上限。

--- a/devlog/2026-08-26_plugin-identity-sticky/WORKLOG.md
+++ b/devlog/2026-08-26_plugin-identity-sticky/WORKLOG.md
@@ -1,0 +1,25 @@
+# 工作日志
+
+## 排查路径
+1. 42947 代理日志: pluginAgent null, 22:41 responses 请求 injectTool=true(wire)。
+2. 插桩插件(probe-plugin.js, 注入 __log 到 /tmp/ompreg/plugin.log)从 omp 进程内部取证:
+   session_start→manifest GET→identity register POST 全链路正常(单发/TUI/-r 均验证)。
+3. plugin-conversations.json: conversation 01a03e4e→responses session 9b62 有映射,
+   但 pluginAgent 永远 null → register 从未被 responses 请求消费。
+4. 决定性复现: launcher TUI + chat mock(19989)+responses mock(19981), chat 消费 register
+   后切 responses 模型 → injectTool=true。bug 实锤。
+
+## 修复
+- src/plugin.ts consumePluginRegisterFor: 命中时 delete+set(LRU 刷新), 不再删除。
+- tests/launcher-plugin-mode.test.ts +1 测试(双 upstream, 同 conversation, 切换后仍 plugin mode)。
+- 红绿验证: 旧代码新测试 FAIL("upstream B"), 新代码 8/8 PASS。
+
+## 验证
+- launcher-plugin-mode 8/8; 全量 647/647; typecheck; build。
+
+## 事故与恢复
+- 一次 launcher 测试漏带 PI_CODING_AGENT_DIR, 改写用户 overlay agent-bili/models.yml
+  为死端口 19998 —— 已 sed 恢复到用户活代理 42947(6 处), 备份
+  /tmp/ompreg/models.yml.clobbered.bak。
+- chatmock 初版 req.on("close") 在 Node 25 过早触发清掉 interval → SSE 零字节;
+  去掉 close 处理后正常。

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -246,7 +246,16 @@ const registeredIds = new Map<string, string>();
  *  ordering race with the shell's initialize. */
 export function consumePluginRegisterFor(conversationId: string): string | undefined {
     const agent = registeredIds.get(conversationId);
-    if (agent !== undefined) registeredIds.delete(conversationId);
+    if (agent !== undefined) {
+        // The registration describes the CONVERSATION, not a one-shot token:
+        // switching models/upstreams mid-conversation resolves to a NEW
+        // session (session key = protocol|upstream|apiKey|conversation) that
+        // must still bind — omp TUI flows that switch models would otherwise
+        // drop back to wire mode on every switch. Keep the entry and refresh
+        // LRU order so the size cap evicts least-recently-active conversations.
+        registeredIds.delete(conversationId);
+        registeredIds.set(conversationId, agent);
+    }
     return agent;
 }
 

--- a/tests/launcher-plugin-mode.test.ts
+++ b/tests/launcher-plugin-mode.test.ts
@@ -94,6 +94,7 @@ async function startRig(): Promise<Rig> {
     await listen(proxy);
     const proxyPort = (proxy.address() as { port: number }).port;
     return {
+        proxyPort,
         upstreamPort,
         proxyUrl: (path) => `http://127.0.0.1:${proxyPort}${path}`,
         modelUrl: () => `http://127.0.0.1:${proxyPort}/bili/http://127.0.0.1:${upstreamPort}/v1/messages`,
@@ -168,6 +169,42 @@ test("launcher headless pending binding: register BEFORE the first request binds
         assert.ok(status.ok, "pending register consumed by the new session");
         assert.equal(status.pluginAgent, "mcp");
     } finally {
+        await rig.closeAll();
+    }
+});
+
+test("launcher identity binding survives model switches (one conversation, multiple sessions)", async () => {
+    const rig = await startRig();
+    const upstream2Bodies: string[] = [];
+    const upstream2 = http.createServer((req, res) => {
+        const chunks: Buffer[] = [];
+        req.on("data", (c: Buffer) => chunks.push(c));
+        req.on("end", () => {
+            upstream2Bodies.push(Buffer.concat(chunks).toString("utf8"));
+            res.writeHead(200, { "content-type": "text/event-stream" });
+            res.end(textScript());
+        });
+    });
+    upstream2.listen(0, "127.0.0.1");
+    await listen(upstream2);
+    try {
+        const port2 = (upstream2.address() as { port: number }).port;
+        const postUpstream2 = (): Promise<Response> => fetch(`http://127.0.0.1:${rig.proxyPort}/bili/http://127.0.0.1:${port2}/v1/messages`, {
+            method: "POST",
+            headers: { "content-type": "application/json", "x-claude-code-session-id": "sess-switch" },
+            body: JSON.stringify({ model: "l162-model", max_tokens: 10, stream: true, messages: [{ role: "user", content: "hello" }] }),
+        });
+        // First model (upstream A): binds via identity as usual.
+        await register(rig, "sess-switch", { agent: "omp", identity: true });
+        await postModel(rig, "sess-switch");
+        assert.ok(!rig.upstreamBodies[0]!.includes("\"compress\""), "upstream A: wire injection suppressed after identity binding");
+        // Model switch mid-conversation: upstream B resolves a NEW session
+        // under the SAME conversation id. The omp TUI flow (e.g. GLM chat →
+        // qwen responses) must keep plugin mode on the new session too.
+        await postUpstream2();
+        assert.ok(!upstream2Bodies[0]!.includes("\"compress\""), "upstream B: identity binding survives the model switch");
+    } finally {
+        await close(upstream2);
         await rig.closeAll();
     }
 });


### PR DESCRIPTION
Model: qwen3.8-27b (vllm)

## Root cause

`consumePluginRegisterFor` treated an identity registration (`identity: true`, the omp / claude-code path) as a one-shot token: the first request carrying the conversation id consumed and **deleted** it, binding only THAT session into plugin mode.

Switching models or upstreams mid-conversation resolves a **new session** (session key = `protocol|upstream|apiKey|conversation`). The registration was already gone, so the new session silently dropped back to wire injection — native tools gone, the model roleplaying `acp_status` output in the conversation.

Wild-caught on the omp TUI: GLM (chat) → qwen (responses) switch, "原生模式消失了".

## Reproduction (full-fidelity launcher TUI + dual-protocol mocks)

- fresh conversation, chat-protocol model: identity register consumed, plugin mode ✓ (`injectTool=false`)
- switch to responses-protocol model (same conversation, new session): `injectTool=true` — wire ✗

Plugin-side flow verified healthy via an instrumented plugin (module/session_start/before_provider_request logs): manifest fetch, tool registration, identity register POST all fire correctly in one-shot, TUI, and `-r` resume modes. The bug is purely the server-side one-shot consume.

## Fix

Identity registrations are sticky for the conversation: `consumePluginRegisterFor` keeps the entry and refreshes LRU order on hit, bounded by the existing `MAX_PENDING_REGISTERS = 64` cap (least-recently-active conversations evicted first). This matches the documented #162 semantic: "bind the moment any of their requests shows up" — every request, not just the first.

## Test

`launcher identity binding survives model switches (one conversation, multiple sessions)` — dual upstreams, same conversation id, asserts wire suppression on BOTH sessions. Red/green verified: old code fails the new test, fixed code passes.

- launcher-plugin-mode: 8/8
- full suite: 647/647, typecheck, build ✅