### PR TITLE
fix: generate real changelog in GitHub Releases via generate_release_notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,14 +75,11 @@ jobs:
 
       - name: Create GitHub Release
         if: steps.check.outputs.is_release == 'true'
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: v${{ steps.version.outputs.version }}
-          release_name: v${{ steps.version.outputs.version }}
-          prerelease: ${{ steps.pre.outputs.prerelease }}
-          body: |
-            ## Release v${{ steps.version.outputs.version }}
-
-            See [commits since last tag](https://github.com/${{ github.repository }}/compare/$(git describe --tags --abbrev=0 v${{ steps.version.outputs.version }}^ 2>/dev/null || echo HEAD~10)...v${{ steps.version.outputs.version }})
+        run: |
+          VER="${{ steps.version.outputs.version }}"
+          curl -sS -f -X POST \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${{ github.repository }}/releases" \
+            -d "{\"tag_name\":\"v${VER}\",\"name\":\"v${VER}\",\"prerelease\":${{ steps.pre.outputs.prerelease }},\"generate_release_notes\":true}"


### PR DESCRIPTION
Model: glm-5.3 (vllm, via pi)

# What

Every GitHub Release since the beginning shipped a placeholder body with an unexpanded shell command:

```
See [commits since last tag](.../compare/$(git describe --tags --abbrev=0 v0.1.63^ 2>/dev/null || echo HEAD~10)...v0.1.63)
```

because `actions/create-release@v1` writes `body:` verbatim — no shell expansion happens inside the workflow file.

# Fix

Replace the archived `actions/create-release@v1` step with a REST call that sets `generate_release_notes: true`. GitHub then auto-generates the "Full changelog" compare link + the merged-PR list per release. prerelease flag is preserved.

- v0.1.63's release page was already patched by hand with a proper changelog (378952735)
- future releases get it automatically

# Risk

Release-trigger/publish path untouched; only the GitHub-Release-creation step changes.

# Pre-flight

- yaml lint ✓ (workflow parses, 10 steps)