### PR TITLE
feat: #189 compress observability + gated staged/tail-bias steering (smooth transition)

### DIFF
--- a/src/compress-loop-responses.ts
+++ b/src/compress-loop-responses.ts
@@ -5,7 +5,7 @@ import {
     type Config,
     type CoreMessage,
 } from "acp-kernel";
-import type { Session } from "./session.js";
+import { lastCompressSuffix, type Session } from "./session.js";
 import { parseCompressInput, PROXY_TOOL_NAMES, MUTATING_PROXY_TOOLS, COMPRESS_TOOL_NAME, ACP_TEXT_OPEN, ACP_TEXT_CLOSE } from "./compress-tool.js";
 import { log as loggerLog } from "./logger.js";
 import { applyRanges } from "./stream.js";
@@ -219,8 +219,10 @@ export async function compressLoopResponsesJson(
             body: JSON.stringify(requestBody),
             ...(ctx.proxyUrl ? { dispatcher: proxyDispatcher(ctx.proxyUrl) } : {}),
         }, undefined, undefined, (info) => {
-            ctx.log(`[acp-proxy: responses upstream rejected replay (HTTP ${info.status}: ${info.detail.slice(0, 120)}); likely provider risk-control — retrying in ${info.delayMs}ms (attempt ${info.attempt}/${info.maxAttempts})]`);
-            loggerLog("warn", `[acp-compress-responses] upstream rejected replay (HTTP ${info.status}); retrying in ${info.delayMs}ms (attempt ${info.attempt}/${info.maxAttempts})`);
+            // #189: correlate the rejection with the rewrite that preceded it.
+            const lc = lastCompressSuffix(ctx.session.lastCompress);
+            ctx.log(`[acp-proxy: responses upstream rejected replay (HTTP ${info.status}: ${info.detail.slice(0, 120)}); likely provider risk-control — retrying in ${info.delayMs}ms (attempt ${info.attempt}/${info.maxAttempts})${lc}]`);
+            loggerLog("warn", `[acp-compress-responses] upstream rejected replay (HTTP ${info.status}); retrying in ${info.delayMs}ms (attempt ${info.attempt}/${info.maxAttempts})${lc}`);
         }).catch((e) => {
             if (e instanceof UpstreamHttpError) {
                 const suffix = e.attempts > 1 ? ` after ${e.attempts} attempt(s)` : "";

--- a/src/compress-tool.ts
+++ b/src/compress-tool.ts
@@ -10,6 +10,7 @@
  */
 import { parseCompressArgs } from "acp-kernel";
 import { log as loggerLog } from "./logger.js";
+import { maxShrinkPerCompress } from "./fetch-util.js";
 
 export {
     COMPRESS_TOOL_NAME,
@@ -53,4 +54,20 @@ export function parseCompressInput(input: unknown, callId?: string) {
         loggerLog("warn", `[acp-compress-input] rejected: kind=${diagnostics.kind} invalidItems=${diagnostics.invalidItems}${diagnostics.keys ? ` keys=[${diagnostics.keys.join(",")}]` : ""}${diagnostics.length !== undefined ? ` len=${diagnostics.length}` : ""}`);
     }
     return ranges;
+}
+
+// #189 staged-compression / prefix-survival guidance, appended to the nudge
+// text ONLY when BILI_MAX_SHRINK_PER_COMPRESS is set (the "smooth transition"
+// switch). It steers the model — at the moment it is choosing the range —
+// toward smaller, tail-biased folds so the stable prefix (m00001..foldPoint)
+// survives for prefix caching and each round's request-shape change stays
+// gentle (the sharp change is what trips provider risk-control, GLM 3007).
+const STAGED_COMPRESS_GUIDANCE =
+    "\n\n[Smooth-transition guidance: when you compress, prefer a SMALLER, TAIL-biased range — compress the most recent large content and keep the stable prefix (the earliest messages) intact. A large single rewrite changes the request shape sharply and can trip provider risk-control; smaller tail-biased folds keep the prefix cache alive and the transition gentle.]";
+
+/** Append the staged-compress guidance to a rendered nudge text. Returns the
+ *  input unchanged when the smooth-transition switch is off (default). */
+export function withStagedCompressGuidance(text: string): string {
+    if (maxShrinkPerCompress() === undefined) return text;
+    return text + STAGED_COMPRESS_GUIDANCE;
 }

--- a/src/fetch-util.ts
+++ b/src/fetch-util.ts
@@ -126,6 +126,17 @@ export function replayBaseDelayMs(): number {
     return Number.isFinite(raw) && raw >= 0 ? raw : 1500;
 }
 
+/** Max shrink FRACTION (0,1] a single compress may remove before the proxy
+ *  steers the model toward smaller, tail-biased ranges (#189 staged
+ *  compression). A rewrite larger than this is the request-shape change that
+ *  trips provider risk-control (GLM 3007); capping it keeps each round's
+ *  transition gentle and the prefix cache alive. Unset (or out of range) =
+ *  no steering (legacy behavior). Read on each call so tests can tune it live. */
+export function maxShrinkPerCompress(): number | undefined {
+    const raw = Number(process.env.BILI_MAX_SHRINK_PER_COMPRESS);
+    return Number.isFinite(raw) && raw > 0 && raw <= 1 ? raw : undefined;
+}
+
 /** Exponential backoff for the given 1-based attempt: base * 2^(attempt-1). */
 export function replayBackoffMs(attempt: number): number {
     return replayBaseDelayMs() * 2 ** (attempt - 1);

--- a/src/loop/core.ts
+++ b/src/loop/core.ts
@@ -8,7 +8,7 @@ import {
     type CoreMessage,
     type NudgeDecision,
 } from "acp-kernel";
-import type { Session } from "../session.js";
+import { lastCompressSuffix, type Session } from "../session.js";
 import type { BiliMessage } from "acp-kernel/wire";
 import {
     parseCompressInput,
@@ -441,8 +441,11 @@ export async function* runCompressLoop(
                     undefined,
                     signal,
                     (info) => {
-                        ctx.log(`[acp-proxy: upstream rejected replay (HTTP ${info.status}: ${info.detail.slice(0, 120)}); likely provider risk-control — retrying in ${info.delayMs}ms (attempt ${info.attempt}/${info.maxAttempts})]`);
-                        loggerLog("warn", `[acp-loop] upstream rejected replay (HTTP ${info.status}); retrying in ${info.delayMs}ms (attempt ${info.attempt}/${info.maxAttempts})`);
+                        // #189: correlate the rejection with the rewrite that
+                        // preceded it (shrink ratio + fold point), if any.
+                        const lc = lastCompressSuffix(ctx.session.lastCompress);
+                        ctx.log(`[acp-proxy: upstream rejected replay (HTTP ${info.status}: ${info.detail.slice(0, 120)}); likely provider risk-control — retrying in ${info.delayMs}ms (attempt ${info.attempt}/${info.maxAttempts})${lc}]`);
+                        loggerLog("warn", `[acp-loop] upstream rejected replay (HTTP ${info.status}); retrying in ${info.delayMs}ms (attempt ${info.attempt}/${info.maxAttempts})${lc}`);
                     },
                 );
 

--- a/src/preflight.ts
+++ b/src/preflight.ts
@@ -10,7 +10,7 @@ import { buildCompressSystemPrompt, parseCompressInput } from "./compress-tool.j
 import { applyRanges, type RewriteCtx } from "./stream.js";
 import { fetchWithRetry, UpstreamHttpError } from "./fetch-util.js";
 import { proxyDispatcher } from "./upstream-proxy.js";
-import type { Session } from "./session.js";
+import { lastCompressSuffix, type Session } from "./session.js";
 
 // #247: proactive pre-forward compression. When the session's real context
 // (previous turn's upstream input_tokens) exceeds the current model's window
@@ -175,7 +175,10 @@ async function summarizeRange(deps: PreflightDeps, content: string, startRef: st
         },
         undefined,
         deps.signal,
-        (info) => deps.log("warn", `[preflight] summary attempt ${info.attempt} got HTTP ${info.status}; retrying in ${info.delayMs}ms`),
+        (info) => {
+            // #189: correlate the rejection with the rewrite that preceded it.
+            deps.log("warn", `[preflight] summary attempt ${info.attempt} got HTTP ${info.status}; retrying in ${info.delayMs}ms${lastCompressSuffix(deps.session.lastCompress)}`);
+        },
     );
     try {
         const text = await response.text();

--- a/src/server.ts
+++ b/src/server.ts
@@ -40,7 +40,7 @@ import {
     subagentNamespace,
 } from "acp-kernel/wire";
 import { getSession, listSessions, type Session, initSessions, markDirty, flushAllSessions, acquireInFlight, releaseInFlight, withSessionLock, markNativeCompactionBoundary, reconcileNativeCompactionBoundary, snapshotMessages } from "./session.js";
-import { COMPRESS_TOOL, ACP_TOOLS_ANTHROPIC, ACP_TOOLS_OPENAI, ACP_TOOLS_RESPONSES, ACP_READONLY_TOOLS_RESPONSES, COMPRESS_TOOL_NAME, buildCompressSystemPrompt, buildCompressHybridSystemPrompt } from "./compress-tool.js";
+import { COMPRESS_TOOL, ACP_TOOLS_ANTHROPIC, ACP_TOOLS_OPENAI, ACP_TOOLS_RESPONSES, ACP_READONLY_TOOLS_RESPONSES, COMPRESS_TOOL_NAME, buildCompressSystemPrompt, buildCompressHybridSystemPrompt, withStagedCompressGuidance } from "./compress-tool.js";
 import { rewriteSseStream, rewriteJsonResponse, type RewriteCtx } from "./stream.js";
 import { applyRanges } from "./stream.js";
 import { preflightCompress, estimateCoreMessages } from "./preflight.js";
@@ -1105,7 +1105,7 @@ function prepareAnthropic(
             try {
                 const rendered = renderNudgeText(turn.nudge, prompts);
                 if (rendered.text) {
-                    rebuiltMessages = [...rebuiltMessages, { role: "user", content: rendered.text }];
+                    rebuiltMessages = [...rebuiltMessages, { role: "user", content: withStagedCompressGuidance(rendered.text) }];
                 }
             } catch {
             }
@@ -1203,7 +1203,7 @@ function prepareOpenai(
             try {
                 const rendered = renderNudgeText(turn.nudge, prompts);
                 if (rendered.text) {
-                    rebuiltMessages = [...rebuiltMessages, { role: "user", content: rendered.text }];
+                    rebuiltMessages = [...rebuiltMessages, { role: "user", content: withStagedCompressGuidance(rendered.text) }];
                 }
             } catch {
             }
@@ -1344,7 +1344,7 @@ function prepareResponses(
                     const inputItems: ResponseInputItem[] = typeof rebuiltInput === "string"
                         ? [{ type: "message", role: "user", content: rebuiltInput }]
                         : rebuiltInput;
-                    inputItems.push({ type: "message", role: "user", content: rendered.text });
+                    inputItems.push({ type: "message", role: "user", content: withStagedCompressGuidance(rendered.text) });
                     rebuiltInput = inputItems;
                 }
             } catch {

--- a/src/session.ts
+++ b/src/session.ts
@@ -6,6 +6,26 @@ export type BlockContent = {
     full: { text: string; count: number };
 };
 
+/** One successful compress, recorded for #189 observability: correlating a
+ *  downstream transient upstream rejection (e.g. GLM 3007 captcha) with the
+ *  context rewrite that preceded it. `shrinkRatio` is the fraction of the
+ *  pre-compress context removed by this compress; `foldPoint` is the start ref
+ *  of the earliest folded range (where the prefix structure rewrites). */
+export type LastCompressInfo = {
+    at: number;
+    shrinkRatio: number;
+    foldPoint: string;
+    blocks: number;
+    tokensCompressed: number;
+};
+
+/** Compact suffix for retry/error logs: the rewrite that may have triggered a
+ *  transient upstream rejection. Empty when no compress has been recorded. */
+export function lastCompressSuffix(info: LastCompressInfo | undefined): string {
+    if (!info) return "";
+    return ` [after compress: shrink ${Math.round(info.shrinkRatio * 100)}% foldPoint=${info.foldPoint} blocks=${info.blocks} ~${info.tokensCompressed}tok]`;
+}
+
 export type Session = {
     id: string;
     /** Identity / descriptive metadata. Populated on first request. */
@@ -92,6 +112,11 @@ export type Session = {
      *  drop a never-persisted session on flush failure (that would be a
      *  permanent loss). */
     persisted: boolean;
+    /** In-memory only (NOT persisted — buildRecord omits it): the most recent
+     *  successful compress, set by applyRanges and read by the replay/preflight
+     *  retry callbacks to correlate a transient upstream rejection with the
+     *  rewrite that preceded it (#189). A fresh process has none. */
+    lastCompress?: LastCompressInfo;
     /** Promise chain for per-session serialization. Two concurrent requests
      *  sharing a session id would interleave processTurn / stream-rewriter
      *  mutations on session.state, corrupting it. withSessionLock chains each

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -4,6 +4,7 @@ import { COMPRESS_TOOL_NAME, parseCompressInput, PROXY_TOOL_NAMES } from "./comp
 import { resolveDecompress } from "./decompress-shared.js";
 import { normalizeSseLineEndings } from "./sse-util.js";
 import { containsRenderTagText, stripAcpTags } from "./loop/tag-echo-filter.js";
+import { maxShrinkPerCompress } from "./fetch-util.js";
 
 export type RewriteCtx = {
     core: CompressionCore;
@@ -218,6 +219,12 @@ function executeAnthropicProxyTool(toolName: string, args: Record<string, unknow
     return `[Unknown proxy tool: ${toolName}]`;
 }
 
+/** Numeric part of a ref ("m00042" → 42, "b3" → 3); 0 for non-numeric. Used to
+ *  order ranges by position when picking the fold point (#189 observability). */
+function refNum(ref: string): number {
+    return Number(ref.replace(/\D/g, "")) || 0;
+}
+
 export function applyRanges(ranges: ReturnType<typeof parseCompressInput>, ctx: RewriteCtx): string {
     if (ranges.length === 0) {
         ctx.log("[acp-proxy: compress call had no valid ranges; nothing compressed.]");
@@ -264,8 +271,26 @@ export function applyRanges(ranges: ReturnType<typeof parseCompressInput>, ctx: 
             return `[Compression FAILED: ${errs}]`;
         }
 
+        // #189 observability: record the rewrite magnitude + fold point so a
+        // downstream transient rejection (GLM 3007) can be correlated with it.
+        // preContext is read BEFORE the credit netting below (lastInputTokens
+        // still holds the pre-compress context at this point).
+        const preContext = ctx.session.stats.lastInputTokens;
+        const shrinkRatio = preContext > 0 ? r.tokensCompressed / preContext : 0;
+        const foldPoint = [...ranges].sort((a, b) => refNum(a.startRef) - refNum(b.startRef))[0]?.startRef ?? "unknown";
+        ctx.session.lastCompress = { at: Date.now(), shrinkRatio, foldPoint, blocks: r.blocksCreated, tokensCompressed: r.tokensCompressed };
+        ctx.log(`[acp-compress-obs] shrink ${Math.round(shrinkRatio * 100)}% (~${r.tokensCompressed}/${preContext} tok) foldPoint=${foldPoint} blocks=${r.blocksCreated}`);
+
         const warn = r.warnings.length > 0 ? ` ${r.warnings.join("; ")}` : "";
-        const msg = `[Compressed ${detail} → ${r.blocksCreated} block(s), ~${r.tokensCompressed} tokens saved.${warn}]`;
+        let msg = `[Compressed ${detail} → ${r.blocksCreated} block(s), ~${r.tokensCompressed} tokens saved.${warn}]`;
+        // #189 staged compression (gated): a rewrite above the configured max
+        // shrink is the shape that trips provider risk-control; steer the model
+        // toward smaller, tail-biased ranges so the prefix (m00001..foldPoint)
+        // survives for prefix caching and each round's transition stays gentle.
+        const maxShrink = maxShrinkPerCompress();
+        if (maxShrink !== undefined && shrinkRatio > maxShrink) {
+            msg += ` [Staged-compress: this rewrite shrank context ${Math.round(shrinkRatio * 100)}%, above your ${Math.round(maxShrink * 100)}% per-compress target — the shape that trips provider risk-control (3007). Next time compress a SMALLER, TAIL-biased range (the most recent large content) and keep the stable prefix intact.]`;
+        }
         ctx.log(`[acp-proxy: ${msg}]`);
         // The fold materializes only at the NEXT request's processTurn; the
         // post-compress re-request re-sends the unfolded history (prefix-cache

--- a/tests/compress-observability.test.ts
+++ b/tests/compress-observability.test.ts
@@ -1,0 +1,199 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { Config, CoreMessage } from "acp-kernel";
+import { createCore, createInitialState, assignRefs, emptyRefMap, defaultConfig } from "acp-kernel";
+import type { Session, LastCompressInfo } from "../src/session.ts";
+import { lastCompressSuffix } from "../src/session.ts";
+import { maxShrinkPerCompress } from "../src/fetch-util.ts";
+import { withStagedCompressGuidance } from "../src/compress-tool.ts";
+import { parseCompressInput } from "../src/compress-tool.ts";
+import { applyRanges, type RewriteCtx } from "../src/stream.ts";
+
+type Ctx = Omit<RewriteCtx, "log"> & { log: (m: string) => void; logs: string[] };
+
+function makeCtx(messages: CoreMessage[]): Ctx {
+    const logs: string[] = [];
+    return {
+        core: createCore(),
+        config: defaultConfig(200000),
+        messages,
+        session: {
+            id: "compress-obs-test",
+            meta: {},
+            stats: { requests: 0, tokensSaved: 0, inputTokens: 0, cachedTokens: 0, outputTokens: 0, cacheSamples: 0, lastInputTokens: 0, compressCreditTokens: 0, contextTokens: 0 },
+            metadata: {},
+            state: createInitialState(),
+            createdAt: Date.now(),
+            lastSeen: Date.now(),
+            blockContents: new Map(),
+            inFlight: 0,
+            persisted: false,
+        },
+        log: (m: string) => { logs.push(m); },
+        logs,
+    };
+}
+
+function withRefs(ctx: Ctx): Ctx {
+    const res = assignRefs(ctx.messages, { existing: emptyRefMap(), nextIndex: 0 });
+    ctx.session.state.messageRefs = res.map;
+    return ctx;
+}
+
+function textMsg(id: string, role: "user" | "assistant", text: string): CoreMessage {
+    return { id, role, contentType: "text", text };
+}
+
+function makeCompressibleCtx(): Ctx {
+    return withRefs(makeCtx([
+        textMsg("raw_1", "user", "x".repeat(20000)),
+        textMsg("raw_2", "assistant", "x".repeat(20000)),
+        textMsg("raw_3", "user", "x".repeat(5000)),
+        textMsg("raw_4", "assistant", "x".repeat(5000)),
+        textMsg("raw_5", "user", "x".repeat(5000)),
+        textMsg("raw_6", "assistant", "x".repeat(5000)),
+        textMsg("raw_7", "user", "x".repeat(5000)),
+    ]));
+}
+
+const COMPRESS_ARGS = { content: [{ startId: "m00001", endId: "m00002", summary: "OBS-TEST-SUMMARY-PAYLOAD-LONG-ENOUGH-FOR-THE-KERNEL-MIN-LENGTH-CHECK" }] };
+
+function runApply(ctx: Ctx, args: unknown): string {
+    const ranges = parseCompressInput(args);
+    return applyRanges(ranges, ctx);
+}
+
+test("#189: applyRanges records lastCompress (shrink ratio + fold point) and logs observability", () => {
+    const ctx = makeCompressibleCtx();
+    ctx.session.stats.lastInputTokens = 100000;
+    const out = runApply(ctx, COMPRESS_ARGS);
+    assert.ok(out.startsWith("[Compressed"), `expected success, got: ${out}`);
+    const lc = ctx.session.lastCompress;
+    assert.ok(lc, "lastCompress recorded");
+    assert.ok(lc!.shrinkRatio > 0, `shrinkRatio > 0 (got ${lc!.shrinkRatio})`);
+    assert.ok(lc!.shrinkRatio <= 1, `shrinkRatio <= 1 (got ${lc!.shrinkRatio})`);
+    assert.equal(lc!.foldPoint, "m00001", "fold point is the earliest range start");
+    assert.ok(lc!.blocks >= 1, "blocks >= 1");
+    assert.ok(lc!.tokensCompressed > 0, "tokensCompressed > 0");
+    assert.ok(lc!.at > 0, "timestamp set");
+    const obs = ctx.logs.find((l) => l.includes("[acp-compress-obs]"));
+    assert.ok(obs, "observability line logged");
+    assert.ok(obs!.includes("foldPoint=m00001"), `obs has fold point: ${obs}`);
+    assert.ok(obs!.includes("shrink"), `obs has shrink: ${obs}`);
+});
+
+test("#189: fold point picks the EARLIEST range start across multiple ranges", () => {
+    const ctx = makeCompressibleCtx();
+    ctx.session.stats.lastInputTokens = 100000;
+    const args = { content: [
+        { startId: "m00005", endId: "m00006", summary: "OBS-TEST-SUMMARY-PAYLOAD-LONG-ENOUGH-FOR-THE-KERNEL-MIN-LENGTH-CHECK" },
+        { startId: "m00001", endId: "m00002", summary: "OBS-TEST-SUMMARY-PAYLOAD-LONG-ENOUGH-FOR-THE-KERNEL-MIN-LENGTH-CHECK" },
+    ] };
+    runApply(ctx, args);
+    assert.equal(ctx.session.lastCompress?.foldPoint, "m00001", "earliest start wins regardless of arg order");
+});
+
+test("#189: no pre-compress context → shrinkRatio 0 (no div-by-zero), still records", () => {
+    const ctx = makeCompressibleCtx();
+    ctx.session.stats.lastInputTokens = 0;
+    const out = runApply(ctx, COMPRESS_ARGS);
+    assert.ok(out.startsWith("[Compressed"), `expected success, got: ${out}`);
+    assert.equal(ctx.session.lastCompress?.shrinkRatio, 0, "shrinkRatio 0 when preContext is 0");
+});
+
+test("#189: failed compress records no lastCompress", () => {
+    const ctx = makeCompressibleCtx();
+    ctx.session.stats.lastInputTokens = 100000;
+    // Sub-viability range (kernel minCompressRange) → compress FAILS.
+    const badArgs = { content: [{ startId: "m00007", endId: "m00007", summary: "s" }] };
+    const out = runApply(ctx, badArgs);
+    assert.ok(out.startsWith("[Compression FAILED"), `expected failure, got: ${out}`);
+    assert.equal(ctx.session.lastCompress, undefined, "no lastCompress on failure");
+});
+
+test("#189: staged-compress steering note appended when shrink exceeds the configured max", () => {
+    const prev = process.env.BILI_MAX_SHRINK_PER_COMPRESS;
+    process.env.BILI_MAX_SHRINK_PER_COMPRESS = "0.05";
+    try {
+        const ctx = makeCompressibleCtx();
+        ctx.session.stats.lastInputTokens = 100000;
+        const out = runApply(ctx, COMPRESS_ARGS);
+        assert.ok(out.includes("[Staged-compress:"), `steering note present: ${out}`);
+        assert.ok(out.includes("TAIL-biased"), "note steers toward tail-biased ranges");
+    } finally {
+        if (prev === undefined) delete process.env.BILI_MAX_SHRINK_PER_COMPRESS;
+        else process.env.BILI_MAX_SHRINK_PER_COMPRESS = prev;
+    }
+});
+
+test("#189: no steering note when the switch is off (default)", () => {
+    const prev = process.env.BILI_MAX_SHRINK_PER_COMPRESS;
+    delete process.env.BILI_MAX_SHRINK_PER_COMPRESS;
+    try {
+        const ctx = makeCompressibleCtx();
+        ctx.session.stats.lastInputTokens = 100000;
+        const out = runApply(ctx, COMPRESS_ARGS);
+        assert.ok(!out.includes("[Staged-compress:"), `no note when switch off: ${out}`);
+    } finally {
+        if (prev !== undefined) process.env.BILI_MAX_SHRINK_PER_COMPRESS = prev;
+    }
+});
+
+test("#189: no steering note when shrink is under the configured max", () => {
+    const prev = process.env.BILI_MAX_SHRINK_PER_COMPRESS;
+    process.env.BILI_MAX_SHRINK_PER_COMPRESS = "0.9";
+    try {
+        const ctx = makeCompressibleCtx();
+        ctx.session.stats.lastInputTokens = 100000;
+        const out = runApply(ctx, COMPRESS_ARGS);
+        assert.ok(!out.includes("[Staged-compress:"), `no note when under max: ${out}`);
+    } finally {
+        if (prev === undefined) delete process.env.BILI_MAX_SHRINK_PER_COMPRESS;
+        else process.env.BILI_MAX_SHRINK_PER_COMPRESS = prev;
+    }
+});
+
+test("#189: lastCompressSuffix formats the correlation; empty when unset", () => {
+    assert.equal(lastCompressSuffix(undefined), "");
+    const info: LastCompressInfo = { at: 123, shrinkRatio: 0.57, foldPoint: "m00100", blocks: 3, tokensCompressed: 74000 };
+    const s = lastCompressSuffix(info);
+    assert.ok(s.includes("shrink 57%"), s);
+    assert.ok(s.includes("foldPoint=m00100"), s);
+    assert.ok(s.includes("blocks=3"), s);
+    assert.ok(s.includes("~74000tok"), s);
+});
+
+test("#189: maxShrinkPerCompress parses the env fraction; rejects out-of-range", () => {
+    const prev = process.env.BILI_MAX_SHRINK_PER_COMPRESS;
+    try {
+        delete process.env.BILI_MAX_SHRINK_PER_COMPRESS;
+        assert.equal(maxShrinkPerCompress(), undefined, "unset → undefined");
+        process.env.BILI_MAX_SHRINK_PER_COMPRESS = "0.3";
+        assert.equal(maxShrinkPerCompress(), 0.3, "valid fraction");
+        process.env.BILI_MAX_SHRINK_PER_COMPRESS = "0";
+        assert.equal(maxShrinkPerCompress(), undefined, "0 → undefined");
+        process.env.BILI_MAX_SHRINK_PER_COMPRESS = "1.5";
+        assert.equal(maxShrinkPerCompress(), undefined, ">1 → undefined");
+        process.env.BILI_MAX_SHRINK_PER_COMPRESS = "abc";
+        assert.equal(maxShrinkPerCompress(), undefined, "non-numeric → undefined");
+    } finally {
+        if (prev === undefined) delete process.env.BILI_MAX_SHRINK_PER_COMPRESS;
+        else process.env.BILI_MAX_SHRINK_PER_COMPRESS = prev;
+    }
+});
+
+test("#189: withStagedCompressGuidance appends only when the switch is on", () => {
+    const prev = process.env.BILI_MAX_SHRINK_PER_COMPRESS;
+    try {
+        delete process.env.BILI_MAX_SHRINK_PER_COMPRESS;
+        assert.equal(withStagedCompressGuidance("NUDGE"), "NUDGE", "off → unchanged");
+        process.env.BILI_MAX_SHRINK_PER_COMPRESS = "0.3";
+        const out = withStagedCompressGuidance("NUDGE");
+        assert.ok(out.startsWith("NUDGE"), "keeps the original nudge");
+        assert.ok(out.includes("Smooth-transition guidance"), "appends guidance");
+        assert.ok(out.includes("TAIL-biased"), "steers toward tail-biased ranges");
+    } finally {
+        if (prev === undefined) delete process.env.BILI_MAX_SHRINK_PER_COMPRESS;
+        else process.env.BILI_MAX_SHRINK_PER_COMPRESS = prev;
+    }
+});


### PR DESCRIPTION
## What
Lands request 2 (「平滑压缩过渡」/ smooth compression transition) from #189 — the structural fix for the GLM 3007 (`captcha verify failed`) that fires on the post-compress acp-loop replay request after a large context rewrite (131K→57K). Built on the already-shipped retry (`7fae454`), which makes 3007 recoverable; this lowers the *rate*.

Three parts:

1. **Observability (always on)** — `applyRanges` now records the last successful compress on the session (shrink ratio, fold point, blocks, tokens) and logs an `[acp-compress-obs] shrink N% (~X/Y tok) foldPoint=Z blocks=N` line per compress. This is the 「观测先行」 step: data before validating a fix.

2. **3007 correlation** — the replay/preflight retry callbacks (`src/loop/core.ts`, `src/compress-loop-responses.ts`, `src/preflight.ts`) now append `[after compress: shrink N% foldPoint=X blocks=N ~Ntok]` to the risk-control retry log, so a transient upstream rejection is correlated with the rewrite that preceded it.

3. **Staged compression + prefix survival (gated)** — behind `BILI_MAX_SHRINK_PER_COMPRESS` (a fraction in (0,1]; unset/out-of-range = off, legacy behavior). When a single compress shrinks context more than the configured fraction, the tool result steers the model toward a *smaller, TAIL-biased* range (compress the most recent large content, keep the stable prefix `m00001..foldPoint` intact), and the nudge text gains a smooth-transition guidance block. Rationale: the sharp request-shape change is what trips provider risk-control, and a late fold point keeps the prefix cache alive.

### Design notes
- **Staged compression is a soft steer, not a hard range-split.** A hard split would force the model's single full-range summary onto a sub-range (summary/range mismatch → quality loss). Since the shipped retry already makes 3007 recoverable (correctness), this is an optimization to cut the rate, so steering the model's *next* range choice is appropriate and safe.
- **Tail-bias is appended to the nudge text** (the moment the model picks the range) via a proxy-side append — it does NOT touch the kernel's load-bearing prompts, so there's no summary-quality regression risk.
- **Env var, not a file setting**, matching the existing retry-config pattern (`BILI_REPLAY_RETRY_MAX` / `BILI_REPLAY_RETRY_BASE_MS` in `src/fetch-util.ts`) and avoiding threading a new field through `RewriteCtx` + the three-level compress-config merge. One knob acts as both the switch and the threshold.
- `session.lastCompress` is **in-memory only** (not persisted) — a fresh process has none, which is correct (the correlation is only meaningful within a process that just compressed).

## Pre-flight
- `npm run typecheck` — clean
- `npm test` — 708 pass / 0 fail (698 prior + 10 new in `tests/compress-observability.test.ts`)
- `npm run build` — success

## Verify (reporter)
1. Update to the release containing this (≥ v0.1.60).
2. Set `BILI_MAX_SHRINK_PER_COMPRESS=0.3` (or your target per-compress shrink).
3. Run your 5×3007 scenario; watch the `[acp-compress-obs]` and the retry logs (now correlated with the preceding compress). Confirm the 3007 rate drops and the model starts choosing smaller, tail-biased ranges.

Issue stays open until the rate is thoroughly down (owner instruction).
