### PR TITLE
fix: warn when running process is stale relative to on-disk install (#327)

### DIFF
--- a/src/update.ts
+++ b/src/update.ts
@@ -67,6 +67,15 @@ function isNewer(latest: string, current: string): boolean {
     return false;
 }
 
+/** Stale-install decision for the up-to-date branch of an update check —
+ *  exported for tests. "restart" means the on-disk install is newer than the
+ *  running process: an auto-update landed in-place but the process was never
+ *  restarted, so the one-time "Restart to finish" message is long gone and
+ *  every "up to date" line since has been misleading (#327). */
+export function staleInstallStatus(diskVersion: string | undefined, runningVersion: string): "restart" | "current" {
+    return diskVersion !== undefined && isNewer(diskVersion, runningVersion) ? "restart" : "current";
+}
+
 async function readLastCheck(): Promise<number> {
     try {
         const data = await readFile(THROTTLE_FILE, "utf-8");
@@ -354,7 +363,11 @@ export async function checkForUpdate(opts: UpdateOptions, force = false): Promis
         const currentVersion = diskVersion ?? opts.currentVersion;
 
         if (!isNewer(latest, currentVersion)) {
-            loggerLog("info", `[update] current=${currentVersion} latest=${latest} (up to date)`);
+            if (staleInstallStatus(diskVersion, opts.currentVersion) === "restart") {
+                loggerLog("warn", `[update] running v${opts.currentVersion} but v${diskVersion} is installed — restart bili to activate (auto-update replaced the on-disk install; this process is still on the old code)`);
+            } else {
+                loggerLog("info", `[update] current=${currentVersion} latest=${latest} (up to date)`);
+            }
             return;
         }
 

--- a/tests/update-restart-reminder.test.ts
+++ b/tests/update-restart-reminder.test.ts
@@ -1,0 +1,24 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { staleInstallStatus } from "../src/update.ts";
+
+test("staleInstallStatus: disk newer than running process → restart (#327 scenario)", () => {
+    assert.equal(staleInstallStatus("0.1.62", "0.1.55"), "restart");
+});
+
+test("staleInstallStatus: disk == running → current", () => {
+    assert.equal(staleInstallStatus("0.1.62", "0.1.62"), "current");
+});
+
+test("staleInstallStatus: disk older than running (manual downgrade) → current", () => {
+    assert.equal(staleInstallStatus("0.1.55", "0.1.62"), "current");
+});
+
+test("staleInstallStatus: no install dir found → current", () => {
+    assert.equal(staleInstallStatus(undefined, "0.1.62"), "current");
+});
+
+test("staleInstallStatus: numeric (not lexicographic) compare across digit widths", () => {
+    assert.equal(staleInstallStatus("0.1.10", "0.1.9"), "restart");
+    assert.equal(staleInstallStatus("0.1.9", "0.1.10"), "current");
+});


### PR DESCRIPTION
## What

`checkForUpdate` reads the version from the **on-disk** install (`diskVersion ?? opts.currentVersion`) before comparing with the npm registry. When an auto-update has already replaced the on-disk install but the process was never restarted, every periodic check logs `[update] current=0.1.62 latest=0.1.62 (up to date)` — misleading, because the *running* code is still the old version. The one-time "Restart to finish" message at install time is the only signal, and once missed, it is gone forever.

This PR makes the up-to-date branch detect that state and log a persistent warning instead:

```
[update] running v0.1.55 but v0.1.62 is installed — restart bili to activate (auto-update replaced the on-disk install; this process is still on the old code)
```

## Why (issue #327)

The reported symptom (context meter jumping 0% → 405% then an EMERGENCY compress) was caused by a stale v0.1.5x process: preflight payload-estimate trigger (v0.1.60) and credit netting (v0.1.56) were not running. Disk already had 0.1.62, so the updater kept saying "up to date" and the user had no way to know a restart was needed. Restarting fixes the symptom; this PR fixes the *silence*.

## Changes

- `src/update.ts`: new exported pure fn `staleInstallStatus(diskVersion, runningVersion) → "restart" | "current"` (reuses existing strict `isNewer`); up-to-date branch of `checkForUpdate` warns when disk > running.
- `tests/update-restart-reminder.test.ts`: 5 unit tests (disk-newer / equal / disk-older / undefined / numeric-vs-lexicographic compare).

No control-flow change to the download/extract/install path — log-only in the check path.

## Pre-flight

- `npm run typecheck` — clean
- `npm test` — 745/745 pass (740 existing + 5 new)
- `npm run build` — success

## Release note (§5)

This touches `src/update.ts`, so per the no-op-release rule this is flagged for human decision: the change is log-only in the version-check path (no download/extract/install/version-compare behavior change), but a no-op release first is the conservative route if you want the rule applied strictly.