### PR TITLE
feat: session id is the client-provided conversation value verbatim; 400 without identity (#286)

### DIFF
--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -795,7 +795,7 @@ export function prepareHermesHome(
         const rawLine = lines[i];
         const m = /^(\s*(?:api|base_url|url):\s*)(\S+)(\s+#.*)?$/.exec(rawLine);
         if (!m) continue;
-        const rawUrl = m[2];
+        const rawUrl = m[2].replace(/^["']|["']$/g, "");
         if (!/^https?:\/\//i.test(rawUrl)) continue;
         const real = unwrapUpstream(rawUrl);
         if (!wrapSet.has(real)) continue;
@@ -807,6 +807,113 @@ export function prepareHermesHome(
     if (!refreshOverlayHome(hermesHome, overlay, "config.yaml")) return undefined;
     writeOverlayFileAtomic(overlay, "config.yaml", lines.join(eol));
     return overlay;
+}
+
+/** Write the hermes session-identity plugin into the bili overlay home.
+ *  Hermes sends NO conversation identity on the wire by default: its native
+ *  `prompt_cache_key` support (transports/chat_completions.py) is gated on
+ *  `supports_prompt_cache_key`, which no bundled provider profile enables —
+ *  so every custom-provider request reaches the proxy anonymous and gets a
+ *  400 (#286). User plugins under $HERMES_HOME/plugins/model-providers/<name>/
+ *  override bundled profiles (discovery order bundled → user, last-writer-
+ *  wins), and the profile hook `build_api_kwargs_extras(session_id=...)`
+ *  receives the REAL hermes session id — its top_level return value is
+ *  merged straight into the request body. The generated plugin subclasses
+ *  the bundled "custom" profile and stamps prompt_cache_key = session_id,
+ *  giving the proxy the same stable per-conversation id omp/pi provide.
+ *  Registered names: "custom" (model.base_url / provider: custom) plus
+ *  "custom:<name>" for every provider key bili rewrites (named providers
+ *  resolve to that shape — agent_init only maps "custom"/"custom:<key>"
+ *  to custom endpoints, and a bare "custom:<key>" lookup otherwise misses
+ *  the profile registry and falls to the legacy no-pck path).
+ *  Skipped (returns false) when the REAL ~/.hermes already has a plugins/
+ *  dir — refreshOverlayHome symlinks it into the overlay, and writing
+ *  through the symlink would mutate the user's real home. The proxy then
+ *  400s anonymous requests with the fix-it message. */
+export function writeHermesIdentityPlugin(hermesHome: string, overlay: string, rewrites: HttpRewrite[]): boolean {
+    try {
+        if (fs.existsSync(path.join(hermesHome, "plugins"))) return false;
+    } catch {
+        return false;
+    }
+    const dir = path.join("plugins", "model-providers", "bili-session-identity");
+    try {
+        fs.mkdirSync(path.join(overlay, dir), { recursive: true });
+    } catch {
+        return false;
+    }
+    const keys = rewrites.map((r) => r.key);
+    const pluginDir = path.join(overlay, dir);
+    try {
+        fs.writeFileSync(path.join(pluginDir, "__init__.py"), hermesIdentityPluginSource(keys));
+        fs.writeFileSync(path.join(pluginDir, "plugin.yaml"), [
+        "name: bili-session-identity",
+        "kind: model-provider",
+        "version: 1.0.0",
+        "description: billion-context session identity (installed by `bili hermes` — safe to delete)",
+        "author: billion-context",
+        "",
+    ].join("\n"));
+    } catch {
+        return false;
+    }
+    try {
+        return fs.existsSync(path.join(overlay, dir, "__init__.py"));
+    } catch {
+        return false;
+    }
+}
+
+function hermesIdentityPluginSource(providerKeys: string[]): string {
+    return [
+        '"""Installed by `bili hermes` (billion-context) — safe to delete.',
+        "",
+        "Re-registers hermes's `custom` provider profile (plus a `custom:<name>`",
+        "profile for every provider the proxy fronts) with one addition: the",
+        "REAL hermes session id is sent as `prompt_cache_key` on every request,",
+        "which the billion-context proxy uses as the stable conversation",
+        'identity for its compression sessions. Removing this file restores',
+        'stock behavior (no prompt_cache_key)."""',
+        "from providers import get_provider_profile, register_provider",
+        "from providers.base import ProviderProfile",
+        "",
+        `_PROVIDER_KEYS = ${JSON.stringify(providerKeys)}`,
+        "",
+        '_custom = get_provider_profile("custom")',
+        "_BASE = type(_custom) if _custom is not None else ProviderProfile",
+        "",
+        "",
+        "class _BiliSessionIdentity(_BASE):",
+        "    def build_api_kwargs_extras(self, *, session_id=None, **ctx):",
+        "        extra_body, top_level = _BASE.build_api_kwargs_extras(",
+        "            self, session_id=session_id, **ctx",
+        "        )",
+        '        sid = str(session_id or "").strip()',
+        "        if sid:",
+        '            top_level.setdefault("prompt_cache_key", sid[:64])',
+        "        return extra_body, top_level",
+        "",
+        "",
+        "def _register(name, template, with_aliases):",
+        "    fields = {}",
+        "    if template is not None:",
+        "        # Aliases are copied ONLY for the canonical custom",
+        "        # re-registration: copying them onto custom:<name> entries",
+        "        # would steal the aliases (register_provider re-points each",
+        "        # alias at the registering name).",
+        '        for attr in ((\"aliases\",) if with_aliases else ()) + (\"env_vars\", \"base_url\", \"default_max_tokens\"):',
+        "            value = getattr(template, attr, None)",
+        "            if value:",
+        "                fields[attr] = value",
+        "    register_provider(_BiliSessionIdentity(name=name, **fields))",
+        "",
+        "",
+        "if _custom is not None:",
+        '    _register("custom", _custom, True)',
+        "for _key in _PROVIDER_KEYS:",
+        '    _register("custom:" + _key, _custom, False)',
+        "",
+    ].join("\n");
 }
 
 /** dsh counterpart of prepareHermesHome: a persistent `<dshHome>-bili` overlay
@@ -1257,6 +1364,17 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
         hermesOverlayHome = prepareHermesHome(resolveHermesHome(process.env), origin, routes.httpRewrites);
         if (hermesOverlayHome) {
             env.HERMES_HOME = hermesOverlayHome;
+            // Session identity for the proxied custom providers: hermes sends
+            // no conversation id on the wire, so the proxy 400s anonymous
+            // requests (#286). The plugin stamps the real hermes session id as
+            // prompt_cache_key. Skipped (identity stays anonymous) when the
+            // real ~/.hermes already has a plugins/ dir — writing through the
+            // overlay symlink would mutate the user's home.
+            if (!writeHermesIdentityPlugin(resolveHermesHome(process.env), hermesOverlayHome, routes.httpRewrites)) {
+                console.error(
+                    "bili: ~/.hermes has its own plugins/ — skipping the session-identity plugin; hermes requests will be rejected by the proxy without an identity (see #286).",
+                );
+            }
         } else {
             console.error(
                 routes.httpRewrites.length === 0
@@ -1275,6 +1393,18 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
         // symlinks and the real ~/.dsh is never touched.
         env = { ...process.env, BILLION_CONTEXT_PROXY: origin };
         env.DEEPSEEK_BASE_URL = wrapUpstream(origin, "https://api.deepseek.com");
+        // Session identity for the proxy: dsh's pi-ai stack keys its
+        // `prompt_cache_key` body field (the dsh session id) off
+        // cacheRetention — every non-api.openai.com base URL defaults to
+        // "short", which sends NO key and leaves the request anonymous (the
+        // proxy then 400s, #286). "long" + compat.supportsLongCacheRetention
+        // (true for deepseek/custom base URLs) makes every request carry
+        // prompt_cache_key = the dsh session uuid. The extra
+        // prompt_cache_retention field this also emits is stripped by the
+        // proxy before forwarding upstream. A per-provider cacheRetention set
+        // in the user's own settings.yaml still wins (explicit profile value
+        // overrides the env fallback).
+        env.PI_CACHE_RETENTION = "long";
         const dshHomeDir = resolveDshHome(process.env);
         dshOverlayHome = prepareDshHome(dshHomeDir, origin, routes.httpRewrites);
         if (dshOverlayHome) {

--- a/src/persist.ts
+++ b/src/persist.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
+import { rm } from "node:fs/promises";
 import * as path from "node:path";
-import { StateStore, type PersistedEnvelope } from "acp-kernel/persist";
+import { StateStore, flatFileNameFor, type PersistedEnvelope } from "acp-kernel/persist";
 import { sessionsDir } from "./paths.js";
 import { log as loggerLog } from "./logger.js";
 import { createInitialState, type CompressionState, type CoreMessage } from "acp-kernel";
@@ -163,13 +164,15 @@ function relPathFor(id: string, protocol?: string, upstreamOrigin?: string): str
  *  server.ts / export.ts. */
 export class SessionStore {
     readonly enabled: boolean;
+    private readonly dir: string;
     private readonly store: StateStore<PersistedSession>;
 
     constructor(opts?: { dir?: string; debounceMs?: number; enabled?: boolean; log?: Logger }) {
         const debounceMs = opts?.debounceMs ?? defaultDebounce();
         this.enabled = (opts?.enabled ?? true) && debounceMs >= 0;
+        this.dir = opts?.dir ?? defaultDir();
         this.store = new StateStore<PersistedSession>({
-            dir: opts?.dir ?? defaultDir(),
+            dir: this.dir,
             version: PERSIST_VERSION,
             debounceMs: Math.max(0, debounceMs),
             enabled: this.enabled,
@@ -194,6 +197,72 @@ export class SessionStore {
             out.set(id, buildSession(envelope.payload));
         }
         return out;
+    }
+
+    /** One-time migration for the #286 identity change: sessions persisted
+     *  under the old derived hash id are re-keyed to the client-provided
+     *  conversation value stored in meta.label (which is now the session id
+     *  itself). Collisions on the same label keep the most recently saved
+     *  record; the losers, and any label already claimed by a new-format
+     *  session, are deleted. Records without a label cannot be mapped and are
+     *  left in place (they load under their old id but are never requested
+     *  again — the new proxy 400s anonymous requests). Self-terminating:
+     *  after one pass no loaded id differs from its label. */
+    async migrateLegacyIds(): Promise<void> {
+        if (!this.enabled) return;
+        const loaded = await this.store.loadAll();
+        const claimed = new Set<string>();
+        const byLabel = new Map<string, { id: string; savedAt: number; session: Session }>();
+        let unlabeled = 0;
+        for (const [id, envelope] of loaded) {
+            const session = buildSession(envelope.payload);
+            const label = session.meta.label;
+            if (!label) {
+                unlabeled++;
+                continue;
+            }
+            if (label === id) {
+                claimed.add(id);
+                continue;
+            }
+            const prev = byLabel.get(label);
+            if (!prev || envelope.savedAt >= prev.savedAt) {
+                if (prev) await this.removeLegacyFile(prev.id, prev.session);
+                byLabel.set(label, { id, savedAt: envelope.savedAt, session });
+            } else {
+                await this.removeLegacyFile(id, session);
+            }
+        }
+        let rekeyed = 0;
+        for (const [label, { id, session }] of byLabel) {
+            if (claimed.has(label)) {
+                await this.removeLegacyFile(id, session);
+                continue;
+            }
+            session.id = label;
+            await this.store.writeNow(label, () => buildRecord(session));
+            await this.removeLegacyFile(id, session);
+            claimed.add(label);
+            rekeyed++;
+        }
+        if (rekeyed || unlabeled) {
+            loggerLog("info", `[persist] one-time migration (#286): rekeyed ${rekeyed} legacy session(s), left ${unlabeled} unlabeled legacy file(s) in place`);
+        }
+    }
+
+    /** Remove a legacy session file. The kernel store never deletes (cleanup
+     *  is downstream policy), so the path is recomputed here: the namespaced
+     *  layout for v2+/v3 files, the _unknown/ fallback, and the flat default
+     *  name for pre-envelope v1 files. */
+    private async removeLegacyFile(id: string, session: Session): Promise<void> {
+        const candidates = new Set([
+            relPathFor(id, session.meta.protocol, session.meta.upstreamOrigin),
+            relPathFor(id),
+            flatFileNameFor(id),
+        ]);
+        for (const rel of candidates) {
+            await rm(path.join(this.dir, rel), { force: true }).catch(() => {});
+        }
     }
 
     /** Synchronous reload of a single session. Used on a memory miss (after

--- a/src/server.ts
+++ b/src/server.ts
@@ -1298,11 +1298,14 @@ function prepareResponses(
     }
 
     const rebuilt: ResponsesRequestBody = { ...parsed, input: rebuiltInput, tools: toolsOut };
+    // Route with the upstream THIS request goes to — session.meta.upstreamOrigin
+    // is first-wins and would keep injecting pck toward a relay we switched
+    // away from (same class of bug as the compressProtocol fix above, #286).
     const promptCacheKey = resolvePromptCacheKey(
         rebuilt.prompt_cache_key,
         identity,
         opts.promptCache.routing,
-        session.meta.upstreamOrigin,
+        upstreamOrigin,
     );
     if (promptCacheKey && !rebuilt.prompt_cache_key) rebuilt.prompt_cache_key = promptCacheKey;
     // This adapter is stateless: we replay the FULL conversation in `input`.

--- a/src/server.ts
+++ b/src/server.ts
@@ -1172,6 +1172,14 @@ function prepareOpenai(
     }
 
     const rebuilt: OpenAIRequestBody = { ...parsed, messages: rebuiltMessages, tools: toolsOut as OpenAITool[] | undefined };
+    // prompt_cache_retention is an OpenAI-host-only cache directive; the dsh
+    // launcher forces PI_CACHE_RETENTION=long (for the session-id
+    // prompt_cache_key) which makes the client also emit it. Third-party
+    // OpenAI-compatible upstreams may reject unknown fields, and cache policy
+    // is the upstream's business — strip it. prompt_cache_key itself passes
+    // through: upstreams that ignore it lose nothing, upstreams that use it
+    // get a per-conversation routing hint.
+    delete (rebuilt as Record<string, unknown>).prompt_cache_retention;
     // OpenAI Chat Completions only emits a usage object in the final stream
     // chunk when the client sets stream_options.include_usage=true. Without
     // it, streaming sessions never learn their real input_tokens →
@@ -1320,6 +1328,10 @@ function prepareResponses(
     // (top-level instructions must stay empty for code_mode tool exposure).
     if (process.env.ACP_KEEP_RESPONSE_ID !== "1") delete rebuilt.previous_response_id;
     delete rebuilt.instructions;
+    // Same rationale as prepareOpenai: strip the OpenAI-host-only cache
+    // directive; keep prompt_cache_key. Sent by hermes' codex transport and
+    // by any PI_CACHE_RETENTION=long client.
+    delete (rebuilt as Record<string, unknown>).prompt_cache_retention;
     // Log the final tools we forward upstream so we can confirm ACP tools are
     // present. Distinguishes "compress" (top-level function) from Codex
     // namespace items (type:namespace/custom).

--- a/src/server.ts
+++ b/src/server.ts
@@ -757,7 +757,17 @@ async function handle(
                   responsesIdentity?.value ?? conversationSignalResponses(parsed as ResponsesRequestBody, convHeader),
                   (parsed as ResponsesRequestBody).instructions,
               );
-        const sessionId = deriveProxySessionId(req.headers, protocol, upstreamOrigin, conversation);
+        // Strong-signal sessions (client-provided conversation id) key on
+        // (protocol, conversation) only — AND-ing credential/upstream would
+        // orphan the session state on bearer rotation or relay switching
+        // (#286). Weak-signal (content fingerprint) keeps the 4-dim key so the
+        // account/upstream dimensions still isolate colliding fingerprints.
+        const clientProvided = protocol === "responses"
+            ? (responsesIdentity?.clientProvided ?? false)
+            : protocol === "openai"
+              ? (openaiIdentity?.clientProvided ?? false)
+              : !!convHeader;
+        const sessionId = deriveProxySessionId(req.headers, protocol, upstreamOrigin, conversation, clientProvided);
         // Two separate uses of the conversation signal:
         //  - `affinity`: header value forwarded upstream for sticky-routing /
         //    cache pools. Synthesized as ses_<conversation> when the client

--- a/src/server.ts
+++ b/src/server.ts
@@ -54,7 +54,7 @@ import { sanitizeResponsesInputIds, dropWhitespaceResponsesMessages, normalizeRe
 import { rewriteOpenaiJsonResponse } from "./stream-openai.js";
 import { rewriteResponsesJsonResponse } from "./stream-responses.js";
 import { emitStreamError } from "./stream-error.js";
-import { deriveSessionId as deriveProxySessionId, affinityToken, clientConversationHeader, preferPromptCacheKeyIdentity, type ConversationIdentity } from "./session-id.js";
+import { affinityToken, clientConversationHeader, preferPromptCacheKeyIdentity, type ConversationIdentity } from "./session-id.js";
 import { consumePluginRegisterFor, flushConversations, handlePluginManifest, handlePluginRegister, handlePluginStatus, handlePluginTool, loadConversations, pipePluginJson, pipePluginResponsesWithStrip, pipeThroughWithUsage, pluginAgentHeader, pluginConversationHeader, pluginReportedContextWindow, recordPluginSession, rememberPluginMessages, takePendingPluginRegister } from "./plugin.js";
 import { setupMitm, readMitmUpstream } from "./mitm.js";
 import type { BiliMessage } from "acp-kernel/wire";
@@ -89,6 +89,20 @@ const LAUNCHER_MODEL_WINDOWS: Readonly<Record<string, number>> = parseLauncherMo
 function launcherContextWindow(model: string): number | undefined {
     return LAUNCHER_MODEL_WINDOWS[model];
 }
+
+/** Session ids are client-provided verbatim (#286) — sanitize before using
+ *  one in a debug-dump FILENAME so a hostile value cannot escape the dir. */
+function safeSessionId(id: string | undefined): string {
+    return (id ?? "unknown").replace(/[^a-zA-Z0-9._-]/g, "_");
+}
+
+/** 400 body for requests carrying no client-provided conversation identity.
+ *  Content-fingerprint sessions are disabled (#286): the fingerprint has a
+ *  real collision surface and a silent session would orphan state the moment
+ *  the account or relay changes, so anonymous requests fail explicitly. */
+const NO_IDENTITY_MESSAGE =
+    "Missing stable conversation identity. Send one of the headers: x-session-id, x-session-affinity, x-acp-session, x-opencode-session, x-claude-code-session-id, session-id — or body session_id / prompt_cache_key (responses/openai). " +
+    "Content-fingerprint sessions are disabled (#286).";
 
 const UPSTREAM_HOP_HEADERS = new Set([
     "host",
@@ -757,17 +771,27 @@ async function handle(
                   responsesIdentity?.value ?? conversationSignalResponses(parsed as ResponsesRequestBody, convHeader),
                   (parsed as ResponsesRequestBody).instructions,
               );
-        // Strong-signal sessions (client-provided conversation id) key on
-        // (protocol, conversation) only — AND-ing credential/upstream would
-        // orphan the session state on bearer rotation or relay switching
-        // (#286). Weak-signal (content fingerprint) keeps the 4-dim key so the
-        // account/upstream dimensions still isolate colliding fingerprints.
+        // The session ID is the client-provided conversation value VERBATIM —
+        // no hash, no protocol/credential/upstream dimensions (#286): those
+        // are all mutable mid-conversation (bearer rotation, relay switching,
+        // protocol translation), and only the client's own conversation id is
+        // bound to the conversation. Requests without a client-provided
+        // identity are rejected: content-fingerprint sessions have a real
+        // collision surface and would silently orphan state.
         const clientProvided = protocol === "responses"
             ? (responsesIdentity?.clientProvided ?? false)
             : protocol === "openai"
               ? (openaiIdentity?.clientProvided ?? false)
               : !!convHeader;
-        const sessionId = deriveProxySessionId(req.headers, protocol, upstreamOrigin, conversation, clientProvided);
+        if (!clientProvided) {
+            log("warn", `400: no stable conversation identity on ${protocol} request → ${upstreamOrigin}; refusing to create a content-fingerprint session (#286)`);
+            res.writeHead(400, { "content-type": "application/json" });
+            res.end(JSON.stringify(protocol === "anthropic"
+                ? { type: "error", error: { type: "invalid_request_error", message: NO_IDENTITY_MESSAGE } }
+                : { error: { type: "invalid_request_error", message: NO_IDENTITY_MESSAGE } }));
+            return;
+        }
+        const sessionId = conversation;
         // Two separate uses of the conversation signal:
         //  - `affinity`: header value forwarded upstream for sticky-routing /
         //    cache pools. Synthesized as ses_<conversation> when the client
@@ -888,7 +912,7 @@ async function handle(
                             ? prepareOpenai(parsed as OpenAIRequestBody, req, opts, core, reqConfig, reqPrompts, log, session, pluginMode)
                             : responsesCompact
                               ? prepareResponsesCompact(bodyBuffer, parsed as ResponsesRequestBody, session)
-                              : prepareResponses(parsed as ResponsesRequestBody, req, opts, core, reqConfig, reqPrompts, log, session, responsesIdentity!, pluginMode);
+                              : prepareResponses(parsed as ResponsesRequestBody, req, opts, core, reqConfig, reqPrompts, log, session, responsesIdentity!, pluginMode, upstreamOrigin);
                 prepared = runPrepare();
                 if (!countTokens && !responsesCompact) {
                     prepared = await preflightCompressIfNeeded(
@@ -1173,6 +1197,7 @@ function prepareResponses(
     session: Session,
     identity: ConversationIdentity,
     pluginMode: boolean,
+    upstreamOrigin: string,
 ): Prepared {
     const sessionId = session.id;
     const stream = parsed.stream === true;
@@ -1207,8 +1232,11 @@ function prepareResponses(
 
     const shouldInject = opts.compress.injectTool;
     const injectTools = shouldInject && !pluginMode;
+    // Route config is keyed by the upstream THIS request goes to (#286: a
+    // session can outlive its first relay — session.meta.upstreamOrigin is
+    // first-wins and would silently ignore the new relay's route settings).
     const responsesTextProtocol = FORCE_TEXT_PROTOCOL ||
-        resolveCompressProtocol(opts.routes, session.meta.upstreamOrigin) === "marker";
+        resolveCompressProtocol(opts.routes, upstreamOrigin) === "marker";
 
     try {
         const projection = responsesToCore(parsed);
@@ -1632,7 +1660,7 @@ async function forward(
                 const dumpDir = process.env.ACP_DUMP_DIR || `${stateDir()}/dumps`;
                 try { fs.mkdirSync(dumpDir, { recursive: true }); } catch { /* best-effort */ }
                 const sid = prepared?.session.id ?? "unknown";
-                const out = `${dumpDir}/req-${Date.now()}-${sid}.json`;
+                const out = `${dumpDir}/req-${Date.now()}-${safeSessionId(sid)}.json`;
                 try {
                     const pretty = JSON.stringify(JSON.parse(body), null, 2);
                     fs.writeFileSync(out, pretty);
@@ -1661,7 +1689,7 @@ async function forward(
                   try {
                       const rawDir = process.env.ACP_RAW_DUMP_DIR || `${stateDir()}/raw`;
                       fs.mkdirSync(rawDir, { recursive: true });
-                      return `${rawDir}/${Date.now()}-${prepared?.session.id ?? "unknown"}`;
+                      return `${rawDir}/${Date.now()}-${safeSessionId(prepared?.session.id)}`;
                   } catch {
                       return "";
                   }
@@ -1889,7 +1917,7 @@ async function forward(
         if (opts.dumpSse) {
             const [a, b] = (upstream.body as ReadableStream<Uint8Array>).tee();
             streamToRead = a;
-            dumpRaw = dumpStreamToFile(b, opts.dumpSse, `${Date.now()}-${prepared.session.id}-raw.sse`);
+            dumpRaw = dumpStreamToFile(b, opts.dumpSse, `${Date.now()}-${safeSessionId(prepared.session.id)}-raw.sse`);
         }
         // P1.1: wrap the rewriter loops in try/catch. If a rewriter throws
         // (decompress/search edge case, JSON.parse failure, fetch abort),

--- a/src/session-id.ts
+++ b/src/session-id.ts
@@ -9,21 +9,41 @@ export type ConversationIdentity = {
 /**
  * Session identity for the proxy's OWN compression state.
  *
- * A session is uniquely keyed by FOUR dimensions (all AND-ed):
+ * A session is keyed in one of two tiers:
+ *
+ * Strong signal (clientProvided = true) — the client explicitly stated which
+ * conversation this is (codex `session-id`/`thread-id`, claude
+ * `x-claude-code-session-id`, opencode `x-opencode-session`, Responses body
+ * `session_id` / `metadata.session_id`, `prompt_cache_key`, ...). The id is
  *   1. protocol  — "anthropic" | "openai" | "responses"  (different wire
  *                  formats must never share compression state)
+ *   2. conversation — the client-provided identity value.
+ *
+ * Weak signal (clientProvided = false) — the conversation value is a content
+ * fingerprint (hash of the first user message / whole input), which has a real
+ * collision surface, so isolation is restored with the full key (all AND-ed):
+ *   1. protocol
  *   2. upstream  — the resolved upstream origin, e.g. "https://open.bigmodel.cn"
- *                  (same key hitting two providers must not share state)
+ *                  (same content hitting two providers must not share state)
  *   3. apiKey    — the account credential from Authorization / x-api-key
  *                  (different accounts must never share state, even if they
  *                  happen to send the same conversation content)
- *   4. conversation — the client's own notion of "which conversation this is",
- *                  taken from a client-provided signal when available, falling
- *                  back to a content fingerprint.
+ *   4. conversation — the content fingerprint.
+ *
+ * Why two tiers: the credential and upstream dimensions are NOT stable across
+ * a client's life — ChatGPT OAuth bearers rotate, users switch relays and
+ * accounts at will. AND-ing them into the id orphans every bit of compression
+ * state (in-memory blocks, lastInputTokens, persisted records) the moment any
+ * one of them changes, and the client then replays full raw history into a
+ * window it has already compressed (#280). A client-provided conversation id
+ * is the only invariant that actually binds to the conversation, so strong-
+ * signal sessions key on (protocol, conversation) alone and survive
+ * credential/upstream changes.
  *
  * The result is a stable, opaque id used ONLY inside the proxy (to key the
- * compression-state store). It is NEVER sent upstream — it embeds the key and
- * upstream origin, which the upstream either already knows or must not see.
+ * compression-state store). It is NEVER sent upstream — the weak-signal form
+ * embeds the key and upstream origin, which the upstream either already knows
+ * or must not see.
  *
  * If a client-provided per-conversation signal is needed for upstream routing,
  * use `affinityToken()` below. Generated proxy identities are never forwarded.
@@ -77,14 +97,22 @@ export function clientConversationHeader(headers: Record<string, string | string
  * fingerprint fallback inside this function — a silent "" default would
  * collapse every anonymous session onto one id. If `conversation` is missing
  * the caller has a bug and we throw rather than silently mis-isolating.
+ *
+ * `clientProvided` selects the keying tier (see module docs above): true →
+ * hash(protocol|conversation), stable across credential rotation and
+ * upstream/relay switching; false → the full 4-dimension hash, where
+ * credential + upstream restore isolation for the collision-prone content
+ * fingerprint.
  */
 export function deriveSessionId(
     headers: Record<string, string | string[] | undefined>,
     protocol: "anthropic" | "openai" | "responses",
     upstream: string,
     conversation: string,
+    clientProvided: boolean,
 ): string {
     if (!conversation) throw new Error("deriveSessionId: conversation dimension is required (pass the conversationSignal* output)");
+    if (clientProvided) return hashId(`${protocol}|${conversation}`);
     const key = extractKey(headers);
     return hashId(`${protocol}|${upstream}|${key}|${conversation}`);
 }

--- a/src/session-id.ts
+++ b/src/session-id.ts
@@ -1,5 +1,3 @@
-import { hashId } from "./util.js";
-
 export type ConversationIdentity = {
     value: string;
     source: "header" | "body-session" | "metadata-session" | "previous-response" | "prompt-cache-key" | "content-fingerprint" | "generated";
@@ -9,61 +7,30 @@ export type ConversationIdentity = {
 /**
  * Session identity for the proxy's OWN compression state.
  *
- * A session is keyed in one of two tiers:
+ * The session ID is the client-provided conversation value VERBATIM — no hash,
+ * no other dimensions. The client explicitly states which conversation this
+ * is (codex `session-id`/`thread-id`, claude `x-claude-code-session-id`,
+ * opencode `x-opencode-session`, Responses body `session_id` /
+ * `metadata.session_id`, `prompt_cache_key`, ...), and that value is the only
+ * invariant that actually binds to the conversation. Everything else is
+ * mutable mid-conversation and must not break session continuity (#280, #286):
+ * credentials rotate (ChatGPT OAuth bearers), users switch relays/upstreams,
+ * and the wire protocol itself can change (relay translation, cross-protocol
+ * model switches).
  *
- * Strong signal (clientProvided = true) — the client explicitly stated which
- * conversation this is (codex `session-id`/`thread-id`, claude
- * `x-claude-code-session-id`, opencode `x-opencode-session`, Responses body
- * `session_id` / `metadata.session_id`, `prompt_cache_key`, ...). The id is
- *   1. protocol  — "anthropic" | "openai" | "responses"  (different wire
- *                  formats must never share compression state)
- *   2. conversation — the client-provided identity value.
+ * A protocol switch is safe under one id because session state is
+ * protocol-neutral (kernel-normalized CompressionState, text block contents,
+ * CoreMessage snapshots) and the client re-sends the full history every turn,
+ * where the current protocol's adapter re-normalizes it.
  *
- * Weak signal (clientProvided = false) — the conversation value is a content
- * fingerprint (hash of the first user message / whole input), which has a real
- * collision surface, so isolation is restored with the full key (all AND-ed):
- *   1. protocol
- *   2. upstream  — the resolved upstream origin, e.g. "https://open.bigmodel.cn"
- *                  (same content hitting two providers must not share state)
- *   3. apiKey    — the account credential from Authorization / x-api-key
- *                  (different accounts must never share state, even if they
- *                  happen to send the same conversation content)
- *   4. conversation — the content fingerprint.
+ * Requests WITHOUT a client-provided identity are rejected with 400 by the
+ * server: the content-fingerprint fallback has a real collision surface and
+ * would silently orphan state, so anonymous requests fail explicitly instead.
  *
- * Why two tiers: the credential and upstream dimensions are NOT stable across
- * a client's life — ChatGPT OAuth bearers rotate, users switch relays and
- * accounts at will. AND-ing them into the id orphans every bit of compression
- * state (in-memory blocks, lastInputTokens, persisted records) the moment any
- * one of them changes, and the client then replays full raw history into a
- * window it has already compressed (#280). A client-provided conversation id
- * is the only invariant that actually binds to the conversation, so strong-
- * signal sessions key on (protocol, conversation) alone and survive
- * credential/upstream changes.
- *
- * The result is a stable, opaque id used ONLY inside the proxy (to key the
- * compression-state store). It is NEVER sent upstream — the weak-signal form
- * embeds the key and upstream origin, which the upstream either already knows
- * or must not see.
- *
- * If a client-provided per-conversation signal is needed for upstream routing,
- * use `affinityToken()` below. Generated proxy identities are never forwarded.
+ * The id is used ONLY inside the proxy (compression-state store, persistence,
+ * UI label). It is NEVER sent upstream — if a per-conversation signal is
+ * needed for upstream routing, use `affinityToken()` below.
  */
-
-/** Extract the account credential from common auth headers, verbatim.
- *  The value is fed into a hash — it is NEVER stored, logged, or compared.
- *  Normalization is intentionally minimal: trim whitespace only. We do NOT
- *  lowercase: while that reduces hash collisions in theory (two keys that
- *  differ only in case would hash the same), in practice API keys are
- *  case-sensitive and a lowercase normalization would collapse two distinct
- *  valid keys into one hash bucket — a silent isolation violation. Keep the
- *  raw value so each distinct key hashes distinctly. */
-function extractKey(headers: Record<string, string | string[] | undefined>): string {
-    const auth = headers["authorization"];
-    if (typeof auth === "string" && auth.length > 0) return auth.trim();
-    const apiKey = headers["x-api-key"];
-    if (typeof apiKey === "string" && apiKey.length > 0) return `key:${apiKey.trim()}`;
-    return "(no-key)";
-}
 
 /** Pull a client-provided conversation signal from headers, if any. */
 export function clientConversationHeader(headers: Record<string, string | string[] | undefined>): string | undefined {
@@ -87,34 +54,6 @@ export function clientConversationHeader(headers: Record<string, string | string
         if (typeof v === "string" && v.trim().length > 0) return v.trim();
     }
     return undefined;
-}
-
-/**
- * Derive the proxy-internal session id. The conversation dimension MUST be
- * supplied by the caller via `extra.conversation` (typically the output of
- * the per-protocol conversationSignal* helper, which already falls back to a
- * hash of the first user message). There is intentionally NO content-
- * fingerprint fallback inside this function — a silent "" default would
- * collapse every anonymous session onto one id. If `conversation` is missing
- * the caller has a bug and we throw rather than silently mis-isolating.
- *
- * `clientProvided` selects the keying tier (see module docs above): true →
- * hash(protocol|conversation), stable across credential rotation and
- * upstream/relay switching; false → the full 4-dimension hash, where
- * credential + upstream restore isolation for the collision-prone content
- * fingerprint.
- */
-export function deriveSessionId(
-    headers: Record<string, string | string[] | undefined>,
-    protocol: "anthropic" | "openai" | "responses",
-    upstream: string,
-    conversation: string,
-    clientProvided: boolean,
-): string {
-    if (!conversation) throw new Error("deriveSessionId: conversation dimension is required (pass the conversationSignal* output)");
-    if (clientProvided) return hashId(`${protocol}|${conversation}`);
-    const key = extractKey(headers);
-    return hashId(`${protocol}|${upstream}|${key}|${conversation}`);
 }
 
 /**

--- a/src/session.ts
+++ b/src/session.ts
@@ -114,6 +114,7 @@ export async function initSessions(): Promise<void> {
     initialized = true;
     const store = getStore();
     if (!store.enabled) return;
+    await store.migrateLegacyIds();
     const loaded = await store.loadAll();
     if (loaded.size > MAX_SESSIONS) {
         const entries = [...loaded.entries()].sort((a, b) => (b[1].createdAt ?? 0) - (a[1].createdAt ?? 0));

--- a/tests/e2e-anthropic.test.ts
+++ b/tests/e2e-anthropic.test.ts
@@ -213,7 +213,7 @@ async function callAnthropic(h: Harness, messages: AnthropicUserMessage[], tools
     const started = Date.now();
     const resp = await fetch(`http://127.0.0.1:${h.proxyPort}/bili/http://127.0.0.1:${h.upstreamPort}/v1/messages`, {
         method: "POST",
-        headers: { "content-type": "application/json" },
+        headers: { "content-type": "application/json", "x-acp-session": "e2e-anthropic" },
         body: JSON.stringify({
             model: "claude-test",
             max_tokens: 1024,

--- a/tests/e2e-compress-prompts.test.ts
+++ b/tests/e2e-compress-prompts.test.ts
@@ -73,7 +73,7 @@ async function runProxyWithPrompts(routeCompress: ProxyOptions["routes"][string]
         const url = `http://127.0.0.1:${proxyPort}/bili/http://127.0.0.1:${upstreamPort}/v1/chat/completions`;
         const resp = await fetch(url, {
             method: "POST",
-            headers: { "content-type": "application/json" },
+            headers: { "content-type": "application/json", "x-acp-session": "compress-prompts-e2e" },
             body: JSON.stringify({
                 model: "gpt-test",
                 stream: false,

--- a/tests/e2e-proxy-smoke.test.ts
+++ b/tests/e2e-proxy-smoke.test.ts
@@ -155,7 +155,7 @@ test("e2e proxy smoke: compress tool-call -> re-request -> round-2 streams in re
     try {
         const resp = await fetch(url, {
             method: "POST",
-            headers: { "content-type": "application/json" },
+            headers: { "content-type": "application/json", "x-acp-session": "proxy-smoke-e2e" },
             body: JSON.stringify(body),
         });
         assert.equal(resp.status, 200);

--- a/tests/e2e-responses-chat-relay.test.ts
+++ b/tests/e2e-responses-chat-relay.test.ts
@@ -217,6 +217,7 @@ async function callResponses(h: Harness, input: unknown[], tools?: unknown[]): P
         stream: true,
         instructions: "You are a test assistant.",
         input,
+        session_id: "e2e-responses-chat-relay",
     };
     if (tools) body.tools = tools;
     const resp = await fetch(url, {

--- a/tests/e2e-session-identity.test.ts
+++ b/tests/e2e-session-identity.test.ts
@@ -1,0 +1,287 @@
+import assert from "node:assert";
+import http from "node:http";
+import { once } from "node:events";
+import test from "node:test";
+
+process.env.NODE_ENV = "test";
+
+import { defaultConfig } from "acp-kernel";
+import { startServer, type ProxyOptions } from "../src/server.ts";
+import { SessionStore, _setStoreForTest } from "../src/persist.ts";
+import { _setForTest as setRegistryForTest } from "../src/registry.ts";
+import { _resetSessionsForTest } from "../src/session.ts";
+
+// #286: strong-signal (clientProvided) conversation identities must key the
+// session on (protocol, conversation) only — credential rotation (ChatGPT
+// OAuth bearer) and upstream/relay switches must not orphan the session and
+// its compression state. Weak signals (content fingerprints) keep the full
+// 4-dim key (protocol|upstream|credential|conversation) for isolation.
+
+function responsesSse(): string {
+    const block = (type: string, data: Record<string, unknown>): string => `event: ${type}\ndata: ${JSON.stringify({ type, ...data })}\n\n`;
+    const item = { type: "message", id: "msg_1", role: "assistant", status: "completed", content: [{ type: "output_text", text: "ok" }] };
+    return (
+        block("response.created", { response: { id: "resp_1", status: "in_progress" } }) +
+        block("response.in_progress", { response: { id: "resp_1", status: "in_progress" } }) +
+        block("response.output_item.added", { output_index: 0, item: { ...item, status: "in_progress", content: [] } }) +
+        block("response.content_part.added", { item_id: "msg_1", output_index: 0, content_index: 0, part: { type: "output_text", text: "" } }) +
+        block("response.output_text.delta", { item_id: "msg_1", output_index: 0, content_index: 0, delta: "ok" }) +
+        block("response.output_text.done", { item_id: "msg_1", output_index: 0, text: "ok" }) +
+        block("response.content_part.done", { item_id: "msg_1", output_index: 0, content_index: 0 }) +
+        block("response.output_item.done", { output_index: 0, item }) +
+        block("response.completed", { response: { id: "resp_1", status: "completed", output: [item], usage: { input_tokens: 10, output_tokens: 3 } } })
+    );
+}
+
+function anthropicSse(): string {
+    const block = (event: string, data: Record<string, unknown>): string => `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+    return (
+        block("message_start", { type: "message_start", message: { id: "msg_1", role: "assistant", usage: { input_tokens: 10 } } }) +
+        block("content_block_start", { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } }) +
+        block("content_block_delta", { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "ok" } }) +
+        block("content_block_stop", { type: "content_block_stop", index: 0 }) +
+        block("message_delta", { type: "message_delta", delta: { stop_reason: "end_turn", stop_sequence: null }, usage: { output_tokens: 3 } }) +
+        block("message_stop", { type: "message_stop" })
+    );
+}
+
+function chatSse(): string {
+    const chunk = (choices: unknown): string =>
+        `data: ${JSON.stringify({ id: "c1", object: "chat.completion.chunk", created: 1, model: "gpt", choices })}\n\n`;
+    return (
+        chunk([{ index: 0, delta: { role: "assistant" }, finish_reason: null }]) +
+        chunk([{ index: 0, delta: { content: "ok" }, finish_reason: null }]) +
+        chunk([{ index: 0, delta: {}, finish_reason: "stop" }]) +
+        "data: [DONE]\n\n"
+    );
+}
+
+interface MockUpstream {
+    server: http.Server;
+    port: number;
+    close(): Promise<void>;
+}
+
+async function startMockUpstream(): Promise<MockUpstream> {
+    const server = http.createServer((req, res) => {
+        const chunks: Buffer[] = [];
+        req.on("data", (c: Buffer) => chunks.push(c));
+        req.on("end", () => {
+            const url = req.url ?? "";
+            if (req.method !== "POST") {
+                res.writeHead(404, { "content-type": "application/json" });
+                res.end(JSON.stringify({ error: { message: "mock upstream: unsupported" } }));
+                return;
+            }
+            res.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache" });
+            if (url.endsWith("/v1/messages")) res.end(anthropicSse());
+            else if (url.endsWith("/responses")) res.end(responsesSse());
+            else if (url.endsWith("/chat/completions")) res.end(chatSse());
+            else res.end(responsesSse());
+        });
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const port = (server.address() as { port: number }).port;
+    return {
+        server,
+        port,
+        close: () => new Promise<void>((resolve, reject) => server.close((e) => (e ? reject(e) : resolve()))),
+    };
+}
+
+interface Harness {
+    proxyPort: number;
+    upstreams: MockUpstream[];
+    close(): Promise<void>;
+}
+
+async function startHarness(upstreamCount = 1): Promise<Harness> {
+    const upstreams: MockUpstream[] = [];
+    for (let i = 0; i < upstreamCount; i++) upstreams.push(await startMockUpstream());
+    _resetSessionsForTest();
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    setRegistryForTest({});
+    const routes: ProxyOptions["routes"] = {};
+    for (const u of upstreams) {
+        routes[`http://127.0.0.1:${u.port}`] = { models: { "gpt-test": { context: 100_000 }, "claude-test": { context: 100_000 } } };
+    }
+    const proxy = await startServer({
+        port: 0,
+        host: "127.0.0.1",
+        upstream: "http://127.0.0.1",
+        routes,
+        modelContextLimit: 100_000,
+        kernelConfig: defaultConfig(100_000),
+        compress: { injectTool: true, injectNudge: true },
+        promptCache: { routing: "auto" },
+        log: false,
+        sessionHeader: "x-acp-session",
+        debug: false,
+        passthrough: false,
+        autoUpdate: false,
+        mitm: { enabled: false, domains: [] },
+    });
+    await once(proxy, "listening");
+    const proxyPort = (proxy.address() as { port: number }).port;
+    return {
+        proxyPort,
+        upstreams,
+        close: async () => {
+            proxy.close();
+            await once(proxy, "close");
+            await Promise.all(upstreams.map((u) => u.close()));
+        },
+    };
+}
+
+interface StatsSession {
+    id: string;
+    protocol: string;
+    upstream: string;
+    requests: number;
+}
+
+async function getSessions(h: Harness): Promise<StatsSession[]> {
+    const resp = await fetch(`http://127.0.0.1:${h.proxyPort}/__bili/stats`);
+    assert.equal(resp.status, 200);
+    const json = (await resp.json()) as { sessions: StatsSession[] };
+    return json.sessions;
+}
+
+async function post(h: Harness, upstreamIdx: number, path: string, body: Record<string, unknown>, headers: Record<string, string> = {}): Promise<void> {
+    const up = h.upstreams[upstreamIdx]!;
+    const resp = await fetch(`http://127.0.0.1:${h.proxyPort}/bili/http://127.0.0.1:${up.port}${path}`, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...headers },
+        body: JSON.stringify(body),
+    });
+    assert.equal(resp.status, 200, `proxy returned ${resp.status}`);
+    await resp.text();
+}
+
+function responsesBody(extra: Record<string, unknown> = {}): Record<string, unknown> {
+    return {
+        model: "gpt-test",
+        stream: true,
+        instructions: "You are a test assistant.",
+        input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "hello" }] }],
+        ...extra,
+    };
+}
+
+function anthropicBody(): Record<string, unknown> {
+    return { model: "claude-test", max_tokens: 1024, stream: true, system: "You are a test assistant.", messages: [{ role: "user", content: "hello" }] };
+}
+
+function chatBody(extra: Record<string, unknown> = {}): Record<string, unknown> {
+    return { model: "gpt-test", stream: true, messages: [{ role: "user", content: "hello" }], ...extra };
+}
+
+test("e2e session identity: responses body.session_id survives bearer rotation (#286, #280)", async () => {
+    const h = await startHarness();
+    try {
+        const body = responsesBody({ session_id: "019fdc81-a420-7a00-bbd1-0a64e3eb772c" });
+        await post(h, 0, "/v1/responses", body, { authorization: "Bearer bearer-old" });
+        await post(h, 0, "/v1/responses", body, { authorization: "Bearer bearer-new" });
+        const sessions = await getSessions(h);
+        assert.equal(sessions.length, 1, `expected 1 session, got ${JSON.stringify(sessions)}`);
+        assert.equal(sessions[0]!.protocol, "responses");
+        assert.equal(sessions[0]!.requests, 2);
+    } finally {
+        await h.close();
+    }
+});
+
+test("e2e session identity: responses session-id header survives bearer rotation (#286)", async () => {
+    const h = await startHarness();
+    try {
+        const body = responsesBody();
+        await post(h, 0, "/v1/responses", body, { authorization: "Bearer bearer-old", "session-id": "019fdc81-a420-7a00-bbd1-0a64e3eb772c" });
+        await post(h, 0, "/v1/responses", body, { authorization: "Bearer bearer-new", "session-id": "019fdc81-a420-7a00-bbd1-0a64e3eb772c" });
+        const sessions = await getSessions(h);
+        assert.equal(sessions.length, 1, `expected 1 session, got ${JSON.stringify(sessions)}`);
+        assert.equal(sessions[0]!.protocol, "responses");
+        assert.equal(sessions[0]!.requests, 2);
+    } finally {
+        await h.close();
+    }
+});
+
+test("e2e session identity: responses body.session_id survives upstream/relay switch (#286)", async () => {
+    const h = await startHarness(2);
+    try {
+        const body = responsesBody({ session_id: "019fdc81-a420-7a00-bbd1-0a64e3eb772c" });
+        await post(h, 0, "/v1/responses", body, { authorization: "Bearer keyA" });
+        await post(h, 1, "/v1/responses", body, { authorization: "Bearer keyA" });
+        const sessions = await getSessions(h);
+        assert.equal(sessions.length, 1, `expected 1 session, got ${JSON.stringify(sessions)}`);
+        assert.equal(sessions[0]!.requests, 2);
+    } finally {
+        await h.close();
+    }
+});
+
+test("e2e session identity: anthropic x-claude-code-session-id survives x-api-key rotation (#286)", async () => {
+    const h = await startHarness();
+    try {
+        const body = anthropicBody();
+        await post(h, 0, "/v1/messages", body, { "x-api-key": "sk-ant-old", "x-claude-code-session-id": "claude-sess-1" });
+        await post(h, 0, "/v1/messages", body, { "x-api-key": "sk-ant-new", "x-claude-code-session-id": "claude-sess-1" });
+        const sessions = await getSessions(h);
+        assert.equal(sessions.length, 1, `expected 1 session, got ${JSON.stringify(sessions)}`);
+        assert.equal(sessions[0]!.protocol, "anthropic");
+        assert.equal(sessions[0]!.requests, 2);
+    } finally {
+        await h.close();
+    }
+});
+
+test("e2e session identity: openai prompt_cache_key survives bearer rotation (#286)", async () => {
+    const h = await startHarness();
+    try {
+        const body = chatBody({ prompt_cache_key: "pck-omp-1" });
+        await post(h, 0, "/v1/chat/completions", body, { authorization: "Bearer bearer-old" });
+        await post(h, 0, "/v1/chat/completions", body, { authorization: "Bearer bearer-new" });
+        const sessions = await getSessions(h);
+        assert.equal(sessions.length, 1, `expected 1 session, got ${JSON.stringify(sessions)}`);
+        assert.equal(sessions[0]!.protocol, "openai");
+        assert.equal(sessions[0]!.requests, 2);
+    } finally {
+        await h.close();
+    }
+});
+
+test("e2e session identity: weak signal (content fingerprint) keeps credential isolation (#286)", async () => {
+    const h = await startHarness();
+    try {
+        const body = responsesBody();
+        // No session signal at all → content fingerprint. Same content, no
+        // credential → same session (fingerprint stability).
+        await post(h, 0, "/v1/responses", body, {});
+        await post(h, 0, "/v1/responses", body, {});
+        // Same content, different credential → different session: the 4-dim
+        // key still isolates anonymous content by account.
+        await post(h, 0, "/v1/responses", body, { authorization: "Bearer keyX" });
+        // Different content, no credential → different session.
+        await post(h, 0, "/v1/responses", responsesBody({ input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "different opener" }] }] }), {});
+        const sessions = await getSessions(h);
+        assert.equal(sessions.length, 3, `expected 3 sessions, got ${JSON.stringify(sessions)}`);
+        const requests = sessions.map((s) => s.requests).sort((a, b) => a - b);
+        assert.deepEqual(requests, [1, 1, 2]);
+    } finally {
+        await h.close();
+    }
+});
+
+test("e2e session identity: distinct session_ids stay separate (#286)", async () => {
+    const h = await startHarness();
+    try {
+        await post(h, 0, "/v1/responses", responsesBody({ session_id: "sess-A" }), { authorization: "Bearer keyA" });
+        await post(h, 0, "/v1/responses", responsesBody({ session_id: "sess-B" }), { authorization: "Bearer keyA" });
+        const sessions = await getSessions(h);
+        assert.equal(sessions.length, 2, `expected 2 sessions, got ${JSON.stringify(sessions)}`);
+    } finally {
+        await h.close();
+    }
+});

--- a/tests/e2e-session-identity.test.ts
+++ b/tests/e2e-session-identity.test.ts
@@ -11,11 +11,11 @@ import { SessionStore, _setStoreForTest } from "../src/persist.ts";
 import { _setForTest as setRegistryForTest } from "../src/registry.ts";
 import { _resetSessionsForTest } from "../src/session.ts";
 
-// #286: strong-signal (clientProvided) conversation identities must key the
-// session on (protocol, conversation) only — credential rotation (ChatGPT
-// OAuth bearer) and upstream/relay switches must not orphan the session and
-// its compression state. Weak signals (content fingerprints) keep the full
-// 4-dim key (protocol|upstream|credential|conversation) for isolation.
+// #286: the session ID is the client-provided conversation value VERBATIM —
+// no hash, no other dimensions. Credential rotation (ChatGPT OAuth bearer),
+// upstream/relay switches, and even wire-protocol switches must not orphan
+// the session and its compression state. Requests WITHOUT a client-provided
+// identity are rejected with 400 (content-fingerprint sessions disabled).
 
 function responsesSse(): string {
     const block = (type: string, data: Record<string, unknown>): string => `event: ${type}\ndata: ${JSON.stringify({ type, ...data })}\n\n`;
@@ -150,14 +150,17 @@ async function getSessions(h: Harness): Promise<StatsSession[]> {
 }
 
 async function post(h: Harness, upstreamIdx: number, path: string, body: Record<string, unknown>, headers: Record<string, string> = {}): Promise<void> {
+    const resp = await postRaw(h, upstreamIdx, path, body, headers);
+    assert.equal(resp.status, 200, `proxy returned ${resp.status}: ${await resp.text()}`);
+}
+
+async function postRaw(h: Harness, upstreamIdx: number, path: string, body: Record<string, unknown>, headers: Record<string, string> = {}): Promise<Response> {
     const up = h.upstreams[upstreamIdx]!;
-    const resp = await fetch(`http://127.0.0.1:${h.proxyPort}/bili/http://127.0.0.1:${up.port}${path}`, {
+    return fetch(`http://127.0.0.1:${h.proxyPort}/bili/http://127.0.0.1:${up.port}${path}`, {
         method: "POST",
         headers: { "content-type": "application/json", ...headers },
         body: JSON.stringify(body),
     });
-    assert.equal(resp.status, 200, `proxy returned ${resp.status}`);
-    await resp.text();
 }
 
 function responsesBody(extra: Record<string, unknown> = {}): Record<string, unknown> {
@@ -178,7 +181,7 @@ function chatBody(extra: Record<string, unknown> = {}): Record<string, unknown> 
     return { model: "gpt-test", stream: true, messages: [{ role: "user", content: "hello" }], ...extra };
 }
 
-test("e2e session identity: responses body.session_id survives bearer rotation (#286, #280)", async () => {
+test("e2e session identity: responses body.session_id survives bearer rotation; id is the value verbatim (#286, #280)", async () => {
     const h = await startHarness();
     try {
         const body = responsesBody({ session_id: "019fdc81-a420-7a00-bbd1-0a64e3eb772c" });
@@ -186,6 +189,7 @@ test("e2e session identity: responses body.session_id survives bearer rotation (
         await post(h, 0, "/v1/responses", body, { authorization: "Bearer bearer-new" });
         const sessions = await getSessions(h);
         assert.equal(sessions.length, 1, `expected 1 session, got ${JSON.stringify(sessions)}`);
+        assert.equal(sessions[0]!.id, "019fdc81-a420-7a00-bbd1-0a64e3eb772c");
         assert.equal(sessions[0]!.protocol, "responses");
         assert.equal(sessions[0]!.requests, 2);
     } finally {
@@ -193,7 +197,7 @@ test("e2e session identity: responses body.session_id survives bearer rotation (
     }
 });
 
-test("e2e session identity: responses session-id header survives bearer rotation (#286)", async () => {
+test("e2e session identity: responses session-id header survives bearer rotation; id is the value verbatim (#286)", async () => {
     const h = await startHarness();
     try {
         const body = responsesBody();
@@ -201,6 +205,7 @@ test("e2e session identity: responses session-id header survives bearer rotation
         await post(h, 0, "/v1/responses", body, { authorization: "Bearer bearer-new", "session-id": "019fdc81-a420-7a00-bbd1-0a64e3eb772c" });
         const sessions = await getSessions(h);
         assert.equal(sessions.length, 1, `expected 1 session, got ${JSON.stringify(sessions)}`);
+        assert.equal(sessions[0]!.id, "019fdc81-a420-7a00-bbd1-0a64e3eb772c");
         assert.equal(sessions[0]!.protocol, "responses");
         assert.equal(sessions[0]!.requests, 2);
     } finally {
@@ -216,6 +221,7 @@ test("e2e session identity: responses body.session_id survives upstream/relay sw
         await post(h, 1, "/v1/responses", body, { authorization: "Bearer keyA" });
         const sessions = await getSessions(h);
         assert.equal(sessions.length, 1, `expected 1 session, got ${JSON.stringify(sessions)}`);
+        assert.equal(sessions[0]!.id, "019fdc81-a420-7a00-bbd1-0a64e3eb772c");
         assert.equal(sessions[0]!.requests, 2);
     } finally {
         await h.close();
@@ -230,6 +236,7 @@ test("e2e session identity: anthropic x-claude-code-session-id survives x-api-ke
         await post(h, 0, "/v1/messages", body, { "x-api-key": "sk-ant-new", "x-claude-code-session-id": "claude-sess-1" });
         const sessions = await getSessions(h);
         assert.equal(sessions.length, 1, `expected 1 session, got ${JSON.stringify(sessions)}`);
+        assert.equal(sessions[0]!.id, "claude-sess-1");
         assert.equal(sessions[0]!.protocol, "anthropic");
         assert.equal(sessions[0]!.requests, 2);
     } finally {
@@ -245,6 +252,7 @@ test("e2e session identity: openai prompt_cache_key survives bearer rotation (#2
         await post(h, 0, "/v1/chat/completions", body, { authorization: "Bearer bearer-new" });
         const sessions = await getSessions(h);
         assert.equal(sessions.length, 1, `expected 1 session, got ${JSON.stringify(sessions)}`);
+        assert.equal(sessions[0]!.id, "pck-omp-1");
         assert.equal(sessions[0]!.protocol, "openai");
         assert.equal(sessions[0]!.requests, 2);
     } finally {
@@ -252,23 +260,59 @@ test("e2e session identity: openai prompt_cache_key survives bearer rotation (#2
     }
 });
 
-test("e2e session identity: weak signal (content fingerprint) keeps credential isolation (#286)", async () => {
+test("e2e session identity: same conversation value continues across a protocol switch (relay translation, #286)", async () => {
     const h = await startHarness();
     try {
-        const body = responsesBody();
-        // No session signal at all → content fingerprint. Same content, no
-        // credential → same session (fingerprint stability).
-        await post(h, 0, "/v1/responses", body, {});
-        await post(h, 0, "/v1/responses", body, {});
-        // Same content, different credential → different session: the 4-dim
-        // key still isolates anonymous content by account.
-        await post(h, 0, "/v1/responses", body, { authorization: "Bearer keyX" });
-        // Different content, no credential → different session.
-        await post(h, 0, "/v1/responses", responsesBody({ input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "different opener" }] }] }), {});
+        // The same client conversation id first speaks the Responses API, then
+        // the OpenAI chat API (e.g. a relay that translates between them).
+        // Session state is protocol-neutral, so the session must continue.
+        await post(h, 0, "/v1/responses", responsesBody({ session_id: "cross-proto-1" }), { authorization: "Bearer keyA" });
+        await post(h, 0, "/v1/chat/completions", chatBody(), { authorization: "Bearer keyA", "x-session-id": "cross-proto-1" });
         const sessions = await getSessions(h);
-        assert.equal(sessions.length, 3, `expected 3 sessions, got ${JSON.stringify(sessions)}`);
-        const requests = sessions.map((s) => s.requests).sort((a, b) => a - b);
-        assert.deepEqual(requests, [1, 1, 2]);
+        assert.equal(sessions.length, 1, `expected 1 session, got ${JSON.stringify(sessions)}`);
+        assert.equal(sessions[0]!.id, "cross-proto-1");
+        assert.equal(sessions[0]!.requests, 2);
+    } finally {
+        await h.close();
+    }
+});
+
+test("e2e session identity: anonymous responses request → 400, no session created (#286)", async () => {
+    const h = await startHarness();
+    try {
+        const resp = await postRaw(h, 0, "/v1/responses", responsesBody(), {});
+        assert.equal(resp.status, 400);
+        const json = (await resp.json()) as { error?: { message?: string } };
+        assert.match(json.error?.message ?? "", /Missing stable conversation identity/);
+        assert.equal((await getSessions(h)).length, 0);
+    } finally {
+        await h.close();
+    }
+});
+
+test("e2e session identity: anonymous anthropic request → 400 anthropic error shape (#286)", async () => {
+    const h = await startHarness();
+    try {
+        const resp = await postRaw(h, 0, "/v1/messages", anthropicBody(), { "x-api-key": "sk-ant" });
+        assert.equal(resp.status, 400);
+        const json = (await resp.json()) as { type?: string; error?: { type?: string; message?: string } };
+        assert.equal(json.type, "error");
+        assert.equal(json.error?.type, "invalid_request_error");
+        assert.match(json.error?.message ?? "", /Missing stable conversation identity/);
+        assert.equal((await getSessions(h)).length, 0);
+    } finally {
+        await h.close();
+    }
+});
+
+test("e2e session identity: anonymous openai request → 400, even with credentials (#286)", async () => {
+    const h = await startHarness();
+    try {
+        const resp = await postRaw(h, 0, "/v1/chat/completions", chatBody(), { authorization: "Bearer keyX" });
+        assert.equal(resp.status, 400);
+        const json = (await resp.json()) as { error?: { message?: string } };
+        assert.match(json.error?.message ?? "", /Missing stable conversation identity/);
+        assert.equal((await getSessions(h)).length, 0);
     } finally {
         await h.close();
     }
@@ -281,6 +325,8 @@ test("e2e session identity: distinct session_ids stay separate (#286)", async ()
         await post(h, 0, "/v1/responses", responsesBody({ session_id: "sess-B" }), { authorization: "Bearer keyA" });
         const sessions = await getSessions(h);
         assert.equal(sessions.length, 2, `expected 2 sessions, got ${JSON.stringify(sessions)}`);
+        const ids = sessions.map((s) => s.id).sort();
+        assert.deepEqual(ids, ["sess-A", "sess-B"]);
     } finally {
         await h.close();
     }

--- a/tests/forward-absolute-url.test.ts
+++ b/tests/forward-absolute-url.test.ts
@@ -75,6 +75,7 @@ test("forward: absolute-URL proxy-mode request reaches the correct upstream (no 
                     headers: {
                         "content-type": "application/json",
                         host: upstreamHost,
+                        "x-acp-session": "forward-absolute-url-test",
                         "content-length": String(Buffer.byteLength(body)),
                     },
                 },

--- a/tests/launcher-plugin-mode.test.ts
+++ b/tests/launcher-plugin-mode.test.ts
@@ -163,7 +163,10 @@ test("launcher headless pending binding: register BEFORE the first request binds
     const rig = await startRig();
     try {
         await register(rig, "headless-conv-1", { agent: "mcp" });
-        await postModel(rig); // no session header at all
+        // Strong signal that does NOT match the registered id (#286: anonymous
+        // requests are 400 now), so the identity lookup misses and the headless
+        // pending path has to fire.
+        await postModel(rig, "headless-req-1");
         assert.ok(!rig.upstreamBodies[0]!.includes("\"compress\""), "wire tool injection suppressed from the very first request");
         const status = await (await fetch(rig.proxyUrl("/__bili/plugin/status?conversationId=headless-conv-1"))).json() as { ok: boolean; pluginAgent?: string };
         assert.ok(status.ok, "pending register consumed by the new session");
@@ -355,8 +358,11 @@ test("mcp stdio shell (codex style): BILI_CONVERSATION_ID self-register → head
                 if (lines.length === 1) {
                     // initialize answered → the headless register has landed
                     // (the shell awaits it before responding). Consume it via
-                    // a fresh model session, then ask for tools.
-                    void postModel(rig).then(() => {
+                    // a fresh model session, then ask for tools. The model
+                    // request carries a strong signal that does NOT match the
+                    // self-registered conversation id (#286: anonymous requests
+                    // are 400 now), so the headless pending path has to fire.
+                    void postModel(rig, "codex-e2e-req-1").then(() => {
                         send({ jsonrpc: "2.0", id: 2, method: "tools/list" });
                         send({ jsonrpc: "2.0", id: 3, method: "tools/call", params: { name: "acp_status", arguments: {} } });
                     });

--- a/tests/launcher.test.ts
+++ b/tests/launcher.test.ts
@@ -36,6 +36,7 @@ import {
     readHermesConfig,
     resolveHermesHome,
     prepareHermesHome,
+    writeHermesIdentityPlugin,
     parseDshSettingsYaml,
     readDshConfig,
     resolveDshHome,
@@ -1336,6 +1337,69 @@ test("prepareHermesHome: returns undefined for unreadable config even with rewri
     }
 });
 
+test("prepareHermesHome: rewrites quoted YAML api values (quotes stripped before match)", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "hermes-home-"));
+    try {
+        fs.writeFileSync(path.join(dir, "config.yaml"), [
+            "providers:",
+            "  bili:",
+            '    api: "https://api.example.com/v1"',
+            "  glm:",
+            "    api: 'http://10.0.0.5:1234/v1'",
+        ].join("\n"));
+        const rewrites: HttpRewrite[] = [
+            { key: "bili", realUpstream: "https://api.example.com/v1" },
+            { key: "glm", realUpstream: "http://10.0.0.5:1234/v1" },
+        ];
+        const tmp = prepareHermesHome(dir, "http://127.0.0.1:8787", rewrites);
+        assert.ok(tmp, "quoted values must still be rewritten");
+        const txt = fs.readFileSync(path.join(tmp!, "config.yaml"), "utf8");
+        assert.ok(txt.includes("api: http://127.0.0.1:8787/bili/https://api.example.com/v1"));
+        assert.ok(txt.includes("api: http://127.0.0.1:8787/bili/http://10.0.0.5:1234/v1"));
+        fs.rmSync(tmp!, { recursive: true, force: true });
+    } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test("writeHermesIdentityPlugin: drops the identity plugin into the overlay, keyed by provider names", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "hermes-home-"));
+    try {
+        fs.writeFileSync(path.join(dir, "config.yaml"), "providers:\n  bili:\n    api: https://api.example.com/v1\n");
+        const rewrites: HttpRewrite[] = [{ key: "bili", realUpstream: "https://api.example.com/v1" }];
+        const overlay = prepareHermesHome(dir, "http://127.0.0.1:8787", rewrites);
+        assert.ok(overlay);
+        assert.equal(writeHermesIdentityPlugin(dir, overlay!, rewrites), true);
+        const init = fs.readFileSync(path.join(overlay!, "plugins/model-providers/bili-session-identity/__init__.py"), "utf8");
+        assert.ok(init.includes('_PROVIDER_KEYS = ["bili"]'));
+        assert.ok(init.includes('_register("custom", _custom, True)'));
+        assert.ok(init.includes('_register("custom:" + _key, _custom, False)'));
+        assert.ok(init.includes('top_level.setdefault("prompt_cache_key", sid[:64])'));
+        assert.ok(fs.existsSync(path.join(overlay!, "plugins/model-providers/bili-session-identity/plugin.yaml")));
+        // Idempotent rewrite on the next launch.
+        assert.equal(writeHermesIdentityPlugin(dir, overlay!, rewrites), true);
+        fs.rmSync(overlay!, { recursive: true, force: true });
+    } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test("writeHermesIdentityPlugin: skipped when the real home has its own plugins dir", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "hermes-home-"));
+    try {
+        fs.writeFileSync(path.join(dir, "config.yaml"), "providers:\n  bili:\n    api: https://api.example.com/v1\n");
+        fs.mkdirSync(path.join(dir, "plugins"), { recursive: true });
+        const rewrites: HttpRewrite[] = [{ key: "bili", realUpstream: "https://api.example.com/v1" }];
+        const overlay = prepareHermesHome(dir, "http://127.0.0.1:8787", rewrites);
+        assert.ok(overlay);
+        assert.equal(writeHermesIdentityPlugin(dir, overlay!, rewrites), false);
+        assert.ok(!fs.existsSync(path.join(overlay!, "plugins", "model-providers")));
+        fs.rmSync(overlay!, { recursive: true, force: true });
+    } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+    }
+});
+
 test("readDshConfig + resolveDshHome + parseDshSettingsYaml", () => {
     assert.equal(resolveDshHome({ DSH_HOME: "/tmp/dd" }), "/tmp/dd");
     assert.ok(resolveDshHome({}).endsWith(path.join(".dsh")));
@@ -1547,6 +1611,9 @@ test("runLaunch dsh: DSH_HOME overlay + DEEPSEEK_BASE_URL env, real home untouch
         const origin = seenEnv.BILLION_CONTEXT_PROXY;
         assert.ok(/^http:\/\/127\.0\.0\.1:\d+$/.test(String(origin)));
         assert.equal(seenEnv.DEEPSEEK_BASE_URL, `${origin}/bili/https://api.deepseek.com`);
+        // Session identity for the proxy: forces dsh's pi-ai stack to stamp
+        // prompt_cache_key (the dsh session id) on every request.
+        assert.equal(seenEnv.PI_CACHE_RETENTION, "long");
         assert.equal(seenEnv.DSH_HOME, `${dshHome}-bili`);
         assert.deepEqual(exitCalls, [0]);
         assert.equal(fs.readFileSync(path.join(dshHome, "settings.yaml"), "utf8"), original);

--- a/tests/openai-pck-identity.test.ts
+++ b/tests/openai-pck-identity.test.ts
@@ -95,6 +95,14 @@ function postChat(rig: Rig, pck: string): Promise<Response> {
     });
 }
 
+function postChatRaw(rig: Rig, body: Record<string, unknown>): Promise<Response> {
+    return fetch(rig.chatUrl(), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ model: "glm-test", messages: [{ role: "user", content: "hello" }], ...body }),
+    });
+}
+
 async function register(rig: Rig, conversationId: string, agent: string, identity: boolean): Promise<void> {
     const res = await fetch(rig.proxyUrl("/__bili/plugin/register"), {
         method: "POST",
@@ -142,6 +150,19 @@ test("openai pck: identity register + matching pck binds pluginMode (wire inject
         const s = await status(rig, "omp-uuid-bind");
         assert.equal(s.ok, true, "bound conversation is found");
         assert.equal(s.pluginAgent, "omp", "pluginAgent recorded as omp");
+    } finally {
+        await rig.closeAll();
+    }
+});
+
+test("openai: prompt_cache_retention stripped, prompt_cache_key forwarded (dsh PI_CACHE_RETENTION=long)", async () => {
+    const rig = await startRig();
+    try {
+        await postChatRaw(rig, { prompt_cache_key: "dsh-session-uuid", prompt_cache_retention: "24h" });
+        assert.equal(rig.upstreamBodies.length, 1);
+        const sent = JSON.parse(rig.upstreamBodies[0]!) as Record<string, unknown>;
+        assert.equal(sent.prompt_cache_key, "dsh-session-uuid", "session id passes through");
+        assert.equal("prompt_cache_retention" in sent, false, "OpenAI-host-only cache directive stripped");
     } finally {
         await rig.closeAll();
     }

--- a/tests/proxy-persist.test.ts
+++ b/tests/proxy-persist.test.ts
@@ -341,3 +341,45 @@ await withTempStore("pre-envelope flat file is adopted and re-persisted as envel
     assert.ok("payload" in envelope, "re-persisted as envelope");
     assert.equal(envelope.payload.stats.requests, 6, "payload carries the update");
 });
+
+await withTempStore("one-time migration re-keys legacy hash-id sessions to their client-provided label (#286)", async (store, dir) => {
+    const label = "conv-legacy-1";
+    const legacyA = "legacy-" + "a".repeat(24);
+    const legacyB = "legacy-" + "b".repeat(24);
+
+    const a = makeSession(legacyA);
+    a.meta.label = label;
+    a.meta.protocol = "responses";
+    a.meta.upstreamOrigin = "https://chatgpt.com";
+    a.stats.requests = 7;
+    await store.writeNow(a);
+
+    const b = makeSession(legacyB);
+    b.meta.label = label;
+    b.meta.protocol = "responses";
+    b.meta.upstreamOrigin = "https://chatgpt.com";
+    b.stats.requests = 1;
+    await store.writeNow(b);
+
+    const fileB = jsonFilesUnder(dir).find((f) => JSON.parse(readFileSync(f, "utf8")).id === legacyB)!;
+    const envB = JSON.parse(readFileSync(fileB, "utf8"));
+    envB.savedAt -= 1000; // A is newer → A wins the same-label collision
+    writeFileSync(fileB, JSON.stringify(envB));
+
+    // A fresh store mirrors a new process: no discovered-file cache.
+    const cold = new SessionStore({ dir, debounceMs: 5, enabled: true });
+    try {
+        await cold.migrateLegacyIds();
+
+        const all = await cold.loadAll();
+        assert.ok(all.has(label), "re-keyed under the client-provided label");
+        assert.ok(!all.has(legacyA) && !all.has(legacyB), "legacy ids no longer resolve");
+        assert.equal(all.get(label)!.stats.requests, 7, "newest savedAt wins the collision");
+        assert.equal(jsonFilesUnder(dir).length, 1, "loser and old files removed");
+
+        await cold.migrateLegacyIds();
+        assert.equal((await cold.loadAll()).size, 1, "second migration is a no-op");
+    } finally {
+        cold.cancelAll();
+    }
+});

--- a/tests/proxy-session-id.test.ts
+++ b/tests/proxy-session-id.test.ts
@@ -67,77 +67,118 @@ test("preferPromptCacheKeyIdentity: derived session id stable across growing tur
     const id1 = preferPromptCacheKeyIdentity(conversationIdentityResponses(body1, undefined), body1)!;
     const id2 = preferPromptCacheKeyIdentity(conversationIdentityResponses(body2, undefined), body2)!;
     assert.equal(
-        deriveSessionId(h, "responses", "http://127.0.0.1:8199", id1.value),
-        deriveSessionId(h, "responses", "http://127.0.0.1:8199", id2.value),
+        deriveSessionId(h, "responses", "http://127.0.0.1:8199", id1.value, id1.clientProvided),
+        deriveSessionId(h, "responses", "http://127.0.0.1:8199", id2.value, id2.clientProvided),
     );
     assert.equal(affinityToken(id1), "pck-omp-1");
 });
 
-test("deriveSessionId: same conversation + same key + same protocol + same upstream → stable", () => {
-    const a = deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://bailian.example", "hello world");
-    const b = deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://bailian.example", "hello world");
+test("deriveSessionId: same conversation + same key + same protocol + same upstream → stable (weak signal)", () => {
+    const a = deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://bailian.example", "hello world", false);
+    const b = deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://bailian.example", "hello world", false);
     assert.equal(a, b);
 });
 
-test("deriveSessionId: stable for same (key, protocol, upstream, conversation)", () => {
-    const a = deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://bailian.example", "hello world");
-    const b = deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://bailian.example", "hello world");
+test("deriveSessionId: stable for same (key, protocol, upstream, conversation) (weak signal)", () => {
+    const a = deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://bailian.example", "hello world", false);
+    const b = deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://bailian.example", "hello world", false);
     assert.equal(a, b);
 });
 
-test("deriveSessionId: different API key → different session (no cross-account bleed)", () => {
-    const a = deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://bailian.example", "hello world");
-    const b = deriveSessionId(hdrs("Bearer keyB"), "anthropic", "https://bailian.example", "hello world");
+test("deriveSessionId: different API key → different session (no cross-account bleed, weak signal)", () => {
+    const a = deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://bailian.example", "hello world", false);
+    const b = deriveSessionId(hdrs("Bearer keyB"), "anthropic", "https://bailian.example", "hello world", false);
     assert.notEqual(a, b);
 });
 
-test("deriveSessionId: credentials remain case-sensitive opaque values", () => {
-    const upper = deriveSessionId(hdrs("Bearer AbCd"), "responses", "https://chatgpt.com", "session");
-    const lower = deriveSessionId(hdrs("Bearer abcd"), "responses", "https://chatgpt.com", "session");
+test("deriveSessionId: credentials remain case-sensitive opaque values (weak signal)", () => {
+    const upper = deriveSessionId(hdrs("Bearer AbCd"), "responses", "https://chatgpt.com", "session", false);
+    const lower = deriveSessionId(hdrs("Bearer abcd"), "responses", "https://chatgpt.com", "session", false);
     assert.notEqual(upper, lower);
 });
 
-test("deriveSessionId: different upstream origin → different session (no cross-provider bleed)", () => {
-    const a = deriveSessionId(hdrs("Bearer keyA"), "openai", "https://zhipu.example", "hello");
-    const b = deriveSessionId(hdrs("Bearer keyA"), "openai", "https://bailian.example", "hello");
+test("deriveSessionId: different upstream origin → different session (no cross-provider bleed, weak signal)", () => {
+    const a = deriveSessionId(hdrs("Bearer keyA"), "openai", "https://zhipu.example", "hello", false);
+    const b = deriveSessionId(hdrs("Bearer keyA"), "openai", "https://bailian.example", "hello", false);
     assert.notEqual(a, b);
 });
 
-test("deriveSessionId: different protocol → different session (no cross-format bleed)", () => {
-    const a = deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://bailian.example", "hello");
-    const b = deriveSessionId(hdrs("Bearer keyA"), "openai", "https://bailian.example", "hello");
+test("deriveSessionId: different protocol → different session (no cross-format bleed, weak signal)", () => {
+    const a = deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://bailian.example", "hello", false);
+    const b = deriveSessionId(hdrs("Bearer keyA"), "openai", "https://bailian.example", "hello", false);
     assert.notEqual(a, b);
 });
 
-test("deriveSessionId: different conversation → different session", () => {
-    const a = deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://bailian.example", "hello");
-    const b = deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://bailian.example", "goodbye");
+test("deriveSessionId: different conversation → different session (weak signal)", () => {
+    const a = deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://bailian.example", "hello", false);
+    const b = deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://bailian.example", "goodbye", false);
     assert.notEqual(a, b);
 });
 
-test("deriveSessionId: conversation signal is the only conversation dimension", () => {
+test("deriveSessionId: conversation signal is the only conversation dimension (weak signal)", () => {
     // The conversation dimension is whatever the caller passes — typically the
     // output of conversationSignal*, which already prefers a client header
     // and falls back to a content hash. Here we just confirm the passed value
     // is what matters (same key/proto/upstream, different convo → different).
-    const a = deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://up", "ses_111");
-    const b = deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://up", "ses_222");
+    const a = deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://up", "ses_111", false);
+    const b = deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://up", "ses_222", false);
     assert.notEqual(a, b);
     // Same convo signal → same session, regardless of anything else.
-    assert.equal(a, deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://up", "ses_111"));
+    assert.equal(a, deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://up", "ses_111", false));
 });
 
-test("deriveSessionId: no Authorization header → still works (uses placeholder key)", () => {
-    const id = deriveSessionId({}, "anthropic", "https://up", "convo-1");
+test("deriveSessionId: no Authorization header → still works (uses placeholder key, weak signal)", () => {
+    const id = deriveSessionId({}, "anthropic", "https://up", "convo-1", false);
     assert.ok(id.length > 0);
     // Two keyless requests with same content → same session.
-    assert.equal(id, deriveSessionId({}, "anthropic", "https://up", "convo-1"));
+    assert.equal(id, deriveSessionId({}, "anthropic", "https://up", "convo-1", false));
 });
 
 test("deriveSessionId: empty conversation dimension THROWS (no silent collapse)", () => {
     // A caller that forgets to pass the conversation signal must fail loudly,
     // not silently collapse every anonymous session onto one id.
-    assert.throws(() => deriveSessionId({}, "anthropic", "https://up", ""), /conversation dimension is required/);
+    assert.throws(() => deriveSessionId({}, "anthropic", "https://up", "", false), /conversation dimension is required/);
+});
+
+test("deriveSessionId: strong signal ignores credential rotation (ChatGPT OAuth bearer, #286)", () => {
+    const convo = "019fdc81-a420-7a00-bbd1-0a64e3eb772c";
+    const a = deriveSessionId(hdrs("Bearer bearer-old"), "responses", "https://chatgpt.com", convo, true);
+    const b = deriveSessionId(hdrs("Bearer bearer-new"), "responses", "https://chatgpt.com", convo, true);
+    assert.equal(a, b);
+});
+
+test("deriveSessionId: strong signal survives upstream/relay switching (#286)", () => {
+    const convo = "019fdc81-a420-7a00-bbd1-0a64e3eb772c";
+    const a = deriveSessionId(hdrs("Bearer keyA"), "responses", "https://relay-1.example", convo, true);
+    const b = deriveSessionId(hdrs("Bearer keyA"), "responses", "https://relay-2.example", convo, true);
+    assert.equal(a, b);
+});
+
+test("deriveSessionId: strong signal stable for same (protocol, conversation)", () => {
+    const a = deriveSessionId(hdrs("Bearer keyA"), "responses", "https://chatgpt.com", "convo-1", true);
+    const b = deriveSessionId(hdrs("Bearer keyB"), "responses", "https://other.example", "convo-1", true);
+    assert.equal(a, b);
+});
+
+test("deriveSessionId: strong signal different conversation → different session", () => {
+    const a = deriveSessionId(hdrs("Bearer keyA"), "responses", "https://chatgpt.com", "convo-1", true);
+    const b = deriveSessionId(hdrs("Bearer keyA"), "responses", "https://chatgpt.com", "convo-2", true);
+    assert.notEqual(a, b);
+});
+
+test("deriveSessionId: strong signal different protocol → different session (no cross-format bleed)", () => {
+    const a = deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://chatgpt.com", "convo-1", true);
+    const b = deriveSessionId(hdrs("Bearer keyA"), "responses", "https://chatgpt.com", "convo-1", true);
+    assert.notEqual(a, b);
+});
+
+test("deriveSessionId: strong and weak tiers never collide for the same conversation value", () => {
+    // hash(protocol|convo) and hash(protocol|upstream|key|convo) are different
+    // hash inputs, so a session must not migrate between tiers when the
+    // client's signal strength changes mid-flight.
+    const strong = deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://up", "hello", true);
+    const weak = deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://up", "hello", false);
+    assert.notEqual(strong, weak);
 });
 
 test("affinityToken: uses client signal when present (passthrough, preserves ses_ format)", () => {

--- a/tests/proxy-session-id.test.ts
+++ b/tests/proxy-session-id.test.ts
@@ -1,15 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { deriveSessionId, affinityToken, clientConversationHeader, preferPromptCacheKeyIdentity } from "../src/session-id.ts";
+import { affinityToken, clientConversationHeader, preferPromptCacheKeyIdentity } from "../src/session-id.ts";
 import { conversationIdentityResponses, conversationSignalResponses } from "acp-kernel/wire";
-
-/** Helper: build a minimal headers object. */
-function hdrs(auth?: string, sessionAffinity?: string): Record<string, string> {
-    const h: Record<string, string> = {};
-    if (auth) h.authorization = auth;
-    if (sessionAffinity) h["x-session-affinity"] = sessionAffinity;
-    return h;
-}
 
 test("preferPromptCacheKeyIdentity: fingerprint + prompt_cache_key → stable client-provided identity (omp stateless replay)", () => {
     // omp replays full history with no headers/session_id/previous_response_id:
@@ -60,125 +52,13 @@ test("preferPromptCacheKeyIdentity: no/blank/non-string prompt_cache_key keeps f
     assert.equal(preferPromptCacheKeyIdentity(undefined, { prompt_cache_key: "x" }), undefined);
 });
 
-test("preferPromptCacheKeyIdentity: derived session id stable across growing turns + affinity forwards it", () => {
+test("preferPromptCacheKeyIdentity: client-provided value IS the session id, stable across growing turns (#286)", () => {
     const body1 = { input: [{ type: "message", role: "user", content: "hi" }], prompt_cache_key: "pck-omp-1" };
     const body2 = { input: [...body1.input, { type: "message", role: "user", content: "turn 2" }], prompt_cache_key: "pck-omp-1" };
-    const h = hdrs("Bearer keyOmp");
     const id1 = preferPromptCacheKeyIdentity(conversationIdentityResponses(body1, undefined), body1)!;
     const id2 = preferPromptCacheKeyIdentity(conversationIdentityResponses(body2, undefined), body2)!;
-    assert.equal(
-        deriveSessionId(h, "responses", "http://127.0.0.1:8199", id1.value, id1.clientProvided),
-        deriveSessionId(h, "responses", "http://127.0.0.1:8199", id2.value, id2.clientProvided),
-    );
+    assert.equal(id1.value, id2.value);
     assert.equal(affinityToken(id1), "pck-omp-1");
-});
-
-test("deriveSessionId: same conversation + same key + same protocol + same upstream → stable (weak signal)", () => {
-    const a = deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://bailian.example", "hello world", false);
-    const b = deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://bailian.example", "hello world", false);
-    assert.equal(a, b);
-});
-
-test("deriveSessionId: stable for same (key, protocol, upstream, conversation) (weak signal)", () => {
-    const a = deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://bailian.example", "hello world", false);
-    const b = deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://bailian.example", "hello world", false);
-    assert.equal(a, b);
-});
-
-test("deriveSessionId: different API key → different session (no cross-account bleed, weak signal)", () => {
-    const a = deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://bailian.example", "hello world", false);
-    const b = deriveSessionId(hdrs("Bearer keyB"), "anthropic", "https://bailian.example", "hello world", false);
-    assert.notEqual(a, b);
-});
-
-test("deriveSessionId: credentials remain case-sensitive opaque values (weak signal)", () => {
-    const upper = deriveSessionId(hdrs("Bearer AbCd"), "responses", "https://chatgpt.com", "session", false);
-    const lower = deriveSessionId(hdrs("Bearer abcd"), "responses", "https://chatgpt.com", "session", false);
-    assert.notEqual(upper, lower);
-});
-
-test("deriveSessionId: different upstream origin → different session (no cross-provider bleed, weak signal)", () => {
-    const a = deriveSessionId(hdrs("Bearer keyA"), "openai", "https://zhipu.example", "hello", false);
-    const b = deriveSessionId(hdrs("Bearer keyA"), "openai", "https://bailian.example", "hello", false);
-    assert.notEqual(a, b);
-});
-
-test("deriveSessionId: different protocol → different session (no cross-format bleed, weak signal)", () => {
-    const a = deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://bailian.example", "hello", false);
-    const b = deriveSessionId(hdrs("Bearer keyA"), "openai", "https://bailian.example", "hello", false);
-    assert.notEqual(a, b);
-});
-
-test("deriveSessionId: different conversation → different session (weak signal)", () => {
-    const a = deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://bailian.example", "hello", false);
-    const b = deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://bailian.example", "goodbye", false);
-    assert.notEqual(a, b);
-});
-
-test("deriveSessionId: conversation signal is the only conversation dimension (weak signal)", () => {
-    // The conversation dimension is whatever the caller passes — typically the
-    // output of conversationSignal*, which already prefers a client header
-    // and falls back to a content hash. Here we just confirm the passed value
-    // is what matters (same key/proto/upstream, different convo → different).
-    const a = deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://up", "ses_111", false);
-    const b = deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://up", "ses_222", false);
-    assert.notEqual(a, b);
-    // Same convo signal → same session, regardless of anything else.
-    assert.equal(a, deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://up", "ses_111", false));
-});
-
-test("deriveSessionId: no Authorization header → still works (uses placeholder key, weak signal)", () => {
-    const id = deriveSessionId({}, "anthropic", "https://up", "convo-1", false);
-    assert.ok(id.length > 0);
-    // Two keyless requests with same content → same session.
-    assert.equal(id, deriveSessionId({}, "anthropic", "https://up", "convo-1", false));
-});
-
-test("deriveSessionId: empty conversation dimension THROWS (no silent collapse)", () => {
-    // A caller that forgets to pass the conversation signal must fail loudly,
-    // not silently collapse every anonymous session onto one id.
-    assert.throws(() => deriveSessionId({}, "anthropic", "https://up", "", false), /conversation dimension is required/);
-});
-
-test("deriveSessionId: strong signal ignores credential rotation (ChatGPT OAuth bearer, #286)", () => {
-    const convo = "019fdc81-a420-7a00-bbd1-0a64e3eb772c";
-    const a = deriveSessionId(hdrs("Bearer bearer-old"), "responses", "https://chatgpt.com", convo, true);
-    const b = deriveSessionId(hdrs("Bearer bearer-new"), "responses", "https://chatgpt.com", convo, true);
-    assert.equal(a, b);
-});
-
-test("deriveSessionId: strong signal survives upstream/relay switching (#286)", () => {
-    const convo = "019fdc81-a420-7a00-bbd1-0a64e3eb772c";
-    const a = deriveSessionId(hdrs("Bearer keyA"), "responses", "https://relay-1.example", convo, true);
-    const b = deriveSessionId(hdrs("Bearer keyA"), "responses", "https://relay-2.example", convo, true);
-    assert.equal(a, b);
-});
-
-test("deriveSessionId: strong signal stable for same (protocol, conversation)", () => {
-    const a = deriveSessionId(hdrs("Bearer keyA"), "responses", "https://chatgpt.com", "convo-1", true);
-    const b = deriveSessionId(hdrs("Bearer keyB"), "responses", "https://other.example", "convo-1", true);
-    assert.equal(a, b);
-});
-
-test("deriveSessionId: strong signal different conversation → different session", () => {
-    const a = deriveSessionId(hdrs("Bearer keyA"), "responses", "https://chatgpt.com", "convo-1", true);
-    const b = deriveSessionId(hdrs("Bearer keyA"), "responses", "https://chatgpt.com", "convo-2", true);
-    assert.notEqual(a, b);
-});
-
-test("deriveSessionId: strong signal different protocol → different session (no cross-format bleed)", () => {
-    const a = deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://chatgpt.com", "convo-1", true);
-    const b = deriveSessionId(hdrs("Bearer keyA"), "responses", "https://chatgpt.com", "convo-1", true);
-    assert.notEqual(a, b);
-});
-
-test("deriveSessionId: strong and weak tiers never collide for the same conversation value", () => {
-    // hash(protocol|convo) and hash(protocol|upstream|key|convo) are different
-    // hash inputs, so a session must not migrate between tiers when the
-    // client's signal strength changes mid-flight.
-    const strong = deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://up", "hello", true);
-    const weak = deriveSessionId(hdrs("Bearer keyA"), "anthropic", "https://up", "hello", false);
-    assert.notEqual(strong, weak);
 });
 
 test("affinityToken: uses client signal when present (passthrough, preserves ses_ format)", () => {
@@ -205,8 +85,8 @@ test("clientConversationHeader: reads known session header names in priority ord
 });
 
 test("affinityToken: client-provided identity passes through verbatim (credentials never in scope)", () => {
-    // After the refactor, affinityToken receives only the resolved identity
-    // object ({ value, source, clientProvided }) — never raw headers or the
+    // affinityToken receives only the resolved identity object
+    // ({ value, source, clientProvided }) — never raw headers or the
     // API key — so credential leakage is impossible by construction.
     const token = affinityToken({ value: "client-session", source: "body-session", clientProvided: true });
     assert.equal(token, "client-session");
@@ -238,7 +118,7 @@ test("conversationSignalResponses: header (opencode x-session-affinity) still wi
     assert.equal(sig, "ses_opencode-123");
 });
 
-test("conversationIdentityResponses: previous_response_id provides a stable conversation link", () => {
+test("conversationIdentityResponses: previous_response_id is NOT client-provided (per-turn, not a stable conversation id)", () => {
     const body = {
         input: "hello",
         previous_response_id: "resp_xyz",
@@ -249,7 +129,7 @@ test("conversationIdentityResponses: previous_response_id provides a stable conv
     assert.equal(identity.clientProvided, false);
 });
 
-test("conversationIdentityResponses: identical anonymous openers share a content fingerprint (enables compression)", () => {
+test("conversationIdentityResponses: identical anonymous openers share a content fingerprint (rejected upstream by the server, #286)", () => {
     const body = { input: "hello world" } as unknown as Parameters<typeof conversationSignalResponses>[0];
     const a = conversationSignalResponses(body, undefined);
     const b = conversationSignalResponses({ input: "hello world" } as never, undefined);

--- a/tests/vscode-copilot.test.ts
+++ b/tests/vscode-copilot.test.ts
@@ -106,6 +106,7 @@ test("vscode-copilot #177 (1): OpenAI streaming final chunk carries total_tokens
             headers: {
                 "content-type": "application/json",
                 authorization: "Bearer fake-key",
+                "x-acp-session": "vscode-copilot-test",
             },
             body: JSON.stringify({
                 model: "deepseek-v4-flash",


### PR DESCRIPTION
## #286：session ID = client-provided conversation 值原文（无 hash、无其他维度）

### 设计（owner 确认）
- **session ID = client-provided conversation 值原文**：codex `session-id`/`thread-id`、claude `x-claude-code-session-id`、opencode `x-opencode-session`、Responses body `session_id` / `metadata.session_id`、`prompt_cache_key` 等。
- 无强信号 → **400**（错误信息列出可用身份字段）；content-fingerprint 会话禁用（指纹有真实碰撞面，静默建会话只会孤儿化状态）。
- credential（OAuth bearer 轮换）、upstream（中转切换）、protocol（中转翻译 / 跨协议切模型）都是可变的，均不参与身份。会话状态本身协议中立（kernel CompressionState + 文本 blocks + CoreMessage），客户端每轮重发全量历史，协议切换不断状态。
- meta.protocol / upstreamOrigin 保持 first-wins（持久化文件名命名空间 `sessions/<proto>/<host>_<sha>.json` 由此派生，更新会孤儿化旧文件）；persist.ts 无需改动（文件名已是 id 的 sha256，id 从文件体读取）。

### 变更
- `src/session-id.ts`：删除 `deriveSessionId` / `extractKey`；保留 `clientConversationHeader` / `affinityToken` / `preferPromptCacheKeyIdentity`。
- `src/server.ts`：
  - 无强信号 → 400（anthropic 与 openai/responses 各自的错误格式）。
  - `sessionId = conversation`（原文）。
  - **修复本设计暴露的潜在 bug**：route 的 `compressProtocol` 配置原先按 `session.meta.upstreamOrigin`（first-wins）解析——切换中转后新中转的配置会被静默忽略；现按请求实际 upstream 解析。
  - debug dump 文件名 sanitize（`safeSessionId`）——id 现在是客户端原始值。
- 测试：`e2e-session-identity.test.ts` 重写（10 例：bearer 轮换 / 中转切换 / 跨协议续接 / 匿名 400 ×3 / 隔离）；7 处匿名测试调用点补强信号；2 个 headless-binding 测试首请求带与 register 不同的强信号（保持走 pending 路径）。

### 代价
- 一次性：存量持久化会话重新定键（旧记录孤儿化）——可接受（owner 确认）。
- 无原生 session id 的客户端（hermes/dsh 无 plugin、通用客户端）现在会收到 400——显式失败，而非静默丢状态。

### 验证
- typecheck clean；657/657 tests pass。