### PR TITLE
release v0.1.61

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.60",
+  "version": "0.1.61",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Model: glm-5.3

Version bump only (0.1.60 → 0.1.61).

## Changes since v0.1.60

The complete fix chain for the #292 context-leak incident (four supervisor-reviewed PRs):

- **#303** (issue #300): stitched-stream usage double-count — `message_delta` usage is adopted atomically as a complete object (zeros may overwrite stale values), partial reports keep the `>0` guard so relay-echoed `input_tokens: 0` can't regress to undercounting. Fixes the fake 131% EMERGENCY trigger.
- **#304** (issue #299): chained-bili detection — per-server `instanceId`, `x-bili-hop` marker stamped on requests this instance actually prepares; inbound marker → `[warn]` + full passthrough. Prevents double-processing when two bili proxies are chained.
- **#305** (issue #302): `anthropic-beta: context-1m` window detection — beta header resolves to the real 1M window per request, ahead of plugin/launcher/registry/config/table.
- **#306** (issue #301): preflight fail-fast — payload-own estimate (not floored on possibly-stale `lastInputTokens`); unfixable overflow answers a structured `preflight_compress_failed` error (429→503 + retry-after) instead of forwarding a guaranteed-400 payload; a fitting payload forwards as-is.

Also included: v0.1.60's #311 anonymous prefix-affinity fallback (#309).

## Pre-flight

- typecheck ✓
- 727/727 tests ✓
- build ✓