### PR TITLE
feat: intercept + forge codex native compaction when ACP is healthy (#321 PR-E2)

### DIFF
--- a/src/codex-compact.ts
+++ b/src/codex-compact.ts
@@ -1,0 +1,84 @@
+import { randomUUID } from "node:crypto";
+import type { Session } from "./session.js";
+
+export const CODEX_COMPACT_ID_PREFIX = "fc_bili_";
+export const CODEX_COMPACT_SENTINEL = "bili:acp:";
+
+const CODEX_UA_PREFIX = "codex_cli_rs/";
+
+export type CodexCompactMode = "intercept" | "pass";
+
+// Read per-request (not cached at startup) so a running proxy can flip the
+// kill-switch without a restart.
+export function codexCompactMode(): CodexCompactMode {
+    const v = process.env.BILI_CODEX_COMPACT?.trim().toLowerCase();
+    return v === "intercept" ? "intercept" : "pass";
+}
+
+// The `originator` header is only sent for non-default thread originators, so
+// the UA prefix (DEFAULT_ORIGINATOR in codex's default_client.rs) is the
+// reliable client signal.
+export function isCodexClient(headers: Record<string, string | string[] | undefined>): boolean {
+    const ua = headers["user-agent"];
+    if (!ua) return false;
+    const s = Array.isArray(ua) ? ua[0] : ua;
+    return typeof s === "string" && s.startsWith(CODEX_UA_PREFIX);
+}
+
+export function hasCompactionTrigger(input: unknown): boolean {
+    if (!Array.isArray(input)) return false;
+    const last = input[input.length - 1] as { type?: unknown } | undefined;
+    return last?.type === "compaction_trigger";
+}
+
+// Recognize a compaction item WE generated (id prefix or sentinel in the blob).
+// Codex echoes it back in the next request; stripping it keeps the summary
+// sourced from state (no double-count). Real OpenAI blobs carry neither marker,
+// so they are left untouched.
+export function isBiliCompactionItem(item: unknown): boolean {
+    const it = item as { type?: unknown; id?: unknown; encrypted_content?: unknown } | null;
+    if (!it || it.type !== "compaction") return false;
+    if (typeof it.id === "string" && it.id.startsWith(CODEX_COMPACT_ID_PREFIX)) return true;
+    if (typeof it.encrypted_content === "string" && it.encrypted_content.startsWith(CODEX_COMPACT_SENTINEL)) return true;
+    return false;
+}
+
+export function stripBiliCompactionItems<T>(input: T[]): T[] {
+    return input.filter((item) => !isBiliCompactionItem(item));
+}
+
+// Safety valve: forge ONLY when the transform succeeded, the steady-state
+// context is below the 90% threshold (codex's own auto-compact point — above
+// it, bili's ACP has failed to keep up and native compaction must backstop),
+// and there is at least one active block (a real summary to hand off).
+export function codexCompactGate(session: Session, effectiveLimit: number, transformOk: boolean): boolean {
+    if (!transformOk || effectiveLimit <= 0) return false;
+    if (session.stats.lastInputTokens >= effectiveLimit * 0.9) return false;
+    return session.state.blocks.some((b) => b.active);
+}
+
+// Minimal legal forged SSE stream for the trigger form: exactly one compaction
+// output item + response.completed. Codex's parser (codex-api/src/sse/responses.rs)
+// ignores every other event kind and requires response.completed to parse with
+// id + usage{input_tokens,output_tokens,total_tokens}.
+export function buildTriggerForgeSse(
+    summaryText: string,
+    usage: { inputTokens: number; outputTokens: number; totalTokens: number },
+): string {
+    const compactionItem = {
+        type: "compaction",
+        id: `${CODEX_COMPACT_ID_PREFIX}${randomUUID()}`,
+        encrypted_content: `${CODEX_COMPACT_SENTINEL}${summaryText}`,
+    };
+    const completed = {
+        id: `resp_bili_${randomUUID()}`,
+        usage: {
+            input_tokens: usage.inputTokens,
+            output_tokens: usage.outputTokens,
+            total_tokens: usage.totalTokens,
+        },
+    };
+    const frame1 = `data: ${JSON.stringify({ type: "response.output_item.done", item: compactionItem })}\n\n`;
+    const frame2 = `data: ${JSON.stringify({ type: "response.completed", response: completed })}\n\n`;
+    return frame1 + frame2;
+}

--- a/src/codex-compact.ts
+++ b/src/codex-compact.ts
@@ -4,7 +4,7 @@ import type { Session } from "./session.js";
 export const CODEX_COMPACT_ID_PREFIX = "fc_bili_";
 export const CODEX_COMPACT_SENTINEL = "bili:acp:";
 
-const CODEX_UA_PREFIX = "codex_cli_rs/";
+const CODEX_UA_PREFIXES = ["codex_cli_rs/", "codex_exec/"];
 
 export type CodexCompactMode = "intercept" | "pass";
 
@@ -22,7 +22,7 @@ export function isCodexClient(headers: Record<string, string | string[] | undefi
     const ua = headers["user-agent"];
     if (!ua) return false;
     const s = Array.isArray(ua) ? ua[0] : ua;
-    return typeof s === "string" && s.startsWith(CODEX_UA_PREFIX);
+    return typeof s === "string" && CODEX_UA_PREFIXES.some((p) => s.startsWith(p));
 }
 
 export function hasCompactionTrigger(input: unknown): boolean {

--- a/src/server.ts
+++ b/src/server.ts
@@ -53,6 +53,7 @@ import { defaultLogFile, stateDir, proxyOriginFile } from "./paths.js";
 import { compressLoopResponsesJson } from "./compress-loop-responses.js";
 import { runCompressLoop, pickAdapter } from "./loop/index.js";
 import { sanitizeResponsesInputIds, dropWhitespaceResponsesMessages, normalizeResponsesMessageItems } from "./loop/adapter-responses.js";
+import { codexCompactMode, isCodexClient, hasCompactionTrigger, stripBiliCompactionItems, codexCompactGate, buildTriggerForgeSse } from "./codex-compact.js";
 import { rewriteOpenaiJsonResponse } from "./stream-openai.js";
 import { rewriteResponsesJsonResponse } from "./stream-responses.js";
 import { emitStreamError } from "./stream-error.js";
@@ -444,11 +445,15 @@ type Prepared = {
      *  rebuilt payload and compress-loop round must re-inject it. */
     openaiSystemText?: string;
     nudge?: NudgeDecision;
-    /** Effective compression prompts for this request (three-level cascade,
-     *  defaults to the kernel's defaultPrompts). Carried so the compress loop
-     *  in forward() rebuilds the SAME system prompt the request was prepared
-     *  with. */
+     /** Effective compression prompts for this request (three-level cascade,
+      *  defaults to the kernel's defaultPrompts). Carried so the compress loop
+      *  in forward() rebuilds the SAME system prompt the request was prepared
+      *  with. */
     prompts?: Prompts;
+    /** Set when a codex native-compaction request was intercepted and a
+     *  success response was forged locally (BILI_CODEX_COMPACT=intercept +
+     *  gate passed). forward() serves `body` without contacting upstream. */
+    codexForge?: { kind: "endpoint" | "trigger"; body: string; contentType: string };
 };
 
 
@@ -1047,7 +1052,7 @@ async function handle(
                           : protocol === "openai"
                             ? prepareOpenai(parsed as OpenAIRequestBody, req, opts, core, reqConfig, reqPrompts, log, session, pluginMode)
                             : responsesCompact
-                              ? prepareResponsesCompact(bodyBuffer, parsed as ResponsesRequestBody, session)
+                               ? prepareResponsesCompact(bodyBuffer, parsed as ResponsesRequestBody, session, req, core, reqConfig, log)
                               : prepareResponses(parsed as ResponsesRequestBody, req, opts, core, reqConfig, reqPrompts, log, session, responsesIdentity!, pluginMode, upstreamOrigin);
                 prepared = runPrepare();
                 if (!countTokens && !responsesCompact) {
@@ -1375,12 +1380,24 @@ function prepareResponses(
         log("info", `[${sessionId}] reconciled ACP state after native Responses compact boundary`);
     }
 
+    // A codex client echoes our forged compaction item back in the next request;
+    // drop it so the summary is sourced from state (no double-count). Real
+    // OpenAI blobs carry no bili marker and pass through untouched.
+    if (Array.isArray(parsed.input)) {
+        const cleaned = stripBiliCompactionItems(parsed.input);
+        if (cleaned.length !== parsed.input.length) {
+            log("info", `[${sessionId}] stripped ${parsed.input.length - cleaned.length} bili compaction item(s) echoed by codex`);
+            parsed.input = cleaned;
+        }
+    }
+
     let processedMessages: CoreMessage[] = [];
     let originalMessages: CoreMessage[] = [];
     let nudge: NudgeDecision | undefined;
     let responsesProjection: ResponsesProjection | undefined;
     let rebuiltInput: ResponseInputItem[] | string = parsed.input;
     let toolsOut = parsed.tools;
+    let transformOk = false;
 
     // #242: over-long input item ids (poisoned rollouts) 400 upstream on every
     // request; rewrite them to short deterministic ids before anything reads
@@ -1469,9 +1486,31 @@ function prepareResponses(
             } catch {
             }
         }
+        transformOk = true;
     } catch (err) {
         log("warn", `[${sessionId}] kernel transform failed, forwarding unchanged: ${String(err)}`);
         processedMessages = [];
+    }
+
+    // E2 trigger form: codex's native remote-compaction request (final input item
+    // is compaction_trigger). When the kill-switch is on, the client is codex, and
+    // the safety gate passes, forge a success SSE (one compaction item +
+    // response.completed) and skip upstream — a deterministic handoff to the ACP
+    // state instead of a foreign compaction blob.
+    let codexForge: Prepared["codexForge"] | undefined;
+    if (transformOk
+        && codexCompactMode() === "intercept"
+        && isCodexClient(req.headers)
+        && hasCompactionTrigger(parsed.input)
+        && codexCompactGate(session, config.modelContextLimit, transformOk)) {
+        const summaries = session.state.blocks.filter((b) => b.active).map((b) => b.summary);
+        const total = session.stats.lastInputTokens;
+        codexForge = {
+            kind: "trigger",
+            body: buildTriggerForgeSse(summaries.join("\n\n"), { inputTokens: total, outputTokens: 0, totalTokens: total }),
+            contentType: "text/event-stream",
+        };
+        log("info", `[${sessionId}] codex compact intercepted (trigger); forged SSE with ${summaries.length} block summary(s), upstream not contacted`);
     }
 
     const rebuilt: ResponsesRequestBody = { ...parsed, input: rebuiltInput, tools: toolsOut };
@@ -1527,6 +1566,7 @@ function prepareResponses(
         responsesTextProtocol,
         nudge,
         prompts,
+        codexForge,
     };
 }
 
@@ -1576,9 +1616,17 @@ export function prepareCountTokens(
     }
 }
 
