### PR TITLE
release v0.1.57

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.56",
+  "version": "0.1.57",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.56",
+      "version": "0.1.57",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.56",
+  "version": "0.1.57",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Model: qwen3.8-27b (vllm)

Version bump only: 0.1.56 → 0.1.57.

## Changes since v0.1.56

- **#254** — preflight-compress oversized context before forward on model switch (#247: switching from a 1M-window model to a 262k one no longer 400s; context is compressed pre-forward until it fits)
- **#264** — stamp `type:"message"` on type-less Responses input items (omp wire form) so user prompts enter the kernel
- **#267** — omp chat-completions sessions get prompt_cache_key identity + `/acp` panel (supersedes #266)
- **#269** — identity plugin binding survives model switches across sessions (one conversation, many sessions; LRU sticky)

Joint regression done pre-merge (653/653 then, 657/657 on this branch incl. new tests; model-switch e2e verified against a live omp + dual-protocol mock).

Pre-flight: typecheck ✅ · 657/657 ✅ · build ✅