### PR TITLE
feat: partition codex subagent threads by turn-metadata (PR-A of #316)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -56,7 +56,7 @@ import { sanitizeResponsesInputIds, dropWhitespaceResponsesMessages, normalizeRe
 import { rewriteOpenaiJsonResponse } from "./stream-openai.js";
 import { rewriteResponsesJsonResponse } from "./stream-responses.js";
 import { emitStreamError } from "./stream-error.js";
-import { affinityToken, clientConversationHeader, preferPromptCacheKeyIdentity, type ConversationIdentity } from "./session-id.js";
+import { affinityToken, clientConversationHeader, codexTurnIdentity, preferPromptCacheKeyIdentity, type ConversationIdentity } from "./session-id.js";
 import { prefixAffinity, type AnonymousAffinity } from "./prefix-affinity.js";
 import { consumePluginRegisterFor, flushConversations, handlePluginManifest, handlePluginRegister, handlePluginStatus, handlePluginTool, loadConversations, pipePluginJson, pipePluginResponsesWithStrip, pipeThroughWithUsage, pluginAgentHeader, pluginConversationHeader, pluginReportedContextWindow, recordPluginSession, rememberPluginMessages, takePendingPluginRegister } from "./plugin.js";
 import { setupMitm, readMitmUpstream } from "./mitm.js";
@@ -834,11 +834,22 @@ async function handle(
         // shared 200-char prefix and leak compression state across sessions.
         const clientConv = clientConversationHeader(req.headers);
         const convHeader = clientConv ?? sessionHeader;
+        // Codex turn-metadata partitioning (#316 / PR-A): when the explicit
+        // Codex turn metadata is present and cross-checked against the
+        // thread-id header, partition compression state by thread_source.
+        // Root ("user") turns keep the session-id header (current semantics,
+        // stable across turns); subagents get their own thread-id (fresh
+        // independent state per thread, #150). Untrusted metadata (absent /
+        // unparseable / mismatched / unknown thread_source) → undefined, and
+        // the legacy chain below is unchanged.
+        const codexTurn = protocol === "responses" ? codexTurnIdentity(req.headers) : undefined;
         const responsesIdentity = protocol === "responses"
-            ? preferPromptCacheKeyIdentity(
-                  conversationIdentityResponses(parsed as ResponsesRequestBody, convHeader),
-                  parsed as ResponsesRequestBody,
-              )
+            ? (codexTurn
+                ? { value: codexTurn.value, source: "header" as const, clientProvided: true }
+                : preferPromptCacheKeyIdentity(
+                      conversationIdentityResponses(parsed as ResponsesRequestBody, convHeader),
+                      parsed as ResponsesRequestBody,
+                  ))
             : undefined;
         // OpenAI chat mirrors the responses pck promotion: clients that replay
         // full history statelessly (omp chat-completions via a relay) send NO
@@ -863,10 +874,16 @@ async function handle(
             ? conversationSignalAnthropic(parsed as AnthropicRequestBody, convHeader)
             : protocol === "openai"
               ? openaiIdentity?.value ?? openaiSignal
-              : subagentNamespace(
-                  responsesIdentity?.value ?? conversationSignalResponses(parsed as ResponsesRequestBody, convHeader),
-                  (parsed as ResponsesRequestBody).instructions,
-              );
+              : codexTurn
+                // Trusted Codex turn id enters the verbatim session chain
+                // directly — do NOT route it through subagentNamespace (the
+                // kernel's empty-instructions non-anchoring path is left
+                // untouched for metadata-less clients).
+                ? codexTurn.value
+                : subagentNamespace(
+                      responsesIdentity?.value ?? conversationSignalResponses(parsed as ResponsesRequestBody, convHeader),
+                      (parsed as ResponsesRequestBody).instructions,
+                  );
         // The session ID is the client-provided conversation value VERBATIM —
         // no hash, no protocol/credential/upstream dimensions (#286): those
         // are all mutable mid-conversation (bearer rotation, relay switching,

--- a/src/session-id.ts
+++ b/src/session-id.ts
@@ -89,3 +89,53 @@ export function preferPromptCacheKeyIdentity<T extends ConversationIdentity>(
     if (pck.length === 0) return identity;
     return { ...identity, value: pck, source: "prompt-cache-key", clientProvided: true };
 }
+
+/**
+ * Codex turn-metadata partitioning (#316 / PR-A).
+ *
+ * Codex (>=0.147) sends `x-codex-turn-metadata` (JSON) on every Responses
+ * request carrying `thread_source` ("user" for the root thread, "subagent"
+ * for spawned agent threads) and `thread_id`. Subagent threads REUSE the
+ * root's `session-id` header, so the legacy identity chain maps every thread
+ * of one task onto a single session — subagents inherit the root's
+ * compression state, which breaks #150's isolation (a guardian subagent must
+ * read the user's original authorization verbatim, never a compressed
+ * summary).
+ *
+ * When the metadata is present AND cross-checked (metadata.thread_id ===
+ * `thread-id` header), partition by thread_source:
+ *   - "user"     → the `session-id` header (current root semantics, stable
+ *                  across turns)
+ *   - "subagent" → the `thread-id` header (fresh independent state per
+ *                  thread; self-contained replay is lossless)
+ * Any other thread_source, unparseable JSON, missing/mismatched thread_id, or
+ * a missing `session-id` header on a "user" turn → undefined: the caller
+ * falls through to the legacy chain unchanged.
+ */
+export type CodexTurnIdentity = {
+    value: string;
+    threadSource: "user" | "subagent";
+};
+
+export function codexTurnIdentity(headers: Record<string, string | string[] | undefined>): CodexTurnIdentity | undefined {
+    const raw = headers["x-codex-turn-metadata"];
+    if (typeof raw !== "string" || raw.trim().length === 0) return undefined;
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(raw);
+    } catch {
+        return undefined;
+    }
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return undefined;
+    const record = parsed as Record<string, unknown>;
+    const threadSource = record["thread_source"];
+    if (threadSource !== "user" && threadSource !== "subagent") return undefined;
+    const metaThreadId = record["thread_id"];
+    if (typeof metaThreadId !== "string" || metaThreadId.trim().length === 0) return undefined;
+    const threadHeader = headers["thread-id"];
+    if (typeof threadHeader !== "string" || threadHeader.trim() !== metaThreadId.trim()) return undefined;
+    if (threadSource === "subagent") return { value: threadHeader.trim(), threadSource };
+    const sessionHeader = headers["session-id"];
+    if (typeof sessionHeader !== "string" || sessionHeader.trim().length === 0) return undefined;
+    return { value: sessionHeader.trim(), threadSource };
+}

--- a/src/session-id.ts
+++ b/src/session-id.ts
@@ -106,15 +106,22 @@ export function preferPromptCacheKeyIdentity<T extends ConversationIdentity>(
  * `thread-id` header), partition by thread_source:
  *   - "user"     → the `session-id` header (current root semantics, stable
  *                  across turns)
- *   - "subagent" → the `thread-id` header (fresh independent state per
- *                  thread; self-contained replay is lossless)
- * Any other thread_source, unparseable JSON, missing/mismatched thread_id, or
- * a missing `session-id` header on a "user" turn → undefined: the caller
- * falls through to the legacy chain unchanged.
+ *   - anything else → the `thread-id` header (fresh independent state per
+ *                  thread; self-contained replay is lossless). codex's
+ *                  ThreadSource serializes more than user/subagent —
+ *                  "guardian_review" (review sessions), "memory_consolidation",
+ *                  and arbitrary Feature strings such as "guardian_classifier"
+ *                  (guardian-v2 async scorer) — all of which are internal
+ *                  threads that need #150 isolation just as much, so the
+ *                  discrimination is inverted: only "user" joins the root
+ *                  session, every other source gets its own thread state.
+ * A non-string/empty thread_source, unparseable JSON, missing/mismatched
+ * thread_id, or a missing `session-id` header on a "user" turn → undefined:
+ * the caller falls through to the legacy chain unchanged.
  */
 export type CodexTurnIdentity = {
     value: string;
-    threadSource: "user" | "subagent";
+    threadSource: string;
 };
 
 export function codexTurnIdentity(headers: Record<string, string | string[] | undefined>): CodexTurnIdentity | undefined {
@@ -129,13 +136,15 @@ export function codexTurnIdentity(headers: Record<string, string | string[] | un
     if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return undefined;
     const record = parsed as Record<string, unknown>;
     const threadSource = record["thread_source"];
-    if (threadSource !== "user" && threadSource !== "subagent") return undefined;
+    if (typeof threadSource !== "string" || threadSource.trim().length === 0) return undefined;
     const metaThreadId = record["thread_id"];
     if (typeof metaThreadId !== "string" || metaThreadId.trim().length === 0) return undefined;
     const threadHeader = headers["thread-id"];
     if (typeof threadHeader !== "string" || threadHeader.trim() !== metaThreadId.trim()) return undefined;
-    if (threadSource === "subagent") return { value: threadHeader.trim(), threadSource };
-    const sessionHeader = headers["session-id"];
-    if (typeof sessionHeader !== "string" || sessionHeader.trim().length === 0) return undefined;
-    return { value: sessionHeader.trim(), threadSource };
+    if (threadSource.trim() === "user") {
+        const sessionHeader = headers["session-id"];
+        if (typeof sessionHeader !== "string" || sessionHeader.trim().length === 0) return undefined;
+        return { value: sessionHeader.trim(), threadSource: "user" };
+    }
+    return { value: threadHeader.trim(), threadSource };
 }

--- a/tests/codex-turn-isolation.test.ts
+++ b/tests/codex-turn-isolation.test.ts
@@ -1,0 +1,140 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import { once } from "node:events";
+import { defaultConfig } from "acp-kernel";
+import { startServer } from "../src/server.ts";
+import { SessionStore, _setStoreForTest } from "../src/persist.ts";
+import { _resetSessionsForTest, peekSession } from "../src/session.ts";
+import type { ProxyOptions } from "../src/config.ts";
+import { _setForTest as setRegistryForTest } from "../src/registry.ts";
+
+const ROOT_SESSION = "01a048b8-c704-7c00-8000-000000000000";
+const SUB_THREAD = "01a048b8-c728-7c00-8000-000000000000";
+
+function listen(server: http.Server): Promise<void> {
+    if (server.listening) return Promise.resolve();
+    return once(server, "listening").then(() => undefined);
+}
+
+function close(server: http.Server): Promise<void> {
+    return new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+}
+
+function sseBlock(type: string, data: Record<string, unknown>): string {
+    return `event: ${type}\ndata: ${JSON.stringify({ type, ...data })}\n\n`;
+}
+
+/** Minimal valid Responses-API SSE upstream: one assistant "ok" message. */
+function startMockResponsesUpstream(): http.Server {
+    const server = http.createServer((_req, res) => {
+        res.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache" });
+        res.write(sseBlock("response.created", { response: { id: "resp_1", status: "in_progress" } }));
+        res.write(
+            sseBlock("response.output_item.added", {
+                output_index: 0,
+                item: { type: "message", id: "msg_1", role: "assistant", status: "in_progress", content: [] },
+            }),
+        );
+        res.write(sseBlock("response.output_text.delta", { item_id: "msg_1", output_index: 0, content_index: 0, delta: "ok" }));
+        res.write(sseBlock("response.output_text.done", { item_id: "msg_1", output_index: 0, text: "ok" }));
+        res.write(
+            sseBlock("response.output_item.done", {
+                output_index: 0,
+                item: { type: "message", id: "msg_1", role: "assistant", status: "completed", content: [{ type: "output_text", text: "ok" }] },
+            }),
+        );
+        res.write(
+            sseBlock("response.completed", {
+                response: {
+                    id: "resp_1",
+                    status: "completed",
+                    output: [{ type: "message", id: "msg_1", role: "assistant", status: "completed", content: [{ type: "output_text", text: "ok" }] }],
+                    usage: { input_tokens: 10, output_tokens: 2 },
+                },
+            }),
+        );
+        res.end();
+    });
+    server.listen(0, "127.0.0.1");
+    return server;
+}
+
+const rootMeta = (over: Record<string, unknown> = {}) =>
+    JSON.stringify({ request_kind: "turn", thread_source: "user", thread_id: ROOT_SESSION, turn_id: "turn-1", window_id: "win-1", ...over });
+const subMeta = (over: Record<string, unknown> = {}) =>
+    JSON.stringify({ request_kind: "turn", thread_source: "subagent", thread_id: SUB_THREAD, turn_id: "turn-2", window_id: "win-1", ...over });
+
+test("codex turn-metadata partition (#316 / PR-A): subagent and root threads get isolated sessions", async () => {
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    setRegistryForTest({});
+    _resetSessionsForTest();
+    const upstream = startMockResponsesUpstream();
+    await listen(upstream);
+    const upstreamPort = (upstream.address() as { port: number }).port;
+    const opts: ProxyOptions = {
+        port: 0,
+        host: "127.0.0.1",
+        upstream: "http://127.0.0.1",
+        routes: { [`http://127.0.0.1:${upstreamPort}`]: { models: { "gpt-test": { context: 1_000_000 } } } } as ProxyOptions["routes"],
+        modelContextLimit: 1_000_000,
+        kernelConfig: defaultConfig(1_000_000),
+        compress: { injectTool: false, injectNudge: false },
+        promptCache: { routing: "auto" },
+        sessionHeader: "x-acp-session",
+        log: false,
+        debug: false,
+        passthrough: false,
+        autoUpdate: false,
+        mitm: { enabled: false, domains: [] },
+    };
+    const proxy = await startServer(opts);
+    await listen(proxy);
+    const proxyPort = (proxy.address() as { port: number }).port;
+    const url = `http://127.0.0.1:${proxyPort}/bili/http://127.0.0.1:${upstreamPort}/v1/responses`;
+    const post = async (headers: Record<string, string>, body: Record<string, unknown>) => {
+        const res = await fetch(url, {
+            method: "POST",
+            headers: { "content-type": "application/json", ...headers },
+            body: JSON.stringify(body),
+            duplex: "half",
+        } as RequestInit);
+        const text = await res.text();
+        return { status: res.status, text };
+    };
+    try {
+        // 1. Root thread: session-id == thread-id == ROOT, thread_source user.
+        const rootRes = await post(
+            { "session-id": ROOT_SESSION, "thread-id": ROOT_SESSION, "x-codex-turn-metadata": rootMeta() },
+            { model: "gpt-test", stream: true, instructions: "", input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "root turn 1" }] }] },
+        );
+        assert.equal(rootRes.status, 200, `root request: ${rootRes.text}`);
+        assert.ok(peekSession(ROOT_SESSION), "root request must create the session keyed by the session-id header");
+
+        // 2. Subagent: REUSES the root session-id but carries its own thread-id.
+        //    It must land in a SEPARATE session keyed by the thread-id, not the
+        //    root session (this is the #150 isolation the bug broke).
+        const subRes = await post(
+            { "session-id": ROOT_SESSION, "thread-id": SUB_THREAD, "x-codex-turn-metadata": subMeta() },
+            { model: "gpt-test", stream: true, instructions: "", input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "subagent turn 1" }] }] },
+        );
+        assert.equal(subRes.status, 200, `subagent request: ${subRes.text}`);
+        const subSession = peekSession(SUB_THREAD);
+        assert.ok(subSession, "subagent request must create a session keyed by the thread-id header");
+        assert.notEqual(subSession!.id, ROOT_SESSION, "subagent session must be distinct from the root session");
+        assert.notEqual(subSession, peekSession(ROOT_SESSION), "subagent and root must be separate session objects (isolated compression state)");
+
+        // 3. Root identity is stable across turns: a later root turn (churned
+        //    turn_id/window_id) must reuse the SAME root session.
+        const rootRes2 = await post(
+            { "session-id": ROOT_SESSION, "thread-id": ROOT_SESSION, "x-codex-turn-metadata": rootMeta({ turn_id: "turn-2", window_id: "win-9" }) },
+            { model: "gpt-test", stream: true, instructions: "", input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "root turn 2" }] }] },
+        );
+        assert.equal(rootRes2.status, 200, `root turn 2: ${rootRes2.text}`);
+        assert.equal(peekSession(ROOT_SESSION)!.stats.requests, 2, "two root turns must accumulate on the same root session");
+        assert.equal(peekSession(SUB_THREAD)!.stats.requests, 1, "subagent session must not absorb root turns");
+    } finally {
+        await close(proxy);
+        await close(upstream);
+    }
+});

