### PR TITLE
fix: recognize Codex context-overflow errors and learn conservative window when unparseable

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1772,7 +1772,22 @@ async function forward(
                     s.metadata.learnedContextLimits = learnedMap;
                     log("warn", `[${s.id}] upstream context overflow — learned real window ${info.window} for ${reqModel ?? "(unknown model)"} (was ${prev ?? "unset"}); arming emergency shrink`);
                 } else {
-                    log("warn", `[${s.id}] upstream context overflow (window not parseable): ${info.message}`);
+                    // No window number in the body (e.g. Codex's
+                    // "context_window_exceeded" error). The rejected payload's
+                    // size is a safe upper bound on the real window — learn it
+                    // so the next turn re-centers the limit and the pre-flight
+                    // compresses below it. Only shrink, never grow: a previously
+                    // learned (smaller) value is the tighter bound.
+                    const payloadEstimate = estimateCoreMessages(prepared.processedMessages);
+                    const prev = (reqModel ? learnedMap[reqModel] : undefined) ?? (s.metadata.learnedContextLimit as number | undefined);
+                    if (payloadEstimate >= 1000 && (prev === undefined || payloadEstimate < prev)) {
+                        if (reqModel) learnedMap[reqModel] = payloadEstimate;
+                        else s.metadata.learnedContextLimit = payloadEstimate;
+                        s.metadata.learnedContextLimits = learnedMap;
+                        log("warn", `[${s.id}] upstream context overflow (window not parseable) — learned conservative window ${payloadEstimate} for ${reqModel ?? "(unknown model)"} from rejected payload size (was ${prev ?? "unset"}); arming emergency shrink`);
+                    } else {
+                        log("warn", `[${s.id}] upstream context overflow (window not parseable): ${info.message}`);
+                    }
                 }
                 // Arm the emergency shrink: force the next turn's usage to >=100%
                 // so the kernel's emergency nudge + tool-result truncate fire.

