### PR TITLE
fix: bind headerless identity registrations to single-client sessions (#268)

### DIFF
--- a/src/agent/pi.ts
+++ b/src/agent/pi.ts
@@ -111,13 +111,14 @@ type RegisterState = { sid?: string; toolsFor?: string; toolsReady?: boolean; pe
 
 // omp never emits before_provider_headers, so the x-bili-plugin marker cannot
 // be stamped per request. Register the conversation id once (after tools are
-// ready): the proxy binds any request carrying that id into plugin mode —
-// same launcher path claude/codex use (#162).
+// ready) with headerless:true — omp's requests carry NO conversation identity
+// header, so the proxy's exact-match identity path can never fire for it; the
+// flag marks the registration for single-client attribution instead (#268).
 async function postIdentityRegister(proxyBase: string, conversationId: string, agent: string): Promise<void> {
     const res = await fetch(`${proxyBase}/__bili/plugin/register`, {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ conversationId, agent, identity: true }),
+        body: JSON.stringify({ conversationId, agent, identity: true, headerless: true }),
         signal: AbortSignal.timeout(5000),
     });
     if (!res.ok) throw new Error(`register HTTP ${res.status}`);

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -199,8 +199,12 @@ const pendingRegisters: PendingPluginRegister[] = [];
  *  === CLAUDE_CODE_SESSION_ID) — bind by identity match only. `identity:
  *  false` (headless codex spawn) means requests carry no matching id — bind
  *  the next NEW session instead. Splitting the two keeps a foreign session