-function prepareResponsesCompact(body: Buffer, parsed: ResponsesRequestBody, session: Session): Prepared {
+function prepareResponsesCompact(
+    body: Buffer,
+    parsed: ResponsesRequestBody,
+    session: Session,
+    req: http.IncomingMessage,
+    core: CompressionCore,
+    config: Config,
+    log: (level: string, msg: string) => void,
+): Prepared {
     ++session.stats.requests;
-    return {
+    const base: Prepared = {
         body,
         session,
         processedMessages: [],
@@ -1588,6 +1636,33 @@ function prepareResponsesCompact(body: Buffer, parsed: ResponsesRequestBody, ses
         compressInjected: false,
         resetAfterSuccess: true,
     };
+    if (codexCompactMode() !== "intercept" || !isCodexClient(req.headers) || !Array.isArray(parsed.input)) {
+        return base;
+    }
+    // E2 endpoint form: /responses/compact. When the gate passes, run the same
+    // fold pipeline as a normal turn and forge the compacted history as
+    // {"output": [...]} — a deterministic handoff to the ACP state instead of a
+    // foreign compaction blob.
+    const cleaned = stripBiliCompactionItems(parsed.input);
+    const forgeBody: ResponsesRequestBody = { ...parsed, input: cleaned };
+    let transformOk = false;
+    try {
+        const projection = responsesToCore(forgeBody);
+        const turn = core.processTurn({ messages: projection.msgs, state: session.state, config, tokenCount: session.stats.lastInputTokens, renderTags: process.env.ACP_RENDER_NONE ? "none" : "text-only" });
+        session.state = turn.state;
+        transformOk = true;
+        if (!codexCompactGate(session, config.modelContextLimit, transformOk)) return base;
+        const processed = stripKernelSummaries(turn.messages, turn.state);
+        const output = patchResponsesInput(projection, processed);
+        if (typeof output === "string") return base;
+        snapshotMessages(session, projection.msgs);
+        markDirty(session);
+        log("info", `[${session.id}] codex compact intercepted (endpoint); forged history with ${output.length} item(s), upstream not contacted`);
+        return { ...base, codexForge: { kind: "endpoint", body: JSON.stringify({ output }), contentType: "application/json" } };
+    } catch (err) {
+        log("warn", `[${session.id}] codex compact forge failed (${String(err)}); passing through to upstream`);
+        return base;
+    }
 }
 
 export function isChatGptCodexUpstream(upstream: string | undefined): boolean {
@@ -1867,6 +1942,14 @@ async function forward(
     instanceId: string,
     affinity?: string,
 ): Promise<void> {
+    // E2: a codex native-compaction request intercepted in prepare() carries a
+    // forged success response — serve it without contacting upstream.
+    if (prepared?.codexForge) {
+        log("info", `[${prepared.session.id}] codex compact served locally (${prepared.codexForge.kind}); upstream not contacted`);
+        res.writeHead(200, { "content-type": prepared.codexForge.contentType });
+        res.end(prepared.codexForge.body);
+        return;
+    }
     // #300: stamp the chain marker ONLY when this instance actually processed
     // the request (prepared !== null). A passthrough forward (prepared === null)
     // must NOT claim processing — otherwise a downstream processing bili would

--- a/tests/codex-compact-e2e.test.ts
+++ b/tests/codex-compact-e2e.test.ts
@@ -1,0 +1,230 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import { once } from "node:events";
+import test from "node:test";
+
+process.env.NODE_ENV = "test";
+
+import { defaultConfig } from "acp-kernel";
+import { startServer, type ProxyOptions } from "../src/server.ts";
+import { SessionStore, _setStoreForTest } from "../src/persist.ts";
+import { _setForTest as setRegistryForTest } from "../src/registry.ts";
+import { listSessions, _resetSessionsForTest } from "../src/session.ts";
+
+// Issue #321 PR-E2: conditional interception + forgery of codex's native
+// compaction requests. When BILI_CODEX_COMPACT=intercept, the client is codex,
+// and the ACP state is healthy (transform ok + steady-state < 90% + an active
+// block to hand off), bili forges a success response and never contacts
+// upstream — a deterministic handoff to the ACP state. Otherwise (kill-switch
+// off, ACP not keeping up, or nothing compressed yet) the request passes
+// through to upstream and native compaction backstops.
+
+const CODEX_UA = "codex_cli_rs/0.1.0 (linux x86_64)";
+const SESSION = "trig-sess";
+
+function sse(type: string, data: unknown): string {
+    return `event: ${type}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+function completed(inputTokens: number): string {
+    return sse("response.completed", {
+        response: { id: "resp_done", status: "completed", output: [], usage: { input_tokens: inputTokens, output_tokens: 5, total_tokens: inputTokens + 5 } },
+    });
+}
+function fcEvents(callId: string, args: string): string {
+    return [
+        sse("response.output_item.added", { item: { type: "function_call", id: `fc_${callId}`, call_id: callId, name: "compress" }, output_index: 0 }),
+        sse("response.function_call_arguments.delta", { item_id: `fc_${callId}`, delta: args }),
+        sse("response.output_item.done", { item: { type: "function_call", id: `fc_${callId}`, call_id: callId, name: "compress", arguments: args }, output_index: 0 }),
+    ].join("");
+}
+// 7 messages × ~4400 chars (~1100 tokens each, ~7700 total). Below the 10k
+// window so preflight never fires; above the recent-tail protection so
+// m00001/m00002 are compressible by the model.
+function conversation() {
+    const input: { type: string; role: string; content: string }[] = [];
+    for (let i = 0; i < 7; i++) {
+        input.push({ type: "message", role: i % 2 === 0 ? "user" : "assistant", content: `Message ${i} of the working session. ` + `WORK_${i}_content_`.repeat(290) });
+    }
+    return input;
+}
+
+type Harness = {
+    proxy: http.Server;
+    upstream: http.Server;
+    bodies: string[];
+    url: string;
+    compactUrl: string;
+};
+
+async function withHarness(opts: { mode?: string; firstTurnTokens: number }, fn: (h: Harness) => Promise<void>): Promise<void> {
+    const bodies: string[] = [];
+    const upstream = http.createServer((req, res) => {
+        const chunks: Buffer[] = [];
+        req.on("data", (c: Buffer) => chunks.push(c));
+        req.on("end", () => {
+            const raw = Buffer.concat(chunks).toString("utf8");
+            bodies.push(raw);
+            if ((req.url ?? "").includes("/responses/compact")) {
+                res.writeHead(200, { "content-type": "application/json" });
+                res.end(JSON.stringify({ output: [] }));
+                return;
+            }
+            res.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache" });
+            if (bodies.length === 1) {
+                // First turn: the model compresses the oldest pair → active block.
+                const compressArgs = JSON.stringify({
+                    content: [{ startId: "m00001", endId: "m00002", topic: "setup", summary: "MAIN-SUMMARY-SETUP-CONTEXT-FOLDED-BY-COMPRESSION-LONG-ENOUGH-FOR-KERNEL-MIN-LENGTH-CHECK" }],
+                });
+                res.write(fcEvents("call_p", compressArgs));
+            }
+            res.write(completed(opts.firstTurnTokens));
+            res.end();
+        });
+    });
+    upstream.listen(0, "127.0.0.1");
+    await once(upstream, "listening");
+    const upstreamPort = upstream.address().port;
+
+    if (opts.mode === undefined) delete process.env.BILI_CODEX_COMPACT;
+    else process.env.BILI_CODEX_COMPACT = opts.mode;
+
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    _resetSessionsForTest();
+    setRegistryForTest({});
+    const proxy = await startServer({
+        port: 0,
+        host: "127.0.0.1",
+        upstream: "http://127.0.0.1",
+        routes: { [`http://127.0.0.1:${upstreamPort}`]: { models: { "gpt-resp": { context: 10_000 } } } },
+        modelContextLimit: 10_000,
+        kernelConfig: defaultConfig(10_000),
+        compress: { injectTool: true, injectNudge: true },
+        promptCache: { routing: "auto" },
+        sessionHeader: "x-acp-session",
+        log: false,
+        debug: false,
+        passthrough: false,
+        autoUpdate: false,
+        mitm: { enabled: false, domains: [] },
+    } as ProxyOptions);
+    await once(proxy, "listening");
+    const proxyPort = proxy.address().port;
+    const base = `http://127.0.0.1:${proxyPort}/bili/http://127.0.0.1:${upstreamPort}/v1`;
+    const h: Harness = { proxy, upstream, bodies, url: `${base}/responses`, compactUrl: `${base}/responses/compact` };
+    try {
+        await fn(h);
+    } finally {
+        proxy.close();
+        await once(proxy, "close");
+        upstream.close();
+        await once(upstream, "close");
+        delete process.env.BILI_CODEX_COMPACT;
+    }
+}
+
+// Turn 1: a normal turn where the model compresses the oldest pair, leaving an
+// active block. Returns the upstream-request count after setup.
+async function setupCompressedSession(h: Harness): Promise<number> {
+    const r1 = await fetch(h.url, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ model: "gpt-resp", stream: true, session_id: SESSION, instructions: "You are the test coding agent.", input: conversation() }),
+    });
+    assert.equal(r1.status, 200);
+    await r1.text();
+    const s = listSessions().find((x) => x.meta.label === SESSION);
+    assert.ok(s, "session exists");
+    assert.ok((s!.state.blocks ?? []).some((b) => b.active), "setup created an active block");
+    return h.bodies.length;
+}
+
+test("e2e E2 (trigger form): intercept + healthy ACP → forged 2-frame SSE, upstream untouched", async () => {
+    await withHarness({ mode: "intercept", firstTurnTokens: 1000 }, async (h) => {
+        const afterSetup = await setupCompressedSession(h);
+        const s = listSessions().find((x) => x.meta.label === SESSION)!;
+        assert.ok(s.stats.lastInputTokens < 9000, "low steady-state usage → gate passes");
+
+        const r2 = await fetch(h.url, {
+            method: "POST",
+            headers: { "content-type": "application/json", "user-agent": CODEX_UA },
+            body: JSON.stringify({ model: "gpt-resp", stream: true, session_id: SESSION, instructions: "You are the test coding agent.", input: [...conversation(), { type: "compaction_trigger" }] }),
+        });
+        assert.equal(r2.status, 200, "intercepted compact returns 200");
+        assert.equal(r2.headers.get("content-type"), "text/event-stream", "forged SSE");
+        const frames = (await r2.text()).split("\n\n").filter((f) => f.startsWith("data: "));
+        assert.equal(frames.length, 2, "exactly two data frames");
+        const e1 = JSON.parse(frames[0]!.slice("data: ".length)) as { type: string; item: { type: string; id: string; encrypted_content: string } };
+        assert.equal(e1.type, "response.output_item.done");
+        assert.equal(e1.item.type, "compaction");
+        assert.ok(e1.item.id.startsWith("fc_bili_"), "bili compaction id prefix");
+        assert.ok(e1.item.encrypted_content.startsWith("bili:acp:"), "sentinel in blob");
+        const e2 = JSON.parse(frames[1]!.slice("data: ".length)) as { type: string; response: { id: string; usage: { total_tokens: number } } };
+        assert.equal(e2.type, "response.completed");
+        assert.ok(e2.response.id.startsWith("resp_bili_"), "forged response id");
+
+        assert.equal(h.bodies.length, afterSetup, "upstream NOT contacted for the intercepted compact");
+    });
+});
+
+test("e2e E2 (trigger form): kill-switch off (default) → forwarded to upstream", async () => {
+    await withHarness({ mode: undefined, firstTurnTokens: 1000 }, async (h) => {
+        const afterSetup = await setupCompressedSession(h);
+        const r2 = await fetch(h.url, {
+            method: "POST",
+            headers: { "content-type": "application/json", "user-agent": CODEX_UA },
+            body: JSON.stringify({ model: "gpt-resp", stream: true, session_id: SESSION, instructions: "You are the test coding agent.", input: [...conversation(), { type: "compaction_trigger" }] }),
+        });
+        assert.equal(r2.status, 200);
+        await r2.text();
+        assert.equal(h.bodies.length, afterSetup + 1, "compact request forwarded to upstream");
+    });
+});
+
+test("e2e E2 (trigger form): intercept + ACP not keeping up (≥90%) → forwarded (native backstop)", async () => {
+    await withHarness({ mode: "intercept", firstTurnTokens: 15000 }, async (h) => {
+        const afterSetup = await setupCompressedSession(h);
+        const s = listSessions().find((x) => x.meta.label === SESSION)!;
+        assert.ok(s.stats.lastInputTokens >= 9000, "high steady-state usage → gate fails");
+        const r2 = await fetch(h.url, {
+            method: "POST",
+            headers: { "content-type": "application/json", "user-agent": CODEX_UA },
+            body: JSON.stringify({ model: "gpt-resp", stream: true, session_id: SESSION, instructions: "You are the test coding agent.", input: [...conversation(), { type: "compaction_trigger" }] }),
+        });
+        assert.equal(r2.status, 200);
+        await r2.text();
+        assert.equal(h.bodies.length, afterSetup + 1, "unhealthy ACP → compact forwarded to upstream");
+    });
+});
+
+test("e2e E2 (trigger form): intercept + nothing compressed yet → forwarded (no summary to hand off)", async () => {
+    await withHarness({ mode: "intercept", firstTurnTokens: 1000 }, async (h) => {
+        // Fresh session, no setup compression — the compact request is the first.
+        const r = await fetch(h.url, {
+            method: "POST",
+            headers: { "content-type": "application/json", "user-agent": CODEX_UA },
+            body: JSON.stringify({ model: "gpt-resp", stream: true, session_id: "fresh-sess", instructions: "You are the test coding agent.", input: [...conversation(), { type: "compaction_trigger" }] }),
+        });
+        assert.equal(r.status, 200);
+        const text = await r.text();
+        assert.ok(!text.includes("fc_bili_"), "no active block → compact NOT forged (forwarded to upstream)");
+        assert.ok(!text.includes("resp_bili_"), "no forged response id");
+        assert.ok(h.bodies.length >= 1, "compact request reached upstream");
+    });
+});
+
+test("e2e E2 (endpoint form): intercept + healthy ACP → forged JSON {output}, upstream untouched", async () => {
+    await withHarness({ mode: "intercept", firstTurnTokens: 1000 }, async (h) => {
+        const afterSetup = await setupCompressedSession(h);
+        const r2 = await fetch(h.compactUrl, {
+            method: "POST",
+            headers: { "content-type": "application/json", "user-agent": CODEX_UA },
+            body: JSON.stringify({ model: "gpt-resp", stream: false, session_id: SESSION, instructions: "You are the test coding agent.", input: conversation() }),
+        });
+        assert.equal(r2.status, 200, "intercepted endpoint compact returns 200");
+        assert.ok((r2.headers.get("content-type") ?? "").includes("application/json"), "forged JSON");
+        const parsed = JSON.parse(await r2.text()) as { output: unknown[] };
+        assert.ok(Array.isArray(parsed.output), "output is an array");
+        assert.ok(parsed.output.length > 0, "output carries the compacted history");
+        assert.equal(h.bodies.length, afterSetup, "upstream NOT contacted for the intercepted endpoint compact");
+    });
+});

