### PR TITLE
fix: preflight compress fails fast on upstream errors instead of forwarding over-window payloads (#301)

### DIFF
--- a/src/preflight.ts
+++ b/src/preflight.ts
@@ -44,9 +44,27 @@ export interface PreflightDeps {
     log: (level: string, msg: string) => void;
 }
 
+export type PreflightFailureKind = "upstream" | "exhausted" | "aborted";
+
+export interface PreflightFailure {
+    kind: PreflightFailureKind;
+    /** Upstream HTTP status when kind === "upstream" and the failure was an HTTP response. */
+    status?: number;
+    /** Human-readable cause (safe to surface to the client). */
+    detail: string;
+}
+
 export interface PreflightResult {
     compressedRanges: number;
     savedTokens: number;
+    /** Token estimate of the final (post-fold) payload, from the payload
+     *  itself — NOT floored on the session's lastInputTokens, which can be
+     *  stale (e.g. a double-counted usage report, #300). The caller uses it
+     *  to decide whether forwarding as-is is actually safe. */
+    payloadEstimate: number;
+    /** Why the loop stopped while the payload still overflows the window.
+     *  Undefined when the payload fits. */
+    failure?: PreflightFailure;
 }
 
 function refMaps(messages: CoreMessage[], state: Session["state"]): { refToIdx: Map<string, number>; idxToRef: Map<number, string> } {
@@ -198,9 +216,11 @@ async function summarizeRange(deps: PreflightDeps, content: string, startRef: st
     }
 }
 
+const ABORTED_FAILURE: PreflightFailure = { kind: "aborted", detail: "the client disconnected during preflight compression" };
+
 export async function preflightCompress(deps: PreflightDeps, messages: CoreMessage[]): Promise<PreflightResult> {
     const limit = deps.config.modelContextLimit;
-    const result: PreflightResult = { compressedRanges: 0, savedTokens: 0 };
+    const result: PreflightResult = { compressedRanges: 0, savedTokens: 0, payloadEstimate: estimateCoreMessages(messages) };
     if (limit <= 0) return result;
     const budget = Math.max(MIN_CHUNK_TOKENS, Math.floor(limit * CHUNK_FRACTION));
     // applyCompression rejects ranges below config.compress.minCompressRange
@@ -212,8 +232,12 @@ export async function preflightCompress(deps: PreflightDeps, messages: CoreMessa
     // overflows the smaller window.
     let currentTokens = deps.session.stats.lastInputTokens;
     let startTokens = -1;
+    let failure: PreflightFailure | undefined;
     for (let round = 0; round < MAX_PREFLIGHT_ROUNDS; round++) {
-        if (deps.signal?.aborted) break;
+        if (deps.signal?.aborted) {
+            failure = ABORTED_FAILURE;
+            break;
+        }
         // Re-run the pipeline each round: every successful compress renumbers
         // the surviving refs, so the previous round's range refs are stale.
         const turn = deps.core.processTurn({
@@ -228,19 +252,31 @@ export async function preflightCompress(deps: PreflightDeps, messages: CoreMessa
         // input_tokens also covers the system prompt + tool definitions, which
         // are not in turn.messages, so the direct estimate can undershoot.
         currentTokens = Math.max(deps.session.stats.lastInputTokens, estimateCoreMessages(turn.messages));
+        // The caller's forward/fail-fast gate uses the payload's own estimate
+        // (the floor can be stale — see PreflightResult.payloadEstimate).
+        result.payloadEstimate = estimateCoreMessages(turn.messages);
         if (startTokens < 0) startTokens = currentTokens;
         if (currentTokens < limit) break;
         const ranges = viableRanges(turn.nudge?.compressibleRanges ?? []);
-        if (ranges.length === 0) break;
+        if (ranges.length === 0) {
+            failure = { kind: "exhausted", detail: "no compressible ranges remain in the conversation" };
+            break;
+        }
         const range = [...ranges].sort((a, b) => refNum(a.startRef) - refNum(b.startRef))[0];
         const { refToIdx } = refMaps(messages, deps.session.state);
         const startIdx = refToIdx.get(range.startRef);
         const endIdx = refToIdx.get(range.endRef);
-        if (startIdx === undefined || endIdx === undefined || startIdx > endIdx) break;
+        if (startIdx === undefined || endIdx === undefined || startIdx > endIdx) {
+            failure = { kind: "exhausted", detail: "the compressible range no longer resolves to payload messages" };
+            break;
+        }
         let appliedThisRound = 0;
         for (const [cs, ce] of splitChunks(messages, startIdx, endIdx, budget)) {
             if (currentTokens < limit) break;
-            if (deps.signal?.aborted) break;
+            if (deps.signal?.aborted) {
+                failure = ABORTED_FAILURE;
+                break;
+            }
             const maps = refMaps(messages, deps.session.state);
             const startRef = maps.idxToRef.get(cs);
             const endRef = maps.idxToRef.get(ce);
@@ -253,8 +289,19 @@ export async function preflightCompress(deps: PreflightDeps, messages: CoreMessa
                 summary = await summarizeRange(deps, content, startRef, endRef);
             } catch (err) {
                 if (err instanceof UpstreamHttpError) {
+                    failure = {
+                        kind: "upstream",
+                        status: err.status,
+                        detail: err.status === 429
+                            ? `the summarization call was rate-limited by the upstream (HTTP 429)`
+                            : `the summarization call was rejected by the upstream (HTTP ${err.status})`,
+                    };
                     deps.log("warn", `[preflight] summarization failed: HTTP ${err.status} ${err.body.slice(0, 200)}`);
+                } else if (deps.signal?.aborted) {
+                    failure = ABORTED_FAILURE;
+                    deps.log("warn", `[preflight] summarization aborted: client disconnected`);
                 } else {
+                    failure = { kind: "upstream", detail: `the summarization call failed: ${String(err)}` };
                     deps.log("warn", `[preflight] summarization failed: ${String(err)}`);
                 }
                 break;
@@ -281,9 +328,18 @@ export async function preflightCompress(deps: PreflightDeps, messages: CoreMessa
             appliedThisRound += 1;
             result.compressedRanges += 1;
         }
-        if (appliedThisRound === 0) break;
+        if (appliedThisRound === 0) {
+            if (!failure) {
+                failure = { kind: "exhausted", detail: "no range could be compressed (chunks below minCompressRange or the summarization responses were unusable)" };
+            }
+            break;
+        }
+    }
+    if (!failure && currentTokens >= limit) {
+        failure = { kind: "exhausted", detail: `the compress budget was exhausted after ${MAX_PREFLIGHT_ROUNDS} rounds` };
     }
     if (result.compressedRanges > 0) deps.session.stats.lastInputTokens = currentTokens;
     result.savedTokens = Math.max(0, startTokens - currentTokens);
+    if (currentTokens >= limit) result.failure = failure;
     return result;
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1051,7 +1051,7 @@ async function handle(
                               : prepareResponses(parsed as ResponsesRequestBody, req, opts, core, reqConfig, reqPrompts, log, session, responsesIdentity!, pluginMode, upstreamOrigin);
                 prepared = runPrepare();
                 if (!countTokens && !responsesCompact) {
-                    prepared = await preflightCompressIfNeeded(
+                    const outcome = await preflightCompressIfNeeded(
                         prepared,
                         runPrepare,
                         req,
@@ -1065,6 +1065,30 @@ async function handle(
                         log,
                         instanceId,
                     );
+                    if (isPreflightFailFast(outcome)) {
+                        // #301: the payload still overflows the window and
+                        // preflight could not fix it — answer with a
+                        // structured error instead of forwarding.
+                        if (outcome.respond && !res.headersSent && !res.destroyed) {
+                            // Retry-After on the 503 (rate-limited) path: gives
+                            // well-behaved clients a backoff signal instead of
+                            // hammering the rate-limited upstream (#301).
+                            res.writeHead(outcome.status, {
+                                "content-type": "application/json",
+                                ...(outcome.status === 503 ? { "retry-after": "30" } : {}),
+                            });
+                            res.end(JSON.stringify({
+                                error: {
+                                    type: "server_error",
+                                    code: "preflight_compress_failed",
+                                    message: outcome.message,
+                                    retryable: outcome.retryable,
+                                },
+                            }));
+                        }
+                        return;
+                    }
+                    prepared = outcome;
                 }
                 await forward(req, res, opts, prepared!.body, prepared!, core, reqConfig, log, route, instanceId, affinity);
                 // Remember for ALL modes (not just plugin): wire clients (dsh,
@@ -1723,6 +1747,23 @@ function buildForwardTarget(
 // the model sees it), so the session would be stuck. Compress oldest
 // compressible ranges first (summarization calls sized to fit the smaller
 // window), then rebuild the payload.
+/** Fail-fast outcome (#301): the payload still overflows the window and
+ *  preflight could not fix it, so the proxy answers with a structured error
+ *  instead of forwarding a guaranteed-400 payload (wasted quota + retry
+ *  storms). */
+interface PreflightFailFast {
+    failFast: true;
+    status: number;
+    message: string;
+    retryable: boolean;
+    /** False when the client already disconnected — there is nothing to write. */
+    respond: boolean;
+}
+
+function isPreflightFailFast(outcome: Prepared | PreflightFailFast): outcome is PreflightFailFast {
+    return "failFast" in outcome;
+}
+
 async function preflightCompressIfNeeded(
     prepared: Prepared,
     runPrepare: () => Prepared,
@@ -1736,15 +1777,35 @@ async function preflightCompressIfNeeded(
     affinity: string | undefined,
     log: (level: string, msg: string) => void,
     instanceId: string,
-): Promise<Prepared> {
+): Promise<Prepared | PreflightFailFast> {
     const session = prepared.session;
     const limit = config.modelContextLimit;
     // A fresh session (id rotated, e.g. after a model switch) has
     // lastInputTokens = 0 while still carrying a full raw history; size the
     // trigger on the real post-fold payload too.
-    const tokenCount = Math.max(session.stats.lastInputTokens, estimateCoreMessages(prepared.processedMessages));
+    const payloadEstimate = estimateCoreMessages(prepared.processedMessages);
+    const tokenCount = Math.max(session.stats.lastInputTokens, payloadEstimate);
     if (limit <= 0 || !model || tokenCount < limit) return prepared;
-    if ((prepared.nudge?.compressibleRanges ?? []).length === 0) return prepared;
+    // #301: forwarding as-is is safe ONLY when the payload's own estimate
+    // fits the window. The trigger (and the loop's fit check) floor on
+    // session.stats.lastInputTokens, which can be stale — e.g. a
+    // double-counted usage report (#300) — and must not turn a fitting
+    // payload into a fail-fast false positive.
+    const failFast = (status: number, detail: string, retryable: boolean): PreflightFailFast => {
+        const message =
+            `context ~${tokenCount} tokens exceeds the model window ${limit} (model=${model}) ` +
+            `and preflight compression could not bring it under: ${detail}. ` +
+            `The over-window payload was NOT forwarded.`;
+        log("error", `[${session.id}] preflight fail-fast ${status} (retryable=${retryable}): ${message}`);
+        return { failFast: true, status, message, retryable, respond: !res.writableEnded };
+    };
+    if ((prepared.nudge?.compressibleRanges ?? []).length === 0) {
+        if (payloadEstimate < limit) {
+            log("warn", `[${session.id}] preflight trigger fired on a stale baseline (~${tokenCount}) but the payload fits (~${payloadEstimate}/${limit}); forwarding as-is`);
+            return prepared;
+        }
+        return failFast(502, "no part of the conversation is compressible (nothing left to fold)", false);
+    }
     log("warn", `[${session.id}] context ${tokenCount} tokens exceeds model window ${limit} (model=${model}); preflight compressing before forward`);
     // #300: stamp the chain marker so a downstream bili skips these
     // summarization calls too (preflight always processes).
@@ -1770,16 +1831,27 @@ async function preflightCompressIfNeeded(
         },
         prepared.originalMessages,
     );
-    if (result.compressedRanges > 0) {
-        log("info", `[${session.id}] preflight compressed ${result.compressedRanges} range(s), ~${result.savedTokens} tokens saved (${tokenCount} → ${session.stats.lastInputTokens}) in ${Date.now() - started}ms; rebuilding payload`);
-        const rebuilt = runPrepare();
-        // runPrepare re-incremented stats.requests; the rebuild is internal
-        // to this single client request.
-        session.stats.requests -= 1;
-        return rebuilt;
+    if (result.payloadEstimate < limit) {
+        if (result.compressedRanges > 0) {
+            log("info", `[${session.id}] preflight compressed ${result.compressedRanges} range(s), ~${result.savedTokens} tokens saved (${tokenCount} → ${session.stats.lastInputTokens}) in ${Date.now() - started}ms; rebuilding payload`);
+            const rebuilt = runPrepare();
+            // runPrepare re-incremented stats.requests; the rebuild is internal
+            // to this single client request.
+            session.stats.requests -= 1;
+            return rebuilt;
+        }
+        log("warn", `[${session.id}] preflight made no progress but the payload fits (~${result.payloadEstimate}/${limit}); forwarding as-is`);
+        return prepared;
     }
-    log("warn", `[${session.id}] preflight could not compress enough (~${result.savedTokens} tokens saved); forwarding as-is`);
-    return prepared;
+    // The payload still overflows the window: fail fast with a diagnostic
+    // error instead of forwarding a guaranteed-400 payload (#301).
+    const f = result.failure;
+    if (f?.kind === "aborted") {
+        log("warn", `[${session.id}] preflight aborted (${f.detail}); not forwarding`);
+        return { failFast: true, status: 0, message: f.detail, retryable: false, respond: false };
+    }
+    const status = f?.kind === "upstream" && f.status === 429 ? 503 : 502;
+    return failFast(status, f?.detail ?? "unknown reason", status === 503);
 }
 
 async function forward(

--- a/tests/preflight-fail-fast.test.ts
+++ b/tests/preflight-fail-fast.test.ts
@@ -1,0 +1,227 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import { once } from "node:events";
+import test from "node:test";
+
+process.env.NODE_ENV = "test";
+// Fail fast on the very first 429 instead of the default 3 attempts with
+// exponential backoff — these tests are about the post-retry behavior.
+process.env.BILI_REPLAY_RETRY_MAX = "1";
+
+import { defaultConfig } from "acp-kernel";
+import { startServer, type ProxyOptions } from "../src/server.ts";
+import { SessionStore, _setStoreForTest } from "../src/persist.ts";
+import { _setForTest as setRegistryForTest } from "../src/registry.ts";
+
+// #301: when preflight (overflow) compression cannot proceed — the summary
+// upstream is rate-limiting, or the compress budget is exhausted — the proxy
+// must FAIL FAST with a structured error instead of forwarding the over-window
+// payload as-is (guaranteed upstream 400, wasted quota, client retry storms;
+// log evidence in #292). Forwarding as-is stays legal ONLY when the payload's
+// own estimate actually fits the window (the trigger floors on
+// stats.lastInputTokens, which can be stale — #300 double-counted usage).
+
+function okSse(inputTokens: number): string {
+    return (
+        `event: message_start\ndata: ${JSON.stringify({ type: "message_start", message: { id: "m1", role: "assistant", usage: { input_tokens: inputTokens } } })}\n\n` +
+        `event: content_block_start\ndata: ${JSON.stringify({ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } })}\n\n` +
+        `event: content_block_delta\ndata: ${JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "ok" } })}\n\n` +
+        `event: content_block_stop\ndata: ${JSON.stringify({ type: "content_block_stop", index: 0 })}\n\n` +
+        `event: message_delta\ndata: ${JSON.stringify({ type: "message_delta", delta: { stop_reason: "end_turn", stop_sequence: null }, usage: { output_tokens: 3 } })}\n\n` +
+        `event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`
+    );
+}
+
+function bigConversation(): Array<{ role: string; content: string }> {
+    const msgs: Array<{ role: string; content: string }> = [];
+    for (let i = 0; i < 12; i++) {
+        const role = i % 2 === 0 ? "user" : "assistant";
+        const filler = `MARKER_${i}_content_`.repeat(250);
+        msgs.push({ role, content: `Message ${i} of the long conversation. ${filler}` });
+    }
+    return msgs;
+}
+
+type Call = { stream: boolean; body: string };
+
+function makeUpstream429(calls?: Call[]): http.Server {
+    return http.createServer((req, res) => {
+        const chunks: Buffer[] = [];
+        req.on("data", (c: Buffer) => chunks.push(c));
+        req.on("end", () => {
+            const raw = Buffer.concat(chunks).toString("utf8");
+            let parsed: { stream?: boolean } = {};
+            try { parsed = JSON.parse(raw); } catch { /* keep {} */ }
+            calls?.push({ stream: !!parsed.stream, body: raw });
+            if (parsed.stream) {
+                res.writeHead(200, { "content-type": "text/event-stream" });
+                res.end(okSse(1000));
+            } else {
+                res.writeHead(429, { "content-type": "application/json" });
+                res.end(JSON.stringify({ error: { message: "rate limited", type: "rate_limit_error" } }));
+            }
+        });
+    });
+}
+
+function startProxy(upstreamPort: number, models: Record<string, { context: number }>): Promise<http.Server> {
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    setRegistryForTest({});
+    return startServer({
+        port: 0,
+        host: "127.0.0.1",
+        upstream: "http://127.0.0.1",
+        routes: { [`http://127.0.0.1:${upstreamPort}`]: { models } },
+        modelContextLimit: 400_000,
+        kernelConfig: defaultConfig(400_000),
+        compress: { injectTool: true, injectNudge: true },
+        promptCache: { routing: "auto" },
+        sessionHeader: "x-acp-session",
+        log: false,
+        debug: false,
+        passthrough: false,
+        autoUpdate: false,
+        mitm: { enabled: false, domains: [] },
+    } as ProxyOptions);
+}
+
+test("e2e #301: overflow + summary upstream 429 → structured 503, over-window payload NOT forwarded", async () => {
+    const calls: Call[] = [];
+    // The preflight summarization call hits the same rate-limited upstream as
+    // the main request (the #292 scenario).
+    const upstream = makeUpstream429(calls);
+    upstream.listen(0, "127.0.0.1");
+    await once(upstream, "listening");
+    const upstreamPort = upstream.address().port;
+
+    const proxy = await startProxy(upstreamPort, { "claude-small": { context: 10_000 } });
+    await once(proxy, "listening");
+    const proxyPort = proxy.address().port;
+
+    try {
+        // Fresh session: a ~13k-token history against a 10k window — the
+        // payload itself overflows, preflight fires, its summarization call
+        // 429s. The proxy must fail fast, NOT forward the over-window body.
+        const r = await fetch(`http://127.0.0.1:${proxyPort}/bili/http://127.0.0.1:${upstreamPort}/v1/messages`, {
+            method: "POST",
+            headers: { "content-type": "application/json", "x-acp-session": "preflight-429-sess" },
+            body: JSON.stringify({ model: "claude-small", max_tokens: 1024, stream: true, messages: bigConversation() }),
+        });
+        assert.equal(r.status, 503, "fail-fast 503 when the summary upstream rate-limits");
+        const json = JSON.parse(await r.text()) as { error?: { type?: string; code?: string; message?: string; retryable?: boolean } };
+        assert.equal(json.error?.type, "server_error");
+        assert.equal(json.error?.code, "preflight_compress_failed");
+        assert.equal(json.error?.retryable, true);
+        assert.ok(json.error?.message?.includes("429"), `message names the cause (got: ${json.error?.message})`);
+        assert.ok(json.error?.message?.includes("NOT forwarded"), `message states the payload was withheld (got: ${json.error?.message})`);
+        assert.equal(calls.filter((c) => c.stream).length, 0, "the over-window payload was NOT forwarded upstream");
+        assert.ok(calls.filter((c) => !c.stream).length >= 1, "preflight attempted the (429'd) summarization call");
+    } finally {
+        proxy.close();
+        await once(proxy, "close");
+        upstream.close();
+        await once(upstream, "close");
+    }
+});
+
+test("e2e #301: payload fits the window + preflight 429 → request still forwarded (no false positive)", async () => {
+    const calls: Call[] = [];
+    let streamCalls = 0;
+    const upstream = http.createServer((req, res) => {
+        const chunks: Buffer[] = [];
+        req.on("data", (c: Buffer) => chunks.push(c));
+        req.on("end", () => {
+            const raw = Buffer.concat(chunks).toString("utf8");
+            let parsed: { stream?: boolean } = {};
+            try { parsed = JSON.parse(raw); } catch { /* keep {} */ }
+            calls.push({ stream: !!parsed.stream, body: raw });
+            if (parsed.stream) {
+                streamCalls += 1;
+                // The first forward (big model) reports a 300k-token context
+                // — a stale floor for the later small-model request.
+                res.writeHead(200, { "content-type": "text/event-stream" });
+                res.end(okSse(streamCalls === 1 ? 300_000 : 1000));
+            } else {
+                res.writeHead(429, { "content-type": "application/json" });
+                res.end(JSON.stringify({ error: { message: "rate limited", type: "rate_limit_error" } }));
+            }
+        });
+    });
+    upstream.listen(0, "127.0.0.1");
+    await once(upstream, "listening");
+    const upstreamPort = upstream.address().port;
+
+    const proxy = await startProxy(upstreamPort, {
+        "claude-big": { context: 400_000 },
+        "claude-small": { context: 20_000 },
+    });
+    await once(proxy, "listening");
+    const proxyPort = proxy.address().port;
+
+    try {
+        const headers = { "content-type": "application/json", "x-acp-session": "preflight-fits-429-sess" };
+
+        const r1 = await fetch(`http://127.0.0.1:${proxyPort}/bili/http://127.0.0.1:${upstreamPort}/v1/messages`, {
+            method: "POST",
+            headers,
+            body: JSON.stringify({ model: "claude-big", max_tokens: 1024, stream: true, messages: [{ role: "user", content: "hello" }] }),
+        });
+        assert.equal(r1.status, 200);
+        await r1.text();
+
+        // The ~13k-token conversation FITS the 20k window, but the trigger
+        // fires on the stale 300k floor: preflight runs, its summarization
+        // call 429s — and the proxy must STILL forward the fitting payload.
+        const r2 = await fetch(`http://127.0.0.1:${proxyPort}/bili/http://127.0.0.1:${upstreamPort}/v1/messages`, {
+            method: "POST",
+            headers,
+            body: JSON.stringify({ model: "claude-small", max_tokens: 1024, stream: true, messages: bigConversation() }),
+        });
+        assert.equal(r2.status, 200, "a fitting payload is forwarded even when preflight 429s");
+        await r2.text();
+
+        assert.ok(calls.filter((c) => !c.stream).length >= 1, "preflight did attempt the (429'd) summarization call");
+        assert.equal(calls.filter((c) => c.stream).length, 2, "both requests were forwarded upstream");
+    } finally {
+        proxy.close();
+        await once(proxy, "close");
+        upstream.close();
+        await once(upstream, "close");
+    }
+});
+
+test("e2e #301: over-window payload with nothing compressible → structured 502, no summary call, no forward", async () => {
+    const calls: Call[] = [];
+    const upstream = makeUpstream429(calls);
+    upstream.listen(0, "127.0.0.1");
+    await once(upstream, "listening");
+    const upstreamPort = upstream.address().port;
+
+    const proxy = await startProxy(upstreamPort, { "claude-small": { context: 10_000 } });
+    await once(proxy, "listening");
+    const proxyPort = proxy.address().port;
+
+    try {
+        // A single ~12k-token message against a 10k window: over-window, but
+        // the kernel never folds the lone (first) user message → no
+        // compressible ranges → preflight cannot proceed at all.
+        const filler = "FILLER_".repeat(7000);
+        const r = await fetch(`http://127.0.0.1:${proxyPort}/bili/http://127.0.0.1:${upstreamPort}/v1/messages`, {
+            method: "POST",
+            headers: { "content-type": "application/json", "x-acp-session": "preflight-exhausted-sess" },
+            body: JSON.stringify({ model: "claude-small", max_tokens: 1024, stream: true, messages: [{ role: "user", content: filler }] }),
+        });
+        assert.equal(r.status, 502, "fail-fast 502 when nothing is compressible");
+        const json = JSON.parse(await r.text()) as { error?: { code?: string; message?: string; retryable?: boolean } };
+        assert.equal(json.error?.code, "preflight_compress_failed");
+        assert.equal(json.error?.retryable, false);
+        assert.ok(json.error?.message?.includes("NOT forwarded"), `message states the payload was withheld (got: ${json.error?.message})`);
+        assert.equal(calls.filter((c) => !c.stream).length, 0, "no summarization call was spent on an incompressible payload");
+        assert.equal(calls.filter((c) => c.stream).length, 0, "the over-window payload was NOT forwarded upstream");
+    } finally {
+        proxy.close();
+        await once(proxy, "close");
+        upstream.close();
+        await once(upstream, "close");
+    }
+});


### PR DESCRIPTION
## What changed

When preflight (overflow) compression cannot proceed, the proxy previously gave up and **forwarded the original over-window payload unchanged** (`src/server.ts:1677` logged "forwarding as-is") — a guaranteed upstream 400, wasted quota, and client retry storms (log evidence in #292: 261K-token payload forwarded after both summary attempts 429'd).

Now it **fails fast** with a structured error instead:

- `503` + `Retry-After: 30` when the summary upstream returned 429 (rate limited — retryable)
- `502` for other upstream errors (5xx, network) or an exhausted compress budget (no compressible ranges left / nothing to fold)
- Body: `{ "error": { "type": "server_error", "code": "preflight_compress_failed", "message": "...", "retryable": true|false } }` — the message names the cause (e.g. `the summarization call was rate-limited by the upstream (HTTP 429)`) and states the payload was NOT forwarded.
- No response write when the client already disconnected (abort is detected, forward skipped).

**Forwarding as-is stays legal only when the payload's own estimate fits the window.** The trigger and the loop's fit check floor on `session.stats.lastInputTokens`, which can be stale (double-counted usage, #300) — the new `PreflightResult.payloadEstimate` (payload-only estimate, no floor) is the gate for the forward/fail-fast decision, so a fitting payload is never failed fast on a stale baseline (no false positive).

## Details

- `src/preflight.ts` — `PreflightResult` gains `payloadEstimate` + `failure` (`kind: "upstream" | "exhausted" | "aborted"`, HTTP status for upstream failures). Every loop break path now records its reason.
- `src/server.ts` — `preflightCompressIfNeeded` returns `Prepared | PreflightFailFast`; the call site writes the structured error and skips `forward()`. The "no compressible ranges" early-out gets the same fits-gate (forward if it actually fits, fail fast otherwise).
- Backoff already exists in `fetchWithRetry` (3 attempts, exponential 1.5s base, tunable via `BILI_REPLAY_RETRY_MAX` / `BILI_REPLAY_RETRY_BASE_MS`), so the optional separate-summary-model config from the issue is not included here.

## Tests (`tests/preflight-fail-fast.test.ts`, 3 new e2e)

1. **Overflow + summary upstream 429** → client gets structured 503 (`code: preflight_compress_failed`, message names 429), and **zero** stream forwards reach the upstream.
2. **Payload fits window (20k) + stale 300k baseline + preflight 429** → request still forwarded (200) — no false positive.
3. **Over-window payload with nothing compressible** (single 12k-token message, 10k window) → structured 502, no summarization call spent, no forward.

## Pre-flight

- `npm run typecheck` — clean
- `npm test` — 694/694 pass (691 existing + 3 new)
- `npm run build` — success