--- a/src/util.ts
+++ b/src/util.ts
@@ -106,11 +106,13 @@ export interface ContextOverflowInfo {
 // client should back off on), not a context overflow.
 const CONTEXT_OVERFLOW_PATTERNS: RegExp[] = [
     /context_length_exceeded/i,
+    /context_window_exceeded/i,
     /context length exceeded/i,
     /maximum context length/i,
     /max context length/i,
     /maximum context size/i,
     /exceeds the context window/i,
+    /out of room in the model/i,
     /exceeded model token limit/i,
     /prompt is too long/i,
     /prompt_too_long/i,

--- a/tests/context-overflow.test.ts
+++ b/tests/context-overflow.test.ts
@@ -67,6 +67,30 @@ test("overflow with no parseable window → isOverflow true, window undefined", 
     assert.equal(info.window, undefined);
 });
 
+test("Codex: context_window_exceeded code (no window number) → overflow, window undefined", () => {
+    // Codex/ChatGPT relays reject an oversized context with this body — no
+    // window number anywhere, so self-heal must fall back to the rejected
+    // payload size (see the e2e in e2e-overflow-selfheal.test.ts).
+    const body = JSON.stringify({
+        error: {
+            code: "context_window_exceeded",
+            message: "The model's context window was exceeded. Start a new thread or clear earlier history before retrying.",
+        },
+    });
+    const info = inspectContextOverflow(400, body);
+    assert.equal(info.isOverflow, true);
+    assert.equal(info.window, undefined);
+});
+
+test("Codex client phrasing 'ran out of room in the model's context window' → overflow", () => {
+    const info = inspectContextOverflow(
+        400,
+        "Codex ran out of room in the model's context window. Start a new thread or clear earlier history before retrying.",
+    );
+    assert.equal(info.isOverflow, true);
+    assert.equal(info.window, undefined);
+});
+
 test("auth error (400, no context marker) is NOT an overflow", () => {
     const info = inspectContextOverflow(400, '{"error":{"message":"Invalid API key","type":"authentication_error"}}');
     assert.equal(info.isOverflow, false);

--- a/tests/e2e-overflow-selfheal.test.ts
+++ b/tests/e2e-overflow-selfheal.test.ts
@@ -155,3 +155,157 @@ test("e2e: upstream context overflow → learn window + arm shrink + pass throug
         await once(upstream, "close");
     }
 });
+
+// #280: Codex's overflow error carries NO window number ("context_window_exceeded"),
+// so the proxy can't learn the real window from the body. It must still recognize
+// the overflow, learn a CONSERVATIVE window from the rejected payload's size, and
+// on the next request the pre-flight must compress the oversized history below
+// that window before forwarding — instead of re-sending the same oversized
+// payload forever (the stuck loop the issue reports).
+
+const CODEX_OVERFLOW_BODY = JSON.stringify({
+    error: {
+        code: "context_window_exceeded",
+        message: "The model's context window was exceeded. Start a new thread or clear earlier history before retrying.",
+    },
+});
+
+const SUMMARY_TEXT =
+    "PREFLIGHT SUMMARY: the segment covered a multi-step debugging session. Key decisions: chose the preflight approach over lossy truncation because the payload must stay coherent. Files touched: src/a.ts:10, src/b.ts:20. Outcome: fixed and verified by tests.";
+
+function summaryJson(): string {
+    return JSON.stringify({
+        id: "msg_summary",
+        type: "message",
+        role: "assistant",
+        model: "claude-test",
+        content: [{ type: "text", text: SUMMARY_TEXT }],
+        stop_reason: "end_turn",
+        usage: { input_tokens: 500, output_tokens: 50 },
+    });
+}
+
+function bigConversation(): Array<{ role: string; content: string }> {
+    const msgs: Array<{ role: string; content: string }> = [];
+    for (let i = 0; i < 12; i++) {
+        const role = i % 2 === 0 ? "user" : "assistant";
+        msgs.push({ role, content: `Message ${i} of the long conversation. ` + `MARKER_${i}_content_`.repeat(250) });
+    }
+    return msgs;
+}
+
+test("e2e #280: Codex overflow without window number → learn conservative window → preflight recovers", async () => {
+    let streamingCall = 0;
+    let summaryCalls = 0;
+    const bodies: string[] = [];
+    const upstream = http.createServer((req, res) => {
+        const chunks: Buffer[] = [];
+        req.on("data", (c: Buffer) => chunks.push(c));
+        req.on("end", () => {
+            const raw = Buffer.concat(chunks).toString("utf8");
+            bodies.push(raw);
+            let parsed: { stream?: boolean } = {};
+            try {
+                parsed = JSON.parse(raw);
+            } catch {
+                parsed = {};
+            }
+            if (parsed.stream === false) {
+                // Pre-flight summarization call (non-streaming).
+                summaryCalls += 1;
+                res.writeHead(200, { "content-type": "application/json" });
+                res.end(summaryJson());
+                return;
+            }
+            // First streaming forward: Codex overflow (no window number).
+            if (streamingCall === 0) {
+                res.writeHead(400, { "content-type": "application/json" });
+                res.end(CODEX_OVERFLOW_BODY);
+            } else {
+                res.writeHead(200, { "content-type": "text/event-stream" });
+                res.end(okSse());
+            }
+            streamingCall += 1;
+        });
+    });
+    upstream.listen(0, "127.0.0.1");
+    await once(upstream, "listening");
+    const upstreamPort = upstream.address().port;
+
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    setRegistryForTest({});
+    const proxy = await startServer({
+        port: 0,
+        host: "127.0.0.1",
+        upstream: "http://127.0.0.1",
+        routes: { [`http://127.0.0.1:${upstreamPort}`]: { models: { "claude-test": { context: 400_000 } } } },
+        modelContextLimit: 400_000,
+        kernelConfig: defaultConfig(400_000),
+        compress: { injectTool: true, injectNudge: true },
+        promptCache: { routing: "auto" },
+        sessionHeader: "x-acp-session",
+        log: false,
+        debug: false,
+        passthrough: false,
+        autoUpdate: false,
+        mitm: { enabled: false, domains: [] },
+    } as ProxyOptions);
+    await once(proxy, "listening");
+    const proxyPort = proxy.address().port;
+
+    try {
+        const url = `http://127.0.0.1:${proxyPort}/bili/http://127.0.0.1:${upstreamPort}/v1/messages`;
+        const body = JSON.stringify({ model: "claude-test", max_tokens: 1024, stream: true, messages: bigConversation() });
+
+        // --- Request 1: oversized history forwarded (no usage known yet) → Codex 400 ---
+        const r1 = await fetch(url, {
+            method: "POST",
+            headers: { "content-type": "application/json", "x-acp-session": "codex-sess" },
+            body,
+        });
+        assert.equal(r1.status, 400);
+        const r1text = await r1.text();
+        assert.ok(r1text.includes("context_window_exceeded"), "Codex error passes through verbatim");
+
+        // The proxy recognized the overflow and learned a conservative window
+        // from the rejected payload's size (~13k tokens, NOT the configured 400k).
+        const s = listSessions().find(
+            (x) => (x.metadata.learnedContextLimits as Record<string, number> | undefined)?.["claude-test"] !== undefined,
+        );
+        assert.ok(s, "session learned a conservative window from the rejected payload");
+        const learned = (s!.metadata.learnedContextLimits as Record<string, number>)["claude-test"];
+        assert.ok(learned >= 1000 && learned < 20_000, `conservative window ≈ rejected payload size (got ${learned})`);
+        assert.ok(s!.stats.lastInputTokens >= learned, "emergency shrink armed (lastInputTokens >= learned window)");
+
+        // --- Request 2: same oversized history → self-heal re-centers the limit
+        // to the learned window → pre-flight compresses below it → recovery ---
+        const r2 = await fetch(url, {
+            method: "POST",
+            headers: { "content-type": "application/json", "x-acp-session": "codex-sess" },
+            body,
+        });
+        assert.equal(r2.status, 200, "second request recovers");
+        await r2.text(); // drain
+
+        assert.ok(summaryCalls >= 1, "pre-flight made a summarization call before the forward");
+        const lastForward = bodies[bodies.length - 1];
+        // The kernel always keeps the first user message raw (task anchor), so
+        // the rest of the compressed range (markers 1-3) must be gone.
+        assert.ok(!lastForward.includes("MARKER_1_"), "compressed range folded out of the rebuilt payload");
+        assert.ok(!lastForward.includes("MARKER_2_"), "compressed range folded out of the rebuilt payload");
+        assert.ok(!lastForward.includes("MARKER_3_"), "compressed range folded out of the rebuilt payload");
+        assert.ok(lastForward.includes("MARKER_11_"), "recent messages retained");
+        assert.ok(lastForward.includes(SUMMARY_TEXT), "summary replaces the compressed range");
+
+        // The real usage report from the recovered turn overwrote the armed
+        // value. (The preflight summary call goes direct to the upstream, not
+        // through the proxy, so it lands no usage on this session.)
+        const s2 = listSessions().find((x) => x.id === s!.id);
+        assert.equal(s2?.stats.lastInputTokens, 5000);
+    } finally {
+        proxy.close();
+        await once(proxy, "close");
+        upstream.close();
+        await once(upstream, "close");
+    }
+});

--- a/tests/preflight-compress-responses.test.ts
+++ b/tests/preflight-compress-responses.test.ts
@@ -1,0 +1,175 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import { once } from "node:events";
+import test from "node:test";
+
+process.env.NODE_ENV = "test";
+
+import { defaultConfig } from "acp-kernel";
+import { startServer, type ProxyOptions } from "../src/server.ts";
+import { SessionStore, _setStoreForTest } from "../src/persist.ts";
+import { _setForTest as setRegistryForTest } from "../src/registry.ts";
+import { listSessions } from "../src/session.ts";
+
+// Issue #280 regression (Responses protocol): a long Codex session that was
+// compressed once, then rebound/restored — the client replays the FULL raw
+// history to a fresh session whose lastInputTokens is 0. The nudge is blind at
+// tokenCount=0, so only the preflight fit check (payload estimate vs window)
+// can catch it. The proxy must compress the oversized history BEFORE forward,
+// never replaying it verbatim to a smaller upstream window.
+
+const SUMMARY_TEXT =
+    "PREFLIGHT SUMMARY: the segment covered a multi-step debugging session. Key decisions: chose the preflight approach over lossy truncation because the payload must stay coherent. Files touched: src/a.ts:10, src/b.ts:20. Outcome: fixed and verified by tests.";
+
+function sse(type: string, data: unknown): string {
+    return `event: ${type}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+function completed(inputTokens: number): string {
+    return sse("response.completed", {
+        response: { id: "resp_done", status: "completed", output: [], usage: { input_tokens: inputTokens, output_tokens: 5, total_tokens: inputTokens + 5 } },
+    });
+}
+
+function fcEvents(callId: string, args: string): string {
+    return [
+        sse("response.output_item.added", { item: { type: "function_call", id: `fc_${callId}`, call_id: callId, name: "compress" }, output_index: 0 }),
+        sse("response.function_call_arguments.delta", { item_id: `fc_${callId}`, delta: args }),
+        sse("response.output_item.done", { item: { type: "function_call", id: `fc_${callId}`, call_id: callId, name: "compress", arguments: args }, output_index: 0 }),
+    ].join("");
+}
+
+function longInput() {
+    const input: { type: string; role: string; content: string }[] = [];
+    for (let i = 0; i < 12; i++) {
+        input.push({ type: "message", role: i % 2 === 0 ? "user" : "assistant", content: `Message ${i} of the long conversation. ` + `MARKER_${i}_content_`.repeat(250) });
+    }
+    return input;
+}
+
+test("e2e #280 (Responses): restored session with lastInputTokens=0 → preflight compresses the raw history before forward", async () => {
+    let summaryCalls = 0;
+    const bodies: string[] = [];
+    const upstream = http.createServer((req, res) => {
+        const chunks: Buffer[] = [];
+        req.on("data", (c: Buffer) => chunks.push(c));
+        req.on("end", () => {
+            const raw = Buffer.concat(chunks).toString("utf8");
+            bodies.push(raw);
+            const parsed = JSON.parse(raw) as { stream?: boolean };
+            if (parsed.stream === false) {
+                summaryCalls += 1;
+                res.writeHead(200, { "content-type": "application/json" });
+                res.end(JSON.stringify({ output_text: SUMMARY_TEXT }));
+                return;
+            }
+            if (bodies.length === 1) {
+                // Session A's first turn: the model compresses the oldest pair.
+                // Refs are the kernel's sequential message refs (m00001...);
+                // `instructions` becomes systemParts and consumes no ref.
+                const compressArgs = JSON.stringify({
+                    content: [
+                        {
+                            startId: "m00001",
+                            endId: "m00002",
+                            topic: "session setup",
+                            summary: "MAIN-SUMMARY-SETUP-CONTEXT-FOLDED-BY-COMPRESSION-LONG-ENOUGH-FOR-KERNEL-MIN-LENGTH-CHECK",
+                        },
+                    ],
+                });
+                res.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache" });
+                res.write(fcEvents("call_p", compressArgs));
+                res.write(completed(3000));
+            } else {
+                res.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache" });
+                res.write(completed(1000));
+            }
+            res.end();
+        });
+    });
+    upstream.listen(0, "127.0.0.1");
+    await once(upstream, "listening");
+    const upstreamPort = upstream.address().port;
+
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    setRegistryForTest({});
+    const proxy = await startServer({
+        port: 0,
+        host: "127.0.0.1",
+        upstream: "http://127.0.0.1",
+        routes: { [`http://127.0.0.1:${upstreamPort}`]: { models: { "gpt-resp": { context: 10_000 } } } },
+        modelContextLimit: 10_000,
+        kernelConfig: defaultConfig(10_000),
+        compress: { injectTool: true, injectNudge: true },
+        promptCache: { routing: "auto" },
+        sessionHeader: "x-acp-session",
+        log: false,
+        debug: false,
+        passthrough: false,
+        autoUpdate: false,
+        mitm: { enabled: false, domains: [] },
+    } as ProxyOptions);
+    await once(proxy, "listening");
+    const proxyPort = proxy.address().port;
+    const url = `http://127.0.0.1:${proxyPort}/bili/http://127.0.0.1:${upstreamPort}/v1/responses`;
+
+    // Seven ~4.6k-char messages (~1140 tokens each, ~8k total < the 10k window,
+    // so preflight stays off for session A). The kernel protects the last 5
+    // messages (and the 5k-token tail), leaving m00001/m00002 compressible.
+    function setupInput() {
+        return Array.from({ length: 7 }, (_, i) => ({
+            type: "message",
+            role: i % 2 === 0 ? "user" : "assistant",
+            content: `Message ${i} for session setup. ` + `FILLER_${i}_content_`.repeat(268),
+        }));
+    }
+
+    try {
+        // --- Session A: a normal session that compresses once (the original
+        // long session before the rebind) ---
+        const rA = await fetch(url, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ model: "gpt-resp", stream: true, session_id: "resp-sess-a", instructions: "You are the test coding agent.", input: setupInput() }),
+        });
+        assert.equal(rA.status, 200);
+        await rA.text();
+
+        const sA = listSessions().find((x) => x.meta.label === "resp-sess-a");
+        assert.ok(sA, "session A exists");
+        assert.ok((sA!.state.blocks ?? []).some((b) => b.active), "session A compressed once");
+
+        // --- Session B: the rebind/restore — a FRESH session (lastInputTokens=0)
+        // receives the full raw history (~13k tokens > the 10k window). Preflight
+        // must compress it before forward; the raw history must never be replayed
+        // verbatim. ---
+        const rB = await fetch(url, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ model: "gpt-resp", stream: true, session_id: "resp-sess-b", instructions: "You are the test coding agent.", input: longInput() }),
+        });
+        assert.equal(rB.status, 200, "restored session's request succeeds");
+        await rB.text();
+
+        assert.ok(summaryCalls >= 1, `preflight summarization ran for the restored session (got ${summaryCalls})`);
+
+        const finalForward = bodies[bodies.length - 1];
+        // The kernel keeps the first user message raw (task anchor), so the
+        // rest of the compressed range (markers 1-3) must be gone.
+        assert.ok(!finalForward.includes("MARKER_1_"), "compressed range folded out of the forward");
+        assert.ok(!finalForward.includes("MARKER_2_"), "compressed range folded out of the forward");
+        assert.ok(!finalForward.includes("MARKER_3_"), "compressed range folded out of the forward");
+        assert.ok(finalForward.includes("MARKER_11_"), "recent history survives");
+        assert.ok(finalForward.includes(SUMMARY_TEXT), "the compression summary re-enters the payload");
+
+        const sB = listSessions().find((x) => x.meta.label === "resp-sess-b");
+        assert.ok(sB, "session B exists");
+        assert.ok((sB!.state.blocks ?? []).some((b) => b.active), "session B has a compression block from preflight");
+        assert.equal(sB!.stats.lastInputTokens, 1000, "the real usage report lands after the recovered forward");
+    } finally {
+        proxy.close();
+        await once(proxy, "close");
+        upstream.close();
+        await once(upstream, "close");
+    }
+});


