### PR TITLE
release v0.1.60

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.59",
+  "version": "0.1.60",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Model: glm-5.3

版本号 bump only（发布 PR，CI 自动 build + test + publish + tag + GitHub Release）。

## 自 v0.1.59 以来的变更

- **PR #311 — 匿名请求 prefix-affinity 会话兜底（#309 / 取代 #286 硬 400）**
  - 无任何身份信号的客户端（dsh web 等第三方 harness）按最长前缀内容链解析会话：`h_i = sha256(h_{i-1}‖msg_i)`，前缀匹配即延续，分叉自动裂开新会话
  - **内容即唯一键，零环境分区**（#286 教训：协议/上游/凭证都会中途轮换，做键即孤儿化）；确定性 id `pfa-`+sha256(tail‖depth)，重启重放同 id 重挂；全局 LRU 256 / TTL 7 天
  - 空内容 / 仅 system 仍保持显式 400；匿名请求注入 wire 工具面（compress/decompress/search_context/acp_status）
  - 真实客户端实测（dsh × zhipuai-lb × glm-5.3）：主对话建会话 / 第二轮 prefix match 同会话 / 分叉裂开 / 换 key 换上游不断链
  - 测试 710/710

预检：typecheck ✓ / 710 tests ✓ / build ✓