### PR TITLE
release v0.1.63

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.62",
+  "version": "0.1.63",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Model: glm-5.3 (vllm, via pi)

# release v0.1.63

## Since v0.1.62

- **#336** (six-PR codex compact family, merged):
  - `#322` budget alignment — launcher injects codex `model_context_window` / `model_auto_compact_token_limit` via `-c`
  - `#323` semantic rebase gate — judge success by SSE terminal state (`response.completed`/`failed`), not HTTP status
  - `#324` effective window = `min(bili, codex perception)` with codex's bundled model table snapshot (`codex-models-snapshot.json`, `npm run codex-models:snapshot`)
  - `#325` intercept-forged codex native compaction — 2-frame SSE trigger forge / `{output}` endpoint forge, `fc_bili_` echo stripping, sentinel memory; **`BILI_CODEX_COMPACT` default is now `intercept`** (opt out with `pass`)
  - `#317` subagent partitioning — `x-codex-turn-metadata.thread_source == "user"` → session-id identity, anything else → thread-id identity
  - `#319` tail-window anonymous re-attach at arbitrary offsets
  - 12 review fixes (hybrid handoff: history-borne summary message replaces forged echo on re-request; capture fallback)
  - codex local/private upstream → auto-fallback to wire tools (sglang/vllm/ollama can't parse codex namespace MCP tools); explicit `BILI_LAUNCHER_PLUGIN=1/0` still honored
- **#327** warn when running process is stale relative to on-disk install
- **#328** update restart-reminder copy
- **#330** preflight relaxes the soft-protected recent zone under overflow

## Pre-flight

- typecheck ✓
- tests 745/745 ✓
- build ✓

Merge → CI publishes `0.1.63` to npm.