### PR DESCRIPTION
Closes #280

## Background

After a macOS sleep/wake (or any rebind), a restored session starts with `lastInputTokens=0`. The nudge is blind at tokenCount=0, so only the preflight fit check can catch an oversized raw-history replay. The preflight safety net (shipped in v0.1.57 via #247) already covers the main path — but two gaps left Codex sessions stuck:

1. **Codex's overflow error was never recognized.** Codex returns `context_window_exceeded` / "ran out of room in the model's context window" — neither matched `CONTEXT_OVERFLOW_PATTERNS`, so no self-heal ever armed and the same oversized payload was re-sent forever.
2. **No window number in the body.** Even when recognized, Codex's error carries no parseable window, so `parseOverflowWindow` found nothing and the armed floor stayed 0.

## Changes

- `src/util.ts`: recognize `context_window_exceeded` and the "ran out of room in the model's context window" phrasing as context overflow.
- `src/server.ts`: when an overflow is recognized but no window is parseable, learn a conservative window from the rejected payload's own size (only-shrink-never-grow). The next turn's self-heal re-centers the limit and preflight compresses the history below it before forward.

## Tests

- 2 unit tests: Codex error recognition (API code + client phrasing), window stays undefined.
- Codex e2e self-heal: 400 without window number → conservative window learned → preflight folds the history on the retry → 200.
- New Responses-protocol e2e (the scenario suggested in #280): a long session compressed once, then a fresh restored session (lastInputTokens=0) replays the full raw history over the window → preflight compresses before forward; the oversized history is never replayed verbatim.

Full suite: 661/661 pass.

<sub>🤖 ework agent</sub>

<!-- ework-agent-pr -->