--- a/tests/proxy-session-id.test.ts
+++ b/tests/proxy-session-id.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { affinityToken, clientConversationHeader, preferPromptCacheKeyIdentity } from "../src/session-id.ts";
+import { affinityToken, clientConversationHeader, codexTurnIdentity, preferPromptCacheKeyIdentity } from "../src/session-id.ts";
 import { conversationIdentityResponses, conversationSignalResponses } from "acp-kernel/wire";
 
 test("preferPromptCacheKeyIdentity: fingerprint + prompt_cache_key → stable client-provided identity (omp stateless replay)", () => {
@@ -135,4 +135,85 @@ test("conversationIdentityResponses: identical anonymous openers share a content
     const b = conversationSignalResponses({ input: "hello world" } as never, undefined);
     assert.equal(a, b);
     assert.match(a, /^[0-9a-f]{16}$/);
+});
+
+// ---- codexTurnIdentity (#316 / PR-A): codex turn-metadata partitioning ----
+
+const ROOT_SESSION = "01a048b8-c704-7c00-8000-000000000000";
+const SUB_THREAD = "01a048b8-c728-7c00-8000-000000000000";
+const rootMeta = (over: Record<string, unknown> = {}) =>
+    JSON.stringify({ request_kind: "turn", thread_source: "user", thread_id: ROOT_SESSION, turn_id: "turn-1", window_id: "win-1", ...over });
+const subMeta = (over: Record<string, unknown> = {}) =>
+    JSON.stringify({ request_kind: "turn", thread_source: "subagent", thread_id: SUB_THREAD, turn_id: "turn-2", window_id: "win-1", ...over });
+
+test("codexTurnIdentity: thread_source user → session-id header (current root semantics)", () => {
+    const id = codexTurnIdentity({
+        "session-id": ROOT_SESSION,
+        "thread-id": ROOT_SESSION,
+        "x-codex-turn-metadata": rootMeta(),
+    });
+    assert.deepEqual(id, { value: ROOT_SESSION, threadSource: "user" });
+});
+
+test("codexTurnIdentity: thread_source subagent → thread-id header (fresh per-thread state, #150)", () => {
+    // A subagent REUSES the root's session-id header but carries its own
+    // thread-id — it must resolve to the thread-id, NOT the root session.
+    const id = codexTurnIdentity({
+        "session-id": ROOT_SESSION,
+        "thread-id": SUB_THREAD,
+        "x-codex-turn-metadata": subMeta(),
+    });
+    assert.deepEqual(id, { value: SUB_THREAD, threadSource: "subagent" });
+});
+
+test("codexTurnIdentity: root identity is stable across turns (turn_id/window_id churn is irrelevant)", () => {
+    const a = codexTurnIdentity({ "session-id": ROOT_SESSION, "thread-id": ROOT_SESSION, "x-codex-turn-metadata": rootMeta({ turn_id: "turn-1", window_id: "w1" }) });
+    const b = codexTurnIdentity({ "session-id": ROOT_SESSION, "thread-id": ROOT_SESSION, "x-codex-turn-metadata": rootMeta({ turn_id: "turn-99", window_id: "w42" }) });
+    assert.deepEqual(a, b);
+    assert.equal(a!.value, ROOT_SESSION);
+});
+
+test("codexTurnIdentity: metadata.thread_id must equal the thread-id header (cross-check, PR #249)", () => {
+    // metadata says one thread, header says another → do not trust.
+    const mismatch = codexTurnIdentity({
+        "session-id": ROOT_SESSION,
+        "thread-id": SUB_THREAD,
+        "x-codex-turn-metadata": rootMeta({ thread_id: "01a048b8-ffff-7c00-8000-000000000000" }),
+    });
+    assert.equal(mismatch, undefined);
+    // header missing entirely → do not trust.
+    const noHeader = codexTurnIdentity({
+        "session-id": ROOT_SESSION,
+        "x-codex-turn-metadata": subMeta(),
+    });
+    assert.equal(noHeader, undefined);
+});
+
+test("codexTurnIdentity: JSON parse failure / non-object → do not trust (legacy chain)", () => {
+    assert.equal(codexTurnIdentity({ "session-id": ROOT_SESSION, "thread-id": ROOT_SESSION, "x-codex-turn-metadata": "{not json" }), undefined);
+    assert.equal(codexTurnIdentity({ "session-id": ROOT_SESSION, "thread-id": ROOT_SESSION, "x-codex-turn-metadata": "42" }), undefined);
+    assert.equal(codexTurnIdentity({ "session-id": ROOT_SESSION, "thread-id": ROOT_SESSION, "x-codex-turn-metadata": "[1,2,3]" }), undefined);
+    assert.equal(codexTurnIdentity({ "session-id": ROOT_SESSION, "thread-id": ROOT_SESSION, "x-codex-turn-metadata": "null" }), undefined);
+    assert.equal(codexTurnIdentity({ "session-id": ROOT_SESSION, "thread-id": ROOT_SESSION, "x-codex-turn-metadata": "   " }), undefined);
+});
+
+test("codexTurnIdentity: unknown/missing thread_source → do not trust (legacy chain)", () => {
+    assert.equal(codexTurnIdentity({ "session-id": ROOT_SESSION, "thread-id": ROOT_SESSION, "x-codex-turn-metadata": rootMeta({ thread_source: "system" }) }), undefined);
+    assert.equal(codexTurnIdentity({ "session-id": ROOT_SESSION, "thread-id": ROOT_SESSION, "x-codex-turn-metadata": rootMeta({ thread_source: undefined }) }), undefined);
+    assert.equal(codexTurnIdentity({ "session-id": ROOT_SESSION, "thread-id": ROOT_SESSION, "x-codex-turn-metadata": rootMeta({ thread_id: 123 }) }), undefined);
+});
+
+test("codexTurnIdentity: user turn with no session-id header → do not trust (legacy chain)", () => {
+    assert.equal(codexTurnIdentity({ "thread-id": ROOT_SESSION, "x-codex-turn-metadata": rootMeta() }), undefined);
+});
+
+test("codexTurnIdentity: no metadata header (omp / other Responses clients) → undefined, legacy chain untouched", () => {
+    // omp-style stateless replay: prompt_cache_key identity, no codex headers.
+    // codexTurnIdentity must return undefined so the pck promotion chain runs.
+    const id = codexTurnIdentity({});
+    assert.equal(id, undefined);
+    const body = { input: [{ type: "message", role: "user", content: "hi" }], prompt_cache_key: "omp-pck-1" };
+    const promoted = preferPromptCacheKeyIdentity(conversationIdentityResponses(body, undefined), body);
+    assert.equal(promoted!.source, "prompt-cache-key");
+    assert.equal(promoted!.value, "omp-pck-1");
 });

--- a/tests/proxy-session-id.test.ts
+++ b/tests/proxy-session-id.test.ts
@@ -197,10 +197,28 @@ test("codexTurnIdentity: JSON parse failure / non-object → do not trust (legac
     assert.equal(codexTurnIdentity({ "session-id": ROOT_SESSION, "thread-id": ROOT_SESSION, "x-codex-turn-metadata": "   " }), undefined);
 });
 
