### PR TITLE
fix: floor fallback-derived context window at 100k after output-headroom reservation

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -144,6 +144,17 @@ export function lookupContextLimit(model: string | undefined): number | undefine
     return undefined;
 }
 
+/** Floor for the EFFECTIVE context window (after output-headroom reservation)
+ *  when the window came from a low-confidence fallback — the built-in table
+ *  above or the env default — rather than an authoritative source (plugin
+ *  report, launcher declaration, models.dev registry, per-route config, or a
+ *  learned upstream overflow). Fallback values are guesses, and the two error
+ *  directions are asymmetric: a too-small guess strands the session on a
+ *  permanent compression treadmill (issue #282: 128k table value − 64k
+ *  max_tokens → 64k effective for a 1M-window model), while a too-large guess
+ *  self-heals on the first upstream overflow. */
+export const FALLBACK_EFFECTIVE_WINDOW_FLOOR = 100_000;
+
 /** Resolve the context-window limit for a request. Priority:
  *  1. Per-URL per-model declaration in config (user-controlled, most accurate).
  *     The upstreamUrl is matched against config keys by **longest-prefix wins**

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,7 +5,7 @@ import { resolveCompress, resolveCompressPrompts, resolveRequestConfig } from ".
 import type { ProxyOptions } from "./config.js";
 import { loadOptions, loadRoutes } from "./config.js";
 import { resetProxyCache } from "./upstream-proxy.js";
-import { resolveContextLimit, resolveCompressProtocol } from "./config.js";
+import { FALLBACK_EFFECTIVE_WINDOW_FLOOR, lookupContextLimit, resolveConfiguredContextLimit, resolveCompressProtocol } from "./config.js";
 import { contextFromRegistry, loadRegistry, peekRegistryContext } from "./registry.js";
 import { fetchWithTimeout, MAX_REQUEST_BYTES } from "./fetch-util.js";
 import { formatUpstreamError, getUpstreamConnectionStatus, recordUpstreamConnection, resolveProxy, resolveProxyDecision, proxyDispatcher } from "./upstream-proxy.js";
@@ -659,6 +659,12 @@ async function handle(
     // absolute number, a "70%" string of the native window, or unset → native)
     // overrides the table.
     let reqConfig = config;
+    // True when the resolved native window came from a low-confidence fallback
+    // (built-in table / env default) instead of an authoritative source — such
+    // windows get an effective-floor after output-headroom reservation (see
+    // FALLBACK_EFFECTIVE_WINDOW_FLOOR). Cleared if a learned overflow limit or
+    // an async registry hit replaces the value.
+    let nativeFromFallback = false;
     // Effective compression prompts for this request: resolved from the same
     // three-level cascade (global → provider → model) as the limit above, then
     // threaded into every prepare* path so the system prompt, the nudge text,
@@ -684,12 +690,23 @@ async function handle(
             // fallback. Operator tuning via compress.modelContextLimit still
             // outranks everything inside resolveRequestConfig.
             const host = (() => { try { return embeddedUrl ? new URL(embeddedUrl).host : undefined; } catch { return undefined; } })();
-            let native = pluginReportedContextWindow(req.headers)
-                ?? launcherContextWindow(model)
-                ?? (host ? peekRegistryContext(model, host) : undefined)
-                ?? resolveContextLimit(opts.routes, embeddedUrl, model);
+            const pluginWindow = pluginReportedContextWindow(req.headers);
+            const launcherWindow = launcherContextWindow(model);
+            const peekWindow = host ? peekRegistryContext(model, host) : undefined;
+            const configuredWindow = resolveConfiguredContextLimit(opts.routes, embeddedUrl, model);
+            let native = pluginWindow
+                ?? launcherWindow
+                ?? peekWindow
+                ?? configuredWindow
+                ?? lookupContextLimit(model);
+            // Fallback = no authoritative source AND the operator did not
+            // explicitly tune the window via compress.modelContextLimit (an
+            // explicit tuning is owned by the operator — never floored).
+            const operatorWindowTuned = resolveCompress(opts.routes, embeddedUrl, model, opts.compress).modelContextLimit !== undefined;
+            nativeFromFallback = !pluginWindow && !launcherWindow && !peekWindow && !configuredWindow && !operatorWindowTuned;
             if (!native && host) {
                 native = await contextFromRegistry(model, host);
+                if (native) nativeFromFallback = false;
             }
             reqConfig = resolveRequestConfig(config, opts.routes, embeddedUrl, model, native, opts.compress);
             reqPrompts = resolveCompressPrompts(resolveCompress(opts.routes, embeddedUrl, model, opts.compress));
@@ -837,6 +854,9 @@ async function handle(
         if (learnedLimit && learnedLimit > 0 && learnedLimit < reqConfig.modelContextLimit) {
             const resolved = reqConfig.modelContextLimit;
             reqConfig = { ...reqConfig, modelContextLimit: learnedLimit };
+            // A learned limit is ground truth from a real overflow — it must
+            // not be floored back up (that would undo the self-heal).
+            nativeFromFallback = false;
             log("info", `[${session.id}] self-healed context window: ${resolved} → ${learnedLimit} (learned from an upstream overflow)`);
         }
         // Reserve the model's OUTPUT budget for this turn from the window so the
@@ -857,7 +877,16 @@ async function handle(
             const p = parsed as Record<string, unknown>;
             const rawMax = p.max_tokens ?? p.max_completion_tokens ?? p.max_output_tokens;
             const maxOutput = typeof rawMax === "number" ? rawMax : 0;
-            const reserved = reserveOutputHeadroom(reqConfig.modelContextLimit, maxOutput);
+            let reserved = reserveOutputHeadroom(reqConfig.modelContextLimit, maxOutput);
+            // Fallback-derived windows are optimistic guesses: never let the
+            // output-headroom reservation push the effective window below the
+            // floor (issue #282: 128k table − 64k max_tokens → 64k effective
+            // for a 1M-window model). If the real window is smaller, the first
+            // upstream overflow self-heals it.
+            if (nativeFromFallback && reserved < FALLBACK_EFFECTIVE_WINDOW_FLOOR) {
+                log("info", `[${session.id}] fallback context window floored: ${reserved} → ${FALLBACK_EFFECTIVE_WINDOW_FLOOR} (model=${String(p.model ?? "?")} not authoritatively identified; self-heal corrects it if the real window is smaller)`);
+                reserved = FALLBACK_EFFECTIVE_WINDOW_FLOOR;
+            }
             if (reserved !== reqConfig.modelContextLimit) reqConfig = { ...reqConfig, modelContextLimit: reserved };
         }
         // acquireInFlight must precede the lock so evictOldest() cannot flush

--- a/tests/fallback-window-floor.test.ts
+++ b/tests/fallback-window-floor.test.ts
@@ -1,0 +1,218 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import { once } from "node:events";
+import test from "node:test";
+
+process.env.NODE_ENV = "test";
+
+import { defaultConfig } from "acp-kernel";
+import { startServer, type ProxyOptions } from "../src/server.ts";
+import { SessionStore, _setStoreForTest } from "../src/persist.ts";
+import { _setForTest as setRegistryForTest } from "../src/registry.ts";
+
+// #282: when the model window comes from a low-confidence fallback (static
+// table / env default) rather than an authoritative source, the
+// output-headroom reservation must not push the effective window below
+// FALLBACK_EFFECTIVE_WINDOW_FLOOR (100k). Scenario: "deepseek-v4-flash"
+// (table: 128k) behind an unlisted relay host, empty registry, client
+// max_tokens=64000. Without the floor the effective window is 128k−64k=64k
+// and a 50k-token context (78%) trips the OVER-LIMIT nudge (kernel default
+// maxContextLimitPct=0.75); with the floor it is 100k (50% → idle, no
+// nudge). The nudge is observable as a trailing user message appended to the
+// forwarded payload.
+
+function okJson(promptTokens: number): string {
+    return JSON.stringify({
+        id: "chatcmpl-1",
+        object: "chat.completion",
+        choices: [{ index: 0, message: { role: "assistant", content: "ok" }, finish_reason: "stop" }],
+        usage: { prompt_tokens: promptTokens, completion_tokens: 3, total_tokens: promptTokens + 3 },
+    });
+}
+
+test("e2e: fallback-derived window is floored at 100k after output-headroom reservation", async () => {
+    const received: unknown[][] = [];
+    const upstream = http.createServer((req, res) => {
+        const chunks: Buffer[] = [];
+        req.on("data", (c: Buffer) => chunks.push(c));
+        req.on("end", () => {
+            const body = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+            received.push(body.messages ?? []);
+            res.writeHead(200, { "content-type": "application/json" });
+            res.end(okJson(50_000));
+        });
+    });
+    upstream.listen(0, "127.0.0.1");
+    await once(upstream, "listening");
+    const upstreamPort = upstream.address().port;
+
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    setRegistryForTest({});
+    const proxy = await startServer({
+        port: 0,
+        host: "127.0.0.1",
+        upstream: "http://127.0.0.1",
+        routes: {},
+        modelContextLimit: 200_000,
+        kernelConfig: defaultConfig(200_000),
+        compress: { injectTool: true, injectNudge: true },
+        promptCache: { routing: "auto" },
+        sessionHeader: "x-acp-session",
+        log: false,
+        debug: false,
+        passthrough: false,
+        autoUpdate: false,
+        mitm: { enabled: false, domains: [] },
+    } as ProxyOptions);
+    await once(proxy, "listening");
+    const proxyPort = proxy.address().port;
+
+    try {
+        const url = `http://127.0.0.1:${proxyPort}/bili/http://127.0.0.1:${upstreamPort}/v1/chat/completions`;
+        const headers = { "content-type": "application/json", "x-acp-session": "floor-sess" };
+
+        // Turn 1: teaches the session its real context size (50k input tokens
+        // via the upstream usage report).
+        const r1 = await fetch(url, {
+            method: "POST",
+            headers,
+            body: JSON.stringify({ model: "deepseek-v4-flash", max_tokens: 64_000, messages: [{ role: "user", content: "hello" }] }),
+        });
+        assert.equal(r1.status, 200);
+        await r1.text();
+
+        // Turn 2: 50k context (per the turn-1 usage report). Effective window
+        // = table 128k − 64k max_tokens = 64k WITHOUT the floor (78% →
+        // OVER-LIMIT nudge → trailing user message appended to the forwarded
+        // payload); WITH the floor it is 100k (50% → idle, no nudge). The
+        // forwarded payload always carries the leading compress system
+        // message (1 + client messages [+1 nudge]). The long text must sit
+        // OUTSIDE the protected recent zone — both preserveRecentMessages=5
+        // AND the preserveRecentTokens=5000 tail walk — so 24 ~1000-char
+        // filler messages (~6000 tokens) separate it from the tail, giving the
+        // OVER-LIMIT nudge viable compressible content to point at.
+        const longText = "x".repeat(20_000);
+        const filler: { role: "user" | "assistant"; content: string }[] = [];
+        for (let i = 1; i <= 12; i++) {
+            filler.push({ role: "user", content: `q${i} ` + "f".repeat(997) });
+            filler.push({ role: "assistant", content: `a${i} ` + "e".repeat(997) });
+        }
+        const r2 = await fetch(url, {
+            method: "POST",
+            headers,
+            body: JSON.stringify({
+                model: "deepseek-v4-flash",
+                max_tokens: 64_000,
+                messages: [
+                    { role: "user", content: "hello" },
+                    { role: "assistant", content: "ok" },
+                    { role: "user", content: "continue" },
+                    { role: "assistant", content: longText },
+                    ...filler,
+                    { role: "user", content: "now summarize" },
+                ],
+            }),
+        });
+        assert.equal(r2.status, 200);
+        await r2.text();
+
+        assert.equal(received.length, 2, "both turns reached the upstream");
+        assert.equal(received[0].length, 2, "turn 1 forwards system + the single user message");
+        assert.equal(received[1].length, 30, "turn 2 appends no nudge at 50% of the floored 100k window (would be 31 at 78% of the unfloored 64k)");
+    } finally {
+        proxy.close();
+        await once(proxy, "close");
+        upstream.close();
+        await once(upstream, "close");
+    }
+});
+
+test("e2e: per-route context declaration is operator-owned and never floored", async () => {
+    const received: unknown[][] = [];
+    const upstream = http.createServer((req, res) => {
+        const chunks: Buffer[] = [];
+        req.on("data", (c: Buffer) => chunks.push(c));
+        req.on("end", () => {
+            const body = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+            received.push(body.messages ?? []);
+            res.writeHead(200, { "content-type": "application/json" });
+            res.end(okJson(50_000));
+        });
+    });
+    upstream.listen(0, "127.0.0.1");
+    await once(upstream, "listening");
+    const upstreamPort = upstream.address().port;
+
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    setRegistryForTest({});
+    const proxy = await startServer({
+        port: 0,
+        host: "127.0.0.1",
+        upstream: "http://127.0.0.1",
+        routes: { [`http://127.0.0.1:${upstreamPort}`]: { models: { "deepseek-v4-flash": { context: 64_000 } } } },
+        modelContextLimit: 200_000,
+        kernelConfig: defaultConfig(200_000),
+        compress: { injectTool: true, injectNudge: true },
+        promptCache: { routing: "auto" },
+        sessionHeader: "x-acp-session",
+        log: false,
+        debug: false,
+        passthrough: false,
+        autoUpdate: false,
+        mitm: { enabled: false, domains: [] },
+    } as ProxyOptions);
+    await once(proxy, "listening");
+    const proxyPort = proxy.address().port;
+
+    try {
+        const url = `http://127.0.0.1:${proxyPort}/bili/http://127.0.0.1:${upstreamPort}/v1/chat/completions`;
+        const headers = { "content-type": "application/json", "x-acp-session": "floor-sess-2" };
+
+        const r1 = await fetch(url, {
+            method: "POST",
+            headers,
+            body: JSON.stringify({ model: "deepseek-v4-flash", max_tokens: 64_000, messages: [{ role: "user", content: "hello" }] }),
+        });
+        assert.equal(r1.status, 200);
+        await r1.text();
+
+        // Operator explicitly declared context=64000 for this model: the
+        // reservation is degenerate (maxOutput >= window → no reservation) so
+        // the effective window stays the declared 64000 and a 50k context
+        // (78%) MUST trip the nudge — the floor must not touch operator-owned
+        // values. Same history shape as the first test: long text outside the
+        // protected recent zone so the OVER-LIMIT nudge is viable.
+        const longText = "y".repeat(20_000);
+        const filler: { role: "user" | "assistant"; content: string }[] = [];
+        for (let i = 1; i <= 12; i++) {
+            filler.push({ role: "user", content: `q${i} ` + "f".repeat(997) });
+            filler.push({ role: "assistant", content: `a${i} ` + "e".repeat(997) });
+        }
+        const r2 = await fetch(url, {
+            method: "POST",
+            headers,
+            body: JSON.stringify({
+                model: "deepseek-v4-flash",
+                max_tokens: 64_000,
+                messages: [
+                    { role: "user", content: "hello" },
+                    { role: "assistant", content: "ok" },
+                    { role: "user", content: "continue" },
+                    { role: "assistant", content: longText },
+                    ...filler,
+                    { role: "user", content: "now summarize" },
+                ],
+            }),
+        });
+        assert.equal(r2.status, 200);
+        await r2.text();
+
+        assert.equal(received.length, 2);
+        assert.equal(received[1].length, 31, "operator-declared window is not floored: nudge appended at 78% of 64k");
+    } finally {
+        proxy.close();
+        await once(proxy, "close");
+        upstream.close();
+        await once(upstream, "close");
+    }
+});


### PR DESCRIPTION
Follow-up to ranxianglei/billion-context#282 — per maintainer: "识别模型失败应该默认回滚到 20w 最低 10w 而不是 64k".

**Rationale**

The two error directions are asymmetric: a window guessed too **small** causes a permanent compression treadmill (the #282 symptom — 161 compressions in 14h at a 64k effective window); a window guessed too **large** costs at most one extra request, because the first upstream overflow self-heals the real limit (`inspectContextOverflow` → `learnedContextLimits`). Fallbacks should therefore be optimistic.

**Changes**

- `src/config.ts`: `FALLBACK_EFFECTIVE_WINDOW_FLOOR = 100_000`
- `src/server.ts`: track whether the resolved window came from a low-confidence fallback (no plugin report, launcher declaration, registry hit, per-route config, or operator `compress.modelContextLimit`). After `reserveOutputHeadroom`, floor fallback-derived windows at 100k and log: `fallback context window floored: 64000 → 100000 (model=… not authoritatively identified; self-heal corrects it if the real window is smaller)`.
- The flag is cleared when self-heal learns the real limit (measured ground truth — must not be floored back up) and when the async registry lookup lands.
- "Default 20w" already held: all-miss falls to `modelContextLimit` default 200000 (src/config.ts:279); this adds the missing 10w floor.
- Never floored: plugin reports, launcher declarations, registry values, per-route config, operator settings, learned limits.

**Tests**

2 new e2e tests in `tests/fallback-window-floor.test.ts`: (1) fallback-derived 64k is floored to 100k → no nudge at 50k context (would fire at 78% without the floor); (2) per-route declared window is never floored. Full suite 664/664 green; typecheck + build green.

Independent of (and recommended to land after) the registry relay lookup fix — that one is the root fix, this one is the safety net.
