### PR TITLE
test: normalize macOS /var->/private/var tmpdir paths in launcher rewrite tests

### DIFF
--- a/tests/launcher.test.ts
+++ b/tests/launcher.test.ts
@@ -800,7 +800,9 @@ test("buildClaudeEnv: no ANTHROPIC_BASE_URL rewrite → env.ANTHROPIC_BASE_URL u
 });
 
 test("preparePiHttpRewrite: rewrites matching provider, leaves others, symlinks siblings", () => {
-    const home = fs.mkdtempSync(path.join(os.tmpdir(), "bili-pihome-"));
+    // realpath: on macOS os.tmpdir() is /var/folders (a symlink to /private/var);
+    // the realpathSync asserts below compare canonical forms on both sides.
+    const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "bili-pihome-")));
     fs.writeFileSync(
         path.join(home, "models.json"),
         JSON.stringify({
@@ -946,7 +948,9 @@ test("discoverRoutes: omp http + https providers → splits httpsDomains + httpR
 });
 
 test("prepareOmpHttpRewrite: rewrites matching provider, leaves others, symlinks siblings", () => {
-    const home = fs.mkdtempSync(path.join(os.tmpdir(), "bili-omphome-"));
+    // realpath: on macOS os.tmpdir() is /var/folders (a symlink to /private/var);
+    // the realpathSync asserts below compare canonical forms on both sides.
+    const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "bili-omphome-")));
     fs.writeFileSync(
         path.join(home, "models.yml"),
         [


### PR DESCRIPTION
refs #280

Two launcher rewrite tests (pi/omp "symlinks siblings") failed on macOS only:
`fs.realpathSync` resolves the tmpdir through the /var -> /private/var
symlink, so the strictEqual path asserts compared a realpath'd left side
against an un-realpath'd right side (/private/var/folders/... vs
/var/folders/...). Canonicalize the mkdtempSync result up front; no-op on
Linux.

Full suite 687/687 on Linux.

<sub>🤖 ework agent</sub>

<!-- ework-agent-pr -->