### PR TITLE
fix: bili claude/codex auto-inject native MCP tools by default (#290)

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -356,7 +356,7 @@ Environment variables take precedence over the config file. They are useful for 
 | `BILLION_CONTEXT_PROXY` | Exported by the launcher; client-side bili plugins/extensions detect it and self-disable their own compression (no double compression). |
 | `BILLION_CONTEXT_PLUGIN` | Set `0` to disable plugin mode entirely (wire-level tool injection resumes). |
 | `BILI_LAUNCHER_MODEL_WINDOWS` | Internal: the launcher hands the client's own per-model context windows (pi `models.json`, omp `models.yml`, opencode `models.<id>.limit`, codex `model_context_window`) to the spawned proxy as JSON, so the nudge denominator matches the real window for self-hosted models. Only the launcher sets it — no user configuration. |
-| `BILI_LAUNCHER_PLUGIN` | Set `1` to have the launcher inject the bili MCP server for claude/codex (native tools). See [Launcher Reference](#launcher-reference). |
+| `BILI_LAUNCHER_PLUGIN` | Set `0` to disable the launcher's bili MCP server injection for claude/codex (pure wire mode). Native MCP tools are injected by default. See [Launcher Reference](#launcher-reference). |
 | `BILI_LAUNCHER_DIRECT` | Set `1` for direct-URL routing in the launcher (drop MITM/CA trust). See [Launcher Reference](#launcher-reference). |
 | `BILI_CLAUDE_UPSTREAM` | claude direct mode: your relay endpoint, when `ANTHROPIC_BASE_URL` already points at a relay the launcher would otherwise bypass. |
 
@@ -544,7 +544,7 @@ The `/bili/` rewrite modes write a **temp copy** — the real config is never ed
 - **pi** — if the plugin is NOT installed, the launcher rides pi's `-e <file>` flag to load `dist/agent/pi.js` for that run only (nothing is written): native tools + the `/acp` command out of the box. If it IS installed, the symlinked `settings.json` already loads it — no `-e` is added.
 - **omp** — does NOT ship the plugin; the launcher auto-injects `-e dist/agent/omp.js` when the config carries no loadable bili entry (same zero-config ride as pi). Two omp-specific mechanics make the plugin fully native there: omp 17.x mounts extension tools that omit `loadMode` under its `xd://` device URLs (invisible to the model's main turn), so the plugin registers its tools with `loadMode: "essential"` — the model gets the four ACP tools natively; and since omp's fork emits no `before_provider_headers`, the plugin binds the conversation via the launcher identity register (`POST /__bili/plugin/register`, keyed by omp's session id = `prompt_cache_key`/`x-session-id`) — bound sessions run in plugin mode (wire injection suppressed) with the native `/acp` command.
 - **opencode** — the temp config appends the thin plugin automatically.
-- **claude / codex** — opt-in via `BILI_LAUNCHER_PLUGIN=1`: the launcher additionally injects a single `bili` MCP server (`--mcp-config` for claude, `-c mcp_servers.bili.*` for codex — both ephemeral, nothing written to host config). The default stays wire mode while host-flag compatibility soaks (verified with claude 2.1.227 / codex 0.147.0). `BILI_LAUNCHER_PLUGIN=0` forces plain wire mode.
+- **claude / codex** — on by default: the launcher injects a single `bili` MCP server (`--mcp-config` for claude, `-c mcp_servers.bili.*` for codex — both ephemeral, nothing written to host config), so the host gets native tools out of the box (verified with claude 2.1.227 / codex 0.147.0). `BILI_LAUNCHER_PLUGIN=0` falls back to plain wire mode — for hosts older than the verified builds that have not been tested against the injection flags.
 - **hermes** — no plugin API; always wire mode.
 - **dsh** — the launcher always splices a `--patch <file>` flag into dsh's argv (written to `~/.dsh-bili/.bili-acp.patch.yml`), inserting `dist/agent/dsh-acp.js` into the profile's loader tree: the native `/acp` command, same shape as dsh's own `/compact`. Works on every profile that composes the commands service (web/tui interactive surfaces; the `headless` one-shot driver sends its task straight to the model and parses no commands — `/compact` behaves the same there). Subcommand forms are handled: `dsh web` gets the flag after `web`, `dsh plugin`/`--dump-default-config` take none.
 
@@ -552,8 +552,8 @@ Launcher-mode matrix:
 
 | Mode | Tools surface | Setup |
 |---|---|---|
-| Launcher + MCP (`BILI_LAUNCHER_PLUGIN=1`, claude/codex) | native MCP tools | one env var |
-| Launcher wire mode (default for claude/codex) | proxy-injected wire tools | none — just `bili claude` / `bili codex` |
+| Launcher + MCP (default for claude/codex) | native MCP tools | none — just `bili claude` / `bili codex` |
+| Launcher wire mode (claude/codex, `BILI_LAUNCHER_PLUGIN=0`) | proxy-injected wire tools | one env var |
 | Launcher `-e` / auto-plugin (pi, opencode; omp built-in) | native plugin tools | none |
 | Manual plugin (`bili plugin install`) | agent-side plugin | run install |
 | Manual baseURL (`/bili/` prefix) | proxy-injected wire tools | edit client config |
@@ -593,7 +593,7 @@ The installed plugin is a **thin** one (~5 KB, zero runtime deps): it detects th
 
 Kill switch: `BILLION_CONTEXT_PLUGIN=0` disables plugin mode entirely (wire-level injection resumes).
 
-**When do you need `plugin install` at all?** Launcher users mostly don't (see [Launcher Reference](#launcher-reference) — pi/omp get `-e` auto-injected, opencode auto-injects, claude/codex opt in via `BILI_LAUNCHER_PLUGIN=1`, dsh gets the native `/acp` command via `--patch`, hermes is wire-only). It's for a manually-configured client (`/bili/` prefix or MITM) where you want the native panel: pi/omp/opencode get native tools + `/acp` (on omp the fork hides extension tools from the model — the plugin's value there is the `/acp` command); claude/codex get native MCP tools (no `/acp`); dsh gets `/acp` through the launcher's `--patch` (a manually-configured dsh can add the same patch itself); hermes can't (wire only). Without any plugin everything still works — compression runs via wire-injected tools, and the model can be asked to call `acp_status` to check live usage.
+**When do you need `plugin install` at all?** Launcher users mostly don't (see [Launcher Reference](#launcher-reference) — pi/omp get `-e` auto-injected, opencode auto-injects, claude/codex get the MCP server auto-injected, dsh gets the native `/acp` command via `--patch`, hermes is wire-only). It's for a manually-configured client (`/bili/` prefix or MITM) where you want the native panel: pi/omp/opencode get native tools + `/acp` (on omp the fork hides extension tools from the model — the plugin's value there is the `/acp` command); claude/codex get native MCP tools (no `/acp`); dsh gets `/acp` through the launcher's `--patch` (a manually-configured dsh can add the same patch itself); hermes can't (wire only). Without any plugin everything still works — compression runs via wire-injected tools, and the model can be asked to call `acp_status` to check live usage.
 
 ---
 

--- a/CONFIGURATION.zh-CN.md
+++ b/CONFIGURATION.zh-CN.md
@@ -356,7 +356,7 @@
 | `BILLION_CONTEXT_PROXY` | launcher 会导出它；客户端侧 bili 插件/扩展检测到后自禁用自身压缩（避免双重压缩）。 |
 | `BILLION_CONTEXT_PLUGIN` | 设 `0` 彻底关闭插件模式（恢复 wire 层工具注入）。 |
 | `BILI_LAUNCHER_MODEL_WINDOWS` | 内部使用：launcher 把客户端自身配置里的逐模型上下文窗口（pi `models.json`、omp `models.yml`、opencode `models.<id>.limit`、codex `model_context_window`）以 JSON 传给自己拉起的代理，让 nudge 分母对自托管模型也用真实窗口。只有 launcher 会设置，无需用户配置。 |
-| `BILI_LAUNCHER_PLUGIN` | 设 `1` 让 launcher 为 claude/codex 注入 bili MCP 服务器（原生工具）。见[启动器参考](#启动器参考)。 |
+| `BILI_LAUNCHER_PLUGIN` | 设 `0` 关闭 launcher 为 claude/codex 注入 bili MCP 服务器（退回纯 wire 模式）。原生 MCP 工具默认注入。见[启动器参考](#启动器参考)。 |
 | `BILI_LAUNCHER_DIRECT` | 设 `1` 启用 launcher 直连 URL 路由（放弃 MITM/CA 信任）。见[启动器参考](#启动器参考)。 |
 | `BILI_CLAUDE_UPSTREAM` | claude 直连模式：当 `ANTHROPIC_BASE_URL` 已指向某个 relay 时，用它指定你的 relay 端点（否则会被旁路）。 |
 
@@ -544,7 +544,7 @@ Claude Code 的 undici fetch 忽略 `HTTPS_PROXY`，所以证书 MITM 拦不到�
 - **pi** —— 未安装插件时，启动器借用 pi 的 `-e <file>` 参数为本次运行加载 `dist/agent/pi.js`（不写任何东西）：开箱即原生工具 + `/acp` 命令。已安装则符号链接的 `settings.json` 已加载它 —— 不再加 `-e`。
 - **omp** —— 发行版不自带插件；启动器在配置里没有可加载的 bili 条目时自动注入 `-e dist/agent/omp.js`（与 pi 相同的零配置搭车）。两个 omp 专属机制让插件在那里完全原生：omp 17.x 会把未声明 `loadMode` 的扩展工具挂到 `xd://` 设备 URL 下（模型主回合看不到），插件因此用 `loadMode: "essential"` 注册 —— 模型直接拿到四个 ACP 原生工具；omp 分叉不发 `before_provider_headers`，插件改走启动器身份注册（`POST /__bili/plugin/register`，以 omp 会话 id = `prompt_cache_key`/`x-session-id` 为键）绑定会话 —— 绑定后的会话进入插件模式（抑制 wire 注入）并带有原生 `/acp` 命令。
 - **opencode** —— 临时配置自动追加薄插件。
-- **claude / codex** —— 通过 `BILI_LAUNCHER_PLUGIN=1` 选择启用：启动器额外注入单个 `bili` MCP 服务器（claude 用 `--mcp-config`，codex 用 `-c mcp_servers.bili.*` —— 都是临时生效，不写宿主配置）。默认仍是 wire 模式，待宿主参数兼容性充分验证后翻转（已在 claude 2.1.227 / codex 0.147.0 验证）。`BILI_LAUNCHER_PLUGIN=0` 强制 wire 模式。
+- **claude / codex** —— 默认开启：启动器注入单个 `bili` MCP 服务器（claude 用 `--mcp-config`，codex 用 `-c mcp_servers.bili.*` —— 都是临时生效，不写宿主配置），开箱即原生工具（已在 claude 2.1.227 / codex 0.147.0 验证）。`BILI_LAUNCHER_PLUGIN=0` 退回纯 wire 模式 —— 适用于早于已验证版本、未针对注入参数测试的宿主。
 - **hermes** —— 无插件 API；永远 wire 模式。
 - **dsh** —— 启动器始终在 dsh 的 argv 里拼接 `--patch <file>`（写入 `~/.dsh-bili/.bili-acp.patch.yml`），把 `dist/agent/dsh-acp.js` 插进 profile 的加载树：原生 `/acp` 命令，与 dsh 自带 `/compact` 同一形态。在任何组合了 commands 服务的 profile（web/tui 交互表面）都可用；`headless` 一次性驱动器把任务直接发给模型、不解析命令（原生 `/compact` 在那里同样不可用）。子命令形态已处理：`dsh web` 的 flag 插在 `web` 之后，`dsh plugin`/`--dump-default-config` 不注入。
 
@@ -552,8 +552,8 @@ Claude Code 的 undici fetch 忽略 `HTTPS_PROXY`，所以证书 MITM 拦不到�
 
 | 模式 | 工具形态 | 设置 |
 |---|---|---|
-| 启动器 + MCP（`BILI_LAUNCHER_PLUGIN=1`，claude/codex） | 原生 MCP 工具 | 一个环境变量 |
-| 启动器 wire 模式（claude/codex 默认） | 代理注入的 wire 工具 | 无 —— `bili claude` / `bili codex` 即可 |
+| 启动器 + MCP（claude/codex 默认） | 原生 MCP 工具 | 无 —— `bili claude` / `bili codex` 即可 |
+| 启动器 wire 模式（claude/codex，`BILI_LAUNCHER_PLUGIN=0`） | 代理注入的 wire 工具 | 一个环境变量 |
 | 启动器 `-e` / 自动插件（pi、omp、opencode） | 原生插件工具 | 无 |
 | 手动插件（`bili plugin install`） | 客户端侧插件 | 执行 install |
 | 手动 baseURL（`/bili/` 前缀） | 代理注入的 wire 工具 | 改客户端配置 |
@@ -593,7 +593,7 @@ bili plugin remove pi       # 撤销（原文件一次性备份为 *.bili-bak）
 
 总开关：`BILLION_CONTEXT_PLUGIN=0` 彻底关闭插件模式（恢复 wire 层注入）。
 
-**到底什么时候需要 `plugin install`？** 用启动器的基本都不需要（见[启动器参考](#启动器参考) —— pi/omp 自动 `-e`、opencode 自动注入、claude/codex 用 `BILI_LAUNCHER_PLUGIN=1`、dsh 经 `--patch` 自动获得原生 `/acp` 命令、hermes 只能 wire）。它适用于手动配置客户端（`/bili/` 前缀或 MITM）又想要原生面板的场景：pi/omp/opencode 装后获得原生工具 + `/acp`；claude/codex 获得原生 MCP 工具（无 `/acp`）；dsh 的 `/acp` 由启动器 `--patch` 注入（手动配置的 dsh 可自行添加同一 patch）；hermes 装不了（只能 wire）。不装任何插件一切照常工作 —— 压缩走 wire 注入的工具，让模型调 `acp_status` 即可查看实时用量。
+**到底什么时候需要 `plugin install`？** 用启动器的基本都不需要（见[启动器参考](#启动器参考) —— pi/omp 自动 `-e`、opencode 自动注入、claude/codex 自动注入 MCP、dsh 经 `--patch` 自动获得原生 `/acp` 命令、hermes 只能 wire）。它适用于手动配置客户端（`/bili/` 前缀或 MITM）又想要原生面板的场景：pi/omp/opencode 装后获得原生工具 + `/acp`；claude/codex 获得原生 MCP 工具（无 `/acp`）；dsh 的 `/acp` 由启动器 `--patch` 注入（手动配置的 dsh 可自行添加同一 patch）；hermes 装不了（只能 wire）。不装任何插件一切照常工作 —— 压缩走 wire 注入的工具，让模型调 `acp_status` 即可查看实时用量。
 
 ---
 

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -378,14 +378,16 @@ export function launcherDirectUrl(env: NodeJS.ProcessEnv): boolean {
     return env.BILI_LAUNCHER_DIRECT === "1";
 }
 
-/** Plugin-in-launcher MCP injection is OPT-IN (`BILI_LAUNCHER_PLUGIN=1`):
- *  enabling it changes the spawn args of claude/codex, and hosts older than
- *  the verified builds (claude 2.1.227, codex 0.147.0) have not been tested
- *  against `--mcp-config` / `-c mcp_servers.*`. Flip the default to on (with
- *  `!== "0"` semantics) once the flags have soaked; pi is always excluded —
- *  it has its own native extension (billion-context-pi #154). */
+/** Plugin-in-launcher MCP injection is ON by default for claude/codex
+ *  (zero-config, mirroring the pi/omp/opencode auto-injection): the launcher
+ *  injects a single `bili` MCP server so the host gets native tools instead
+ *  of wire-injected ones. `BILI_LAUNCHER_PLUGIN=0` is the kill switch back to
+ *  pure wire mode — for hosts older than the verified builds (claude 2.1.227,
+ *  codex 0.147.0) that have not been tested against `--mcp-config` /
+ *  `-c mcp_servers.*`. pi/omp/opencode/hermes/dsh are always excluded — they
+ *  have their own native plugin surface (or none). */
 export function launcherInjectMcp(env: NodeJS.ProcessEnv, base: string): boolean {
-    return base !== "pi" && base !== "omp" && base !== "opencode" && base !== "hermes" && base !== "dsh" && env.BILI_LAUNCHER_PLUGIN === "1";
+    return base !== "pi" && base !== "omp" && base !== "opencode" && base !== "hermes" && base !== "dsh" && env.BILI_LAUNCHER_PLUGIN !== "0";
 }
 
 /** Ephemeral MCP config for --mcp-config / -c mcp_servers.bili.*: a single
@@ -1203,8 +1205,10 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
         }
     }
     const injectMcp = launcherInjectMcp(process.env, base);
-    if (!injectMcp && (base === "claude" || base === "codex")) {
-        console.error("bili: plugin mode off — set BILI_LAUNCHER_PLUGIN=1 to enable native MCP tools (experimental; verified with claude 2.1.227 / codex 0.147.0).");
+    if (injectMcp) {
+        console.error(`bili: injecting native bili MCP tools for ${base} (disable with BILI_LAUNCHER_PLUGIN=0).`);
+    } else if (base === "claude" || base === "codex") {
+        console.error("bili: native MCP tools disabled (BILI_LAUNCHER_PLUGIN=0) — running in pure wire mode.");
     }
     const origin = handle.origin;
     if (base === "pi") {

--- a/tests/launcher-plugin-mode.test.ts
+++ b/tests/launcher-plugin-mode.test.ts
@@ -227,15 +227,15 @@ test("launcher injection builders: direct-URL env, MCP config JSON, codex -c arg
     assert.equal(launcherDirectUrl({ BILI_LAUNCHER_DIRECT: "1" }), true, "direct URL is opt-in");
     assert.equal(launcherDirectUrl({ BILI_LAUNCHER_DIRECT: "0" }), false, "explicit opt-out honored");
 
-    // MCP injection is OPT-IN (#163): spawn args change when enabled and
-    // hosts older than the verified builds (claude 2.1.227, codex 0.147.0)
-    // are untested against the injection flags — default-off keeps existing
-    // `bili claude` / `bili codex` spawns byte-identical.
-    assert.equal(launcherInjectMcp({}, "claude"), false, "plugin injection off by default (claude)");
-    assert.equal(launcherInjectMcp({}, "codex"), false, "plugin injection off by default (codex)");
-    assert.equal(launcherInjectMcp({ BILI_LAUNCHER_PLUGIN: "0" }, "claude"), false, "explicit opt-out honored");
-    assert.equal(launcherInjectMcp({ BILI_LAUNCHER_PLUGIN: "1" }, "claude"), true, "opt-in enables injection");
-    assert.equal(launcherInjectMcp({ BILI_LAUNCHER_PLUGIN: "1" }, "codex"), true, "opt-in enables injection (codex)");
+    // MCP injection is ON by default for claude/codex (#290): zero-config
+    // native tools, mirroring the pi/omp/opencode auto-injection.
+    // BILI_LAUNCHER_PLUGIN=0 is the kill switch back to pure wire mode for
+    // hosts older than the verified builds (claude 2.1.227, codex 0.147.0).
+    assert.equal(launcherInjectMcp({}, "claude"), true, "plugin injection on by default (claude)");
+    assert.equal(launcherInjectMcp({}, "codex"), true, "plugin injection on by default (codex)");
+    assert.equal(launcherInjectMcp({ BILI_LAUNCHER_PLUGIN: "0" }, "claude"), false, "explicit opt-out honored (claude)");
+    assert.equal(launcherInjectMcp({ BILI_LAUNCHER_PLUGIN: "0" }, "codex"), false, "explicit opt-out honored (codex)");
+    assert.equal(launcherInjectMcp({ BILI_LAUNCHER_PLUGIN: "1" }, "claude"), true, "explicit opt-in still works");
     assert.equal(launcherInjectMcp({ BILI_LAUNCHER_PLUGIN: "1" }, "pi"), false, "pi always excluded (native extension #154)");
 
     const env = buildClaudePluginEnv("http://127.0.0.1:8787", true, { HOME: "/h" });


### PR DESCRIPTION
## What

Fixes #290 — `bili claude` (and `bili codex`) ran in pure wire/service mode by default because native MCP tool injection was opt-in (`BILI_LAUNCHER_PLUGIN=1`).

## Change

- `launcherInjectMcp()` now defaults to **on** for claude/codex: `BILI_LAUNCHER_PLUGIN !== "0"`. Both flag paths were already verified (claude 2.1.227 / codex 0.147.0) and soaked since 08-16; the code comment documented this exact flip as the plan.
- `BILI_LAUNCHER_PLUGIN=0` is the kill switch back to pure wire mode (for hosts older than the verified versions).
- Launcher log line updated to reflect the new default.
- Tests + CONFIGURATION.md / CONFIGURATION.zh-CN.md updated to match.

pi/omp/opencode/dsh behavior unchanged (already auto-inject native plugins); hermes stays wire-only.

## Checks

- `npm run typecheck` ✓
- `npm test` ✓ (657 pass)
- `npm run build` ✓