### PR TITLE
fix: adopt complete terminal usage atomically in anthropic adapter (stitched-stream double-count)

### DIFF
--- a/src/loop/adapter-anthropic.ts
+++ b/src/loop/adapter-anthropic.ts
@@ -288,15 +288,31 @@ export function createAnthropicAdapter(requestBody: Record<string, unknown>, ori
                 } else if (type === "message_delta") {
                     const u = (data.usage ?? {}) as Record<string, unknown>;
                     if (typeof u.output_tokens === "number") roundOutput = u.output_tokens;
-                    // The input context is FIXED within a turn, so message_start is
-                    // authoritative for input/cache tokens. Some relays echo a
-                    // schema-shaped `usage` in message_delta with `input_tokens: 0`
-                    // (the field is normally absent); adopting a 0 would overwrite
-                    // message_start's real value and under-report the context size
-                    // (→ nudge/compression never fires, cache hit rate collapses).
-                    // A 0 can never be a legitimate update, so adopt only > 0.
-                    if (typeof u.input_tokens === "number" && u.input_tokens > 0) roundInput = u.input_tokens;
-                    if (typeof u.cache_read_input_tokens === "number" && u.cache_read_input_tokens > 0) roundCached = u.cache_read_input_tokens;
+                    const input = typeof u.input_tokens === "number" ? u.input_tokens : undefined;
+                    const cached = typeof u.cache_read_input_tokens === "number" ? u.cache_read_input_tokens : undefined;
+                    if (input !== undefined && input > 0 && cached !== undefined) {
+                        // Complete authoritative usage object — e.g. the synthetic
+                        // terminal of a stitched multi-round stream (round1
+                        // message_start + final-round terminal). Adopt atomically so
+                        // the final round's cache_read — legitimately 0 after a
+                        // compress re-request — overwrites the stale value carried by
+                        // an earlier round's message_start. Per-field merging would
+                        // double-count (new input + old cache) and trip false
+                        // EMERGENCY nudges (issue #299).
+                        roundInput = input;
+                        roundCached = cached;
+                    } else {
+                        // Incomplete usage object: the input context is FIXED within
+                        // a turn, so message_start is authoritative for input/cache
+                        // tokens. Some relays echo a schema-shaped `usage` in
+                        // message_delta with `input_tokens: 0` (the field is normally
+                        // absent); adopting a 0 would overwrite message_start's real
+                        // value and under-report the context size (→ nudge/compression
+                        // never fires, cache hit rate collapses). A 0 can never be a
+                        // legitimate update, so adopt only > 0.
+                        if (input !== undefined && input > 0) roundInput = input;
+                        if (cached !== undefined && cached > 0) roundCached = cached;
+                    }
                     const d = (data.delta ?? {}) as Record<string, unknown>;
                     if (typeof d.stop_reason === "string") stopReason = d.stop_reason;
                     if (!usageYielded) {

--- a/tests/loop-adapters.test.ts
+++ b/tests/loop-adapters.test.ts
@@ -161,6 +161,80 @@ test("anthropic adapter: relay-echoed message_delta with input_tokens: 0 must NO
     assert.equal(ctx.session.stats.cachedTokens, 11, "cached portion from message_start preserved");
 });
 
+test("anthropic adapter (#299): stitched stream — terminal's complete usage adopts atomically, no double-count", async () => {
+    // After a compress re-request, the stream handed to a downstream bili is
+    // two rounds stitched: round1's message_start (pre-compress cache_read) +
+    // the final synthetic terminal (post-compress input, cache_read
+    // legitimately 0). The terminal carries a COMPLETE usage object
+    // (input_tokens > 0 AND cache_read_input_tokens present), so it must be
+    // adopted atomically — the 0 overwrites the stale cache_read, else the
+    // total double-counts (142543 + 118663 = 261206 instead of 142543 →
+    // false 131% EMERGENCY nudge + preflight compression).
+    const stitched = [
+        `event: message_start\ndata: ${JSON.stringify({ type: "message_start", message: { id: "msg_1", usage: { input_tokens: 50000, cache_read_input_tokens: 118663 } } })}\n\n`,
+        `event: content_block_start\ndata: ${JSON.stringify({ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } })}\n\n`,
+        `event: content_block_delta\ndata: ${JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "ok" } })}\n\n`,
+        `event: content_block_stop\ndata: ${JSON.stringify({ type: "content_block_stop", index: 0 })}\n\n`,
+        `event: message_delta\ndata: ${JSON.stringify({ type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { input_tokens: 142543, cache_read_input_tokens: 0, output_tokens: 7 } })}\n\n`,
+        `event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`,
+    ].join("");
+    const ctx = { ...makeCtx("anthropic-stitched"), protocol: "anthropic" };
+    await drain(
+        new Response(stitched, { status: 200 }).body!,
+        ctx,
+        createAnthropicAdapter({ model: "claude" }),
+        { model: "claude", messages: [], stream: true, max_tokens: 10 },
+    );
+    assert.equal(ctx.session.stats.lastInputTokens, 142543, "total = terminal input(142543) + terminal cache(0); stale message_start cache_read(118663) NOT double-counted");
+    assert.equal(ctx.session.stats.cachedTokens, 0, "cached portion = terminal's 0 (atomically adopted)");
+});
+
+test("anthropic adapter (#299): stitched terminal after proxy-tool re-request carries complete authoritative usage", async () => {
+    // Generation-side contract: the synthetic terminal emitted after a
+    // compress/proxy-tool re-request must carry BOTH input_tokens and
+    // cache_read_input_tokens with the final round's true values (0 included)
+    // so a downstream parser can adopt the usage atomically.
+    const round1 = [
+        `event: message_start\ndata: ${JSON.stringify({ type: "message_start", message: { id: "msg_1", usage: { input_tokens: 50000, cache_read_input_tokens: 118663 } } })}\n\n`,
+        `event: content_block_start\ndata: ${JSON.stringify({ type: "content_block_start", index: 0, content_block: { type: "tool_use", id: "toolu_s", name: "acp_status", input: {} } })}\n\n`,
+        `event: content_block_delta\ndata: ${JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "input_json_delta", partial_json: "{}" } })}\n\n`,
+        `event: content_block_stop\ndata: ${JSON.stringify({ type: "content_block_stop", index: 0 })}\n\n`,
+        `event: message_delta\ndata: ${JSON.stringify({ type: "message_delta", delta: { stop_reason: "tool_use" }, usage: { output_tokens: 1 } })}\n\n`,
+        `event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`,
+    ].join("");
+    const round2 = [
+        `event: message_start\ndata: ${JSON.stringify({ type: "message_start", message: { id: "msg_2", usage: { input_tokens: 142543, cache_read_input_tokens: 0 } } })}\n\n`,
+        `event: content_block_start\ndata: ${JSON.stringify({ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } })}\n\n`,
+        `event: content_block_delta\ndata: ${JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "done" } })}\n\n`,
+        `event: content_block_stop\ndata: ${JSON.stringify({ type: "content_block_stop", index: 0 })}\n\n`,
+        `event: message_delta\ndata: ${JSON.stringify({ type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 3 } })}\n\n`,
+        `event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`,
+    ].join("");
+    let fetchCalls = 0;
+    const orig = globalThis.fetch;
+    globalThis.fetch = (async () => { fetchCalls++; return new Response(round2, { status: 200 }); }) as typeof fetch;
+    try {
+        const out = await drain(
+            new Response(round1, { status: 200 }).body!,
+            makeCtx("anthropic-stitched-terminal"),
+            createAnthropicAdapter({ model: "claude" }),
+            { model: "claude", messages: [], stream: true, max_tokens: 10 },
+        );
+        assert.equal(fetchCalls, 1, "re-request after proxy tool");
+        const terminalLines = out
+            .split("\n")
+            .filter((l) => l.startsWith("data: ") && l.includes('"message_delta"'))
+            .map((l) => JSON.parse(l.slice("data: ".length)) as Record<string, unknown>);
+        assert.equal(terminalLines.length, 1, "exactly one (synthetic) message_delta in the stitched output");
+        const usage = (terminalLines[0]?.usage ?? {}) as Record<string, unknown>;
+        assert.equal(usage.input_tokens, 142543, "terminal carries final round's input_tokens");
+        assert.equal(usage.cache_read_input_tokens, 0, "terminal carries final round's cache_read (explicit 0, so downstream can adopt atomically)");
+        assert.equal(usage.output_tokens, 3, "terminal carries final round's output_tokens");
+    } finally {
+        globalThis.fetch = orig;
+    }
+});
+
 test("anthropic adapter: acp_status-only round → marker + re-request, no crash", async () => {
     const round1 = [
         `event: message_start\ndata: ${JSON.stringify({ type: "message_start", message: { id: "msg_1", usage: { input_tokens: 3 } } })}\n\n`,


### PR DESCRIPTION
## What

Fixes #299: after a compress re-request, the stream handed to a downstream bili is two rounds stitched (round1 `message_start` + final synthetic terminal). The anthropic adapter's per-field `> 0` guard refused the terminal's `cache_read_input_tokens: 0`, so the stale `cache_read` from round1's `message_start` survived and the total double-counted (142543 + 118663 = 261206 → false 131% EMERGENCY nudge + preflight compression, observed in #292).

### Changes

1. **Parse side (the fix)** — `src/loop/adapter-anthropic.ts` `message_delta` branch: when the usage object carries BOTH `input_tokens` (>0) AND `cache_read_input_tokens`, adopt the pair **atomically** (a 0 may overwrite the stale value). When fields are incomplete, keep the existing per-field `> 0` guard (relay-echo `input_tokens: 0` behavior unchanged).
2. **Generation side (contract pin)** — `buildTerminal` already always emits all three usage fields with the final round's true values (0 included); no code change, but a regression test now pins that contract.

The openai/responses wires are unaffected: their usage events replace the whole object (last-wins), no per-field merging.

## Tests

New in `tests/loop-adapters.test.ts`:
- **stitched stream (parse)**: round1 `message_start` (input=50000, cache_read=118663) + synthetic terminal (input=142543, cache_read=0) → recorded total input = **142543**, not 261206. Verified to fail on unfixed code (`actual: 261206`).
- **stitched terminal (generation)**: 2-round loop with proxy-tool re-request → the synthetic terminal in the output carries `input_tokens: 142543` + `cache_read_input_tokens: 0` (explicit 0) + `output_tokens`.
- Pre-existing relay-echo test (`input_tokens: 0` must NOT overwrite `message_start`) still passes — guard preserved for incomplete objects.

## Pre-flight

- `npm run typecheck` — clean
- `npm test` — 693/693 pass
- `npm run build` — success
