### PR TITLE
feat: clamp effective window to codex's model perception for codex clients (#321 PR-E1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "build": "tsup",
     "registry:snapshot": "node scripts/update-registry-snapshot.mjs",
+    "codex-models:snapshot": "node scripts/update-codex-models-snapshot.mjs",
     "typecheck": "tsc --noEmit --project tsconfig.build.json",
     "test": "node --import tsx --test tests/*.test.ts",
     "start": "node dist/index.js"

--- a/scripts/update-codex-models-snapshot.mjs
+++ b/scripts/update-codex-models-snapshot.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+/** Refresh src/codex-models-snapshot.json from openai/codex (main branch).
+
+The snapshot is the SLIM form of codex's bundled model table
+(codex-rs/models-manager/models.json) — only the fields bili consumes for
+budget alignment (#321 PR-E1): slug, contextWindow, maxContextWindow, and the
+optional autoCompactTokenLimit / effectiveContextWindowPercent. The full
+upstream file is ~424KB of tool/modality metadata bili never reads; the slim
+form keeps the bundle small and the contract explicit.
+
+Run manually or before a release:
+    npm run codex-models:snapshot
+
+Node's global fetch ignores http(s)_proxy env vars, so the script tries the
+configured shell proxy first (undici ProxyAgent) and falls back to a direct
+connection. If BOTH fail the existing snapshot is left untouched (exit 1).
+*/
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SOURCE_URL = "https://raw.githubusercontent.com/openai/codex/main/codex-rs/models-manager/models.json";
+const OUT_FILE = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "src", "codex-models-snapshot.json");
+const proxyUrl = process.env.https_proxy || process.env.HTTPS_PROXY || process.env.http_proxy || process.env.HTTP_PROXY;
+
+async function attempt(dispatcher) {
+    const res = await fetch(SOURCE_URL, {
+        ...(dispatcher ? { dispatcher } : {}),
+        signal: AbortSignal.timeout(20_000),
+        headers: { Accept: "application/json" },
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return res.json();
+}
+
+async function fetchFull() {
+    if (proxyUrl) {
+        try {
+            const { ProxyAgent } = await import("undici");
+            const full = await attempt(new ProxyAgent({ uri: proxyUrl }));
+            console.log(`fetched openai/codex via proxy ${proxyUrl}`);
+            return full;
+        } catch (e) {
+            console.log(`proxy attempt failed (${e.message}); trying direct`);
+        }
+    }
+    const full = await attempt(undefined);
+    console.log("fetched openai/codex direct");
+    return full;
+}
+
+let full;
+try {
+    full = await fetchFull();
+} catch (e) {
+    console.error(`could not fetch ${SOURCE_URL}: ${e.message}`);
+    console.error(`keeping the existing ${path.basename(OUT_FILE)} untouched`);
+    process.exit(1);
+}
+
+const models = Array.isArray(full?.models) ? full.models : null;
+if (!models || models.length === 0) {
+    console.error("unexpected upstream shape: expected { models: [...] }");
+    console.error(`keeping the existing ${path.basename(OUT_FILE)} untouched`);
+    process.exit(1);
+}
+
+const slim = models.map((m) => {
+    const e = { slug: m.slug };
+    for (const [k, key] of [
+        ["context_window", "contextWindow"],
+        ["max_context_window", "maxContextWindow"],
+        ["auto_compact_token_limit", "autoCompactTokenLimit"],
+        ["effective_context_window_percent", "effectiveContextWindowPercent"],
+    ]) {
+        if (m[k] !== null && m[k] !== undefined) e[key] = m[k];
+    }
+    return e;
+});
+
+const body = JSON.stringify({
+    source: `openai/codex main — codex-rs/models-manager/models.json`,
+    fetchedAt: new Date().toISOString().replace(/\.\d+Z$/, "Z"),
+    count: slim.length,
+    models: slim,
+}) + "\n";
+await writeFile(OUT_FILE, body, "utf8");
+console.log(`wrote ${OUT_FILE} (${slim.length} models, ${(body.length / 1024).toFixed(1)} KB)`);

--- a/src/codex-models-snapshot.json
+++ b/src/codex-models-snapshot.json
@@ -1,0 +1,57 @@
+{
+  "source": "openai/codex main (commit 868c9ed) \u2014 codex-rs/models-manager/models.json",
+  "fetchedAt": "2026-08-28T17:09:46Z",
+  "count": 10,
+  "models": [
+    {
+      "slug": "gpt-5.6-sol",
+      "contextWindow": 272000,
+      "maxContextWindow": 872000
+    },
+    {
+      "slug": "gpt-5.6-terra",
+      "contextWindow": 272000,
+      "maxContextWindow": 872000
+    },
+    {
+      "slug": "gpt-5.6-luna",
+      "contextWindow": 272000,
+      "maxContextWindow": 872000
+    },
+    {
+      "slug": "gpt-daybreak-blue-latest",
+      "contextWindow": 272000,
+      "maxContextWindow": 872000
+    },
+    {
+      "slug": "gpt-daybreak-red-latest",
+      "contextWindow": 372000,
+      "maxContextWindow": 372000
+    },
+    {
+      "slug": "gpt-5.5",
+      "contextWindow": 272000,
+      "maxContextWindow": 272000
+    },
+    {
+      "slug": "gpt-5.4",
+      "contextWindow": 272000,
+      "maxContextWindow": 1000000
+    },
+    {
+      "slug": "gpt-5.4-mini",
+      "contextWindow": 272000,
+      "maxContextWindow": 272000
+    },
+    {
+      "slug": "gpt-5.2",
+      "contextWindow": 272000,
+      "maxContextWindow": 272000
+    },
+    {
+      "slug": "codex-auto-review",
+      "contextWindow": 272000,
+      "maxContextWindow": 872000
+    }
+  ]
+}

--- a/src/codex-models.ts
+++ b/src/codex-models.ts
@@ -1,0 +1,107 @@
+import snapshot from "./codex-models-snapshot.json" with { type: "json" };
+
+/** One entry of codex's bundled model table (slim form — see
+ *  scripts/update-codex-models-snapshot.mjs). Mirrors the window fields of
+ *  codex-rs `protocol/src/openai_models.rs` ModelInfo that drive its budget. */
+export interface CodexModelEntry {
+    slug: string;
+    contextWindow?: number;
+    maxContextWindow?: number;
+    autoCompactTokenLimit?: number;
+    effectiveContextWindowPercent?: number;
+}
+
+interface CodexModelsSnapshot {
+    source: string;
+    fetchedAt: string;
+    count: number;
+    models: CodexModelEntry[];
+}
+
+const SNAPSHOT = snapshot as CodexModelsSnapshot;
+const TABLE: CodexModelEntry[] = SNAPSHOT.models;
+
+/** codex's unknown-model fallback window (codex-rs
+ *  models-manager/src/model_info.rs `model_info_from_slug`:
+ *  context_window = max_context_window = 272_000). A model that matches NO
+ *  table slug is NOT "unperceived" by codex — it auto-compacts at 90% of
+ *  this, so the min() alignment must treat it as perceived at 272K. */
+export const CODEX_FALLBACK_CONTEXT_WINDOW = 272_000;
+
+/** codex's perceived window for a model = resolved_context_window() =
+ *  context_window.or(max_context_window) (openai_models.rs). */
+function resolvedWindow(m: CodexModelEntry): number {
+    return m.contextWindow ?? m.maxContextWindow ?? CODEX_FALLBACK_CONTEXT_WINDOW;
+}
+
+/** Emulates codex's table lookup (models-manager/src/manager.rs
+ *  `construct_model_info_from_candidates`): longest-prefix match where the
+ *  REQUESTED model starts with the table slug, then a single namespaced-suffix
+ *  retry (`custom/gpt-5.3-codex` → match on `gpt-5.3-codex`) for provider-like
+ *  namespaces, then the 272K fallback. Config overrides are intentionally NOT
+ *  emulated — a user's `model_context_window` override can only clamp the
+ *  perception DOWN (to max_context_window), never raise it, so the table
+ *  value is the safe upper bound for alignment. */
+function lookupWindow(model: string): number {
+    const direct = longestPrefixMatch(model);
+    if (direct) return resolvedWindow(direct);
+    const slash = model.indexOf("/");
+    if (slash > 0) {
+        const namespace = model.slice(0, slash);
+        const suffix = model.slice(slash + 1);
+        if (!suffix.includes("/") && /^[A-Za-z0-9_-]+$/.test(namespace)) {
+            const m = longestPrefixMatch(suffix);
+            if (m) return resolvedWindow(m);
+        }
+    }
+    return CODEX_FALLBACK_CONTEXT_WINDOW;
+}
+
+function longestPrefixMatch(model: string): CodexModelEntry | undefined {
+    let best: CodexModelEntry | undefined;
+    for (const m of TABLE) {
+        if (!model.startsWith(m.slug)) continue;
+        if (!best || m.slug.length > best.slug.length) best = m;
+    }
+    return best;
+}
+
+/** The context window codex BELIEVES a model has (its own bundled table +
+ *  272K fallback). codex auto-compacts at 90% of this and hard-stops at 95%,
+ *  so bili must never budget a codex client above it (#321 PR-E1). */
+export function codexWindowForModel(model: string): number {
+    return lookupWindow(model);
+}
+
+/** True when the request carries codex CLI's User-Agent. codex sets
+ *  `{originator}/{version} (...)` with DEFAULT_ORIGINATOR = `codex_cli_rs`
+ *  (login/src/auth/default_client.rs) on every request. */
+export function isCodexClient(headers: Record<string, unknown>): boolean {
+    const ua = headers["user-agent"];
+    const list = Array.isArray(ua) ? ua : ua === undefined ? [] : [ua];
+    return list.some((h) => typeof h === "string" && h.startsWith("codex_cli_rs/"));
+}
+
+/** E1 min() alignment: cap bili's effective window at codex's own perception
+ *  when the client is codex. Non-codex clients and limits already at or below
+ *  the perception pass through untouched. */
+export function codexAlignedWindow(
+    limit: number,
+    model: string,
+    headers: Record<string, unknown>,
+): { limit: number; clamped: boolean } {
+    if (!isCodexClient(headers)) return { limit, clamped: false };
+    const w = codexWindowForModel(model);
+    if (limit > w) return { limit: w, clamped: true };
+    return { limit, clamped: false };
+}
+
+/** Test hook: replace the bundled table (mirrors registry._setForTest). */
+export function _setCodexTableForTest(models: CodexModelEntry[]): void {
+    TABLE.length = 0;
+    TABLE.push(...models);
+}
+
+export function _resetCodexTableForTest(): void {
+    _setCodexTableForTest([...SNAPSHOT.models]);
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,6 +8,7 @@ import { loadOptions, loadRoutes } from "./config.js";
 import { resetProxyCache } from "./upstream-proxy.js";
 import { FALLBACK_EFFECTIVE_WINDOW_FLOOR, lookupContextLimit, resolveConfiguredContextLimit, resolveCompressProtocol } from "./config.js";
 import { contextFromRegistry, loadRegistry, peekRegistryContext } from "./registry.js";
+import { codexAlignedWindow } from "./codex-models.js";
 import { fetchWithTimeout, MAX_REQUEST_BYTES } from "./fetch-util.js";
 import { formatUpstreamError, getUpstreamConnectionStatus, recordUpstreamConnection, resolveProxy, resolveProxyDecision, proxyDispatcher } from "./upstream-proxy.js";
 import { maskHeaderForLog, maskHeadersForLog, maskHostPortForLog, maskUrlForLog, maskUrlsInText } from "./log-mask.js";
@@ -799,6 +800,21 @@ async function handle(
                 if (native) nativeFromFallback = false;
             }
             reqConfig = resolveRequestConfig(config, opts.routes, embeddedUrl, model, native, opts.compress);
+            // #321 PR-E1: a codex client carries its OWN window perception
+            // (bundled model table + 272K unknown-model fallback) and
+            // auto-compacts at 90% of it. If bili's budget exceeds what codex
+            // believes, codex's native compaction fires first — the #292
+            // misalignment. Cap the effective window at codex's perception;
+            // the clamped value is authoritative for this client (codex's own
+            // config), so it also clears the low-confidence fallback flag
+            // (no effective-floor after output-headroom reservation).
+            const aligned = codexAlignedWindow(reqConfig.modelContextLimit, model, req.headers);
+            if (aligned.clamped) {
+                const before = reqConfig.modelContextLimit;
+                reqConfig = { ...reqConfig, modelContextLimit: aligned.limit };
+                nativeFromFallback = false;
+                log("info", `[codex] effective window clamped ${before} → ${aligned.limit} (codex's own perception for model=${model}; ACP now compresses before codex's native auto-compact)`);
+            }
             reqPrompts = resolveCompressPrompts(resolveCompress(opts.routes, embeddedUrl, model, opts.compress));
         }
     }

--- a/tests/codex-models.test.ts
+++ b/tests/codex-models.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+process.env.NODE_ENV = "test";
+
+import {
+    CODEX_FALLBACK_CONTEXT_WINDOW,
+    _resetCodexTableForTest,
+    _setCodexTableForTest,
+    codexAlignedWindow,
+    codexWindowForModel,
+    isCodexClient,
+} from "../src/codex-models.ts";
+
+// #321 PR-E1: codex carries its own window perception (bundled model table +
+// 272K unknown-model fallback) and auto-compacts at 90% of it. bili must cap
+// a codex client's effective window at that perception, or codex's native
+// compaction fires first (the #292 misalignment).
+
+const CODEX_UA = "codex_cli_rs/0.53.0 (linux 6.8.0; x86_64) cli";
+
+test("snapshot integrity: every entry has a slug and a resolvable window", () => {
+    assert.ok(codexWindowForModel("gpt-5.5") > 0);
+    assert.equal(CODEX_FALLBACK_CONTEXT_WINDOW, 272_000);
+});
+
+test("in-table exact slug: context_window wins over max_context_window", () => {
+    assert.equal(codexWindowForModel("gpt-5.5"), 272_000);
+    assert.equal(codexWindowForModel("gpt-5.4"), 272_000, "gpt-5.4 max is 1M but codex resolves context_window=272K");
+    assert.equal(codexWindowForModel("gpt-daybreak-red-latest"), 372_000);
+});
+
+test("longest-prefix match: model starting with a table slug inherits it", () => {
+    assert.equal(codexWindowForModel("gpt-5.5-mini"), 272_000, "gpt-5.5-mini → gpt-5.5");
+    assert.equal(codexWindowForModel("gpt-5.4-turbo"), 272_000, "gpt-5.4-turbo → gpt-5.4");
+    assert.equal(codexWindowForModel("gpt-5.4-mini-x"), 272_000, "longest slug wins (gpt-5.4-mini over gpt-5.4)");
+});
+
+test("namespaced suffix retry: provider-like namespace stripped once", () => {
+    assert.equal(codexWindowForModel("custom/gpt-5.5"), 272_000);
+    assert.equal(codexWindowForModel("openai/gpt-5.4"), 272_000);
+});
+
+test("not in table: 272K fallback (codex's model_info_from_slug), NOT unlimited", () => {
+    assert.equal(codexWindowForModel("qwen3.8-27b"), 272_000);
+    assert.equal(codexWindowForModel("my-custom-model"), 272_000);
+    assert.equal(codexWindowForModel("custom/gpt-5.3-codex"), 272_000, "suffix miss → fallback");
+    assert.equal(codexWindowForModel("a/b/gpt-5.5"), 272_000, "double slash → no retry → fallback");
+});
+
+test("isCodexClient: UA prefix codex_cli_rs/ only", () => {
+    assert.equal(isCodexClient({ "user-agent": CODEX_UA }), true);
+    assert.equal(isCodexClient({ "user-agent": "node-fetch/3.1" }), false);
+    assert.equal(isCodexClient({}), false);
+    assert.equal(isCodexClient({ "user-agent": ["node-fetch/3.1", CODEX_UA] }), true, "array headers");
+    assert.equal(isCodexClient({ "user-agent": "Codex_CLI_RS/0.53.0" }), false, "case-sensitive");
+});
+
+test("codexAlignedWindow: min() semantics per acceptance (in-table / not-in-table / user override)", () => {
+    const codex = { "user-agent": CODEX_UA };
+    const other = { "user-agent": "node-fetch/3.1" };
+    // in-table: bili 400K (built-in table) → clamped to codex's 272K
+    assert.deepEqual(codexAlignedWindow(400_000, "gpt-5.5", codex), { limit: 272_000, clamped: true });
+    // not-in-table: bili 1M → clamped to the 272K fallback
+    assert.deepEqual(codexAlignedWindow(1_000_000, "qwen3.8-27b", codex), { limit: 272_000, clamped: true });
+    // bili below perception: untouched (min keeps bili's)
+    assert.deepEqual(codexAlignedWindow(200_000, "gpt-5.5", codex), { limit: 200_000, clamped: false });
+    // equal: untouched
+    assert.deepEqual(codexAlignedWindow(272_000, "gpt-5.5", codex), { limit: 272_000, clamped: false });
+    // non-codex client: never touched
+    assert.deepEqual(codexAlignedWindow(400_000, "gpt-5.5", other), { limit: 400_000, clamped: false });
+    // user override below perception (PR-D style -c model_context_window=100000): untouched
+    assert.deepEqual(codexAlignedWindow(100_000, "gpt-5.5", codex), { limit: 100_000, clamped: false });
+});
+
+test("test hooks: table replacement + reset", () => {
+    _setCodexTableForTest([{ slug: "test-model", contextWindow: 12_345 }]);
+    assert.equal(codexWindowForModel("test-model"), 12_345);
+    assert.equal(codexWindowForModel("test-model-x"), 12_345);
+    _resetCodexTableForTest();
+    assert.equal(codexWindowForModel("gpt-5.5"), 272_000);
+});

--- a/tests/codex-window-align.test.ts
+++ b/tests/codex-window-align.test.ts
@@ -1,0 +1,160 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import { once } from "node:events";
+import test from "node:test";
+
+process.env.NODE_ENV = "test";
+
+import { defaultConfig } from "acp-kernel";
+import { startServer, type ProxyOptions } from "../src/server.ts";
+import { SessionStore, _setStoreForTest } from "../src/persist.ts";
+import { _setForTest as setRegistryForTest } from "../src/registry.ts";
+import { listSessions } from "../src/session.ts";
+
+// #321 PR-E1: a codex client (UA `codex_cli_rs/…`) carries its own window
+// perception and auto-compacts at 90% of it. The proxy caps the effective
+// window at codex's perception (min(bili, codex)), so ACP compresses before
+// codex's native compaction can fire (the #292 misalignment). The cap is
+// per-request (the UA may appear/disappear between requests of one session)
+// and observable via the plugin-reported effectiveContextLimit.
+
+const CODEX_UA = "codex_cli_rs/0.53.0 (linux 6.8.0; x86_64) cli";
+
+function okJson(model: string): string {
+    return JSON.stringify({ id: "msg_s", type: "message", role: "assistant", model, content: [{ type: "text", text: "s" }], stop_reason: "end_turn", usage: { input_tokens: 500, output_tokens: 5 } });
+}
+
+interface Rig {
+    proxyPort: number;
+    upstreamPort: number;
+    proxy: http.Server;
+    upstream: http.Server;
+}
+
+async function startRig(): Promise<Rig> {
+    const upstream = http.createServer((req, res) => {
+        const chunks: Buffer[] = [];
+        req.on("data", (c: Buffer) => chunks.push(c));
+        req.on("end", () => {
+            const raw = Buffer.concat(chunks).toString("utf8");
+            let model = "gpt-5.5";
+            try { model = (JSON.parse(raw) as { model?: string }).model ?? model; } catch { /* keep default */ }
+            res.writeHead(200, { "content-type": "application/json" });
+            res.end(okJson(model));
+        });
+    });
+    upstream.listen(0, "127.0.0.1");
+    await once(upstream, "listening");
+    const upstreamPort = upstream.address().port;
+
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    setRegistryForTest({});
+    const proxy = await startServer({
+        port: 0,
+        host: "127.0.0.1",
+        upstream: "http://127.0.0.1",
+        routes: { [`http://127.0.0.1:${upstreamPort}`]: {} },
+        modelContextLimit: 200_000,
+        kernelConfig: defaultConfig(200_000),
+        compress: { injectTool: true, injectNudge: true },
+        promptCache: { routing: "auto" },
+        sessionHeader: "x-acp-session",
+        log: false,
+        debug: false,
+        passthrough: false,
+        autoUpdate: false,
+        mitm: { enabled: false, domains: [] },
+    } as ProxyOptions);
+    await once(proxy, "listening");
+    const proxyPort = proxy.address().port;
+    return { proxyPort, upstreamPort, proxy, upstream };
+}
+
+function url(rig: Rig): string {
+    return `http://127.0.0.1:${rig.proxyPort}/bili/http://127.0.0.1:${rig.upstreamPort}/v1/messages`;
+}
+
+async function post(rig: Rig, session: string, model: string, codex: boolean): Promise<number> {
+    const headers: Record<string, string> = {
+        "content-type": "application/json",
+        "x-acp-session": session,
+        "x-bili-plugin": "test-agent",
+    };
+    if (codex) headers["user-agent"] = CODEX_UA;
+    const r = await fetch(url(rig), { method: "POST", headers, body: JSON.stringify({ model, max_tokens: 1024, stream: false, messages: [{ role: "user", content: "hi" }] }) });
+    await r.text();
+    return r.status;
+}
+
+function effectiveLimit(session: string): number | undefined {
+    return listSessions().find((s) => s.meta.label === session)?.metadata.effectiveContextLimit;
+}
+
+async function closeRig(rig: Rig): Promise<void> {
+    rig.proxy.close();
+    await once(rig.proxy, "close");
+    rig.upstream.close();
+    await once(rig.upstream, "close");
+}
+
+test("e2e: codex UA + in-table model → window clamped to codex's perception", async () => {
+    const rig = await startRig();
+    try {
+        assert.equal(await post(rig, "cw-in", "gpt-5.5", true), 200);
+        assert.equal(effectiveLimit("cw-in"), 272_000, "gpt-5.5: bili table 400K clamped to codex 272K");
+    } finally {
+        await closeRig(rig);
+    }
+});
+
+test("e2e: non-codex client → no clamp", async () => {
+    const rig = await startRig();
+    try {
+        assert.equal(await post(rig, "cw-plain", "gpt-5.5", false), 200);
+        assert.equal(effectiveLimit("cw-plain"), 400_000, "control: built-in table 400K untouched");
+    } finally {
+        await closeRig(rig);
+    }
+});
+
+test("e2e: codex UA + prefix-matched model → clamped via longest-prefix", async () => {
+    const rig = await startRig();
+    try {
+        assert.equal(await post(rig, "cw-prefix", "gpt-5.5-mini", true), 200);
+        assert.equal(effectiveLimit("cw-prefix"), 272_000, "gpt-5.5-mini → gpt-5.5 (272K)");
+    } finally {
+        await closeRig(rig);
+    }
+});
+
+test("e2e: codex UA + not-in-table model → clamped to the 272K fallback", async () => {
+    const rig = await startRig();
+    try {
+        assert.equal(await post(rig, "cw-fallback", "glm-5", true), 200);
+        assert.equal(effectiveLimit("cw-fallback"), 272_000, "glm-5: bili table 1M clamped to codex's unknown-model 272K");
+    } finally {
+        await closeRig(rig);
+    }
+});
+
+test("e2e: codex UA + bili window below perception → untouched (min keeps bili's)", async () => {
+    const rig = await startRig();
+    try {
+        assert.equal(await post(rig, "cw-below", "claude-sonnet-4-5", true), 200);
+        assert.equal(effectiveLimit("cw-below"), 200_000, "200K < 272K perception → no clamp");
+    } finally {
+        await closeRig(rig);
+    }
+});
+
+test("e2e: per-request resolution — UA disappears, window reverts", async () => {
+    const rig = await startRig();
+    try {
+        assert.equal(await post(rig, "cw-perreq", "gpt-5.5", true), 200);
+        assert.equal(effectiveLimit("cw-perreq"), 272_000, "with codex UA → clamped");
+        assert.equal(await post(rig, "cw-perreq", "gpt-5.5", false), 200);
+        assert.equal(effectiveLimit("cw-perreq"), 400_000, "same session, UA gone → 400K again");
+    } finally {
+        await closeRig(rig);
+    }
+});


### PR DESCRIPTION
**Model: qwen3.8-27b**

## What

PR-E1 of #321 (budget coordination for anonymous MITM codex clients): when the request client is codex, bili's effective window is capped at codex's own perception of that model — `min(bili window, codex perception)` — so ACP always compresses before codex's native auto-compact can fire.

## Why

codex's ledger base is the server-reported usage (which bili controls), but its auto-compact threshold comes from codex's own model table (`auto_compact_token_limit` = 90% of the model's `resolved_context_window`), with zero coordination with bili (#292's root cause). If bili's budget exceeds what codex believes, codex's native compaction fires first. Capping the effective window at codex's perception makes the budgets coincide: ACP (~55%) always goes first; if ACP fails, codex backstops at 90% before its 95% hard cap (local compaction for custom-provider users — benign for bili).

## Boundary correction vs the issue spec

The issue's E1 boundary clause ("模型不在 codex 表内 → codex 无认知 → 永不自动压缩") does not hold: codex's `model_info_from_slug` fallback gives unknown models `context_window = max_context_window = 272000` (models-manager/src/model_info.rs:171-172), i.e. unknown models auto-compact at ~244.8k — exactly the "~244k" trigger observed in #292. This PR treats not-in-table as **codex perception = 272000** (not unlimited), which is what fixes the #292 class. Already flagged in the issue thread.

## Changes

- `src/codex-models-snapshot.json` — bundled codex model table (10 models) generated from `openai/codex` main (commit 868c9ed), `codex-rs/models-manager/models.json`, same snapshot pattern as `registry-snapshot.json`.
- `scripts/update-codex-models-snapshot.mjs` + `npm run codex-models:snapshot` — refresh script (proxy-aware fetch, shape validation, keeps existing snapshot on failure).
- `src/codex-models.ts` — `codexWindowForModel` (emulates codex's lookup: longest-prefix slug match + namespaced-suffix retry + 272K fallback; user config overrides intentionally not emulated — they can only clamp DOWN to `max_context_window`, never raise, so the table value is a safe upper bound), `isCodexClient` (User-Agent starts `codex_cli_rs/` — the default originator; the `originator` header is only sent for non-default thread originators), `codexAlignedWindow` (the min()), test hooks.
- `src/server.ts` — after `resolveRequestConfig`, clamp `reqConfig.modelContextLimit` at codex's perception for codex clients; the clamped value is authoritative (codex's own config), so `nativeFromFallback` is cleared — otherwise the low-confidence fallback floor (100K, applied after output-headroom reservation) would push the budget back above codex's threshold and re-introduce the misalignment. Info log on clamp.

## Verification

- `npm run typecheck` clean
- `npm test`: 754/754 (master baseline 740 + 14 new)
  - `tests/codex-models.test.ts` (8): snapshot integrity; exact slug (context_window wins over max); longest-prefix; namespaced suffix; not-in-table → 272K (incl. double-slash miss); `isCodexClient` variants; min() acceptance matrix (in-table / not-in-table / below-perception untouched / equal untouched / non-codex untouched / user-override-below untouched); test hooks
  - `tests/codex-window-align.test.ts` (6, e2e through the proxy, observed via `metadata.effectiveContextLimit`): in-table clamp (gpt-5.5 400K→272K); non-codex control (400K); prefix (gpt-5.5-mini→272K); not-in-table fallback (glm-5 1M→272K); below-perception untouched (claude-sonnet-4-5 200K); per-request resolution (UA disappears → reverts to 400K)
- `npm run build` success; snapshot verified inlined in `dist/index.js`

Independent of PR #322 (PR-D) and PR #323 (PR-C); branches from master.