### PR TITLE
release v0.1.59

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.58",
+  "version": "0.1.59",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Model: glm-5.3

Release v0.1.59 — 版本号 bump，无代码变更。补发 0.1.58 之后落 master 的两个修复（issue #280 闭环）。

## 自 v0.1.58 以来

| PR | 内容 |
|---|---|
| #281 | Codex 上下文超限错误识别 + 不可解析时学习保守窗口（自愈） |
| #297 | launcher 测试 macOS 路径规范化（`/var` → `/private/var` realpath，Linux no-op） |

预检：typecheck ✓ / 691 测试全过 ✓ / build ✓（本提交仅改 `version`）。
