### PR TITLE
fix: gate native-compaction rebase on semantic terminal state (#321 PR-C)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -55,6 +55,7 @@ import { runCompressLoop, pickAdapter } from "./loop/index.js";
 import { sanitizeResponsesInputIds, dropWhitespaceResponsesMessages, normalizeResponsesMessageItems } from "./loop/adapter-responses.js";
 import { rewriteOpenaiJsonResponse } from "./stream-openai.js";
 import { rewriteResponsesJsonResponse } from "./stream-responses.js";
+import { observeResponsesTerminalState } from "./stream-terminal.js";
 import { emitStreamError } from "./stream-error.js";
 import { affinityToken, clientConversationHeader, preferPromptCacheKeyIdentity, type ConversationIdentity } from "./session-id.js";
 import { prefixAffinity, type AnonymousAffinity } from "./prefix-affinity.js";
@@ -1401,6 +1402,12 @@ function prepareResponses(
 
     const shouldInject = opts.compress.injectTool;
     const injectTools = shouldInject && !pluginMode;
+    // Codex native remote-compact request: no compress prompt/tools (the model
+    // produces the compaction itself), no acp tags, plain passthrough so the
+    // response terminal state can gate the rebase marker.
+    const isCompactionTrigger = Array.isArray(parsed.input)
+        && parsed.input.length > 0
+        && parsed.input[parsed.input.length - 1]!.type === "compaction_trigger";
     // Route config is keyed by the upstream THIS request goes to (#286: a
     // session can outlive its first relay — session.meta.upstreamOrigin is
     // first-wins and would silently ignore the new relay's route settings).
@@ -1416,7 +1423,7 @@ function prepareResponses(
             log("info", `[${sessionId}] input items: ${Array.isArray(parsed.input) ? parsed.input.map((i: ResponseInputItem) => i.type).join(",") : "(string)"}`);
         }
         const tokenCount = session.stats.lastInputTokens;
-        const turn = core.processTurn({ messages: msgs, state: session.state, config, tokenCount, renderTags: process.env.ACP_RENDER_NONE ? "none" : "text-only" });
+        const turn = core.processTurn({ messages: msgs, state: session.state, config, tokenCount, renderTags: process.env.ACP_RENDER_NONE || isCompactionTrigger ? "none" : "text-only" });
         session.state = turn.state;
         // The fold from last turn's compress has now materialized in state —
         // future usage reports are post-fold reality, drop the credit.
@@ -1436,7 +1443,7 @@ function prepareResponses(
         processedMessages = stripKernelSummaries(turn.messages, turn.state);
         reapOrphanBlocks(session, msgs, deactivateBlock);
         rebuiltInput = patchResponsesInput(projection, processedMessages);
-        if (shouldInject && !process.env.ACP_NO_COMPRESS_PROMPT) {
+        if (shouldInject && !isCompactionTrigger && !process.env.ACP_NO_COMPRESS_PROMPT) {
             const prompt = responsesTextProtocol ? buildCompressHybridSystemPrompt(prompts) : buildCompressSystemPrompt(prompts);
             const devContent = [...projection.systemParts, prompt].join("\n\n---\n\n");
             rebuiltInput = injectResponsesDeveloperMessage(rebuiltInput, devContent);
@@ -1448,15 +1455,10 @@ function prepareResponses(
         } else if (projection.systemParts.length > 0) {
             rebuiltInput = injectResponsesDeveloperMessage(rebuiltInput, projection.systemParts.join("\n\n---\n\n"));
         }
-        // Codex's native remote-compact request ends with a `compaction_trigger`
-        // item that the upstream requires to be the FINAL input item (else 400
-        // "must be the final input item"). A nudge appended after it would break
-        // Codex's own compaction, and is redundant — the native compact IS the
-        // compression. Skip the nudge for such requests.
-        const triggerFinal = Array.isArray(rebuiltInput)
-            && rebuiltInput.length > 0
-            && rebuiltInput[rebuiltInput.length - 1]!.type === "compaction_trigger";
-        if (opts.compress.injectNudge && turn.nudge?.shouldInject && shouldInject && !triggerFinal) {
+        // A nudge appended after a trailing `compaction_trigger` would break
+        // the upstream's "must be the final input item" requirement and is
+        // redundant — the native compact IS the compression.
+        if (opts.compress.injectNudge && turn.nudge?.shouldInject && shouldInject && !isCompactionTrigger) {
             try {
                 const rendered = renderNudgeText(turn.nudge, prompts);
                 if (rendered.text) {
@@ -1522,11 +1524,12 @@ function prepareResponses(
         responsesProjection,
         protocol: "responses",
         stream,
-        compressInjected: injectTools,
+        compressInjected: injectTools && !isCompactionTrigger,
         pluginMode,
         responsesTextProtocol,
         nudge,
         prompts,
+        resetAfterSuccess: isCompactionTrigger,
     };
 }
 
@@ -2127,8 +2130,7 @@ async function forward(
         res.end();
         clearUpstreamTimer();
         if (prepared?.resetAfterSuccess) {
-            markNativeCompactionBoundary(prepared.session);
-            log("info", `[${prepared.session.id}] native Responses compact completed; rebase scheduled for next Responses turn`);
+            log("warn", `[${prepared.session.id}] native compact response had no body; rebase NOT scheduled`);
         }
         return;
     }
@@ -2160,11 +2162,21 @@ async function forward(
         prepared.compressInjected &&
         prepared.processedMessages.length > 0;
     if (!useRewriter || prepared === null) {
-        await pipeThrough(upstream.body, res);
-        clearUpstreamTimer();
-        if (prepared?.resetAfterSuccess) {
-            markNativeCompactionBoundary(prepared.session);
-            log("info", `[${prepared.session.id}] native Responses compact completed; rebase scheduled for next Responses turn`);
+        if (prepared && prepared.resetAfterSuccess) {
+            const [toClient, toObserve] = upstream.body.tee();
+            const observed = observeResponsesTerminalState(toObserve, prepared.stream);
+            await pipeThrough(toClient, res);
+            clearUpstreamTimer();
+            const terminal = await observed;
+            if (terminal === "completed") {
+                markNativeCompactionBoundary(prepared.session);
+                log("info", `[${prepared.session.id}] native Responses compact completed; rebase scheduled for next Responses turn`);
+            } else {
+                log("warn", `[${prepared.session.id}] native compact response terminal=${terminal}; rebase NOT scheduled`);
+            }
+        } else {
+            await pipeThrough(upstream.body, res);
+            clearUpstreamTimer();
         }
         return;
     }

--- a/src/stream-terminal.ts
+++ b/src/stream-terminal.ts
@@ -1,0 +1,109 @@
+// #321 PR-C: terminal-state observer for native-compaction responses. The
+// rebase marker may only fire on "completed": a failed/incomplete/truncated
+// stream means the client kept its history, and rebasing on a compaction that
+// never happened discards valid blocks (#249). "unknown" is the safe default
+// (no rebase; the next request self-heals via kernel message-id deactivation).
+
+export type TerminalState = "completed" | "failed" | "unknown";
+
+const SUCCEEDED = "response.completed";
+const FAILED_EVENTS = new Set(["response.failed", "response.incomplete"]);
+const MAX_JSON_BYTES = 16 << 20;
+
+export async function observeResponsesTerminalState(stream: ReadableStream<Uint8Array>, isStream: boolean): Promise<TerminalState> {
+    return isStream ? observeSseTerminalState(stream) : observeJsonTerminalState(stream);
+}
+
+function terminalFromSseLine(line: string): TerminalState | null {
+    if (line.startsWith("event:")) {
+        const name = line.slice(6).trim();
+        if (name === SUCCEEDED) return "completed";
+        if (FAILED_EVENTS.has(name)) return "failed";
+        return null;
+    }
+    if (line.startsWith("data:")) {
+        const data = line.slice(5).trim();
+        if (!data.startsWith("{")) return null;
+        try {
+            const type = (JSON.parse(data) as { type?: unknown }).type;
+            if (type === SUCCEEDED) return "completed";
+            if (type === "response.failed" || type === "response.incomplete") return "failed";
+        } catch {
+            return null;
+        }
+    }
+    return null;
+}
+
+async function observeSseTerminalState(stream: ReadableStream<Uint8Array>): Promise<TerminalState> {
+    const reader = stream.getReader();
+    const decoder = new TextDecoder();
+    let buf = "";
+    let state: TerminalState = "unknown";
+    try {
+        for (;;) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            buf += decoder.decode(value, { stream: true });
+            let nl: number;
+            while ((nl = buf.indexOf("\n")) >= 0) {
+                const line = buf.slice(0, nl).replace(/\r$/, "");
+                buf = buf.slice(nl + 1);
+                const next = terminalFromSseLine(line);
+                if (next !== null) {
+                    state = next;
+                    break;
+                }
+            }
+            if (state !== "unknown") {
+                // Release this tee branch; the client branch keeps draining the source.
+                await reader.cancel().catch(() => {});
+                break;
+            }
+        }
+    } catch {
+        return "unknown";
+    } finally {
+        reader.releaseLock();
+    }
+    return state;
+}
+
+async function observeJsonTerminalState(stream: ReadableStream<Uint8Array>): Promise<TerminalState> {
+    const reader = stream.getReader();
+    const chunks: Buffer[] = [];
+    let size = 0;
+    let overflow = false;
+    try {
+        for (;;) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            if (!overflow) {
+                size += value.length;
+                if (size <= MAX_JSON_BYTES) {
+                    chunks.push(Buffer.from(value));
+                } else {
+                    overflow = true;
+                }
+            }
+        }
+    } catch {
+        return "unknown";
+    } finally {
+        reader.releaseLock();
+    }
+    if (overflow) return "unknown";
+    const text = Buffer.concat(chunks).toString("utf8").trim();
+    if (!text) return "unknown";
+    let body: unknown;
+    try {
+        body = JSON.parse(text);
+    } catch {
+        return "unknown";
+    }
+    if (typeof body !== "object" || body === null) return "unknown";
+    const rec = body as Record<string, unknown>;
+    if (rec.error !== undefined) return "failed";
+    if (Array.isArray(rec.output)) return "completed";
+    return "unknown";
+}

--- a/tests/compaction-trigger-finality.test.ts
+++ b/tests/compaction-trigger-finality.test.ts
@@ -82,10 +82,10 @@ test("e2e #280r2 (Responses): trailing compaction_trigger stays final — nudge 
     const proxyPort = proxy.address().port;
     const url = `http://127.0.0.1:${proxyPort}/bili/http://127.0.0.1:${upstreamPort}/v1/responses`;
 
-    const post = (input: unknown) => fetch(url, {
+    const post = (input: unknown, session = "trig-sess") => fetch(url, {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ model: "gpt-resp", stream: true, session_id: "trig-sess", instructions: "You are the test coding agent.", input }),
+        body: JSON.stringify({ model: "gpt-resp", stream: true, session_id: session, instructions: "You are the test coding agent.", input }),
     });
 
     try {
@@ -108,9 +108,15 @@ test("e2e #280r2 (Responses): trailing compaction_trigger stays final — nudge 
         assert.equal(lastItem.type, "compaction_trigger", "compaction_trigger is the final input item");
         assert.ok(!bodies[bodies.length - 1].includes("Context limit reached"), "no nudge appended after the trigger");
 
-        // Control: same armed session, normal trailing user message — the
-        // nudge must still be injected.
-        const r3 = await post([...conversation(), { type: "message", role: "user", content: "What should we do next?" }]);
+        // Control: normal trailing user message — the nudge must still be
+        // injected. Runs on a SEPARATE session: since #321 PR-C a completed
+        // trigger response marks a native-compaction boundary, so the next
+        // turn on trig-sess rebases (usage reset) and the nudge would be
+        // legitimately unarmed there. The warmup turn arms the usage report.
+        const r3a = await post(conversation(), "trig-ctl");
+        assert.equal(r3a.status, 200);
+        await r3a.text();
+        const r3 = await post([...conversation(), { type: "message", role: "user", content: "What should we do next?" }], "trig-ctl");
         assert.equal(r3.status, 200);
         await r3.text();
         assert.ok(bodies[bodies.length - 1].includes("Context limit reached"), "nudge still injected on a normal request");

--- a/tests/native-compact-terminal.test.ts
+++ b/tests/native-compact-terminal.test.ts
@@ -1,0 +1,193 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import { once } from "node:events";
+import test from "node:test";
+
+process.env.NODE_ENV = "test";
+
+import { defaultConfig } from "acp-kernel";
+import { startServer, type ProxyOptions } from "../src/server.ts";
+import { SessionStore, _setStoreForTest } from "../src/persist.ts";
+import { _setForTest as setRegistryForTest } from "../src/registry.ts";
+import { listSessions } from "../src/session.ts";
+
+// #321 PR-C: the native-compaction rebase marker must fire ONLY when the
+// upstream response semantically completed. failed/incomplete/truncated
+// streams, 2xx error JSON, and empty bodies must NOT schedule a rebase.
+// Also: a trailing compaction_trigger request must be forwarded WITHOUT the
+// compress prompt/tools and with the trigger still final (trigger hardening).
+
+function sse(type: string, data: unknown): string {
+    return `event: ${type}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+function conversation() {
+    const input: { type: string; role: string; content: string }[] = [];
+    for (let i = 0; i < 4; i++) {
+        input.push({ type: "message", role: i % 2 === 0 ? "user" : "assistant", content: `Message ${i}: ` + `WORK_${i}_content_`.repeat(120) });
+    }
+    return input;
+}
+
+function pendingRebase(sessionId: string): boolean | undefined {
+    const s = listSessions().find((x) => x.meta.label === sessionId);
+    if (!s) return undefined;
+    const b = s.metadata.nativeCompactionBoundary as Record<string, unknown> | undefined;
+    return b ? (b.pendingRebase as boolean) : undefined;
+}
+
+test("e2e #321 PR-C: rebase only on completed; trigger request forwarded clean", async () => {
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    setRegistryForTest({});
+    const bodies: string[] = [];
+    const upstream = http.createServer((req, res) => {
+        const chunks: Buffer[] = [];
+        req.on("data", (c: Buffer) => chunks.push(c));
+        req.on("end", () => {
+            const raw = Buffer.concat(chunks).toString("utf8");
+            bodies.push(raw);
+            const mode = (req.url?.split("?")[1] ?? "").includes("mode=") ? new URLSearchParams(req.url?.split("?")[1]).get("mode") : undefined;
+            if (req.url?.includes("/responses/compact")) {
+                if (mode === "json-error") {
+                    res.writeHead(200, { "content-type": "application/json" });
+                    res.end(JSON.stringify({ error: { message: "compact failed" } }));
+                    return;
+                }
+                if (mode === "empty") {
+                    res.writeHead(200, { "content-type": "application/json" });
+                    res.end();
+                    return;
+                }
+                res.writeHead(200, { "content-type": "application/json" });
+                res.end(JSON.stringify({ id: "resp_c", status: "completed", output: [{ type: "message", role: "user", content: "summary" }], usage: { input_tokens: 10, output_tokens: 1 } }));
+                return;
+            }
+            res.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache" });
+            if (mode === "failed") {
+                res.write(sse("response.created", { type: "response.created", response: { id: "r1" } }));
+                res.write(sse("response.failed", { type: "response.failed", response: { id: "r1", status: "failed", error: { code: "boom" } } }));
+                res.end();
+                return;
+            }
+            if (mode === "truncated") {
+                res.write(sse("response.created", { type: "response.created", response: { id: "r1" } }));
+                res.write(sse("response.output_item.added", { type: "response.output_item.added", item: { type: "message" } }));
+                res.end();
+                return;
+            }
+            res.write(sse("response.created", { type: "response.created", response: { id: "r1" } }));
+            res.write(sse("response.completed", { type: "response.completed", response: { id: "r1", status: "completed", output: [], usage: { input_tokens: 100, output_tokens: 5, total_tokens: 105 } } }));
+            res.end();
+        });
+    });
+    upstream.listen(0, "127.0.0.1");
+    await once(upstream, "listening");
+    const upstreamPort = upstream.address().port;
+
+    const proxy = await startServer({
+        port: 0,
+        host: "127.0.0.1",
+        upstream: "http://127.0.0.1",
+        routes: { [`http://127.0.0.1:${upstreamPort}`]: { models: { "gpt-resp": { context: 10_000 } } } },
+        modelContextLimit: 10_000,
+        kernelConfig: defaultConfig(10_000),
+        compress: { injectTool: true, injectNudge: true },
+        promptCache: { routing: "auto" },
+        sessionHeader: "x-acp-session",
+        log: false,
+        debug: false,
+        passthrough: false,
+        autoUpdate: false,
+        mitm: { enabled: false, domains: [] },
+    } as ProxyOptions);
+    await once(proxy, "listening");
+    const proxyPort = proxy.address().port;
+    const base = `http://127.0.0.1:${proxyPort}/bili/http://127.0.0.1:${upstreamPort}/v1`;
+
+    const postResponses = (path: string, body: unknown) => fetch(`${base}${path}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+    });
+
+    try {
+        // 1. Trigger form, SSE completed → rebase scheduled. The forwarded
+        //    body must NOT carry the compress prompt/tools, must keep the
+        //    client instructions, and the trigger must stay final.
+        const r1 = await postResponses("/responses?mode=completed", {
+            model: "gpt-resp",
+            stream: true,
+            session_id: "term-sess",
+            instructions: "You are the test coding agent.",
+            tools: [{ type: "custom", name: "shell" }],
+            input: [...conversation(), { type: "compaction_trigger" }],
+        });
+        assert.equal(r1.status, 200);
+        await r1.text();
+        const fwd = JSON.parse(bodies[bodies.length - 1]) as { input: { type: string; content?: unknown }[]; tools?: { name?: string }[] };
+        assert.equal(fwd.input[fwd.input.length - 1].type, "compaction_trigger", "trigger stays final");
+        const devContent = String(fwd.input.find((i) => i.type === "message" && typeof i.content === "string" && String(i.content).includes("You are the test coding agent."))?.content ?? "");
+        assert.ok(devContent.includes("You are the test coding agent."), "client instructions still forwarded");
+        assert.ok(!JSON.stringify(fwd).includes("Compression Philosophy"), "compress prompt NOT injected");
+        assert.ok(!(fwd.tools ?? []).some((t) => t.name === "compress"), "compress tool NOT injected");
+        assert.equal(pendingRebase("term-sess"), true, "completed trigger response schedules the rebase");
+
+        // Reconcile on the next turn: state reset, marker consumed.
+        const r1b = await postResponses("/responses", {
+            model: "gpt-resp",
+            stream: true,
+            session_id: "term-sess",
+            input: [{ type: "message", role: "user", content: "fresh start" }],
+        });
+        assert.equal(r1b.status, 200);
+        await r1b.text();
+        assert.equal(pendingRebase("term-sess"), false, "rebase reconciled on next turn");
+        const s1 = listSessions().find((x) => x.meta.label === "term-sess");
+        assert.equal(s1?.blockContents.size, 0, "blocks cleared by the rebase");
+
+        // 2. Trigger form, SSE failed → NO rebase.
+        const r2 = await postResponses("/responses?mode=failed", {
+            model: "gpt-resp",
+            stream: true,
+            session_id: "term-failed",
+            input: [...conversation(), { type: "compaction_trigger" }],
+        });
+        assert.equal(r2.status, 200);
+        await r2.text();
+        assert.equal(pendingRebase("term-failed"), undefined, "failed stream must not schedule a rebase");
+
+        // 3. Trigger form, SSE truncated (no terminal event) → NO rebase.
+        const r3 = await postResponses("/responses?mode=truncated", {
+            model: "gpt-resp",
+            stream: true,
+            session_id: "term-trunc",
+            input: [...conversation(), { type: "compaction_trigger" }],
+        });
+        assert.equal(r3.status, 200);
+        await r3.text();
+        assert.equal(pendingRebase("term-trunc"), undefined, "truncated stream must not schedule a rebase");
+
+        // 4. Endpoint form, 2xx JSON error body → NO rebase.
+        const r4 = await postResponses("/responses/compact?mode=json-error", { model: "gpt-resp", session_id: "term-jsonerr" });
+        assert.equal(r4.status, 200);
+        await r4.text();
+        assert.equal(pendingRebase("term-jsonerr"), undefined, "2xx error JSON must not schedule a rebase");
+
+        // 5. Endpoint form, empty body → NO rebase.
+        const r5 = await postResponses("/responses/compact?mode=empty", { model: "gpt-resp", session_id: "term-empty" });
+        assert.equal(r5.status, 200);
+        await r5.text();
+        assert.equal(pendingRebase("term-empty"), undefined, "empty body must not schedule a rebase");
+
+        // 6. Endpoint form, JSON with output → rebase (the #249 happy path).
+        const r6 = await postResponses("/responses/compact", { model: "gpt-resp", session_id: "term-jsonok" });
+        assert.equal(r6.status, 200);
+        await r6.text();
+        assert.equal(pendingRebase("term-jsonok"), true, "JSON output response schedules the rebase");
+    } finally {
+        proxy.close();
+        await once(proxy, "close");
+        upstream.close();
+        await once(upstream, "close");
+    }
+});

--- a/tests/stream-terminal.test.ts
+++ b/tests/stream-terminal.test.ts
@@ -1,0 +1,117 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { observeResponsesTerminalState } from "../src/stream-terminal.ts";
+
+function sseStream(chunks: string[]): ReadableStream<Uint8Array> {
+    const enc = new TextEncoder();
+    return new ReadableStream<Uint8Array>({
+        start(controller) {
+            for (const c of chunks) controller.enqueue(enc.encode(c));
+            controller.close();
+        },
+    });
+}
+
+function sse(type: string, data: unknown): string {
+    return `event: ${type}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+test("SSE: response.completed terminal event → completed", async () => {
+    const stream = sseStream([
+        sse("response.created", { type: "response.created", response: { id: "r1" } }),
+        sse("response.output_item.added", { type: "response.output_item.added", item: { type: "compaction" } }),
+        sse("response.completed", { type: "response.completed", response: { id: "r1", status: "completed" } }),
+    ]);
+    assert.equal(await observeResponsesTerminalState(stream, true), "completed");
+});
+
+test("SSE: response.failed → failed", async () => {
+    const stream = sseStream([
+        sse("response.created", { type: "response.created", response: { id: "r1" } }),
+        sse("response.failed", { type: "response.failed", response: { status: "failed", error: { code: "boom" } } }),
+    ]);
+    assert.equal(await observeResponsesTerminalState(stream, true), "failed");
+});
+
+test("SSE: response.incomplete → failed", async () => {
+    const stream = sseStream([
+        sse("response.incomplete", { type: "response.incomplete", response: { status: "incomplete" } }),
+    ]);
+    assert.equal(await observeResponsesTerminalState(stream, true), "failed");
+});
+
+test("SSE: stream ends without terminal event (truncation) → unknown", async () => {
+    const stream = sseStream([
+        sse("response.created", { type: "response.created", response: { id: "r1" } }),
+        sse("response.output_item.added", { type: "response.output_item.added", item: { type: "message" } }),
+    ]);
+    assert.equal(await observeResponsesTerminalState(stream, true), "unknown");
+});
+
+test("SSE: empty stream → unknown", async () => {
+    assert.equal(await observeResponsesTerminalState(sseStream([]), true), "unknown");
+});
+
+test("SSE: data-line type fallback when event: lines are stripped", async () => {
+    const stream = sseStream([
+        `data: ${JSON.stringify({ type: "response.created", response: { id: "r1" } })}\n\n`,
+        `data: ${JSON.stringify({ type: "response.completed", response: { id: "r1" } })}\n\n`,
+    ]);
+    assert.equal(await observeResponsesTerminalState(stream, true), "completed");
+    const failed = sseStream([`data: ${JSON.stringify({ type: "response.failed", response: {} })}\n\n`]);
+    assert.equal(await observeResponsesTerminalState(failed, true), "failed");
+});
+
+test("SSE: CRLF endings and events split across chunks", async () => {
+    const full = sse("response.created", { type: "response.created" }) + sse("response.completed", { type: "response.completed" });
+    const crlf = full.replace(/\n/g, "\r\n");
+    const mid = Math.floor(crlf.length / 2);
+    assert.equal(await observeResponsesTerminalState(sseStream([crlf.slice(0, mid), crlf.slice(mid)]), true), "completed");
+});
+
+test("SSE: terminal event wins even if more events follow", async () => {
+    const stream = sseStream([
+        sse("response.completed", { type: "response.completed", response: { id: "r1" } }),
+        sse("response.output_item.added", { type: "response.output_item.added", item: {} }),
+    ]);
+    assert.equal(await observeResponsesTerminalState(stream, true), "completed");
+});
+
+test("SSE: non-JSON data lines are ignored, not fatal", async () => {
+    const stream = sseStream([
+        "data: [DONE]\n\n",
+        sse("response.completed", { type: "response.completed", response: { id: "r1" } }),
+    ]);
+    assert.equal(await observeResponsesTerminalState(stream, true), "completed");
+});
+
+test("JSON: output array present → completed", async () => {
+    const stream = sseStream([JSON.stringify({ id: "r1", status: "completed", output: [{ type: "compaction", encrypted_content: "x" }], usage: {} })]);
+    assert.equal(await observeResponsesTerminalState(stream, false), "completed");
+});
+
+test("JSON: error field present → failed", async () => {
+    const stream = sseStream([JSON.stringify({ error: { message: "compact failed" } })]);
+    assert.equal(await observeResponsesTerminalState(stream, false), "failed");
+});
+
+test("JSON: unparseable body → unknown", async () => {
+    assert.equal(await observeResponsesTerminalState(sseStream(["<html>502 bad gateway</html>"]), false), "unknown");
+});
+
+test("JSON: non-object body → unknown", async () => {
+    assert.equal(await observeResponsesTerminalState(sseStream(["42"]), false), "unknown");
+});
+
+test("JSON: empty body → unknown", async () => {
+    assert.equal(await observeResponsesTerminalState(sseStream([]), false), "unknown");
+});
+
+test("JSON: body without output field → unknown", async () => {
+    assert.equal(await observeResponsesTerminalState(sseStream([JSON.stringify({ id: "r1", status: "completed" })]), false), "unknown");
+});
+
+test("JSON: oversized body → unknown (safe default)", async () => {
+    const big = JSON.stringify({ output: ["x".repeat((16 << 20) + 1)] });
+    assert.equal(await observeResponsesTerminalState(sseStream([big]), false), "unknown");
+});


### PR DESCRIPTION
**Model: qwen3.8-27b**

PR-C of #321 — the semantic rebase gate (adopts #249's response-observer design, which was never merged). Follows PR-D (#322); precedes E1/E2.

## Problem

Both `markNativeCompactionBoundary` call sites fired on ANY HTTP 2xx upstream response. When a native compaction request actually FAILED (stream cut before `response.completed`, `response.failed`/`response.incomplete`, empty body, 2xx error JSON), codex kept its history — but bili scheduled a rebase anyway: on the next turn it reset its compression state (blocks cleared, usage zeroed) on top of a compaction that never happened. That is the #249 false-rebase bug: discarded valid blocks + a ledger that no longer matches the client's real context.

A second gap: the trigger form (plain `/responses` ending in `compaction_trigger`) had NO rebase marker at all — it flowed through the rewriter path (`compressInjected: true`), which never marks the boundary, even though a completed trigger response IS a client-side history swap. It also had bili's compress prompt/tools injected into the very request whose job is to produce the compaction.

## Changes

**`src/stream-terminal.ts` (new)** — terminal-state observer for Responses responses:
- SSE: `response.completed` → `completed`; `response.failed` / `response.incomplete` → `failed`; stream ends without a terminal event (truncation) → `unknown`. Checks the `event:` line, with a `data:` JSON `type` fallback for relays that strip `event:` lines. CRLF-safe, chunk-boundary-safe; cancels its tee branch at the first terminal event so it never backpressures the client branch.
- JSON (non-stream): `output` array → `completed`; `error` field → `failed`; unparseable / non-object / empty / >16MB → `unknown`.
- `unknown` is the safe default: no rebase; the next request self-heals via kernel message-id deactivation.

**`src/server.ts`**:
- Both rebase call sites now gate on observed `terminal === completed`. The 2xx empty-body path no longer rebases (logs a warn instead).
- Trigger-path hardening in `prepareResponses`: a trailing `compaction_trigger` is detected BEFORE injection → no compress system prompt, no compress tools, `renderTags: "none"`, `compressInjected: false` (response flows through plain passthrough instead of the rewriter, so the compaction stream reaches codex byte-exact), and `resetAfterSuccess: true` so its terminal state gates the rebase. The nudge skip now keys off the same pre-injection detection (replacing the post-injection `triggerFinal` check).

## Behavior matrix (all e2e-tested through the proxy)

| Response | Rebase? |
|---|---|
| SSE `response.completed` (trigger form) | ✅ yes |
| SSE `response.failed` / `response.incomplete` | ❌ no |
| SSE truncated (no terminal event) | ❌ no |
| 2xx JSON with `output` (endpoint form) | ✅ yes |
| 2xx JSON with `error` | ❌ no |
| 2xx empty body | ❌ no |
| non-2xx | ❌ no (unchanged) |

## Tests

- 16 new unit tests (`tests/stream-terminal.test.ts`): every terminal state, data-line fallback, CRLF/chunk-split, terminal-wins, non-JSON data lines, JSON shapes, oversized body.
- New e2e (`tests/native-compact-terminal.test.ts`): the full matrix above + trigger-forwarding assertions (no compress prompt/tools in the forwarded body, client instructions preserved, trigger stays final) + reconcile-on-next-turn (blocks cleared, marker consumed).
- `tests/compaction-trigger-finality.test.ts`: the nudge control now runs on a separate session — a completed trigger response rebases the compacting session (usage reset), which legitimately disarms its nudge; the control gets a warmup turn to arm usage.
- Pre-flight: `npm run typecheck` clean; `npm test` 757/757 pass (three-protocol regression unchanged); `npm run build` success.

## Notes

- This is the correctness backstop for E2's pass-through path (when ACP is unhealthy, native compaction passes through and this gate decides the rebase) and for all non-codex Responses clients.
- With E2's interception mode eventually defaulting, the boundary marker retires for codex (deterministic handoff) — this gate stays as the safety net for the pass mode and other clients.