### PR TITLE
fix: resolve registry window for relay hosts via provider-prefixed key scan

### DIFF
--- a/src/registry.ts
+++ b/src/registry.ts
@@ -261,6 +261,25 @@ function registryLookup(reg: RegistryShape | null, model: string, host?: string)
         const ctx = entry?.limit?.context;
         if (typeof ctx === "number" && ctx > 0) return ctx;
     }
+    // Relay host (not in HOST_TO_PROVIDER): the bare name can miss while the
+    // model exists under a provider-prefixed key (a relay serving
+    // "deepseek-v4-flash" is stored as "deepseek/deepseek-v4-flash"). Scan
+    // */<model> and adopt the value only when every match agrees — a
+    // conflict means different deployments, and guessing is worse than the
+    // static table. Known-provider hosts keep the old behavior: a miss there
+    // means the model is genuinely unlisted for that provider.
+    if (provider === undefined) {
+        const suffix = `/${model}`;
+        let agreed: number | undefined;
+        for (const key of Object.keys(reg)) {
+            if (!key.endsWith(suffix)) continue;
+            const ctx = reg[key].limit?.context;
+            if (typeof ctx !== "number" || ctx <= 0) continue;
+            if (agreed === undefined) agreed = ctx;
+            else if (agreed !== ctx) return undefined;
+        }
+        return agreed;
+    }
     return undefined;
 }
 

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -34,6 +34,47 @@ test("peekRegistryContext resolves provider-qualified keys from the warm cache",
     assert.equal(peekRegistryContext("deepseek-chat", "api.minimax.chat"), undefined);
 });
 
+test("unknown relay host falls back to provider-prefixed registry keys", () => {
+    _setForTest({
+        "deepseek/deepseek-v4-flash": { limit: { context: 1_000_000 } },
+        "minimax/MiniMax-M2.1": { limit: { context: 204_800 } },
+        "gpt-x": { limit: { context: 400_000 } },
+    });
+    // Relay host absent from HOST_TO_PROVIDER: bare name misses, but the
+    // provider-prefixed key still resolves (issue #282).
+    assert.equal(peekRegistryContext("deepseek-v4-flash", "freeinference.org"), 1_000_000);
+    assert.equal(peekRegistryContext("MiniMax-M2.1", "some-relay.example"), 204_800);
+    // No host at all triggers the same fallback scan.
+    assert.equal(peekRegistryContext("deepseek-v4-flash"), 1_000_000);
+    // A bare key, when present, still wins without scanning.
+    assert.equal(peekRegistryContext("gpt-x", "freeinference.org"), 400_000);
+});
+
+test("conflicting provider-prefixed matches do not guess", () => {
+    _setForTest({
+        "prov-a/ambig": { limit: { context: 100_000 } },
+        "prov-b/ambig": { limit: { context: 200_000 } },
+    });
+    assert.equal(peekRegistryContext("ambig", "relay.example"), undefined);
+});
+
+test("relay fallback scan is slash-bounded (no partial-name matches)", () => {
+    _setForTest({ "deepseek/deepseek-v4-flash": { limit: { context: 1_000_000 } } });
+    assert.equal(peekRegistryContext("v4-flash", "relay.example"), undefined);
+    assert.equal(peekRegistryContext("flash", "relay.example"), undefined);
+});
+
+test("known-provider host does not cross-provider scan on a miss", () => {
+    _setForTest({ "deepseek/deepseek-chat": { limit: { context: 1_000_000 } } });
+    assert.equal(peekRegistryContext("deepseek-chat", "api.minimax.chat"), undefined);
+});
+
+test("bundled snapshot resolves relay-style bare names via provider-prefixed keys", () => {
+    // The exact #282 scenario: freeinference.org serving "deepseek-v4-flash",
+    // which the registry stores only as "deepseek/deepseek-v4-flash" (1M).
+    assert.equal(bundledSnapshotLookup("deepseek-v4-flash", "freeinference.org"), 1_000_000);
+});
+
 test("contextFromRegistry resolves from the warm cache (same lookup, async)", async () => {
     _setForTest({ "minimax/MiniMax-M3": { limit: { context: 512_000 } } });
     assert.equal(await contextFromRegistry("MiniMax-M3", "api.minimax.chat"), 512_000);


### PR DESCRIPTION
Closes the 64k window mismatch on relay hosts: registryLookup now scans provider-prefixed candidates when the host is unknown and the bare key misses (all matches must agree). Includes 5 tests incl. #282 regression.

Agent-prepared (branch pushed by ework-daemon via credhelper); PR opened via git credential API per AGENTS.md flow.