### PR TITLE
feat: opt-in content-fingerprint sessions for header-less clients (#286, #309)

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -107,6 +107,13 @@ Top-level keys that control how the proxy listens and behaves globally.
 - **Status:** ACTIVE
 - **Description:** Forward every request to the upstream **without** compression, tool injection, or nudging. Equivalent to `ACP_PASSTHROUGH=1`. Handy for A/B comparison against the uncompressed baseline.
 
+### `allowFingerprintSessions`
+
+- **Type:** `boolean`
+- **Default:** `false`
+- **Status:** ACTIVE
+- **Description:** #286 opt-in (issue #309). When `true`, requests that carry **no** client-provided conversation id (no session header, no body `session_id`/`prompt_cache_key`) fall back to a content-fingerprint session — keyed by the 4-dimension hash `(protocol, upstream, credential, content)` so different accounts/upstreams never share compression state — instead of being rejected with `400`. Anonymous sessions are logged with a warning and labeled `[fingerprint]` in the web UI. Keep `false` (the default) to preserve #286's hard-reject semantics. See the README *Third-party harnesses* section.
+
 ### `proxy`
 
 - **Type:** `string`
@@ -332,6 +339,7 @@ Environment variables take precedence over the config file. They are useful for 
 |----------|--------|
 | `ACP_DEBUG` | Set to `1` for verbose logging (same as `"debug": true`). |
 | `ACP_PASSTHROUGH` | Set to `1` to forward without compression (same as `"passthrough": true`). |
+| `BILI_ALLOW_FINGERPRINT_SESSIONS` | Set to `1` to let header-less (anonymous) requests fall back to a content-fingerprint session instead of `400` (same as `"allowFingerprintSessions": true`). See #286 / #309. |
 | `ACP_COMPRESS_TOOL` | Set to `0` to disable tool injection (same as `"compress.injectTool": false`). |
 | `ACP_COMPRESS_NUDGE` | Set to `0` to disable nudge injection (same as `"compress.injectNudge": false`). |
 | `ACP_MODEL_CONTEXT_LIMIT` | Override the context limit globally (absolute token count). |
@@ -399,6 +407,8 @@ Anything after `--` in a launcher command is passed through to the client verbat
 | `--debug` | Verbose logging |
 | `--passthrough` | Forward without compression |
 | `--no-passthrough` | Force compression on (overrides config) |
+| `--allow-fingerprint-sessions` | Let header-less (anonymous) requests fall back to a content-fingerprint session instead of `400` (#286 opt-in, #309) |
+| `--no-allow-fingerprint-sessions` | Force the #286 hard-reject for anonymous requests (overrides config) |
 | `--no-auto-update` | Disable background self-update for this run |
 | `--mitm-domain <domain>` | Extra MITM whitelist entry (repeatable; launcher only) |
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ bili --passthrough           # forward without compression (smoke-test mode)
 bili --config ~/my-bili.json # use a different config file
 bili update                  # check & install a newer version now (bypasses throttle)
 bili --no-auto-update        # disable self-update for this run
+bili --allow-fingerprint-sessions  # let header-less clients fall back to a content-fingerprint session instead of 400 (see below)
 ```
 
 Flags override env vars and the config file. `bili --help` lists them all.
@@ -201,6 +202,39 @@ notice — **restart `bili` to pick up the new version**.
 
 Disable permanently via config (`"autoUpdate": false`) or env
 (`ACP_AUTO_UPDATE=0`).
+
+### Third-party harnesses (no session headers)
+
+The proxy keys compression state on a **client-provided conversation id** — a
+header (`x-session-id`, `x-acp-session`, `x-claude-code-session-id`, …) or a
+body field (`session_id`, `prompt_cache_key`). Clients that send **none** of
+these are *anonymous* and, by default, are **rejected with 400** rather than
+silently sharing a content-fingerprint session (which has a collision surface
+and orphans state when credentials/upstream rotate — #286).
+
+- **Preferred:** launch through the matching `bili <client>` launcher. It
+  injects the session identity for you (e.g. `bili dsh` sets
+  `PI_CACHE_RETENTION=long` so dsh's pi-ai stack stamps `prompt_cache_key`
+  with the dsh session uuid) and rewrites the client's config to route through
+  the proxy — you never point the client's `baseURL` at bili by hand.
+- **Manual integration** (you changed the client's `baseURL` to bili yourself
+  and run the client directly): the client must send a conversation id. If it
+  cannot, enable the fingerprint fallback so anonymous requests get a
+  per-`(protocol, upstream, credential, content)` session instead of 400:
+
+  ```bash
+  bili --allow-fingerprint-sessions        # or env BILI_ALLOW_FINGERPRINT_SESSIONS=1
+  # or config:  "allowFingerprintSessions": true
+  ```
+
+  The id is derived from a 4-dimension key, so different accounts/upstreams
+  never share compression state. Anonymous sessions are logged with a warning
+  and labeled `[fingerprint]` in the web UI. **Trade-off:** if the client's
+  credentials or upstream change mid-conversation, the session (and its
+  compression state) orphans — the client then re-sends full history, which is
+  equivalent to starting fresh. For a harness that relies on bili for all of
+  its compression (no built-in compaction), this is the only way to keep
+  compression without the launcher.
 
 ## Configuration
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -105,6 +105,8 @@ Options (override config file / env):
   --debug                          verbose logging
   --passthrough                    forward without compression
   --no-passthrough                 force compression on (overrides config)
+  --allow-fingerprint-sessions     let header-less clients fall back to a content-fingerprint session instead of 400 (#286 opt-in, #309)
+  --no-allow-fingerprint-sessions  force the #286 hard-reject for anonymous requests (overrides config)
   --no-auto-update                 disable background self-update this run
 
 Config: ${defaultConfigFile()}
@@ -173,6 +175,12 @@ export function parseArgs(argv: string[]): Parsed {
                 break;
             case "--no-passthrough":
                 overrides.ACP_PASSTHROUGH = "0";
+                break;
+            case "--allow-fingerprint-sessions":
+                overrides.BILI_ALLOW_FINGERPRINT_SESSIONS = "1";
+                break;
+            case "--no-allow-fingerprint-sessions":
+                overrides.BILI_ALLOW_FINGERPRINT_SESSIONS = "0";
                 break;
             case "--mitm-domain": {
                 const val = argv[++i];

--- a/src/config.ts
+++ b/src/config.ts
@@ -231,6 +231,11 @@ export type ProxyOptions = {
     debug: boolean;
     dumpSse?: string;
     passthrough: boolean;
+    /** #286 opt-in (issue #309): allow requests WITHOUT a client-provided
+     *  conversation identity to fall back to a content-fingerprint session
+     *  (4-dim key protocol|upstream|apiKey|conversation) instead of 400ing.
+     *  Absent/false keeps #286's hard-reject semantics. */
+    allowFingerprintSessions?: boolean;
     autoUpdate: boolean;
     logFile?: string;
     /** MITM transparent-proxy mode. When enabled, an HTTP CONNECT handler is
@@ -349,6 +354,7 @@ export function loadOptions(env: NodeJS.ProcessEnv = process.env): ProxyOptions 
         debug: (env.ACP_DEBUG ?? (fileConfig.debug ? "1" : "0")) === "1",
         dumpSse: env.ACP_DUMP_SSE || fileConfig.dumpSse || undefined,
         passthrough: (env.ACP_PASSTHROUGH ?? (fileConfig.passthrough ? "1" : "0")) === "1",
+        allowFingerprintSessions: (env.BILI_ALLOW_FINGERPRINT_SESSIONS ?? (fileConfig.allowFingerprintSessions ? "1" : "0")) === "1",
         autoUpdate: (env.ACP_AUTO_UPDATE ?? (fileConfig.autoUpdate === false ? "0" : "1")) !== "0",
         logFile: env.ACP_LOG_FILE !== undefined ? (env.ACP_LOG_FILE || undefined) : fileConfig.logFile,
         mitm: {
@@ -380,6 +386,7 @@ type FileConfig = {
     debug?: boolean;
     dumpSse?: string;
     passthrough?: boolean;
+    allowFingerprintSessions?: boolean;
     autoUpdate?: boolean;
     upstreamProxy?: string;
     upstreamProxyMode?: string;

--- a/src/server.ts
+++ b/src/server.ts
@@ -55,7 +55,7 @@ import { sanitizeResponsesInputIds, dropWhitespaceResponsesMessages, normalizeRe
 import { rewriteOpenaiJsonResponse } from "./stream-openai.js";
 import { rewriteResponsesJsonResponse } from "./stream-responses.js";
 import { emitStreamError } from "./stream-error.js";
-import { affinityToken, clientConversationHeader, preferPromptCacheKeyIdentity, type ConversationIdentity } from "./session-id.js";
+import { affinityToken, clientConversationHeader, deriveFingerprintSessionId, preferPromptCacheKeyIdentity, type ConversationIdentity } from "./session-id.js";
 import { consumePluginRegisterFor, flushConversations, handlePluginManifest, handlePluginRegister, handlePluginStatus, handlePluginTool, loadConversations, pipePluginJson, pipePluginResponsesWithStrip, pipeThroughWithUsage, pluginAgentHeader, pluginConversationHeader, pluginReportedContextWindow, recordPluginSession, rememberPluginMessages, takePendingPluginRegister } from "./plugin.js";
 import { setupMitm, readMitmUpstream } from "./mitm.js";
 import type { BiliMessage } from "acp-kernel/wire";
@@ -813,15 +813,29 @@ async function handle(
             : protocol === "openai"
               ? (openaiIdentity?.clientProvided ?? false)
               : !!convHeader;
+        let sessionId: string;
+        let isFingerprint = false;
         if (!clientProvided) {
-            log("warn", `400: no stable conversation identity on ${protocol} request → ${upstreamOrigin}; refusing to create a content-fingerprint session (#286)`);
-            res.writeHead(400, { "content-type": "application/json" });
-            res.end(JSON.stringify(protocol === "anthropic"
-                ? { type: "error", error: { type: "invalid_request_error", message: NO_IDENTITY_MESSAGE } }
-                : { error: { type: "invalid_request_error", message: NO_IDENTITY_MESSAGE } }));
-            return;
+            if (opts.allowFingerprintSessions) {
+                // #286 opt-in (issue #309): an anonymous request (no client-provided
+                // identity) falls back to a content-fingerprint session with the
+                // pre-#286 4-dim isolation key (protocol|upstream|apiKey|conversation),
+                // so header-less third-party harnesses (dsh web, …) keep compression
+                // instead of 400ing. Different accounts/upstreams never share state.
+                sessionId = deriveFingerprintSessionId(req.headers, protocol, upstreamOrigin, conversation);
+                isFingerprint = true;
+                log("warn", `anonymous ${protocol} request → ${upstreamOrigin}: content-fingerprint session ${sessionId} (allowFingerprintSessions=true, #286 opt-in; state orphans if credentials/upstream rotate)`);
+            } else {
+                log("warn", `400: no stable conversation identity on ${protocol} request → ${upstreamOrigin}; refusing to create a content-fingerprint session (#286)`);
+                res.writeHead(400, { "content-type": "application/json" });
+                res.end(JSON.stringify(protocol === "anthropic"
+                    ? { type: "error", error: { type: "invalid_request_error", message: NO_IDENTITY_MESSAGE } }
+                    : { error: { type: "invalid_request_error", message: NO_IDENTITY_MESSAGE } }));
+                return;
+            }
+        } else {
+            sessionId = conversation;
         }
-        const sessionId = conversation;
         // Two separate uses of the conversation signal:
         //  - `affinity`: header value forwarded upstream for sticky-routing /
         //    cache pools. Synthesized as ses_<conversation> when the client
@@ -840,7 +854,7 @@ async function handle(
         const clientLabel = bodyIdentity?.clientProvided
             ? bodyIdentity.value
             : clientConversationHeader(req.headers);
-        const session = getSession(sessionId, { protocol, upstreamOrigin, label: clientLabel ?? undefined });
+        const session = getSession(sessionId, { protocol, upstreamOrigin, label: clientLabel ?? (isFingerprint ? "[fingerprint]" : undefined) });
         // Launcher-mode binding (#162): prefer identity — claude code sends
         // x-claude-code-session-id on every request, equal to the
         // CLAUDE_CODE_SESSION_ID the MCP shell registered, so binding is

--- a/src/session-id.ts
+++ b/src/session-id.ts
@@ -1,3 +1,5 @@
+import { hashId } from "./util.js";
+
 export type ConversationIdentity = {
     value: string;
     source: "header" | "body-session" | "metadata-session" | "previous-response" | "prompt-cache-key" | "content-fingerprint" | "generated";
@@ -88,4 +90,37 @@ export function preferPromptCacheKeyIdentity<T extends ConversationIdentity>(
     const pck = typeof body.prompt_cache_key === "string" ? body.prompt_cache_key.trim() : "";
     if (pck.length === 0) return identity;
     return { ...identity, value: pck, source: "prompt-cache-key", clientProvided: true };
+}
+
+/**
+ * Compute a content-fingerprint session id for an anonymous request (no
+ * client-provided identity), used ONLY when `allowFingerprintSessions` is
+ * enabled (#286 opt-in, issue #309). Restores the pre-#286 fallback with its
+ * 4-dimension isolation key so different accounts/upstreams never share
+ * compression state:
+ *
+ *   hash(protocol | upstream | apiKey | conversation)
+ *
+ * `conversation` is the kernel's content-fingerprint signal (already a stable
+ * hash of the request's first user message / whole input). The 4-dim key keeps
+ * the collision surface bounded (same account + upstream + content) while
+ * letting header-less third-party harnesses (dsh web, …) keep compression
+ * instead of 400ing. The id is proxy-internal only — never sent upstream.
+ */
+export function deriveFingerprintSessionId(
+    headers: Record<string, string | string[] | undefined>,
+    protocol: "anthropic" | "openai" | "responses",
+    upstream: string,
+    conversation: string,
+): string {
+    if (!conversation) throw new Error("deriveFingerprintSessionId: empty conversation signal");
+    return hashId(`${protocol}|${upstream}|${extractKey(headers)}|${conversation}`);
+}
+
+function extractKey(headers: Record<string, string | string[] | undefined>): string {
+    const auth = headers["authorization"];
+    if (typeof auth === "string" && auth.length > 0) return auth.trim();
+    const apiKey = headers["x-api-key"];
+    if (typeof apiKey === "string" && apiKey.length > 0) return `key:${apiKey.trim()}`;
+    return "(no-key)";
 }

--- a/tests/e2e-session-identity.test.ts
+++ b/tests/e2e-session-identity.test.ts
@@ -10,6 +10,7 @@ import { startServer, type ProxyOptions } from "../src/server.ts";
 import { SessionStore, _setStoreForTest } from "../src/persist.ts";
 import { _setForTest as setRegistryForTest } from "../src/registry.ts";
 import { _resetSessionsForTest } from "../src/session.ts";
+import { deriveFingerprintSessionId } from "../src/session-id.ts";
 
 // #286: the session ID is the client-provided conversation value VERBATIM —
 // no hash, no other dimensions. Credential rotation (ChatGPT OAuth bearer),
@@ -96,7 +97,7 @@ interface Harness {
     close(): Promise<void>;
 }
 
-async function startHarness(upstreamCount = 1): Promise<Harness> {
+async function startHarness(upstreamCount = 1, allowFingerprintSessions = false): Promise<Harness> {
     const upstreams: MockUpstream[] = [];
     for (let i = 0; i < upstreamCount; i++) upstreams.push(await startMockUpstream());
     _resetSessionsForTest();
@@ -119,6 +120,7 @@ async function startHarness(upstreamCount = 1): Promise<Harness> {
         sessionHeader: "x-acp-session",
         debug: false,
         passthrough: false,
+        allowFingerprintSessions,
         autoUpdate: false,
         mitm: { enabled: false, domains: [] },
     });
@@ -327,6 +329,90 @@ test("e2e session identity: distinct session_ids stay separate (#286)", async ()
         assert.equal(sessions.length, 2, `expected 2 sessions, got ${JSON.stringify(sessions)}`);
         const ids = sessions.map((s) => s.id).sort();
         assert.deepEqual(ids, ["sess-A", "sess-B"]);
+    } finally {
+        await h.close();
+    }
+});
+
+// --- #286 opt-in (issue #309): allowFingerprintSessions lets header-less
+// third-party harnesses fall back to a content-fingerprint session instead of
+// 400ing. Default (absent/false) keeps the hard-reject above. ---
+
+test("deriveFingerprintSessionId: 4-dim key isolates by protocol/upstream/credential/conversation", () => {
+    const base = { authorization: "Bearer keyA" };
+    const same = deriveFingerprintSessionId(base, "responses", "http://up1", "conv-1");
+    assert.ok(same.length > 0, "non-empty id");
+    assert.equal(deriveFingerprintSessionId(base, "responses", "http://up1", "conv-1"), same, "identical inputs → identical id");
+    assert.notEqual(deriveFingerprintSessionId({ authorization: "Bearer keyB" }, "responses", "http://up1", "conv-1"), same, "different credential → different id");
+    assert.notEqual(deriveFingerprintSessionId(base, "responses", "http://up2", "conv-1"), same, "different upstream → different id");
+    assert.notEqual(deriveFingerprintSessionId(base, "anthropic", "http://up1", "conv-1"), same, "different protocol → different id");
+    assert.notEqual(deriveFingerprintSessionId(base, "responses", "http://up1", "conv-2"), same, "different conversation → different id");
+    assert.throws(() => deriveFingerprintSessionId(base, "responses", "http://up1", ""), /empty conversation signal/);
+});
+
+test("opt-in: anonymous responses request → 200, a fingerprint session is created (#309)", async () => {
+    const h = await startHarness(1, true);
+    try {
+        const resp = await postRaw(h, 0, "/v1/responses", responsesBody(), { authorization: "Bearer keyA" });
+        assert.equal(resp.status, 200, `expected 200 with opt-in, got ${resp.status}: ${await resp.text()}`);
+        const sessions = await getSessions(h);
+        assert.equal(sessions.length, 1, `expected 1 fingerprint session, got ${JSON.stringify(sessions)}`);
+        const s = sessions[0]!;
+        assert.equal(s.protocol, "responses");
+        assert.ok(s.id.length > 0 && s.id !== "hello", "id is a derived fingerprint, not the verbatim content");
+    } finally {
+        await h.close();
+    }
+});
+
+test("opt-in: identical anonymous requests continue one fingerprint session (stable key)", async () => {
+    const h = await startHarness(1, true);
+    try {
+        await post(h, 0, "/v1/responses", responsesBody(), { authorization: "Bearer keyA" });
+        await post(h, 0, "/v1/responses", responsesBody(), { authorization: "Bearer keyA" });
+        const sessions = await getSessions(h);
+        assert.equal(sessions.length, 1, `expected 1 session for identical content, got ${JSON.stringify(sessions)}`);
+        assert.equal(sessions[0]!.requests, 2, "both requests land on the same fingerprint session");
+    } finally {
+        await h.close();
+    }
+});
+
+test("opt-in: different credentials → separate fingerprint sessions (4-dim isolation)", async () => {
+    const h = await startHarness(1, true);
+    try {
+        await post(h, 0, "/v1/responses", responsesBody(), { authorization: "Bearer keyA" });
+        await post(h, 0, "/v1/responses", responsesBody(), { authorization: "Bearer keyB" });
+        const sessions = await getSessions(h);
+        assert.equal(sessions.length, 2, `expected 2 sessions for different credentials, got ${JSON.stringify(sessions)}`);
+    } finally {
+        await h.close();
+    }
+});
+
+test("opt-in: different content → separate fingerprint sessions (content dimension)", async () => {
+    const h = await startHarness(1, true);
+    try {
+        await post(h, 0, "/v1/responses", responsesBody(), { authorization: "Bearer keyA" });
+        await post(h, 0, "/v1/responses", responsesBody({ input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "a totally different prompt" }] }] }), { authorization: "Bearer keyA" });
+        const sessions = await getSessions(h);
+        assert.equal(sessions.length, 2, `expected 2 sessions for different content, got ${JSON.stringify(sessions)}`);
+    } finally {
+        await h.close();
+    }
+});
+
+test("opt-in: a client-provided identity still wins over the fingerprint fallback (#309)", async () => {
+    const h = await startHarness(1, true);
+    try {
+        // Anonymous → fingerprint session.
+        await post(h, 0, "/v1/responses", responsesBody(), { authorization: "Bearer keyA" });
+        // Same content but WITH a session_id → verbatim id, separate session.
+        await post(h, 0, "/v1/responses", responsesBody({ session_id: "explicit-1" }), { authorization: "Bearer keyA" });
+        const sessions = await getSessions(h);
+        assert.equal(sessions.length, 2, `expected 2 sessions (fingerprint + explicit), got ${JSON.stringify(sessions)}`);
+        const ids = sessions.map((s) => s.id).sort();
+        assert.ok(ids.includes("explicit-1"), "the explicit session_id is recorded verbatim");
     } finally {
         await h.close();
     }


### PR DESCRIPTION
## What

#286 replaced the content-fingerprint session fallback with a hard **400** for requests carrying no client-provided conversation identity. That is correct as the *default* (it removes the fingerprint collision surface + silent orphaning), but it 400s the entire class of **header-less third-party harnesses** (dsh web, …) that have no built-in compression and rely wholly on bili — breaking their whole request path, not just degrading compression (#309).

This adds an **opt-in** `allowFingerprintSessions` (default `false`, so #286 semantics are unchanged for everyone). When enabled, an anonymous request falls back to a content-fingerprint session using the **pre-#286 4-dimension isolation key** `hash(protocol | upstream | credential | content)`, so different accounts/upstreams never share compression state. Anonymous sessions are logged with a warning and labeled `[fingerprint]` in the web UI so orphaning stays visible. A client-provided identity always wins over the fallback.

## Surfaces

| Surface | Value |
|---|---|
| CLI | `--allow-fingerprint-sessions` / `--no-allow-fingerprint-sessions` |
| env | `BILI_ALLOW_FINGERPRINT_SESSIONS=1` |
| config | `"allowFingerprintSessions": true` |

## Why opt-in (not a revert)

- Keeps #286's hard-reject as the default — no existing user's behavior changes.
- Gives header-less harnesses a compression-preserving path instead of the binary choice of *400 (unusable) vs `--passthrough` (no compression)*.
- The 4-dim key bounds the collision surface that #286 was worried about (isolation by account + upstream + content), and the warn log + `[fingerprint]` label make the orphaning-on-credential-rotation visible rather than silent.

## Files

- `src/session-id.ts` — new `deriveFingerprintSessionId` (4-dim key; `extractKey` for credential dimension; SHA-256 via existing `hashId`, one-way so no credential leak).
- `src/config.ts` — `allowFingerprintSessions?` on `ProxyOptions` + loader (env > file) + `FileConfig`.
- `src/cli.ts` — `--allow-fingerprint-sessions` / `--no-…` flags + help.
- `src/server.ts` — the `!clientProvided` block now honors the opt-in (fallback + warn) instead of an unconditional 400; `[fingerprint]` label.
- `tests/e2e-session-identity.test.ts` — unit test (4-dim isolation) + 5 e2e tests (anonymous→200+session, continuity, credential isolation, content isolation, client-identity-wins).
- `README.md` / `CONFIGURATION.md` — new "Third-party harnesses (no session headers)" section + config key / env / flag reference rows.

## Pre-flight

- `npm run typecheck` — clean
- `npm test` — **704 pass, 0 fail**
- `npm run build` — success

No dependency changes (`package-lock.json` untouched). Version bump is a separate release PR per the release flow.

## Reporter's immediate workaround (until this ships)

Use `bili dsh web` (the launcher injects `PI_CACHE_RETENTION=long` → `prompt_cache_key` = dsh session uuid) and restore the client's `baseURL` to the real upstream — the launcher does the wrapping/rewrite. Or, on 0.1.58/0.1.59, downgrade to 0.1.57 (last version with the fallback).