--- a/tests/codex-compact.test.ts
+++ b/tests/codex-compact.test.ts
@@ -41,6 +41,7 @@ test("codexCompactMode: kill-switch two states + default + case/trim", () => {
 test("isCodexClient: UA prefix detection (Node lowercases header keys)", () => {
     assert.equal(isCodexClient({ "user-agent": "codex_cli_rs/0.1.0 (linux x86_64)" }), true);
     assert.equal(isCodexClient({ "user-agent": "codex_cli_rs/0.2.1" }), true);
+    assert.equal(isCodexClient({ "user-agent": "codex_exec/0.147.0 (linux x86_64)" }), true, "exec-mode originator (codex 0.147 real-device UA)");
     assert.equal(isCodexClient({ "user-agent": "openai-node/3.0" }), false);
     assert.equal(isCodexClient({}), false, "no UA");
     assert.equal(isCodexClient({ "user-agent": ["codex_cli_rs/0.1.0", "other"] }), true, "array UA takes first");

--- a/tests/codex-compact.test.ts
+++ b/tests/codex-compact.test.ts
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+process.env.NODE_ENV = "test";
+
+import { createInitialState, type CompressionBlock } from "acp-kernel";
+import type { Session } from "../src/session.ts";
+import {
+    codexCompactMode,
+    isCodexClient,
+    hasCompactionTrigger,
+    isBiliCompactionItem,
+    stripBiliCompactionItems,
+    codexCompactGate,
+    buildTriggerForgeSse,
+    CODEX_COMPACT_ID_PREFIX,
+    CODEX_COMPACT_SENTINEL,
+} from "../src/codex-compact.ts";
+
+test("codexCompactMode: kill-switch two states + default + case/trim", () => {
+    const prev = process.env.BILI_CODEX_COMPACT;
+    try {
+        delete process.env.BILI_CODEX_COMPACT;
+        assert.equal(codexCompactMode(), "pass", "default is pass");
+        process.env.BILI_CODEX_COMPACT = "pass";
+        assert.equal(codexCompactMode(), "pass");
+        process.env.BILI_CODEX_COMPACT = "intercept";
+        assert.equal(codexCompactMode(), "intercept");
+        process.env.BILI_CODEX_COMPACT = "INTERCEPT";
+        assert.equal(codexCompactMode(), "intercept", "case-insensitive");
+        process.env.BILI_CODEX_COMPACT = "  intercept  ";
+        assert.equal(codexCompactMode(), "intercept", "trimmed");
+        process.env.BILI_CODEX_COMPACT = "bogus";
+        assert.equal(codexCompactMode(), "pass", "unknown value falls back to pass");
+    } finally {
+        if (prev === undefined) delete process.env.BILI_CODEX_COMPACT;
+        else process.env.BILI_CODEX_COMPACT = prev;
+    }
+});
+
+test("isCodexClient: UA prefix detection (Node lowercases header keys)", () => {
+    assert.equal(isCodexClient({ "user-agent": "codex_cli_rs/0.1.0 (linux x86_64)" }), true);
+    assert.equal(isCodexClient({ "user-agent": "codex_cli_rs/0.2.1" }), true);
+    assert.equal(isCodexClient({ "user-agent": "openai-node/3.0" }), false);
+    assert.equal(isCodexClient({}), false, "no UA");
+    assert.equal(isCodexClient({ "user-agent": ["codex_cli_rs/0.1.0", "other"] }), true, "array UA takes first");
+    assert.equal(isCodexClient({ "user-agent": ["other", "codex_cli_rs/0.1.0"] }), false, "array UA first is not codex");
+});
+
+test("hasCompactionTrigger: only a FINAL compaction_trigger counts", () => {
+    assert.equal(hasCompactionTrigger([{ type: "message" }, { type: "compaction_trigger" }]), true);
+    assert.equal(hasCompactionTrigger([{ type: "compaction_trigger" }]), true);
+    assert.equal(hasCompactionTrigger([{ type: "message" }]), false);
+    assert.equal(hasCompactionTrigger([{ type: "compaction_trigger" }, { type: "message" }]), false, "trigger must be final");
+    assert.equal(hasCompactionTrigger([]), false);
+    assert.equal(hasCompactionTrigger("a string"), false);
+});
+
+test("isBiliCompactionItem: our-vs-real-blob distinction", () => {
+    assert.equal(isBiliCompactionItem({ type: "compaction", id: `${CODEX_COMPACT_ID_PREFIX}abc` }), true, "id prefix");
+    assert.equal(isBiliCompactionItem({ type: "compaction", encrypted_content: `${CODEX_COMPACT_SENTINEL}summary` }), true, "sentinel");
+    assert.equal(isBiliCompactionItem({ type: "compaction", id: "fc_real", encrypted_content: "opaque-blob" }), false, "real OpenAI blob untouched");
+    assert.equal(isBiliCompactionItem({ type: "message", role: "user", content: "hi" }), false, "not a compaction item");
+    assert.equal(isBiliCompactionItem(null), false);
+});
+
+test("stripBiliCompactionItems: removes ours, keeps real blobs + messages", () => {
+    const ours = { type: "compaction", id: `${CODEX_COMPACT_ID_PREFIX}x`, encrypted_content: `${CODEX_COMPACT_SENTINEL}s` };
+    const real = { type: "compaction", id: "fc_real", encrypted_content: "opaque" };
+    const msg = { type: "message", role: "user", content: "hi" };
+    const out = stripBiliCompactionItems([ours, real, msg]);
+    assert.equal(out.length, 2);
+    assert.ok(out.includes(real), "real blob kept");
+    assert.ok(out.includes(msg), "message kept");
+    assert.ok(!out.includes(ours), "ours removed");
+});
+
+function block(active: boolean): CompressionBlock {
+    return {
+        blockId: "b1", runId: "r1", tier: 1, summary: "S",
+        directMessageIds: [], effectiveMessageIds: [], directBlockIds: [],
+        compressedTokens: 100, createdAt: 0, survivedCount: 0, generation: "young", active,
+    };
+}
+
+function mockSession(lastInputTokens: number, blocks: CompressionBlock[]): Session {
+    const state = createInitialState();
+    state.blocks = blocks;
+    return {
+        id: "test",
+        meta: {},
+        stats: { requests: 0, tokensSaved: 0, inputTokens: 0, cachedTokens: 0, outputTokens: 0, cacheSamples: 0, lastInputTokens, compressCreditTokens: 0, contextTokens: 0 },
+        metadata: {},
+        state,
+        createdAt: 0,
+        lastSeen: 0,
+        blockContents: new Map(),
+        inFlight: 0,
+        persisted: false,
+    };
+}
+
+test("codexCompactGate: safety-valve matrix", () => {
+    const limit = 10_000;
+    assert.equal(codexCompactGate(mockSession(1_000, [block(true)]), limit, true), true, "healthy + active block + transform ok");
+    assert.equal(codexCompactGate(mockSession(1_000, [block(true)]), limit, false), false, "transform failed → pass through");
+    assert.equal(codexCompactGate(mockSession(1_000, [block(false)]), limit, true), false, "no active block → pass through");
+    assert.equal(codexCompactGate(mockSession(1_000, []), limit, true), false, "no blocks → pass through");
+    assert.equal(codexCompactGate(mockSession(9_000, [block(true)]), limit, true), false, "at 90% → ACP not keeping up → pass through");
+    assert.equal(codexCompactGate(mockSession(9_500, [block(true)]), limit, true), false, "above 90% → pass through");
+    assert.equal(codexCompactGate(mockSession(8_999, [block(true)]), limit, true), true, "just below 90% → forge");
+    assert.equal(codexCompactGate(mockSession(1_000, [block(true)]), 0, true), false, "zero limit → pass through");
+});
+
+test("buildTriggerForgeSse: minimal legal 2-frame stream", () => {
+    const sse = buildTriggerForgeSse("SUMMARY-TEXT", { inputTokens: 1000, outputTokens: 0, totalTokens: 1000 });
+    const frames = sse.split("\n\n").filter((f) => f.length > 0);
+    assert.equal(frames.length, 2, "exactly two data frames");
+    const e1 = JSON.parse(frames[0]!.slice("data: ".length)) as { type: string; item: { type: string; id: string; encrypted_content: string } };
+    assert.equal(e1.type, "response.output_item.done");
+    assert.equal(e1.item.type, "compaction");
+    assert.ok(e1.item.id.startsWith(CODEX_COMPACT_ID_PREFIX), "compaction id has bili prefix");
+    assert.ok(e1.item.encrypted_content.startsWith(CODEX_COMPACT_SENTINEL), "blob carries the sentinel");
+    assert.ok(e1.item.encrypted_content.includes("SUMMARY-TEXT"), "summary text in blob");
+    const e2 = JSON.parse(frames[1]!.slice("data: ".length)) as { type: string; response: { id: string; usage: { input_tokens: number; output_tokens: number; total_tokens: number } } };
+    assert.equal(e2.type, "response.completed");
+    assert.ok(e2.response.id.startsWith("resp_bili_"), "completed response id");
+    assert.equal(e2.response.usage.input_tokens, 1000);
+    assert.equal(e2.response.usage.output_tokens, 0);
+    assert.equal(e2.response.usage.total_tokens, 1000);
+});


### PR DESCRIPTION
**Model: qwen3.8-27b**

Closes the last major piece of #321 (PR-E2): **conditional interception + forgery of codex's native compaction requests**, giving a deterministic handoff from codex's ledger to the bili/ACP state.

## What

When **all** of these hold, bili forges a success response and **never contacts upstream**:
1. `BILI_CODEX_COMPACT=intercept` (kill-switch; **default `pass`** until real-device validation flips it),
2. the client is codex (User-Agent starts `codex_cli_rs/`),
3. the ACP state is **healthy**: transform ok + steady-state `lastInputTokens < 90%` of the effective window + at least one **active block** to hand off.

Two request shapes are handled, both matching codex's source-verified parsers:
- **Trigger form** (input ends with `compaction_trigger`): forged **2-frame SSE** — `response.output_item.done` carrying exactly one `{type:"compaction", id:"fc_bili_*", encrypted_content:"bili:acp:<ACP summaries>"}` + `response.completed` with honest usage. Matches `collect_compaction_output` (exactly one compaction item + `response.completed`; every other event is ignored; missing completed → retryable error).
- **Endpoint form** (`POST /responses/compact`): forged **JSON `{output:[...]}`** where `output` is the rebuilt history (recent items + ACP summary via the normal `responsesToCore → processTurn → stripKernelSummaries → patchResponsesInput` pipeline). Matches `CompactHistoryResponse`.

Otherwise (kill-switch off, ACP not keeping up ≥90%, or nothing compressed yet) the request **passes through** to upstream and native compaction backstops — rebased correctly by the PR-C semantic gate. Bili-generated compaction items (`fc_bili_` prefix / `bili:acp:` sentinel) are stripped from subsequent requests so codex's echoed item never double-counts; the summaries come from ACP state, not re-sent blobs.

## Why this is the "fundamental" fix

With E2, a healthy ACP state is handed to codex deterministically: codex's ledger resets to the (small) forged usage and its history becomes the ACP summary + recent items. The next request matches the ACP state exactly — no heuristic rebase needed on the happy path. The `markNativeCompactionBoundary`/reconcile machinery remains only as the fallback for the pass-through (unhealthy) case, where PR-C's semantic gate does the rebase.

## Files
- `src/codex-compact.ts` (new): pure helpers — `codexCompactMode`, `isCodexClient`, `hasCompactionTrigger`, `isBiliCompactionItem`, `stripBiliCompactionItems`, `codexCompactGate`, `buildTriggerForgeSse`.
- `src/server.ts`: `Prepared.codexForge` field; `prepareResponses` strips bili items + trigger-form forge; `prepareResponsesCompact` endpoint-form forge; `forward()` top serves the forge (upstream untouched).
- `tests/codex-compact.test.ts` (7 unit): kill-switch 2-state+default, UA detection, trigger detection, item strip, gate matrix, forge SSE shape.
- `tests/codex-compact-e2e.test.ts` (5 e2e): intercept+healthy→forged (trigger+endpoint, upstream untouched); kill-switch off→forwarded; ≥90%→forwarded; no-block→forwarded.

## Pre-flight
- `npm run typecheck` — clean
- `npm test` — **752/752** (7 unit + 5 e2e new; baseline 740)
- `npm run build` — ok; forge code verified inlined in `dist/index.js`

## Notes / follow-ups
- Kill-switch defaults to `pass`; flipping to `intercept` is a one-line change after real-device validation (issue acceptance: "伪造响应通过 codex 真机校验").
- Real-device e2e (local sglang responses endpoint + codex custom provider) is the remaining acceptance item — needs the live test env, not doable in CI.
- Independent of PR-D (#322) and PR-E1 (#324); duplicates the 3-line UA check and gates on bili's own window (no cross-branch dependency).
