### PR TITLE
fix: body dumps off by default (ACP_DUMP_BODY) + reuse log-mask in dumps (#276)

### DIFF
--- a/src/log-mask.ts
+++ b/src/log-mask.ts
@@ -93,3 +93,21 @@ export function maskHeadersForLog(headers: Record<string, string>): Record<strin
     for (const [k, v] of Object.entries(headers)) out[k] = maskHeaderForLog(k, v);
     return out;
 }
+
+/** Scrub a specific host (the tunnel/forward target) from arbitrary error
+ *  text. OS/undici error messages embed the endpoint ("connect ECONNREFUSED
+ *  10.0.0.5:8443", "getaddrinfo ENOTFOUND relay.internal"), so a log line
+ *  that masks the host in its template still leaks it via `err.message`.
+ *  Only the given host is replaced — other addresses in the text (e.g. the
+ *  proxy's) are left as-is, matching the `proxy=` design decision. Handles
+ *  both the bracketed ([::1]) and bare (::1) IPv6 forms. */
+export function maskHostInText(text: string, host: string): string {
+    if (!host || isPublicApiHost(host)) return text;
+    const bare = host.replace(/^\[|\]$/g, "");
+    const forms = new Set<string>([host, bare]);
+    if (bare.includes(":")) forms.add(`[${bare}]`);
+    for (const form of forms) {
+        if (form.length > 0) text = text.split(form).join(PRIVATE_HOST);
+    }
+    return text;
+}