- *  from eating an identity registration it can never claim. */
-export function queuePluginRegister(conversationId: string, agent: string, identity: boolean): void {
+ *  from eating an identity registration it can never claim. `headerless`
+ *  (#268) marks identity registrations whose host CANNOT stamp the id on
+ *  requests (omp has no before_provider_headers event) — the exact-match
+ *  path can never fire for those, so they are additionally eligible for
+ *  single-client attribution (consumeSoleHeaderlessRegister). */
+export function queuePluginRegister(conversationId: string, agent: string, identity: boolean, headerless = false): void {
     if (!identity) {
         for (let i = 0; i < pendingRegisters.length; i++) {
             if (pendingRegisters[i]!.conversationId === conversationId) {
@@ -211,7 +215,7 @@ export function queuePluginRegister(conversationId: string, agent: string, ident
         pendingRegisters.push({ conversationId, agent, ts: Date.now() });
         while (pendingRegisters.length > MAX_PENDING_REGISTERS) pendingRegisters.shift();
     } else {
-        registeredIds.set(conversationId, agent);
+        registeredIds.set(conversationId, { agent, headerless, ts: Date.now() });
         while (registeredIds.size > MAX_PENDING_REGISTERS) {
             const oldest = registeredIds.keys().next().value;
             if (oldest !== undefined) registeredIds.delete(oldest);
@@ -237,7 +241,9 @@ export function takePendingPluginRegister(): PendingPluginRegister | undefined {
     }
     return pendingRegisters.shift();
 }
-const registeredIds = new Map<string, string>();
+type RegisteredIdentity = { agent: string; headerless: boolean; ts: number };
+
+const registeredIds = new Map<string, RegisteredIdentity>();
 
 /** Identity-driven binding (#162): hosts whose model requests carry the SAME
  *  id the MCP shell registered (claude code: every request has
@@ -245,15 +251,39 @@ const registeredIds = new Map<string, string>();
  *  conversation id) bind the moment any of their requests shows up — no
  *  ordering race with the shell's initialize. */
 export function consumePluginRegisterFor(conversationId: string): string | undefined {
-    const agent = registeredIds.get(conversationId);
-    if (agent !== undefined) registeredIds.delete(conversationId);
-    return agent;
+    const entry = registeredIds.get(conversationId);
+    if (entry !== undefined) registeredIds.delete(conversationId);
+    return entry?.agent;
+}
+
+/** Headerless identity binding (#268): omp registers its conversation id but
+ *  cannot stamp it on requests (no before_provider_headers event), so the
+ *  exact-match above can never fire for it. When the incoming request
+ *  carries NO client-provided conversation identity and EXACTLY ONE fresh
+ *  headerless registration is pending, attribute it to this request — the
+ *  single-client case `bili omp` runs in. Two pending registrations are
+ *  ambiguous (left for a later exact match); a stale one is dropped so an
+ *  abandoned session cannot hijack an unrelated request after the TTL.
+ *  Non-headerless entries are left untouched (claude code still binds by
+ *  exact match). */
+export function consumeSoleHeaderlessRegister(): { conversationId: string; agent: string } | undefined {
+    if (registeredIds.size !== 1) return undefined;
+    const first = registeredIds.entries().next().value;
+    if (first === undefined) return undefined;
+    const [conversationId, entry] = first;
+    if (!entry.headerless) return undefined;
+    if (Date.now() - entry.ts > PENDING_REGISTER_TTL_MS) {
+        registeredIds.delete(conversationId);
+        return undefined;
+    }
+    registeredIds.delete(conversationId);
+    return { conversationId, agent: entry.agent };
 }
 
 export function handlePluginRegister(payload: string, res: import("node:http").ServerResponse): void {
-    let parsed: { conversationId?: unknown; agent?: unknown; identity?: unknown };
+    let parsed: { conversationId?: unknown; agent?: unknown; identity?: unknown; headerless?: unknown };
     try {
-        parsed = JSON.parse(payload) as { conversationId?: unknown; agent?: unknown; identity?: unknown };
+        parsed = JSON.parse(payload) as { conversationId?: unknown; agent?: unknown; identity?: unknown; headerless?: unknown };
     } catch {
         res.writeHead(400, { "content-type": "application/json" });
         res.end(JSON.stringify({ ok: false, error: "invalid JSON body" }));
@@ -266,7 +296,7 @@ export function handlePluginRegister(payload: string, res: import("node:http").S
         return;
     }
     const agent = typeof parsed.agent === "string" && parsed.agent.trim() ? parsed.agent.trim() : "launcher";
-    queuePluginRegister(conversationId, agent, parsed.identity === true);
+    queuePluginRegister(conversationId, agent, parsed.identity === true, parsed.headerless === true);
     res.end(JSON.stringify({ ok: true, conversationId, agent }));
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -54,7 +54,7 @@ import { rewriteOpenaiJsonResponse } from "./stream-openai.js";
 import { rewriteResponsesJsonResponse } from "./stream-responses.js";
 import { emitStreamError } from "./stream-error.js";
 import { deriveSessionId as deriveProxySessionId, affinityToken, clientConversationHeader, preferPromptCacheKeyIdentity, type ConversationIdentity } from "./session-id.js";
-import { consumePluginRegisterFor, flushConversations, handlePluginManifest, handlePluginRegister, handlePluginStatus, handlePluginTool, loadConversations, pipePluginJson, pipePluginResponsesWithStrip, pipeThroughWithUsage, pluginAgentHeader, pluginConversationHeader, pluginReportedContextWindow, recordPluginSession, rememberPluginMessages, takePendingPluginRegister } from "./plugin.js";
+import { consumePluginRegisterFor, consumeSoleHeaderlessRegister, flushConversations, handlePluginManifest, handlePluginRegister, handlePluginStatus, handlePluginTool, loadConversations, pipePluginJson, pipePluginResponsesWithStrip, pipeThroughWithUsage, pluginAgentHeader, pluginConversationHeader, pluginReportedContextWindow, recordPluginSession, rememberPluginMessages, takePendingPluginRegister } from "./plugin.js";
 import { setupMitm, readMitmUpstream } from "./mitm.js";
 import type { BiliMessage } from "acp-kernel/wire";
 import { isLoopbackAddress, inspectContextOverflow, reserveOutputHeadroom, shouldReserveOutputHeadroom, usageTotals } from "./util.js";
@@ -766,6 +766,20 @@ async function handle(
             if (identityAgent) {
                 pluginAgent = identityAgent;
                 pluginConversation = clientConv ?? conversation;
+            }
+        }
+        // Headerless identity binding (#268): omp registers its conversation
+        // id but cannot stamp it on requests (no before_provider_headers
+        // event), so the exact-match above can never fire for it. When this
+        // request carries NO client-provided conversation identity and
+        // exactly one fresh headerless registration is pending, attribute it
+        // — the single-client case `bili omp` runs in. No requests===0 gate
+        // on purpose: `bili omp --resume` reuses a pre-existing session.
+        if (!pluginAgent && convHeader === undefined && !responsesIdentity?.clientProvided) {
+            const sole = consumeSoleHeaderlessRegister();
+            if (sole) {
+                pluginAgent = sole.agent;
+                pluginConversation = sole.conversationId;
             }
         }
         if (!pluginAgent && session.stats.requests === 0) {

--- a/tests/launcher-plugin-mode.test.ts
+++ b/tests/launcher-plugin-mode.test.ts
@@ -115,11 +115,11 @@ function postModel(rig: Rig, sessionHeader?: string): Promise<Response> {
     });
 }
 
-async function register(rig: Rig, conversationId: string, opts?: { agent?: string; identity?: boolean }): Promise<void> {
+async function register(rig: Rig, conversationId: string, opts?: { agent?: string; identity?: boolean; headerless?: boolean }): Promise<void> {
     const res = await fetch(rig.proxyUrl("/__bili/plugin/register"), {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ conversationId, agent: opts?.agent, identity: opts?.identity ?? false }),
+        body: JSON.stringify({ conversationId, agent: opts?.agent, identity: opts?.identity ?? false, headerless: opts?.headerless ?? false }),
     });
     assert.equal(res.status, 200, "register accepted");
 }
@@ -180,6 +180,88 @@ test("launcher identity binding does not leak onto other sessions", async () => 
         assert.ok(rig.upstreamBodies[0]!.includes("compress"), "unregistered conversation stays wire mode");
         const status = await (await fetch(rig.proxyUrl("/__bili/plugin/status?conversationId=sess-mine"))).json() as { ok: boolean };
         assert.ok(!status.ok, "registration not consumed by a foreign session");
+    } finally {
+        await rig.closeAll();
+    }
+});
+
+test("omp headerless identity binding: register before the first request binds the headerless session (#268)", async () => {
+    const rig = await startRig();
+    try {
+        // omp cannot stamp its conversation id on requests (no
+        // before_provider_headers event) — the registration is flagged
+        // headerless and the proxy attributes the identity-less request to
+        // the sole pending headerless registration.
+        await register(rig, "omp-conv-1", { agent: "omp", identity: true, headerless: true });
+        await postModel(rig); // no session header at all — omp's real shape
+        assert.ok(!rig.upstreamBodies[0]!.includes("\"compress\""), "wire tool injection suppressed from the very first request");
+        const status = await (await fetch(rig.proxyUrl("/__bili/plugin/status?conversationId=omp-conv-1"))).json() as { ok: boolean; pluginAgent?: string };
+        assert.ok(status.ok, "conversation bound under the registered client id");
+        assert.equal(status.pluginAgent, "omp");
+    } finally {
+        await rig.closeAll();
+    }
+});
+
+test("omp headerless identity binding: register arriving AFTER the first request still binds (tool-ready race)", async () => {
+    const rig = await startRig();
+    try {
+        // The omp plugin registers only after the manifest fetch completes —
+        // the first request may already be in flight.
+        await postModel(rig);
+        assert.ok(rig.upstreamBodies[0]!.includes("compress"), "wire tools injected before the register lands");
+        await register(rig, "omp-conv-2", { agent: "omp", identity: true, headerless: true });
+        await postModel(rig);
+        assert.ok(!rig.upstreamBodies[1]!.includes("\"compress\""), "wire tool injection suppressed after the sole-headerless binding");
+        const status = await (await fetch(rig.proxyUrl("/__bili/plugin/status?conversationId=omp-conv-2"))).json() as { ok: boolean; pluginAgent?: string };
+        assert.ok(status.ok, "conversation registered");
+        assert.equal(status.pluginAgent, "omp");
+    } finally {
+        await rig.closeAll();
+    }
+});
+
+test("headerless binding does not leak onto sessions carrying a client identity", async () => {
+    const rig = await startRig();
+    try {
+        await register(rig, "omp-conv-3", { agent: "omp", identity: true, headerless: true });
+        await postModel(rig, "sess-other"); // carries x-claude-code-session-id
+        assert.ok(rig.upstreamBodies[0]!.includes("compress"), "identified session stays wire mode");
+        await postModel(rig); // the real headerless omp request
+        assert.ok(!rig.upstreamBodies[1]!.includes("\"compress\""), "registration consumed by the headerless request");
+        const status = await (await fetch(rig.proxyUrl("/__bili/plugin/status?conversationId=omp-conv-3"))).json() as { ok: boolean; pluginAgent?: string };
+        assert.ok(status.ok, "bound under the registered client id");
+        assert.equal(status.pluginAgent, "omp");
+    } finally {
+        await rig.closeAll();
+    }
+});
+
+test("non-headerless (claude-style) identity registration is not consumed by a headerless request", async () => {
+    const rig = await startRig();
+    try {
+        await register(rig, "claude-conv-1", { agent: "mcp", identity: true });
+        await postModel(rig); // headerless request — must NOT eat the claude registration
+        assert.ok(rig.upstreamBodies[0]!.includes("compress"), "headerless request stays wire mode");
+        await postModel(rig, "claude-conv-1"); // the real claude request
+        assert.ok(!rig.upstreamBodies[1]!.includes("\"compress\""), "exact-match identity binding still works");
+        const status = await (await fetch(rig.proxyUrl("/__bili/plugin/status?conversationId=claude-conv-1"))).json() as { ok: boolean };
+        assert.ok(status.ok, "claude conversation bound by exact match");
+    } finally {
+        await rig.closeAll();
+    }
+});
+
+test("two pending headerless registrations are ambiguous — no binding", async () => {
+    const rig = await startRig();
+    try {
+        await register(rig, "omp-a", { agent: "omp", identity: true, headerless: true });
+        await register(rig, "omp-b", { agent: "omp", identity: true, headerless: true });
+        await postModel(rig);
+        assert.ok(rig.upstreamBodies[0]!.includes("compress"), "ambiguous — stays wire mode");
+        const a = await (await fetch(rig.proxyUrl("/__bili/plugin/status?conversationId=omp-a"))).json() as { ok: boolean };
+        const b = await (await fetch(rig.proxyUrl("/__bili/plugin/status?conversationId=omp-b"))).json() as { ok: boolean };
+        assert.ok(!a.ok && !b.ok, "neither conversation bound");
     } finally {
         await rig.closeAll();
     }

--- a/tests/plugin-agent.test.ts
+++ b/tests/plugin-agent.test.ts
@@ -56,7 +56,7 @@ test("proxyBaseFromEnv accepts BILLION_CONTEXT_PROXY, detectProxyBase honors kil
 type FakeProxy = {
     origin: string;
     toolCalls: Array<{ conversationId: string; tool: string; args: unknown }>;
-    registers: Array<{ conversationId: string; agent: string; identity: boolean }>;
+    registers: Array<{ conversationId: string; agent: string; identity: boolean; headerless: boolean }>;
     close(): Promise<void>;
 };
 
@@ -92,8 +92,8 @@ async function startFakeProxy(opts: { failRegister?: number } = {}): Promise<Fak
             let body = "";
             req.on("data", (c) => (body += c));
             req.on("end", () => {
-                const data = JSON.parse(body) as { conversationId?: string; agent?: string; identity?: boolean };
-                registers.push({ conversationId: data.conversationId ?? "", agent: data.agent ?? "", identity: data.identity === true });
+                const data = JSON.parse(body) as { conversationId?: string; agent?: string; identity?: boolean; headerless?: boolean };
+                registers.push({ conversationId: data.conversationId ?? "", agent: data.agent ?? "", identity: data.identity === true, headerless: data.headerless === true });
                 if (opts.failRegister !== undefined) {
                     res.writeHead(opts.failRegister);
                     res.end("{}");
@@ -720,7 +720,7 @@ test("omp plugin identity-registers the conversation once tools are ready", asyn
         while (proxy.registers.length === 0 && Date.now() < deadline) {
             await new Promise((r) => setTimeout(r, 25));
         }
-        assert.deepEqual(proxy.registers, [{ conversationId: "omp-sess-7", agent: "omp", identity: true }]);
+        assert.deepEqual(proxy.registers, [{ conversationId: "omp-sess-7", agent: "omp", identity: true, headerless: true }]);
         // Re-driving per-request events must not re-POST (identityAt caches by sid).
         await pi.events.get("before_provider_request")!({}, fakeCtx(proxy, "omp-sess-7"));
         await flush();
@@ -731,7 +731,7 @@ test("omp plugin identity-registers the conversation once tools are ready", asyn
         while (proxy.registers.length < 2 && Date.now() < deadline2) {
             await new Promise((r) => setTimeout(r, 25));
         }
-        assert.deepEqual(proxy.registers[1], { conversationId: "omp-sess-8", agent: "omp", identity: true });
+        assert.deepEqual(proxy.registers[1], { conversationId: "omp-sess-8", agent: "omp", identity: true, headerless: true });
     } finally {
         await proxy.close();
     }

--- a/tests/plugin-protocol.test.ts
+++ b/tests/plugin-protocol.test.ts
@@ -9,7 +9,7 @@ import { defaultConfig } from "acp-kernel";
 import { startServer, type ProxyOptions } from "../src/server.ts";
 import { SessionStore, _setStoreForTest } from "../src/persist.ts";
 import { _setForTest as setRegistryForTest } from "../src/registry.ts";
-import { _resetPluginStateForTest, pluginReportedContextWindow, queuePluginRegister, takePendingPluginRegister } from "../src/plugin.ts";
+import { _resetPluginStateForTest, consumePluginRegisterFor, consumeSoleHeaderlessRegister, pluginReportedContextWindow, queuePluginRegister, takePendingPluginRegister } from "../src/plugin.ts";
 import { clientConversationHeader } from "../src/session-id.ts";
 
 interface Harness {
@@ -534,6 +534,31 @@ test("headless launcher registrations expire after the TTL (no stale poisoning)"
         queuePluginRegister("ttl-fresh", "codex", false);
         assert.equal(takePendingPluginRegister()?.conversationId, "ttl-fresh", "expired registration dropped, fresh one bound");
         assert.equal(takePendingPluginRegister(), undefined, "queue drained");
+    } finally {
+        Date.now = realNow;
+        _resetPluginStateForTest();
+    }
+});
+
+test("headerless identity registrations: sole + fresh binds, stale drops, non-headerless untouched (#268)", () => {
+    _resetPluginStateForTest();
+    const t0 = Date.now();
+    const realNow = Date.now;
+    try {
+        Date.now = () => t0;
+        queuePluginRegister("hl-stale", "omp", true, true);
+        Date.now = () => t0 + 11 * 60 * 1000;
+        assert.equal(consumeSoleHeaderlessRegister(), undefined, "stale registration dropped, not bound");
+        queuePluginRegister("hl-fresh", "omp", true, true);
+        assert.deepEqual(consumeSoleHeaderlessRegister(), { conversationId: "hl-fresh", agent: "omp" }, "fresh sole registration bound");
+        assert.equal(consumeSoleHeaderlessRegister(), undefined, "queue drained");
+        queuePluginRegister("claude-x", "mcp", true);
+        assert.equal(consumeSoleHeaderlessRegister(), undefined, "non-headerless entry not consumed by the heuristic");
+        assert.equal(consumePluginRegisterFor("claude-x"), "mcp", "still consumable by exact match");
+        queuePluginRegister("omp-y", "omp", true, true);
+        queuePluginRegister("omp-z", "omp", true, true);
+        assert.equal(consumeSoleHeaderlessRegister(), undefined, "multiple entries — ambiguous, nothing consumed");
+        assert.equal(consumePluginRegisterFor("omp-y"), "omp", "entries survive for a later exact match");
     } finally {
         Date.now = realNow;
         _resetPluginStateForTest();


### PR DESCRIPTION
## Problem (#268)

`bili omp` + `/acp` always reports "No model request in this conversation yet".

omp cannot stamp the `x-bili-plugin` / `x-bili-plugin-conversation` headers on model requests (omp 18.0.6 has no `before_provider_headers` extension event), so the plugin falls back to the launcher identity register: `POST /__bili/plugin/register {conversationId: <client sid>, agent: "omp", identity: true}`.

The proxy only consumed identity registrations by **exact match** — `consumePluginRegisterFor(clientConv ?? conversation)` — where `clientConv` comes from client identity headers (omp sends none) and `conversation` is the content-derived fingerprint. The derived key never equals the client session id, so the registration was never consumed, `recordPluginSession` never ran, the `conversations` map stayed empty, and `GET /__bili/plugin/status?conversationId=<sid>` 404'd. Compression itself kept working (wire-mode tool injection), so only `/acp` status was broken.

## Fix

Single-client attribution for **headerless** identity registrations:

- `src/agent/pi.ts` — the omp-only identity register now sends `headerless: true` (the plugin knows it cannot stamp headers). claude/codex registrations are unchanged.
- `src/plugin.ts` — `registeredIds` entries carry `{agent, headerless, ts}`; new `consumeSoleHeaderlessRegister()` returns the sole pending registration only when it is headerless and fresh (same 10 min TTL as the headless queue). Non-headerless entries are left untouched, so claude's exact-match path is unaffected.
- `src/server.ts` — after the exact-match identity step, when the request carries **no** client-provided conversation identity (no `x-claude-code-session-id` / `x-session-affinity` / `x-opencode-session` / … and no client-provided `prompt_cache_key`), the sole fresh headerless registration is bound to the request. `pluginConversation` is the registered **client** session id, so `recordPluginSession` keys the map by it and `/acp` (and tool forwarding) work. Deliberately no `requests === 0` gate, so `bili omp --resume` (pre-existing session) also binds.

Safety:

- Requests carrying any client identity never consume the registration (exact match still has first claim).
- Two pending headerless registrations = ambiguous → no binding (degrades to today's wire mode).
- Stale registrations (>10 min) are dropped, so an abandoned omp session cannot hijack a later unrelated request.
- Responses protocol was already unaffected (omp's `prompt_cache_key` is recorded directly).

## Tests

- `tests/launcher-plugin-mode.test.ts` — 5 new e2e tests: register-before-first-request, register-after-first-request (tool-ready race), no leak onto identified sessions, claude-style registration not consumed by headerless requests, ambiguous double registration.
- `tests/plugin-protocol.test.ts` — unit test for `consumeSoleHeaderlessRegister` (fresh/sole/stale/non-headerless/ambiguous).
- `tests/plugin-agent.test.ts` — fake proxy now captures and asserts the `headerless: true` flag.

Checks: `npm run typecheck`, `npm test` (652 pass), `npm run build` — all green.
