### PR TITLE
release v0.1.58

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Model: glm-5.3

Release v0.1.58 — 版本号 bump，无代码变更。

## 自 v0.1.57 以来 master 已合并的变更

| PR | 内容 |
|---|---|
| #278 | 默认关闭 body dump（`ACP_DUMP_BODY=1` 显式开启）、敏感日志全量脱敏（新增 `src/log-mask.ts`）、ws host 泄漏修复 |
| #288 | session id = 客户端 conversation 值原文；匿名 400；启动迁移 re-key；dsh/hermes 身份注入（`PI_CACHE_RETENTION=long` / hermes python 插件 overlay） |
| #284 | relay 域名 → registry provider 前缀键（全一致才采纳） |
| #285 | fallback 窗口 floor 100k |
| #283 | compaction trigger 末项保持（跳过 nudge） |
| #293 | AGENTS.md：无 gh CLI 时开 PR 的方法 |

预检：typecheck ✓ / 687 测试全过 ✓ / build ✓（本提交仅改 `version`）。

> 另有 #291（claude/codex 默认注入 MCP 工具，CI 6/6 绿，tmux 实测三场景通过）仍在 open——如需并入本版请先合 #291 再合本 PR（冲突面：无，但会改变发布内容）。