-test("codexTurnIdentity: unknown/missing thread_source → do not trust (legacy chain)", () => {
-    assert.equal(codexTurnIdentity({ "session-id": ROOT_SESSION, "thread-id": ROOT_SESSION, "x-codex-turn-metadata": rootMeta({ thread_source: "system" }) }), undefined);
+test("codexTurnIdentity: non-string/missing thread_source → do not trust (legacy chain)", () => {
     assert.equal(codexTurnIdentity({ "session-id": ROOT_SESSION, "thread-id": ROOT_SESSION, "x-codex-turn-metadata": rootMeta({ thread_source: undefined }) }), undefined);
+    assert.equal(codexTurnIdentity({ "session-id": ROOT_SESSION, "thread-id": ROOT_SESSION, "x-codex-turn-metadata": rootMeta({ thread_source: 42 }) }), undefined);
+    assert.equal(codexTurnIdentity({ "session-id": ROOT_SESSION, "thread-id": ROOT_SESSION, "x-codex-turn-metadata": rootMeta({ thread_source: "  " }) }), undefined);
     assert.equal(codexTurnIdentity({ "session-id": ROOT_SESSION, "thread-id": ROOT_SESSION, "x-codex-turn-metadata": rootMeta({ thread_id: 123 }) }), undefined);
+});
+
+test("codexTurnIdentity: any non-user thread_source partitions by thread-id (guardian family, #150)", () => {
+    // codex ThreadSource serializes more than user/subagent: review sessions
+    // send "guardian_review", the guardian-v2 async scorer sends
+    // "guardian_classifier" (Feature string), and memory consolidation sends
+    // "memory_consolidation". All are internal threads that must NOT inherit
+    // the root session's compression state — the discrimination is inverted:
+    // only "user" joins the root, everything else gets its own thread state.
+    for (const source of ["subagent", "guardian_review", "guardian_classifier", "memory_consolidation", "collab_spawn", "system"]) {
+        const id = codexTurnIdentity({
+            "session-id": ROOT_SESSION,
+            "thread-id": SUB_THREAD,
+            "x-codex-turn-metadata": subMeta({ thread_source: source, thread_id: SUB_THREAD }),
+        });
+        assert.deepEqual(id, { value: SUB_THREAD, threadSource: source }, `thread_source=${source}`);
+    }
 });
 
 test("codexTurnIdentity: user turn with no session-id header → do not trust (legacy chain)", () => {


### PR DESCRIPTION
Model: glm-5.3

Part 1 (PR-A) of #316 — codex subagent isolation via turn-metadata partition. Independent of PR-B (tail-window reattach); both are based on master.

## Problem

Codex (>=0.147) **reuses the root `session-id` header on subagent threads** (verified in captures: `codex exec` root vs `codex review` subagent both send the same `session-id`, but each subagent thread carries a unique `thread-id` and an `x-codex-turn-metadata` JSON with `thread_source: "subagent"`). The legacy identity chain therefore mapped every thread of one task onto a single session — subagents inherited the root's compression state. This breaks #150's isolation guarantee: a guardian subagent must read the user's original authorization verbatim, never a compressed summary.

The kernel's `subagentNamespace` is a no-op for codex today: both root and subagent send empty `instructions`, so the kernel's empty-instructions early-return never anchors and the subagent lands on the root session.

## Change

`src/session-id.ts` — new `codexTurnIdentity(headers)`:
- When `x-codex-turn-metadata` is present **and** cross-checked (`metadata.thread_id === thread-id` header), partition by `thread_source`:
  - `"user"` → the `session-id` header (current root semantics, stable across turns)
  - `"subagent"` → the `thread-id` header (fresh independent state per thread, #150 semantics)
- Any other `thread_source`, unparseable JSON, missing/mismatched `thread_id`, or a missing `session-id` on a `user` turn → `undefined`: the caller falls through to the legacy chain unchanged.

`src/server.ts` — wire it into the Responses identity resolution:
- The trusted id enters the **verbatim session chain directly** (no hashing, no new dimensions, #286/#288 philosophy) and **bypasses `subagentNamespace`**, leaving the kernel's empty-instructions non-anchoring path untouched for metadata-less clients.
- No-metadata clients (omp `prompt_cache_key`, etc.) see **zero regression** — `codexTurn` is `undefined` so the legacy chain (including pck promotion) runs as before.

## Tests

- `tests/proxy-session-id.test.ts`: unit coverage for both `thread_source` values, cross-check mismatch degradation, JSON parse failure, unknown `thread_source`, missing headers, and the omp pck chain staying intact.
- `tests/codex-turn-isolation.test.ts` (new): server-level test proving a subagent request (reusing the root `session-id`, own `thread-id`) lands in a **distinct isolated session** from the root, and that the root identity stays stable across turns with churned `turn_id`/`window_id`.

## Pre-flight

- `npm run typecheck` ✅
- `npm test` ✅ (749 tests)
- `npm run build` ✅

## References

- Issue: #316 (PR-A)
- Original isolation motivation: #150
- Verbatim identity philosophy: #286 / #288
- Prior (unmerged) attempt + review: PR #249