### PR TITLE
release v0.1.62

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.61",
+  "version": "0.1.62",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Model: glm-5.3

Version bump only, no code changes.

## Since v0.1.61

- **#307** fix(logger): rotated log file orphan inode — inode-compare (fstat vs stat) detection, lossless drain on reopen, stderr-only degradation on failure (fixes #210)
- **#308** feat: compress observability (`[acp-compress-obs]` shrink/foldPoint/blocks + retry-log correlation via `session.lastCompress`) + gated staged/tail-biased compress steering behind `BILI_MAX_SHRINK_PER_COMPRESS` (default off) (fixes #189)

Preflight: typecheck ✓ / 740/740 tests ✓ / build ✓