--- a/src/log-mask.ts
+++ b/src/log-mask.ts
@@ -1,0 +1,95 @@
+/**
+ * Log-safety helpers (#255): keep credentials and non-public API endpoints
+ * out of bili.log / launcher logs.
+ *
+ * Rule: well-known PUBLIC LLM API hosts (openai, anthropic, ...) may appear
+ * in logs verbatim; anything else is a non-public endpoint (private relay,
+ * self-hosted, internal domain) and its host is replaced with a placeholder.
+ * Credential header values (authorization, x-api-key, cookie, ...) are
+ * replaced by a length hint.
+ */
+
+export const PRIVATE_HOST = "<private-host>";
+
+/** Well-known public LLM API host suffixes safe to log verbatim. Suffix
+ *  matching covers subdomains (api.openai.com,
+ *  generativelanguage.googleapis.com, ...). Unknown hosts are masked — the
+ *  safe default. */
+const PUBLIC_HOST_SUFFIXES = [
+    "openai.com",
+    "chatgpt.com",
+    "anthropic.com",
+    "deepseek.com",
+    "googleapis.com",
+    "azure.com",
+    "amazonaws.com",
+    "mistral.ai",
+    "groq.com",
+    "cohere.com",
+    "together.ai",
+    "fireworks.ai",
+    "x.ai",
+    "openrouter.ai",
+    "huggingface.co",
+    "moonshot.ai",
+    "zhipuai.com",
+    "volcengine.com",
+    "aliyuncs.com",
+    "baidu.com",
+    "baidubce.com",
+    "minimax.io",
+];
+
+const CREDENTIAL_HEADER_RE = /key|auth|token|cookie/i;
+
+export function isPublicApiHost(host: string): boolean {
+    const h = host.replace(/^\[|\]$/g, "").toLowerCase();
+    return PUBLIC_HOST_SUFFIXES.some((s) => h === s || h.endsWith(`.${s}`));
+}
+
+export function maskHostForLog(host: string): string {
+    return isPublicApiHost(host) ? host : PRIVATE_HOST;
+}
+
+/** Mask a URL for logging: non-public host → placeholder; userinfo, query and
+ *  hash are always dropped (query strings are a classic key-leak vector);
+ *  the path is kept (debug signal, not sensitive). */
+export function maskUrlForLog(url: string): string {
+    let u: URL;
+    try {
+        u = new URL(url);
+    } catch {
+        return "<unparseable-url>";
+    }
+    const host = isPublicApiHost(u.hostname) ? u.host : `${PRIVATE_HOST}${u.port ? `:${u.port}` : ""}`;
+    return `${u.protocol}//${host}${u.pathname}`;
+}
+
+/** Mask every http(s) URL embedded anywhere in an arbitrary string (request
+ *  paths like /bili/http://relay.internal/v1/..., error text). */
+export function maskUrlsInText(text: string): string {
+    return text.replace(/https?:\/\/[^\s"'<>]+/gi, (m) => maskUrlForLog(m));
+}
+
+/** Mask the host of a `host:port` target (e.g. an HTTP CONNECT request
+ *  line) for logging. */
+export function maskHostPortForLog(target: string): string {
+    const i = target.lastIndexOf(":");
+    if (i <= 0) return maskHostForLog(target);
+    return `${maskHostForLog(target.slice(0, i))}${target.slice(i)}`;
+}
+
+/** Mask a single header value for logging. Credential headers become a
+ *  length hint; the `host` header (host:port) follows the same
+ *  public/private rule as URLs; anything else passes through. */
+export function maskHeaderForLog(name: string, value: string): string {
+    if (name.toLowerCase() === "host") return maskHostPortForLog(value);
+    if (CREDENTIAL_HEADER_RE.test(name)) return `<masked ${value.length} chars>`;
+    return value;
+}
+
+export function maskHeadersForLog(headers: Record<string, string>): Record<string, string> {
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(headers)) out[k] = maskHeaderForLog(k, v);
+    return out;
+}

--- a/src/loop/core.ts
+++ b/src/loop/core.ts
@@ -447,7 +447,7 @@ export async function* runCompressLoop(
                 );
 
             let newBody = adapter.buildRequest(coreMessages, systemPrompt, requestBody);
-            if (process.env.ACP_DUMP_REQ !== "0" && ctx.debug) {
+            if (process.env.ACP_DUMP_BODY === "1") {
                 try {
                     const fs = await import("node:fs");
                     const dumpDir = process.env.ACP_DUMP_DIR || `${process.env.HOME}/.local/state/billion-context/dumps`;

--- a/src/mitm.ts
+++ b/src/mitm.ts
@@ -5,6 +5,7 @@ import { ensureRootCA, getSecureContext } from "./ca.js";
 import { connectThroughProxy } from "./upstream-proxy.js";
 import { discoverMitmDomains } from "./discover.js";
 import { isLoopbackAddress } from "./util.js";
+import { maskHostForLog, maskHostPortForLog } from "./log-mask.js";
 
 // Domains we transparently MITM. These are ONLY the model-inference endpoints
 // hardcoded in client BINARIES with no config file to discover from
@@ -76,7 +77,7 @@ export function setupMitm(
     server.on("connect", (req: http.IncomingMessage, clientSocket: net.Socket, head: Buffer) => {
         const remote = !isLoopbackAddress(clientSocket.remoteAddress);
         if (remote && !allowRemoteClients) {
-            log(`CONNECT ${req.url} rejected: non-loopback client ${clientSocket.remoteAddress} (bind a non-loopback --host to allow remote clients)`);
+            log(`CONNECT ${maskHostPortForLog(req.url ?? "")} rejected: non-loopback client ${clientSocket.remoteAddress} (bind a non-loopback --host to allow remote clients)`);
             // end() (not write+destroy) so the 403 bytes are flushed before close.
             clientSocket.end("HTTP/1.1 403 Forbidden\r\n\r\n");
             return;
@@ -89,7 +90,7 @@ export function setupMitm(
                 // client must not use this proxy as an open TCP relay to
                 // arbitrary hosts. Remote CONNECT is for MITM-whitelisted
                 // model endpoints only.
-                log(`CONNECT ${req.url} rejected: remote client ${clientSocket.remoteAddress} tunneling non-whitelisted host`);
+                log(`CONNECT ${maskHostPortForLog(req.url ?? "")} rejected: remote client ${clientSocket.remoteAddress} tunneling non-whitelisted host`);
                 clientSocket.end("HTTP/1.1 403 Forbidden\r\n\r\n");
                 return;
             }
@@ -134,7 +135,7 @@ function tunnelThrough(
     const connectTimer = setTimeout(() => {
         if (!established) {
             aborted = true;
-            log(`tunnel ${host}:${port} connect timeout`);
+            log(`tunnel ${maskHostForLog(host)}:${port} connect timeout`);
             clientSocket.write("HTTP/1.1 504 Gateway Timeout\r\n\r\n");
             clientSocket.destroy();
         }
@@ -151,7 +152,7 @@ function tunnelThrough(
         upstream.pipe(clientSocket);
         clientSocket.pipe(upstream);
         const cleanup = (where: string, err: Error) => {
-            log(`tunnel ${host}:${port} ${where} closed: ${err.message}`);
+            log(`tunnel ${maskHostForLog(host)}:${port} ${where} closed: ${err.message}`);
             upstream.destroy();
             clientSocket.destroy();
         };
@@ -160,7 +161,7 @@ function tunnelThrough(
     }).catch((err: Error) => {
         if (aborted) return;
         clearTimeout(connectTimer);
-        log(`tunnel ${host}:${port} connect failed: ${err.message}`);
+        log(`tunnel ${maskHostForLog(host)}:${port} connect failed: ${err.message}`);
         clientSocket.write("HTTP/1.1 502 Bad Gateway\r\n\r\n");
         clientSocket.destroy();
     });
@@ -193,7 +194,7 @@ function doMitm(
             ALPNProtocols: ["http/1.1"],
         });
     } catch (e) {
-        log(`mitm ${host}:${port} TLS setup failed: ${(e as Error).message}`);
+        log(`mitm ${maskHostForLog(host)}:${port} TLS setup failed: ${(e as Error).message}`);
         clientSocket.destroy();
         return;
     }
@@ -206,7 +207,7 @@ function doMitm(
     // it as an uncaught exception and crashes the whole proxy. Destroy the
     // underlying socket and log — mirrors tunnelThrough()'s error handling.
     tlsSocket.on("error", (err: Error) => {
-        log(`mitm ${host}:${port} TLS error: ${err.message}`);
+        log(`mitm ${maskHostForLog(host)}:${port} TLS error: ${err.message}`);
         tlsSocket.destroy();
         clientSocket.destroy();
     });
@@ -215,7 +216,7 @@ function doMitm(
     // and our signed-cert context open indefinitely. Arm a handshake timeout;
     // clear it once the handshake completes ('secure'), or on error/close.
     const handshakeTimer = setTimeout(() => {
-        log(`mitm ${host}:${port} TLS handshake timeout`);
+        log(`mitm ${maskHostForLog(host)}:${port} TLS handshake timeout`);
         tlsSocket.destroy();
         clientSocket.destroy();
     }, mitmHandshakeTimeoutMs());
@@ -227,7 +228,7 @@ function doMitm(
     // the cleartext bytes — exactly the same path as a direct (non-proxy)
     // request, so handle()/forward() work unmodified.
     server.emit("connection", tlsSocket);
-    log(`mitm ${host}:${port} tunnel established (TLS terminated locally)`);
+    log(`mitm ${maskHostForLog(host)}:${port} tunnel established (TLS terminated locally)`);
 }
 
 /** Read the MITM upstream marker from a request's underlying socket.

--- a/src/mitm.ts
+++ b/src/mitm.ts
@@ -5,7 +5,7 @@ import { ensureRootCA, getSecureContext } from "./ca.js";
 import { connectThroughProxy } from "./upstream-proxy.js";
 import { discoverMitmDomains } from "./discover.js";
 import { isLoopbackAddress } from "./util.js";
-import { maskHostForLog, maskHostPortForLog } from "./log-mask.js";
+import { maskHostForLog, maskHostInText, maskHostPortForLog } from "./log-mask.js";
 
 // Domains we transparently MITM. These are ONLY the model-inference endpoints
 // hardcoded in client BINARIES with no config file to discover from
@@ -152,7 +152,7 @@ function tunnelThrough(
         upstream.pipe(clientSocket);
         clientSocket.pipe(upstream);
         const cleanup = (where: string, err: Error) => {
-            log(`tunnel ${maskHostForLog(host)}:${port} ${where} closed: ${err.message}`);
+            log(`tunnel ${maskHostForLog(host)}:${port} ${where} closed: ${maskHostInText(err.message, host)}`);
             upstream.destroy();
             clientSocket.destroy();
         };
@@ -161,7 +161,7 @@ function tunnelThrough(
     }).catch((err: Error) => {
         if (aborted) return;
         clearTimeout(connectTimer);
-        log(`tunnel ${maskHostForLog(host)}:${port} connect failed: ${err.message}`);
+        log(`tunnel ${maskHostForLog(host)}:${port} connect failed: ${maskHostInText(err.message, host)}`);
         clientSocket.write("HTTP/1.1 502 Bad Gateway\r\n\r\n");
         clientSocket.destroy();
     });

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,6 +9,7 @@ import { resolveContextLimit, resolveCompressProtocol } from "./config.js";
 import { contextFromRegistry, loadRegistry, peekRegistryContext } from "./registry.js";
 import { fetchWithTimeout, MAX_REQUEST_BYTES } from "./fetch-util.js";
 import { formatUpstreamError, getUpstreamConnectionStatus, recordUpstreamConnection, resolveProxy, resolveProxyDecision, proxyDispatcher } from "./upstream-proxy.js";
+import { maskHeaderForLog, maskUrlForLog, maskUrlsInText } from "./log-mask.js";
 // Protocol codecs live in the kernel now (single source of truth shared with
 // the omp/pi adapters): import from "acp-kernel/wire".
 import {
@@ -226,7 +227,7 @@ export async function startServer(opts: ProxyOptions): Promise<http.Server> {
     // built-in fast-fallback (e.g. Codex) that need a clean 426 to switch to
     // HTTP POST immediately.
     server.on("upgrade", (req, socket) => {
-        log("info", `[ws] rejected ${req.method} ${req.url ?? ""} host=${req.headers.host ?? "?"} with 426`);
+        log("info", `[ws] rejected ${req.method} ${maskUrlsInText(req.url ?? "")} host=${req.headers.host ?? "?"} with 426`);
         socket.on("error", () => {}); // client may vanish mid-write; don't let ECONNRESET crash the process
         const body = JSON.stringify({ error: "WebSocket upgrades are not supported; use HTTP POST" });
         socket.end(
@@ -909,7 +910,7 @@ async function handle(
     }
     if (!prepared) {
         if (protocol === null && !opts.passthrough) {
-            log("warn", `unrecognized path ${req.url ?? ""} — not a known protocol (/chat/completions, /v1/messages, /responses, /responses/compact); forwarding unchanged`);
+            log("warn", `unrecognized path ${maskUrlsInText(req.url ?? "")} — not a known protocol (/chat/completions, /v1/messages, /responses, /responses/compact); forwarding unchanged`);
         }
         await forward(req, res, opts, bodyBuffer, null, core, reqConfig, log, route, undefined);
     }
@@ -1592,7 +1593,7 @@ async function forward(
     // primary signal. The provider label is appended only for named routes —
     // zero-config requests have a single routing mode now, so the final
     // proxied URL is the only useful signal in the log.
-    log("info", `forward ${req.method} → ${upstreamUrl}`);
+    log("info", `forward ${req.method} → ${maskUrlForLog(upstreamUrl)}`);
     if (process.env.ACP_DEBUG && prepared) {
         const sid = prepared.session.id;
         const hdrKeys = Object.keys(req.headers);
@@ -1636,7 +1637,10 @@ async function forward(
     if (opts.debug) {
         const hdrLog: Record<string, string> = {};
         for (const [hk, hv] of Object.entries(headers)) {
-            if (typeof hv === "string") hdrLog[hk] = hv.length > 200 ? hv.slice(0, 200) + "..." : hv;
+            if (typeof hv === "string") {
+                const masked = maskHeaderForLog(hk, hv);
+                hdrLog[hk] = masked.length > 200 ? masked.slice(0, 200) + "..." : masked;
+            }
         }
         log("info", `[${prepared?.session.id ?? "unknown"}] → upstream headers: ${JSON.stringify(hdrLog)}`);
     }
@@ -1711,7 +1715,8 @@ async function forward(
         upstream.headers.forEach((v, k) => {
             const lower = k.toLowerCase();
             if (UPSTREAM_HOP_HEADERS.has(lower) || respConnNamed.has(lower)) return;
-            respLog[k] = v.length > 300 ? v.slice(0, 300) + "..." : v;
+            const masked = maskHeaderForLog(k, v);
+            respLog[k] = masked.length > 300 ? masked.slice(0, 300) + "..." : masked;
         });
         log("info", `[${prepared?.session.id ?? "unknown"}] ← upstream response headers: ${JSON.stringify(respLog)}`);
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,7 +9,7 @@ import { resolveContextLimit, resolveCompressProtocol } from "./config.js";
 import { contextFromRegistry, loadRegistry, peekRegistryContext } from "./registry.js";
 import { fetchWithTimeout, MAX_REQUEST_BYTES } from "./fetch-util.js";
 import { formatUpstreamError, getUpstreamConnectionStatus, recordUpstreamConnection, resolveProxy, resolveProxyDecision, proxyDispatcher } from "./upstream-proxy.js";
-import { maskHeaderForLog, maskHeadersForLog, maskUrlForLog, maskUrlsInText } from "./log-mask.js";
+import { maskHeaderForLog, maskHeadersForLog, maskHostPortForLog, maskUrlForLog, maskUrlsInText } from "./log-mask.js";
 // Protocol codecs live in the kernel now (single source of truth shared with
 // the omp/pi adapters): import from "acp-kernel/wire".
 import {
@@ -236,7 +236,7 @@ export async function startServer(opts: ProxyOptions): Promise<http.Server> {
     // built-in fast-fallback (e.g. Codex) that need a clean 426 to switch to
     // HTTP POST immediately.
     server.on("upgrade", (req, socket) => {
-        log("info", `[ws] rejected ${req.method} ${maskUrlsInText(req.url ?? "")} host=${req.headers.host ?? "?"} with 426`);
+        log("info", `[ws] rejected ${req.method} ${maskUrlsInText(req.url ?? "")} host=${req.headers.host ? maskHostPortForLog(req.headers.host) : "?"} with 426`);
         socket.on("error", () => {}); // client may vanish mid-write; don't let ECONNRESET crash the process
         const body = JSON.stringify({ error: "WebSocket upgrades are not supported; use HTTP POST" });
         socket.end(

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,7 +9,7 @@ import { resolveContextLimit, resolveCompressProtocol } from "./config.js";
 import { contextFromRegistry, loadRegistry, peekRegistryContext } from "./registry.js";
 import { fetchWithTimeout, MAX_REQUEST_BYTES } from "./fetch-util.js";
 import { formatUpstreamError, getUpstreamConnectionStatus, recordUpstreamConnection, resolveProxy, resolveProxyDecision, proxyDispatcher } from "./upstream-proxy.js";
-import { maskHeaderForLog, maskUrlForLog, maskUrlsInText } from "./log-mask.js";
+import { maskHeaderForLog, maskHeadersForLog, maskUrlForLog, maskUrlsInText } from "./log-mask.js";
 // Protocol codecs live in the kernel now (single source of truth shared with
 // the omp/pi adapters): import from "acp-kernel/wire".
 import {
@@ -62,6 +62,15 @@ import type { BiliMessage } from "acp-kernel/wire";
 import { isLoopbackAddress, inspectContextOverflow, reserveOutputHeadroom, shouldReserveOutputHeadroom, usageTotals } from "./util.js";
 
 import { decodeRequestBody } from "./content-encoding.js";
+
+// Body dumps (dumps/req-*.json, raw/*-REQ.txt, raw/*-RES.txt, raw/*-INCOMING.txt,
+// req-*-REREQUEST.json) write the full plaintext request body and are off by
+// default. They are decoupled from --debug (verbose logging) and enabled only
+// with ACP_DUMP_BODY=1 so `bili <client>` users don't leak conversation bodies
+// to disk by default (#276).
+function bodyDumpEnabled(): boolean {
+    return process.env.ACP_DUMP_BODY === "1";
+}
 
 // Per-model context windows handed over by a `bili <client>` launcher
 // (BILI_LAUNCHER_MODEL_WINDOWS, JSON model-id → window), read from the
@@ -640,17 +649,20 @@ async function handle(
     // Capture the CLIENT's raw incoming request (before bili rebuilds) to
     // resolve whether codex sends previous_response_id + full input vs delta.
     if (opts.debug && parsed && typeof parsed === "object") {
+        const p = parsed as Record<string, unknown>;
+        const hasPrev = p.previous_response_id !== undefined;
+        const inLen = Array.isArray(p.input) ? p.input.length : 0;
+        log("info", `[debug] INCOMING previous_response_id=${hasPrev ? String(p.previous_response_id).slice(0, 16) : "absent"} input_items=${inLen} instructions=${p.instructions !== undefined ? "present" : "absent"}`);
+    }
+    if (bodyDumpEnabled() && parsed && typeof parsed === "object") {
         try {
-            const p = parsed as Record<string, unknown>;
-            const hasPrev = p.previous_response_id !== undefined;
-            const inLen = Array.isArray(p.input) ? p.input.length : 0;
-            log("info", `[debug] INCOMING previous_response_id=${hasPrev ? String(p.previous_response_id).slice(0, 16) : "absent"} input_items=${inLen} instructions=${p.instructions !== undefined ? "present" : "absent"}`);
-            const rawDir = `${stateDir()}/raw`;
+            const rawDir = process.env.ACP_RAW_DUMP_DIR || `${stateDir()}/raw`;
             try { fs.mkdirSync(rawDir, { recursive: true }); } catch { /* best-effort */ }
-            const hdrs = Object.entries(req.headers)
-                .filter(([k]) => !/authorization|x-api-key|cookie/i.test(k))
-                .map(([k, v]) => `${k}: ${Array.isArray(v) ? v.join(",") : v}`).join("\n");
-            fs.writeFileSync(`${rawDir}/${Date.now()}-INCOMING.txt`, `${req.method} ${req.url}\n${hdrs}\n\n${bodyBuffer.toString("utf8")}`);
+            const hdrs = maskHeadersForLog(
+                Object.fromEntries(Object.entries(req.headers).map(([k, v]) => [k, Array.isArray(v) ? v.join(",") : String(v)])),
+            );
+            const hdrText = Object.entries(hdrs).map(([k, v]) => `${k}: ${v}`).join("\n");
+            fs.writeFileSync(`${rawDir}/${Date.now()}-INCOMING.txt`, `${req.method} ${maskUrlsInText(req.url ?? "")}\n${hdrText}\n\n${bodyBuffer.toString("utf8")}`);
         } catch { /* best-effort dump */ }
     }
     // Per-request context limit + compression tuning: look up body.model against
@@ -1610,16 +1622,18 @@ async function forward(
             }
         }
     }
-    if (opts.debug && typeof body === "string") {
+    if (typeof body === "string" && (opts.debug || bodyDumpEnabled())) {
         try {
             const parsed = JSON.parse(body);
-            const toolNames = (parsed.tools ?? []).map((t: Record<string, unknown>) => {
-                const fn = t.function as { name?: string } | undefined;
-                // chat completions nests under `function`; Responses API is flat.
-                return fn?.name ?? (t.name as string | undefined) ?? "?";
-            });
-            log("info", `[debug] tools=[${toolNames.join(",")}] msgs=${parsed.messages?.length ?? 0} stream=${parsed.stream ?? false} system_len=${JSON.stringify(parsed.messages?.find((m: Record<string, string>) => m.role === "system")?.content ?? "").length}`);
-            if (process.env.ACP_DUMP_REQ !== "0") {
+            if (opts.debug) {
+                const toolNames = (parsed.tools ?? []).map((t: Record<string, unknown>) => {
+                    const fn = t.function as { name?: string } | undefined;
+                    // chat completions nests under `function`; Responses API is flat.
+                    return fn?.name ?? (t.name as string | undefined) ?? "?";
+                });
+                log("info", `[debug] tools=[${toolNames.join(",")}] msgs=${parsed.messages?.length ?? 0} stream=${parsed.stream ?? false} system_len=${JSON.stringify(parsed.messages?.find((m: Record<string, string>) => m.role === "system")?.content ?? "").length}`);
+            }
+            if (bodyDumpEnabled() && process.env.ACP_DUMP_REQ !== "0") {
                 const dumpDir = process.env.ACP_DUMP_DIR || `${stateDir()}/dumps`;
                 try { fs.mkdirSync(dumpDir, { recursive: true }); } catch { /* best-effort */ }
                 const sid = prepared?.session.id ?? "unknown";
@@ -1647,10 +1661,10 @@ async function forward(
     // Raw HTTP capture: dump the COMPLETE exchange (request method/URL/all
     // headers/exact body bytes; response status+headers) so two consecutive
     // requests can be byte-diffed to locate a cache-breaker that the JSON body
-    // dump (which re-formats and omits headers) may hide. Enabled with --debug
-    // (headers written verbatim minus credential values).
+    // dump (which re-formats and omits headers) may hide. Enabled with
+    // ACP_DUMP_BODY=1 (credential header values + non-public hosts masked).
     const rawBase =
-        opts.debug
+        bodyDumpEnabled()
             ? (() => {
                   try {
                       const rawDir = process.env.ACP_RAW_DUMP_DIR || `${stateDir()}/raw`;
@@ -1663,10 +1677,8 @@ async function forward(
             : "";
     if (rawBase) {
         try {
-            const maskHdr = (k: string, v: string) =>
-                /key|auth|token/i.test(k) ? `<masked ${v.length} chars>` : v;
-            const hdrText = Object.entries(headers)
-                .map(([k, v]) => `${k}: ${maskHdr(k, String(v))}`)
+            const hdrText = Object.entries(maskHeadersForLog(headers))
+                .map(([k, v]) => `${k}: ${v}`)
                 .join("\n");
             const bodyText =
                 req.method === "GET" || req.method === "HEAD"
@@ -1675,7 +1687,7 @@ async function forward(
                       ? body
                       : Buffer.from(body).toString("utf8");
             const reqPath = `${rawBase}-REQ.txt`;
-            fs.writeFileSync(reqPath, `${req.method ?? "POST"} ${upstreamUrl}\n${hdrText}\n\n${bodyText}`);
+            fs.writeFileSync(reqPath, `${req.method ?? "POST"} ${maskUrlForLog(upstreamUrl)}\n${hdrText}\n\n${bodyText}`);
             log("info", `[debug] RAW request dump: ${reqPath}`);
         } catch { /* best-effort */ }
     }
@@ -1722,10 +1734,8 @@ async function forward(
     }
     if (rawBase) {
         try {
-            const maskHdr = (k: string, v: string) =>
-                /key|auth|token/i.test(k) ? `<masked ${v.length} chars>` : v;
-            const hdrText = Object.entries(respHeaders)
-                .map(([k, v]) => `${k}: ${maskHdr(k, v)}`)
+            const hdrText = Object.entries(maskHeadersForLog(respHeaders))
+                .map(([k, v]) => `${k}: ${v}`)
                 .join("\n");
             const resPath = `${rawBase}-RES.txt`;
             fs.writeFileSync(resPath, `${upstream.status}\n${hdrText}\n`);

--- a/src/upstream-proxy.ts
+++ b/src/upstream-proxy.ts
@@ -3,6 +3,7 @@ import net from "node:net";
 import tls from "node:tls";
 import { ProxyAgent } from "undici";
 import type { ProviderRoutes } from "./config.js";
+import { isPublicApiHost, maskUrlForLog, PRIVATE_HOST } from "./log-mask.js";
 
 export type ParsedHttpProxy = {
     url: string;
@@ -432,13 +433,24 @@ export function formatUpstreamError(error: unknown, url: string, proxyUrl?: stri
     const chain = errorChain(error);
     const fields = ["code", "errno", "syscall", "address", "port"];
     const parts: string[] = [];
+    // Error text from undici/OS layers embeds the endpoint identity
+    // ("connect ECONNREFUSED 10.0.0.5:8443", "getaddrinfo ENOTFOUND
+    // relay.internal") — swap in the placeholder when the upstream is a
+    // non-public host so the failure log leaks nothing either.
+    const maskHostIn = (s: string): string => {
+        try {
+            const u = new URL(url);
+            if (!isPublicApiHost(u.hostname)) return s.split(u.hostname).join(PRIVATE_HOST);
+        } catch { /* not a URL — nothing to mask */ }
+        return s;
+    };
     for (const field of fields) {
         const value = chain.find((entry) => entry[field] !== undefined)?.[field];
-        if (value !== undefined) parts.push(`${field}=${String(value)}`);
+        if (value !== undefined) parts.push(`${field}=${maskHostIn(String(value))}`);
     }
-    const messages = chain.map((entry) => String(entry.message ?? "")).filter(Boolean);
+    const messages = chain.map((entry) => maskHostIn(String(entry.message ?? ""))).filter(Boolean);
     if (messages.length > 0) parts.push(`message=${messages.join(" <- ")}`);
-    parts.push(`url=${url}`);
+    parts.push(`url=${maskUrlForLog(url)}`);
     parts.push(`proxy=${redactProxyUrl(proxyUrl) ?? "direct"}`);
     return parts.join(" ");
 }

--- a/src/upstream-proxy.ts
+++ b/src/upstream-proxy.ts
@@ -3,7 +3,7 @@ import net from "node:net";
 import tls from "node:tls";
 import { ProxyAgent } from "undici";
 import type { ProviderRoutes } from "./config.js";
-import { isPublicApiHost, maskUrlForLog, PRIVATE_HOST } from "./log-mask.js";
+import { maskHostInText, maskUrlForLog } from "./log-mask.js";
 
 export type ParsedHttpProxy = {
     url: string;
@@ -439,8 +439,7 @@ export function formatUpstreamError(error: unknown, url: string, proxyUrl?: stri
     // non-public host so the failure log leaks nothing either.
     const maskHostIn = (s: string): string => {
         try {
-            const u = new URL(url);
-            if (!isPublicApiHost(u.hostname)) return s.split(u.hostname).join(PRIVATE_HOST);
+            return maskHostInText(s, new URL(url).hostname);
         } catch { /* not a URL — nothing to mask */ }
         return s;
     };

--- a/tests/dump-mask.test.ts
+++ b/tests/dump-mask.test.ts
@@ -1,0 +1,181 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { once } from "node:events";
+import { defaultConfig } from "acp-kernel";
+import { startServer } from "../src/server.ts";
+import type { ProxyOptions } from "../src/config.ts";
+import { SessionStore, _setStoreForTest } from "../src/persist.ts";
+import { _setForTest as setRegistryForTest } from "../src/registry.ts";
+
+/** #276 (Part B of #255): body dumps (dumps/req-*.json, raw/*-REQ.txt,
+ *  raw/*-RES.txt, raw/*-INCOMING.txt) write the full plaintext request body and
+ *  must (a) be OFF by default even under --debug, and (b) when enabled via
+ *  ACP_DUMP_BODY=1, carry no credentials (authorization/x-api-key/cookie) and
+ *  no non-public host (private relay / self-hosted / 127.0.0.1). */
+
+const SECRET_BEARER = "sk-dump-bearer-AAA111";
+const SECRET_APIKEY = "sk-dump-apikey-BBB222";
+const SECRET_COOKIE = "dump-cookie-CCC333";
+const BODY_MARKER = "dump-body-marker-XYZ789";
+
+const DUMP_FILE_RE = /req-.*\.json$|-(REQ|RES|INCOMING)\.txt$/;
+
+function close(server: http.Server): Promise<void> {
+    return new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+}
+
+function listFiles(dir: string): string[] {
+    if (!fs.existsSync(dir)) return [];
+    const out: string[] = [];
+    for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+        const p = path.join(dir, e.name);
+        if (e.isDirectory()) out.push(...listFiles(p));
+        else out.push(p);
+    }
+    return out;
+}
+
+function baseOpts(debug: boolean): ProxyOptions {
+    return {
+        port: 0,
+        host: "127.0.0.1",
+        upstream: "http://127.0.0.1",
+        routes: {},
+        modelContextLimit: 400_000,
+        kernelConfig: defaultConfig(400_000),
+        compress: { injectTool: false, injectNudge: false },
+        promptCache: { routing: "auto" },
+        sessionHeader: "x-acp-session",
+        log: true,
+        debug,
+        passthrough: false,
+        autoUpdate: false,
+        mitm: { enabled: false, domains: [] },
+    };
+}
+
+interface Env {
+    xdg: string | undefined;
+    body: string | undefined;
+}
+
+function saveEnv(): Env {
+    return { xdg: process.env.XDG_STATE_HOME, body: process.env.ACP_DUMP_BODY };
+}
+
+function restoreEnv(prev: Env): void {
+    if (prev.xdg === undefined) delete process.env.XDG_STATE_HOME;
+    else process.env.XDG_STATE_HOME = prev.xdg;
+    if (prev.body === undefined) delete process.env.ACP_DUMP_BODY;
+    else process.env.ACP_DUMP_BODY = prev.body;
+}
+
+async function startHarness(debug: boolean, tmpRoot: string): Promise<{ proxy: http.Server; upstream: http.Server; proxyPort: number; upstreamPort: number }> {
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    setRegistryForTest({});
+    const upstream = http.createServer((_req, res) => {
+        res.writeHead(200, { "content-type": "application/json", "set-cookie": `session=${SECRET_COOKIE}` });
+        res.end(JSON.stringify({ id: "r1", object: "chat.completion", choices: [{ index: 0, message: { role: "assistant", content: "ok" }, finish_reason: "stop" }] }));
+    });
+    upstream.listen(0, "127.0.0.1");
+    await once(upstream, "listening");
+    const upstreamPort = (upstream.address() as { port: number }).port;
+    const opts = baseOpts(debug);
+    opts.routes = { [`http://127.0.0.1:${upstreamPort}`]: { models: { "gpt-test": { context: 400_000 } } } };
+    const proxy = await startServer(opts);
+    await once(proxy, "listening");
+    const proxyPort = (proxy.address() as { port: number }).port;
+    return { proxy, upstream, proxyPort, upstreamPort };
+}
+
+async function sendRequest(proxyPort: number, upstreamPort: number): Promise<void> {
+    const resp = await fetch(`http://127.0.0.1:${proxyPort}/bili/http://127.0.0.1:${upstreamPort}/v1/chat/completions`, {
+        method: "POST",
+        headers: {
+            "content-type": "application/json",
+            "x-acp-session": "dump-mask-1",
+            authorization: `Bearer ${SECRET_BEARER}`,
+            "x-api-key": SECRET_APIKEY,
+            cookie: `session=${SECRET_COOKIE}`,
+        },
+        body: JSON.stringify({ model: "gpt-test", messages: [{ role: "user", content: BODY_MARKER }] }),
+    });
+    assert.equal(resp.status, 200);
+    await resp.text();
+}
+
+test("body dumps are OFF by default even with --debug (#276)", async () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "bili-dump-off-"));
+    const prev = saveEnv();
+    process.env.XDG_STATE_HOME = tmpRoot;
+    delete process.env.ACP_DUMP_BODY;
+    let h: Awaited<ReturnType<typeof startHarness>> | undefined;
+    try {
+        h = await startHarness(true, tmpRoot);
+        await sendRequest(h.proxyPort, h.upstreamPort);
+        const dumpFiles = listFiles(path.join(tmpRoot, "billion-context")).filter((f) => DUMP_FILE_RE.test(f));
+        assert.equal(dumpFiles.length, 0, `expected no body dumps by default, got: ${dumpFiles.join(", ")}`);
+    } finally {
+        restoreEnv(prev);
+        if (h) { await close(h.proxy); await close(h.upstream); }
+        fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+});
+
+test("ACP_DUMP_BODY=1: dumps written, no credentials, no non-public host (#276)", async () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "bili-dump-on-"));
+    const prev = saveEnv();
+    process.env.XDG_STATE_HOME = tmpRoot;
+    process.env.ACP_DUMP_BODY = "1";
+    let h: Awaited<ReturnType<typeof startHarness>> | undefined;
+    try {
+        h = await startHarness(true, tmpRoot);
+        await sendRequest(h.proxyPort, h.upstreamPort);
+        const files = listFiles(path.join(tmpRoot, "billion-context"));
+        const dumpFiles = files.filter((f) => DUMP_FILE_RE.test(f));
+        assert.ok(dumpFiles.some((f) => /req-.*\.json$/.test(f)), `missing req-*.json dump: ${dumpFiles.join(", ")}`);
+        assert.ok(dumpFiles.some((f) => /-REQ\.txt$/.test(f)), `missing *-REQ.txt dump: ${dumpFiles.join(", ")}`);
+        assert.ok(dumpFiles.some((f) => /-RES\.txt$/.test(f)), `missing *-RES.txt dump: ${dumpFiles.join(", ")}`);
+        assert.ok(dumpFiles.some((f) => /-INCOMING\.txt$/.test(f)), `missing *-INCOMING.txt dump: ${dumpFiles.join(", ")}`);
+
+        const all = dumpFiles.map((f) => fs.readFileSync(f, "utf8")).join("\n");
+        assert.ok(!all.includes(SECRET_BEARER), `bearer token leaked into dump:\n${all}`);
+        assert.ok(!all.includes(SECRET_APIKEY), `x-api-key leaked into dump:\n${all}`);
+        assert.ok(!all.includes(SECRET_COOKIE), `cookie value leaked into dump:\n${all}`);
+        assert.ok(!all.includes(`127.0.0.1:${h.upstreamPort}`), `non-public upstream host leaked into dump:\n${all}`);
+        assert.ok(!all.includes(`127.0.0.1:${h.proxyPort}`), `non-public proxy host leaked into dump:\n${all}`);
+        assert.ok(all.includes("<private-host>"), `expected <private-host> placeholder in dumps:\n${all}`);
+
+        const reqJson = dumpFiles.filter((f) => /req-.*\.json$/.test(f)).map((f) => fs.readFileSync(f, "utf8")).join("\n");
+        assert.ok(reqJson.includes(BODY_MARKER), "req JSON dump should still contain the request body");
+    } finally {
+        restoreEnv(prev);
+        if (h) { await close(h.proxy); await close(h.upstream); }
+        fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+});
+
+test("ACP_DUMP_BODY=1 works without --debug (dumps decoupled from verbose logging) (#276)", async () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "bili-dump-nodebug-"));
+    const prev = saveEnv();
+    process.env.XDG_STATE_HOME = tmpRoot;
+    process.env.ACP_DUMP_BODY = "1";
+    let h: Awaited<ReturnType<typeof startHarness>> | undefined;
+    try {
+        h = await startHarness(false, tmpRoot);
+        await sendRequest(h.proxyPort, h.upstreamPort);
+        const dumpFiles = listFiles(path.join(tmpRoot, "billion-context")).filter((f) => DUMP_FILE_RE.test(f));
+        assert.ok(dumpFiles.some((f) => /-REQ\.txt$/.test(f)), `raw REQ dump missing without --debug: ${dumpFiles.join(", ")}`);
+        assert.ok(dumpFiles.some((f) => /-RES\.txt$/.test(f)), `raw RES dump missing without --debug: ${dumpFiles.join(", ")}`);
+        assert.ok(dumpFiles.some((f) => /-INCOMING\.txt$/.test(f)), `INCOMING dump missing without --debug: ${dumpFiles.join(", ")}`);
+        assert.ok(dumpFiles.some((f) => /req-.*\.json$/.test(f)), `req JSON dump missing without --debug: ${dumpFiles.join(", ")}`);
+    } finally {
+        restoreEnv(prev);
+        if (h) { await close(h.proxy); await close(h.upstream); }
+        fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+});

--- a/tests/log-mask.test.ts
+++ b/tests/log-mask.test.ts
@@ -1,0 +1,265 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { once } from "node:events";
+import { defaultConfig } from "acp-kernel";
+import { startServer } from "../src/server.ts";
+import type { ProxyOptions } from "../src/config.ts";
+import { SessionStore, _setStoreForTest } from "../src/persist.ts";
+import { _setForTest as setRegistryForTest } from "../src/registry.ts";
+import { setLogCapture } from "../src/logger.ts";
+import { formatUpstreamError } from "../src/upstream-proxy.ts";
+import {
+    isPublicApiHost,
+    maskHeaderForLog,
+    maskHeadersForLog,
+    maskHostForLog,
+    maskHostPortForLog,
+    maskUrlForLog,
+    maskUrlsInText,
+} from "../src/log-mask.ts";
+
+/** #255 Part B: logs (bili.log + launcher tmp log) must carry no sensitive
+ *  info — credential header values are masked, and non-public API endpoints
+ *  (private relays, self-hosted, internal domains) are replaced. Well-known
+ *  public hosts (openai/anthropic/...) stay verbatim. */
+
+test("isPublicApiHost: well-known public hosts and subdomains", () => {
+    assert.ok(isPublicApiHost("api.openai.com"));
+    assert.ok(isPublicApiHost("openai.com"));
+    assert.ok(isPublicApiHost("chatgpt.com"));
+    assert.ok(isPublicApiHost("api.anthropic.com"));
+    assert.ok(isPublicApiHost("generativelanguage.googleapis.com"));
+    assert.ok(isPublicApiHost("API.DEEPSEEK.COM"));
+    assert.ok(!isPublicApiHost("relay.internal"));
+    assert.ok(!isPublicApiHost("192.168.1.50"));
+    assert.ok(!isPublicApiHost("127.0.0.1"));
+    assert.ok(!isPublicApiHost("localhost"));
+    assert.ok(!isPublicApiHost("evilopenai.com"), "suffix match must require the dot boundary");
+    assert.ok(!isPublicApiHost("openai.com.evil.example"));
+});
+
+test("maskUrlForLog: public host kept, non-public host replaced", () => {
+    assert.equal(maskUrlForLog("https://api.openai.com/v1/chat/completions"), "https://api.openai.com/v1/chat/completions");
+    assert.equal(maskUrlForLog("https://api.anthropic.com/v1/messages"), "https://api.anthropic.com/v1/messages");
+    assert.equal(maskUrlForLog("https://relay.internal:8443/v1/chat/completions"), "https://<private-host>:8443/v1/chat/completions");
+    assert.equal(maskUrlForLog("http://192.168.1.50:11434/v1/chat/completions"), "http://<private-host>:11434/v1/chat/completions");
+    assert.equal(maskUrlForLog("http://127.0.0.1:9090/v1/messages"), "http://<private-host>:9090/v1/messages");
+});
+
+test("maskUrlForLog: userinfo/query/hash always dropped (key-leak vectors)", () => {
+    assert.equal(maskUrlForLog("https://user:pass@relay.internal/v1"), "https://<private-host>/v1");
+    assert.equal(maskUrlForLog("https://api.openai.com/v1/chat/completions?api_key=sk-123"), "https://api.openai.com/v1/chat/completions");
+    assert.equal(maskUrlForLog("https://relay.internal/v1#frag"), "https://<private-host>/v1");
+    assert.equal(maskUrlForLog("not a url"), "<unparseable-url>");
+});
+
+test("maskUrlsInText: masks URLs embedded in arbitrary strings", () => {
+    assert.equal(
+        maskUrlsInText("/bili/http://relay.internal:8443/v1/messages"),
+        "/bili/http://<private-host>:8443/v1/messages",
+    );
+    assert.equal(
+        maskUrlsInText("forward POST → https://api.openai.com/v1/chat/completions"),
+        "forward POST → https://api.openai.com/v1/chat/completions",
+    );
+    assert.equal(maskUrlsInText("no urls here"), "no urls here");
+});
+
+test("maskHostPortForLog: CONNECT targets", () => {
+    assert.equal(maskHostPortForLog("relay.internal:8443"), "<private-host>:8443");
+    assert.equal(maskHostPortForLog("api.anthropic.com:443"), "api.anthropic.com:443");
+    assert.equal(maskHostPortForLog("10.0.0.5"), "<private-host>");
+    assert.equal(maskHostPortForLog("[::1]:443"), "<private-host>:443");
+});
+
+test("maskHeaderForLog: credential headers → length hint, host follows URL rule", () => {
+    assert.equal(maskHeaderForLog("authorization", "Bearer sk-ant-abc123"), "<masked 20 chars>");
+    assert.equal(maskHeaderForLog("x-api-key", "sk-123"), "<masked 6 chars>");
+    assert.equal(maskHeaderForLog("cookie", "session=abc"), "<masked 11 chars>");
+    assert.equal(maskHeaderForLog("set-cookie", "a=b; Path=/"), "<masked 11 chars>");
+    assert.equal(maskHeaderForLog("proxy-authorization", "Basic xyz"), "<masked 9 chars>");
+    assert.equal(maskHeaderForLog("host", "relay.internal"), "<private-host>");
+    assert.equal(maskHeaderForLog("host", "api.anthropic.com"), "api.anthropic.com");
+    assert.equal(maskHeaderForLog("content-type", "application/json"), "application/json");
+    assert.equal(maskHeaderForLog("x-request-id", "abc123"), "abc123");
+});
+
+test("maskHeadersForLog: masks the whole record", () => {
+    const out = maskHeadersForLog({
+        authorization: "Bearer sk-secret",
+        "content-type": "application/json",
+        host: "relay.internal:8443",
+    });
+    assert.equal(out.authorization, "<masked 16 chars>");
+    assert.equal(out["content-type"], "application/json");
+    assert.equal(out.host, "<private-host>:8443");
+});
+
+test("formatUpstreamError: non-public url and endpoint identity masked", () => {
+    const s = formatUpstreamError(new Error("connect ECONNREFUSED 192.168.1.50:8443"), "http://192.168.1.50:8443/v1/chat/completions");
+    assert.ok(s.includes("url=http://<private-host>:8443/v1/chat/completions"), s);
+    assert.ok(!s.includes("192.168.1.50"), s);
+    const dns = formatUpstreamError(new Error("getaddrinfo ENOTFOUND relay.internal"), "https://relay.internal/v1/messages");
+    assert.ok(dns.includes("ENOTFOUND <private-host>"), dns);
+    assert.ok(!dns.includes("relay.internal"), dns);
+});
+
+test("formatUpstreamError: public url kept verbatim", () => {
+    const s = formatUpstreamError(new Error("boom"), "https://api.openai.com/v1/chat/completions");
+    assert.ok(s.includes("url=https://api.openai.com/v1/chat/completions"), s);
+});
+
+function close(server: http.Server): Promise<void> {
+    return new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+}
+
+interface Captured {
+    level: string;
+    msg: string;
+}
+
+test("proxy debug logs: no credentials, no non-public host in ANY log line (#255)", async () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "bili-log-mask-"));
+    const prev = {
+        xdgState: process.env.XDG_STATE_HOME,
+        rawDump: process.env.ACP_RAW_DUMP_DIR,
+        dumpReq: process.env.ACP_DUMP_REQ,
+    };
+    process.env.XDG_STATE_HOME = tmpRoot;
+    process.env.ACP_RAW_DUMP_DIR = path.join(tmpRoot, "raw");
+    process.env.ACP_DUMP_REQ = "0";
+    const captured: Captured[] = [];
+    setLogCapture((level, msg) => captured.push({ level, msg }));
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    setRegistryForTest({});
+    const upstream = http.createServer((req, res) => {
+        res.writeHead(200, { "content-type": "application/json", "set-cookie": "session=secret-cookie-value" });
+        res.end(JSON.stringify({ id: "r1", object: "chat.completion", choices: [{ index: 0, message: { role: "assistant", content: "ok" }, finish_reason: "stop" }] }));
+    });
+    let proxy: http.Server | undefined;
+    try {
+        upstream.listen(0, "127.0.0.1");
+        await once(upstream, "listening");
+        const upstreamPort = (upstream.address() as { port: number }).port;
+        const opts: ProxyOptions = {
+            port: 0,
+            host: "127.0.0.1",
+            upstream: "http://127.0.0.1",
+            routes: {
+                [`http://127.0.0.1:${upstreamPort}`]: { models: { "gpt-test": { context: 400_000 } } },
+            },
+            modelContextLimit: 400_000,
+            kernelConfig: defaultConfig(400_000),
+            compress: { injectTool: false, injectNudge: false },
+            promptCache: { routing: "auto" },
+            sessionHeader: "x-acp-session",
+            log: true,
+            debug: true,
+            passthrough: false,
+            autoUpdate: false,
+            mitm: { enabled: false, domains: [] },
+        };
+        proxy = await startServer(opts);
+        await once(proxy, "listening");
+        const proxyPort = (proxy.address() as { port: number }).port;
+        const resp = await fetch(`http://127.0.0.1:${proxyPort}/bili/http://127.0.0.1:${upstreamPort}/v1/chat/completions`, {
+            method: "POST",
+            headers: {
+                "content-type": "application/json",
+                "x-acp-session": "log-mask-1",
+                authorization: "Bearer sk-test-secret-1234567890",
+                "x-api-key": "sk-test-key-abcdefgh",
+            },
+            body: JSON.stringify({ model: "gpt-test", messages: [{ role: "user", content: "hi" }] }),
+        });
+        assert.equal(resp.status, 200);
+        await resp.text();
+
+        const all = captured.map((c) => c.msg).join("\n");
+        assert.ok(!all.includes("sk-test-secret-1234567890"), `bearer token leaked into logs:\n${all}`);
+        assert.ok(!all.includes("sk-test-key-abcdefgh"), `x-api-key leaked into logs:\n${all}`);
+        assert.ok(!all.includes("secret-cookie-value"), `cookie value leaked into logs:\n${all}`);
+        assert.ok(!all.includes(`127.0.0.1:${upstreamPort}`), `non-public upstream origin leaked into logs:\n${all}`);
+
+        const fwd = captured.find((c) => c.msg.startsWith("forward POST"));
+        assert.ok(fwd, `forward log missing:\n${all}`);
+        assert.ok(fwd.msg.includes("http://<private-host>"), fwd.msg);
+
+        const hdr = captured.find((c) => c.msg.includes("→ upstream headers:"));
+        assert.ok(hdr, `upstream headers log missing:\n${all}`);
+        assert.ok(hdr.msg.includes('"authorization":"<masked'), hdr.msg);
+        assert.ok(hdr.msg.includes('"x-api-key":"<masked'), hdr.msg);
+        assert.ok(hdr.msg.includes('"host":"' + "<private-host>"), hdr.msg);
+
+        const respHdr = captured.find((c) => c.msg.includes("← upstream response headers:"));
+        assert.ok(respHdr, `response headers log missing:\n${all}`);
+        assert.ok(respHdr.msg.includes('"set-cookie":"<masked'), respHdr.msg);
+    } finally {
+        setLogCapture(null);
+        if (prev.xdgState === undefined) delete process.env.XDG_STATE_HOME;
+        else process.env.XDG_STATE_HOME = prev.xdgState;
+        if (prev.rawDump === undefined) delete process.env.ACP_RAW_DUMP_DIR;
+        else process.env.ACP_RAW_DUMP_DIR = prev.rawDump;
+        if (prev.dumpReq === undefined) delete process.env.ACP_DUMP_REQ;
+        else process.env.ACP_DUMP_REQ = prev.dumpReq;
+        await close(proxy!);
+        await close(upstream);
+        fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+});
+
+test("proxy error log: connection failure to non-public upstream leaks nothing (#255)", async () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "bili-log-mask-err-"));
+    const prev = { xdgState: process.env.XDG_STATE_HOME };
+    process.env.XDG_STATE_HOME = tmpRoot;
+    const captured: Captured[] = [];
+    setLogCapture((level, msg) => captured.push({ level, msg }));
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    setRegistryForTest({});
+    let proxy: http.Server | undefined;
+    try {
+        const opts: ProxyOptions = {
+            port: 0,
+            host: "127.0.0.1",
+            upstream: "http://127.0.0.1",
+            routes: {
+                "http://127.0.0.1:59999": { models: { "gpt-test": { context: 400_000 } } },
+            },
+            modelContextLimit: 400_000,
+            kernelConfig: defaultConfig(400_000),
+            compress: { injectTool: false, injectNudge: false },
+            promptCache: { routing: "auto" },
+            sessionHeader: "x-acp-session",
+            log: true,
+            debug: false,
+            passthrough: false,
+            autoUpdate: false,
+            mitm: { enabled: false, domains: [] },
+        };
+        proxy = await startServer(opts);
+        await once(proxy, "listening");
+        const proxyPort = (proxy.address() as { port: number }).port;
+        const resp = await fetch(`http://127.0.0.1:${proxyPort}/bili/http://127.0.0.1:59999/v1/chat/completions`, {
+            method: "POST",
+            headers: { "content-type": "application/json", "x-acp-session": "log-mask-err" },
+            body: JSON.stringify({ model: "gpt-test", messages: [{ role: "user", content: "hi" }] }),
+        });
+        assert.equal(resp.status, 502);
+        await resp.text();
+        const all = captured.map((c) => c.msg).join("\n");
+        assert.ok(!all.includes("127.0.0.1:59999"), `non-public upstream origin leaked into error log:\n${all}`);
+        const errLine = captured.find((c) => c.msg.includes("upstream request failed"));
+        assert.ok(errLine, `error log missing:\n${all}`);
+        assert.ok(errLine.msg.includes("<private-host>"), errLine.msg);
+    } finally {
+        setLogCapture(null);
+        if (prev.xdgState === undefined) delete process.env.XDG_STATE_HOME;
+        else process.env.XDG_STATE_HOME = prev.xdgState;
+        await close(proxy!);
+        fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+});

--- a/tests/log-mask.test.ts
+++ b/tests/log-mask.test.ts
@@ -353,3 +353,63 @@ test("mitm CONNECT tunnel failure: err.message host scrubbed from log (#255)", a
         fs.rmSync(tmpRoot, { recursive: true, force: true });
     }
 });
+
+test("ws upgrade rejection: host header scrubbed from log (#255)", async () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "bili-log-mask-ws-"));
+    const prev = { xdgState: process.env.XDG_STATE_HOME };
+    process.env.XDG_STATE_HOME = tmpRoot;
+    const captured: Captured[] = [];
+    setLogCapture((level, msg) => captured.push({ level, msg }));
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    setRegistryForTest({});
+    let proxy: http.Server | undefined;
+    try {
+        const opts: ProxyOptions = {
+            port: 0,
+            host: "127.0.0.1",
+            upstream: "http://127.0.0.1",
+            routes: {
+                "http://127.0.0.1:59999": { models: { "gpt-test": { context: 400_000 } } },
+            },
+            modelContextLimit: 400_000,
+            kernelConfig: defaultConfig(400_000),
+            compress: { injectTool: false, injectNudge: false },
+            promptCache: { routing: "auto" },
+            sessionHeader: "x-acp-session",
+            log: true,
+            debug: false,
+            passthrough: false,
+            autoUpdate: false,
+            mitm: { enabled: false, domains: [] },
+        };
+        proxy = await startServer(opts);
+        await once(proxy, "listening");
+        const proxyPort = (proxy.address() as { port: number }).port;
+
+        const sock = net.connect(proxyPort, "127.0.0.1");
+        sock.write(
+            "GET /v1/messages HTTP/1.1\r\n" +
+                "Host: relay.internal:443\r\n" +
+                "Upgrade: websocket\r\n" +
+                "Connection: Upgrade\r\n" +
+                "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
+                "Sec-WebSocket-Version: 13\r\n\r\n",
+        );
+        const raw = await once(sock, "data");
+        const head = String(raw[0]).split("\r\n")[0];
+        assert.ok(head.includes("426"), `expected 426, got: ${head}`);
+
+        const all = captured.map((c) => c.msg).join("\n");
+        assert.ok(!all.includes("relay.internal"), `ws host header leaked into log:\n${all}`);
+        const wsLine = captured.find((c) => c.msg.includes("[ws] rejected"));
+        assert.ok(wsLine, `ws rejection log missing:\n${all}`);
+        assert.ok(wsLine.msg.includes("<private-host>"), wsLine.msg);
+        sock.destroy();
+    } finally {
+        setLogCapture(null);
+        if (prev.xdgState === undefined) delete process.env.XDG_STATE_HOME;
+        else process.env.XDG_STATE_HOME = prev.xdgState;
+        await close(proxy!);
+        fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+});

--- a/tests/log-mask.test.ts
+++ b/tests/log-mask.test.ts
@@ -5,6 +5,7 @@ import http from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { once } from "node:events";
+import net from "node:net";
 import { defaultConfig } from "acp-kernel";
 import { startServer } from "../src/server.ts";
 import type { ProxyOptions } from "../src/config.ts";
@@ -17,6 +18,7 @@ import {
     maskHeaderForLog,
     maskHeadersForLog,
     maskHostForLog,
+    maskHostInText,
     maskHostPortForLog,
     maskUrlForLog,
     maskUrlsInText,
@@ -97,6 +99,35 @@ test("maskHeadersForLog: masks the whole record", () => {
     assert.equal(out.authorization, "<masked 16 chars>");
     assert.equal(out["content-type"], "application/json");
     assert.equal(out.host, "<private-host>:8443");
+});
+
+test("maskHostInText: scrubs the tunnel target from error text, leaves other addresses", () => {
+    assert.equal(
+        maskHostInText("connect ECONNREFUSED 192.168.1.50:8443", "192.168.1.50"),
+        "connect ECONNREFUSED <private-host>:8443",
+    );
+    assert.equal(
+        maskHostInText("getaddrinfo ENOTFOUND relay.internal", "relay.internal"),
+        "getaddrinfo ENOTFOUND <private-host>",
+    );
+    assert.equal(
+        maskHostInText("connect ECONNREFUSED api.openai.com:443", "api.openai.com"),
+        "connect ECONNREFUSED api.openai.com:443",
+    );
+    assert.equal(
+        maskHostInText("proxy connect ECONNREFUSED 10.1.2.3:3128", "192.168.1.50"),
+        "proxy connect ECONNREFUSED 10.1.2.3:3128",
+    );
+    assert.equal(
+        maskHostInText("connect ECONNREFUSED [::1]:8443", "[::1]"),
+        "connect ECONNREFUSED <private-host>:8443",
+    );
+    assert.equal(
+        maskHostInText("connect ECONNREFUSED ::1:8443", "::1"),
+        "connect ECONNREFUSED <private-host>:8443",
+    );
+    assert.equal(maskHostInText("no host here", "192.168.1.50"), "no host here");
+    assert.equal(maskHostInText("connect ECONNREFUSED 192.168.1.50:8443", ""), "connect ECONNREFUSED 192.168.1.50:8443");
 });
 
 test("formatUpstreamError: non-public url and endpoint identity masked", () => {
@@ -255,6 +286,65 @@ test("proxy error log: connection failure to non-public upstream leaks nothing (
         const errLine = captured.find((c) => c.msg.includes("upstream request failed"));
         assert.ok(errLine, `error log missing:\n${all}`);
         assert.ok(errLine.msg.includes("<private-host>"), errLine.msg);
+    } finally {
+        setLogCapture(null);
+        if (prev.xdgState === undefined) delete process.env.XDG_STATE_HOME;
+        else process.env.XDG_STATE_HOME = prev.xdgState;
+        await close(proxy!);
+        fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+});
+
+test("mitm CONNECT tunnel failure: err.message host scrubbed from log (#255)", async () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "bili-log-mask-mitm-"));
+    const prev = { xdgState: process.env.XDG_STATE_HOME };
+    process.env.XDG_STATE_HOME = tmpRoot;
+    const captured: Captured[] = [];
+    setLogCapture((level, msg) => captured.push({ level, msg }));
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    setRegistryForTest({});
+    let proxy: http.Server | undefined;
+    try {
+        const holder = http.createServer();
+        holder.listen(0, "127.0.0.1");
+        await once(holder, "listening");
+        const deadPort = (holder.address() as { port: number }).port;
+        await close(holder);
+        const opts: ProxyOptions = {
+            port: 0,
+            host: "127.0.0.1",
+            upstream: "http://127.0.0.1",
+            routes: {
+                "http://127.0.0.1:1": { models: { "gpt-test": { context: 400_000 } } },
+            },
+            modelContextLimit: 400_000,
+            kernelConfig: defaultConfig(400_000),
+            compress: { injectTool: false, injectNudge: false },
+            promptCache: { routing: "auto" },
+            sessionHeader: "x-acp-session",
+            log: true,
+            debug: false,
+            passthrough: false,
+            autoUpdate: false,
+            mitm: { enabled: true, domains: [] },
+        };
+        proxy = await startServer(opts);
+        await once(proxy, "listening");
+        const proxyPort = (proxy.address() as { port: number }).port;
+        const sock = net.connect(proxyPort, "127.0.0.1");
+        let buf = "";
+        await new Promise<void>((resolve, reject) => {
+            sock.on("data", (d) => { buf += d.toString(); if (buf.includes("\r\n\r\n")) resolve(); });
+            sock.on("error", reject);
+            sock.write(`CONNECT 127.0.0.1:${deadPort} HTTP/1.1\r\nHost: 127.0.0.1:${deadPort}\r\n\r\n`);
+        });
+        sock.destroy();
+        assert.ok(buf.startsWith("HTTP/1.1 502"), buf);
+        const all = captured.map((c) => c.msg).join("\n");
+        const tunnelLine = captured.find((c) => c.msg.includes("connect failed"));
+        assert.ok(tunnelLine, `tunnel failure log missing:\n${all}`);
+        assert.ok(tunnelLine.msg.includes(`<private-host>:${deadPort}`), tunnelLine.msg);
+        assert.ok(!all.includes(`127.0.0.1:${deadPort}`), `raw tunnel target leaked into logs via err.message:\n${all}`);
     } finally {
         setLogCapture(null);
         if (prev.xdgState === undefined) delete process.env.XDG_STATE_HOME;


### PR DESCRIPTION
Part B of #255, split out of PR #274 (which covered logs only). **Stacked on `2026-08-27_mask-sensitive-logs`** — depends on `src/log-mask.ts`, so rebase to master once #274 lands.

## Changes

**1. Body dumps off by default** — every plaintext body dump was gated on `--debug`, and the launchers hardcode `debug: true` (`src/launcher.ts:1035`), so every `bili <client>` user silently wrote full conversation bodies to disk. All body dumps are now opt-in via `ACP_DUMP_BODY=1`, decoupled from `--debug`:
- `dumps/req-*.json` (`src/server.ts`)
- `raw/*-REQ.txt` / `raw/*-RES.txt` (`src/server.ts`)
- `raw/*-INCOMING.txt` (`src/server.ts`)
- `req-*-REREQUEST.json` (`src/loop/core.ts`)

`--debug` / `ACP_DEBUG=1` now only produces verbose (already-masked, per #255) logs — no body dumps. Per #255 floor 5 the launcher keeps `debug: true` for troubleshooting; the fix is that dumps no longer follow it.

**2. Dump header filtering reuses `maskHeadersForLog`** (`src/log-mask.ts`) — the old `/key|auth|token/i` regex missed `cookie` / `set-cookie`; the shared rule covers them plus non-public hosts.

**3. Non-public hosts masked in dumps** — `upstreamUrl` in `raw/*-REQ.txt` via `maskUrlForLog`; the incoming path in `raw/*-INCOMING.txt` via `maskUrlsInText` (keeps the path's debug value, masks the embedded host).

**4. INCOMING dump honors `ACP_RAW_DUMP_DIR`** (was hardcoded to `stateDir()/raw`).

**5. Tests** — `tests/dump-mask.test.ts`: dumps off by default under `--debug`; with `ACP_DUMP_BODY=1` dumps carry no credentials (authorization / x-api-key / cookie) and no non-public host; dumps still work without `--debug`.

## Verification
- `npm run typecheck` — clean
- `npm test` — 671 pass (668 + 3 new)
- `npm run build` — success

Response-body SSE dump (`ACP_DUMP_SSE`) is untouched — already opt-in.
