### PR TITLE
fix: omp pck stamp for chat-completions with max_tokens; anthropic wire consumes + strips pck (#268)

### DIFF
--- a/src/agent/pi.ts
+++ b/src/agent/pi.ts
@@ -65,9 +65,14 @@ function sessionIdOf(ctx: Ctx): string | undefined {
 // by the omp session uuid). The before_provider_request return value REPLACES
 // the whole outgoing payload (omp onPayload chain, verified in the omp 17.3.8
 // dist), so stamp prompt_cache_key with the omp session id: the proxy binds
-// pluginMode by that identity and /acp finds the session by it. Chat shape only
-// (messages array, no responses `input`, no anthropic `max_tokens`, no native
-// prompt_cache_key); pi is untouched (it stamps x-bili-plugin-conversation in
+// pluginMode by that identity and /acp finds the session by it.
+// Chat shape = messages array, no responses `input`, no native prompt_cache_key.
+// max_tokens is NOT a discriminator: omp's openai-compat providers send it in
+// every chat-completions body (maxTokensField:"max_tokens") exactly like the
+// anthropic wire — excluding it meant the target shape was never stamped
+// (#268). The anthropic wire gets stamped too: the proxy records the mapping
+// from the body pck there as well and strips the field before forwarding to
+// the real Anthropic. pi is untouched (it stamps x-bili-plugin-conversation in
 // before_provider_headers, which outranks the body field).
 function stampPromptCacheKey(event: unknown, ctx: Ctx, agent: string): Record<string, unknown> | undefined {
     if (agent !== "omp") return undefined;
@@ -75,7 +80,7 @@ function stampPromptCacheKey(event: unknown, ctx: Ctx, agent: string): Record<st
     if (payload === null || typeof payload !== "object" || Array.isArray(payload)) return undefined;
     const p = payload as Record<string, unknown>;
     if (!Array.isArray(p.messages)) return undefined;
-    if (p.input !== undefined || p.max_tokens !== undefined) return undefined;
+    if (p.input !== undefined) return undefined;
     if (typeof p.prompt_cache_key === "string" && p.prompt_cache_key.trim().length > 0) return undefined;
     const sid = sessionIdOf(ctx);
     if (sid === undefined || sid.length === 0) return undefined;

--- a/src/server.ts
+++ b/src/server.ts
@@ -896,8 +896,24 @@ async function handle(
                   parsed as { prompt_cache_key?: unknown },
               )
             : undefined;
-        const conversation = protocol === "anthropic"
+        // Anthropic mirrors the openai pck promotion (#268): the omp plugin
+        // stamps prompt_cache_key on every chat-shaped payload — it cannot
+        // tell the anthropic wire apart by shape (both carry max_tokens). The
+        // proxy consumes the field on this wire too (identity + mapping);
+        // prepareAnthropic strips it before the real Anthropic sees it.
+        const anthropicSignal = protocol === "anthropic"
             ? conversationSignalAnthropic(parsed as AnthropicRequestBody, convHeader)
+            : "";
+        const anthropicIdentity = protocol === "anthropic"
+            ? preferPromptCacheKeyIdentity(
+                  convHeader
+                    ? { value: anthropicSignal, source: "header" as const, clientProvided: true }
+                    : { value: anthropicSignal, source: "content-fingerprint" as const, clientProvided: false },
+                  parsed as { prompt_cache_key?: unknown },
+              )
+            : undefined;
+        const conversation = protocol === "anthropic"
+            ? anthropicIdentity?.value ?? anthropicSignal
             : protocol === "openai"
               ? openaiIdentity?.value ?? openaiSignal
               : codexTurn
@@ -921,7 +937,9 @@ async function handle(
             ? (responsesIdentity?.clientProvided ?? false)
             : protocol === "openai"
               ? (openaiIdentity?.clientProvided ?? false)
-              : !!convHeader;
+              : protocol === "anthropic"
+                ? (anthropicIdentity?.clientProvided ?? false)
+                : !!convHeader;
         // Anonymous fallback (#309): clients with no identity signal at all
         // (no headers, no session_id/prompt_cache_key) still replay their full
         // history — resolve them by longest-prefix affinity instead of the
@@ -965,7 +983,7 @@ async function handle(
         //    body.session_id) — never the synthetic one — so a user can tell
         //    at a glance which client owns a session. pi sends nothing, so its
         //    label stays empty (shown as "—" in the UI).
-        const bodyIdentity = responsesIdentity ?? openaiIdentity;
+        const bodyIdentity = responsesIdentity ?? openaiIdentity ?? anthropicIdentity;
         const affinity = affinityToken(bodyIdentity ?? {
             value: clientConv ?? conversation,
             source: clientConv ? "header" : "generated",
@@ -1013,16 +1031,16 @@ async function handle(
             session.metadata.effectiveContextLimit = reqConfig.modelContextLimit;
             recordPluginSession(pluginConversation ?? conversation, session.id);
         }
-        // Responses AND OpenAI-chat clients that send their own session id as
-        // `prompt_cache_key` (omp) get that conversation recorded even WITHOUT
-        // the x-bili-plugin header, so the /acp command — which looks the
-        // session up by the client's session id — can find it. The session id
-        // itself now ALSO derives from prompt_cache_key (the
+        // Responses, OpenAI-chat AND Anthropic-wire clients that send their
+        // own session id as `prompt_cache_key` (omp) get that conversation
+        // recorded even WITHOUT the x-bili-plugin header, so the /acp command
+        // — which looks the session up by the client's session id — can find
+        // it. The session id itself now ALSO derives from prompt_cache_key (the
         // preferPromptCacheKeyIdentity calls above, which only kick in when the
         // kernel would have fallen to a per-request content fingerprint) — this
         // lookup binding remains for clients that send a real conversation
         // header or session_id.
-        if (protocol === "responses" || protocol === "openai") {
+        if (protocol === "responses" || protocol === "openai" || protocol === "anthropic") {
             const pck = (parsed as { prompt_cache_key?: unknown }).prompt_cache_key;
             if (typeof pck === "string" && pck.trim().length > 0) {
                 recordPluginSession(pck.trim(), session.id);
@@ -1289,6 +1307,10 @@ function prepareAnthropic(
     markDirty(session);
 
     const rebuilt: AnthropicRequestBody = { ...parsed, messages: rebuiltMessages, system: systemOut, tools: toolsOut };
+    // prompt_cache_key is the omp plugin's session id stamped for the proxy's
+    // identity chain (#268), not part of the Anthropic Messages API — strip it
+    // so the real upstream never sees a field it doesn't know.
+    delete (rebuilt as Record<string, unknown>).prompt_cache_key;
     return { body: JSON.stringify(rebuilt), session, processedMessages, originalMessages, anthropicSystem: parsed.system, protocol: "anthropic", stream, compressInjected: injectTools, pluginMode, nudge, prompts } as Prepared;
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -150,7 +150,7 @@ function safeSessionId(id: string | undefined): string {
  *  history are resolved by prefix affinity (#309); only degenerate probes
  *  (empty / system-only, or a fingerprint-sized history) fail explicitly. */
 const NO_IDENTITY_MESSAGE =
-    "Missing stable conversation identity. Send one of the headers: x-session-id, x-session-affinity, x-acp-session, x-opencode-session, x-claude-code-session-id, session-id — or body session_id / prompt_cache_key (responses/openai). Requests replaying a conversation history are matched by content prefix affinity (#309); this one carries no usable history signal.";
+    "Missing stable conversation identity. Send one of the headers: x-session-id, x-session-affinity, x-acp-session, x-opencode-session, x-claude-code-session-id, session-id — or body session_id / prompt_cache_key (responses/openai/anthropic). Requests replaying a conversation history are matched by content prefix affinity (#309); this one carries no usable history signal.";
 
 const UPSTREAM_HOP_HEADERS = new Set([
     "host",
@@ -1687,8 +1687,10 @@ export function prepareCountTokens(
         const stripped = stripKernelSummaries(turn.messages as BiliMessage[], turn.state);
         const rebuiltMessages = coreToAnthropic(stripped, cacheControls);
         log("info", `[${sessionId}] count_tokens pruned: ${msgs.length} → ${stripped.length} msgs`);
+        const rebuilt: AnthropicRequestBody = { ...parsed, messages: rebuiltMessages };
+        delete (rebuilt as Record<string, unknown>).prompt_cache_key;
         return {
-            body: JSON.stringify({ ...parsed, messages: rebuiltMessages }),
+            body: JSON.stringify(rebuilt),
             session,
             processedMessages: [],
             originalMessages: msgs,
@@ -1698,8 +1700,10 @@ export function prepareCountTokens(
         };
     } catch (err) {
         log("warn", `[${sessionId}] count_tokens prune failed, forwarding unchanged: ${String(err)}`);
+        const fallback: AnthropicRequestBody = { ...parsed };
+        delete (fallback as Record<string, unknown>).prompt_cache_key;
         return {
-            body: JSON.stringify(parsed),
+            body: JSON.stringify(fallback),
             session,
             processedMessages: [],
             originalMessages: [],

--- a/tests/anthropic-pck-identity.test.ts
+++ b/tests/anthropic-pck-identity.test.ts
@@ -1,0 +1,173 @@
+import assert from "node:assert";
+import http from "node:http";
+import { once } from "node:events";
+import test from "node:test";
+
+process.env.NODE_ENV = "test";
+
+import { defaultConfig } from "acp-kernel";
+import { startServer, type ProxyOptions } from "../src/server.ts";
+import { SessionStore, _setStoreForTest } from "../src/persist.ts";
+import { _setForTest as setRegistryForTest } from "../src/registry.ts";
+import { _resetPluginStateForTest } from "../src/plugin.ts";
+
+// #268: the omp plugin cannot tell the anthropic wire apart from
+// chat-completions by payload shape (both carry max_tokens), so its
+// prompt_cache_key stamp lands on anthropic bodies too. The proxy must
+// consume the field there deliberately: (a) bind the session identity to the
+// pck, (b) record the conversation mapping so /acp finds the session, and
+// (c) strip the field before the real Anthropic sees a field it doesn't know.
+
+function anthropicSse(event: string, data: unknown): string {
+    return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+function anthropicStream(): string {
+    return (
+        anthropicSse("message_start", { type: "message_start", message: { id: "m1", role: "assistant", usage: { input_tokens: 42 } } }) +
+        anthropicSse("content_block_start", { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } }) +
+        anthropicSse("content_block_delta", { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "ok" } }) +
+        anthropicSse("content_block_stop", { type: "content_block_stop", index: 0 }) +
+        anthropicSse("message_delta", { type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 2 } }) +
+        anthropicSse("message_stop", { type: "message_stop" })
+    );
+}
+
+interface Rig {
+    proxyUrl: (path: string) => string;
+    messagesUrl: () => string;
+    upstreamBodies: string[];
+    closeAll(): Promise<void>;
+}
+
+async function startRig(): Promise<Rig> {
+    const upstreamBodies: string[] = [];
+    const upstream = http.createServer((req, res) => {
+        const chunks: Buffer[] = [];
+        req.on("data", (c: Buffer) => chunks.push(c));
+        req.on("end", () => {
+            upstreamBodies.push(Buffer.concat(chunks).toString("utf8"));
+            res.writeHead(200, { "content-type": "text/event-stream" });
+            res.end(anthropicStream());
+        });
+    });
+    upstream.listen(0, "127.0.0.1");
+    await once(upstream, "listening");
+    const upstreamPort = (upstream.address() as { port: number }).port;
+
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    setRegistryForTest({});
+    _resetPluginStateForTest();
+
+    const opts: ProxyOptions = {
+        port: 0,
+        host: "127.0.0.1",
+        upstream: "http://127.0.0.1",
+        routes: { [`http://127.0.0.1:${upstreamPort}`]: { models: { "claude-test": { context: 100_000 } } } },
+        modelContextLimit: 100_000,
+        kernelConfig: defaultConfig(100_000),
+        compress: { injectTool: true, injectNudge: true },
+        promptCache: { routing: "auto" },
+        log: false,
+        sessionHeader: "x-acp-session",
+        debug: false,
+        passthrough: false,
+        autoUpdate: false,
+        mitm: { enabled: false, domains: [] },
+    };
+    const proxy = await startServer(opts);
+    await once(proxy, "listening");
+    const proxyPort = (proxy.address() as { port: number }).port;
+    const closeOne = (s: http.Server): Promise<void> =>
+        new Promise((resolve, reject) => s.close((e) => (e ? reject(e) : resolve())));
+    return {
+        proxyUrl: (path) => `http://127.0.0.1:${proxyPort}${path}`,
+        messagesUrl: () => `http://127.0.0.1:${proxyPort}/bili/http://127.0.0.1:${upstreamPort}/v1/messages`,
+        upstreamBodies,
+        closeAll: async () => {
+            await closeOne(proxy);
+            await closeOne(upstream);
+        },
+    };
+}
+
+function postMessages(rig: Rig, pck: string): Promise<Response> {
+    return fetch(rig.messagesUrl(), {
+        method: "POST",
+        headers: { "content-type": "application/json", "x-api-key": "test" },
+        body: JSON.stringify({ model: "claude-test", max_tokens: 1024, messages: [{ role: "user", content: "hello" }], prompt_cache_key: pck }),
+    });
+}
+
+async function register(rig: Rig, conversationId: string, agent: string, identity: boolean): Promise<void> {
+    const res = await fetch(rig.proxyUrl("/__bili/plugin/register"), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ conversationId, agent, identity }),
+    });
+    assert.equal(res.status, 200, "register accepted");
+}
+
+async function status(rig: Rig, conversationId: string): Promise<{ ok: boolean; pluginAgent?: string | null; panel?: string }> {
+    const res = await fetch(rig.proxyUrl(`/__bili/plugin/status?conversationId=${encodeURIComponent(conversationId)}`));
+    return (await res.json()) as { ok: boolean; pluginAgent?: string | null; panel?: string };
+}
+
+test("anthropic pck: the session is recorded by prompt_cache_key so /acp (status by pck) finds it", async () => {
+    const rig = await startRig();
+    try {
+        await postMessages(rig, "omp-uuid-anthropic");
+        const s = await status(rig, "omp-uuid-anthropic");
+        assert.equal(s.ok, true, "session found by prompt_cache_key");
+        assert.ok(typeof s.panel === "string" && s.panel.length > 0, "panel rendered, not the armed fallback");
+    } finally {
+        await rig.closeAll();
+    }
+});
+
+test("anthropic pck: prompt_cache_key is stripped before forwarding to the real Anthropic", async () => {
+    const rig = await startRig();
+    try {
+        await postMessages(rig, "omp-uuid-strip");
+        assert.equal(rig.upstreamBodies.length, 1);
+        const sent = JSON.parse(rig.upstreamBodies[0]!) as Record<string, unknown>;
+        assert.equal("prompt_cache_key" in sent, false, "proxy-internal identity field stripped from the upstream body");
+        assert.equal(sent.max_tokens, 1024, "rest of the body preserved");
+    } finally {
+        await rig.closeAll();
+    }
+});
+
+test("anthropic pck: identity register + matching pck binds pluginMode (wire injection suppressed)", async () => {
+    const rig = await startRig();
+    try {
+        // Control: an unregistered anthropic session rides wire mode — the
+        // compress tool IS injected into the outgoing tools array.
+        await postMessages(rig, "omp-uuid-wire");
+        assert.ok(rig.upstreamBodies[0]!.includes('"compress"'), "unregistered anthropic session is wire mode (compress tool injected)");
+
+        await register(rig, "omp-uuid-bind", "omp", true);
+        await postMessages(rig, "omp-uuid-bind");
+        assert.ok(!rig.upstreamBodies[1]!.includes('"compress"'), "wire tool injection suppressed after identity binding");
+        const s = await status(rig, "omp-uuid-bind");
+        assert.equal(s.ok, true, "bound conversation is found");
+        assert.equal(s.pluginAgent, "omp", "pluginAgent recorded as omp");
+    } finally {
+        await rig.closeAll();
+    }
+});
+
+test("anthropic: no pck, no header → anonymous prefix affinity (unchanged)", async () => {
+    const rig = await startRig();
+    try {
+        const res = await fetch(rig.messagesUrl(), {
+            method: "POST",
+            headers: { "content-type": "application/json", "x-api-key": "test" },
+            body: JSON.stringify({ model: "claude-test", max_tokens: 1024, messages: [{ role: "user", content: "hello" }] }),
+        });
+        assert.equal(res.status, 200, "anonymous anthropic request still served via prefix affinity");
+        assert.equal(rig.upstreamBodies.length, 1);
+    } finally {
+        await rig.closeAll();
+    }
+});

--- a/tests/plugin-agent.test.ts
+++ b/tests/plugin-agent.test.ts
@@ -812,6 +812,14 @@ test("omp before_provider_request stamps prompt_cache_key only for chat-completi
         assert.deepEqual(out.messages, payload.messages, "rest of the payload preserved");
         assert.equal(payload.prompt_cache_key, undefined, "original payload not mutated");
     }
+    // real-world chat-completions payload carries max_tokens (omp's openai-compat
+    // providers use maxTokensField:"max_tokens") → stamped (#268)
+    {
+        const pi = mk();
+        const out = handler(pi, { model: "glm-4", messages: [{ role: "user", content: "hi" }], max_tokens: 4096, temperature: 0.7 }) as Record<string, unknown>;
+        assert.equal(out.prompt_cache_key, sid, "chat-completions payload WITH max_tokens stamped");
+        assert.equal(out.max_tokens, 4096, "max_tokens preserved");
+    }
     // native prompt_cache_key already present → not overridden
     {
         const pi = mk();
@@ -824,11 +832,14 @@ test("omp before_provider_request stamps prompt_cache_key only for chat-completi
         const out = handler(pi, { input: [{ role: "user", content: "hi" }] });
         assert.equal(out, undefined, "responses payload (input) untouched");
     }
-    // anthropic wire (max_tokens) → untouched
+    // anthropic wire shape (messages + max_tokens) → stamped too: the plugin
+    // cannot tell the wires apart by shape, and the proxy records the mapping
+    // from the body pck on the anthropic path and strips the field before
+    // forwarding to the real Anthropic (#268)
     {
         const pi = mk();
-        const out = handler(pi, { messages: [{ role: "user", content: "hi" }], max_tokens: 1024, system: "s" });
-        assert.equal(out, undefined, "anthropic wire (max_tokens) untouched");
+        const out = handler(pi, { messages: [{ role: "user", content: "hi" }], max_tokens: 1024, system: "s" }) as Record<string, unknown>;
+        assert.equal(out.prompt_cache_key, sid, "anthropic wire shape stamped (proxy strips before forward)");
     }
     // no session id → untouched
     {


### PR DESCRIPTION
## Problem (#268, still broken in 0.1.62)

`/acp` keeps reporting "No model request in this conversation yet" for `bili omp` sessions on the openai chat-completions wire. User-reported root cause, verified against source and the omp 18.0.6 dist:

`stampPromptCacheKey()` (src/agent/pi.ts) excluded payloads carrying `max_tokens` — intended to skip the anthropic wire — but omp's openai-compat providers send `max_tokens` in **every** chat-completions body (provider config `maxTokensField:"max_tokens"`, confirmed in the omp 18.0.6 dist). So the pck was never stamped, the proxy's openai pck identity path (added in #267) never fired, the conversation map stayed empty, and `/acp` 404'd forever. The #267 test matrix used a synthetic chat payload *without* `max_tokens`, which is why this slipped through.

## Fix

**Plugin (src/agent/pi.ts)** — the user's one-line guard fix: drop `max_tokens` from the stamp exclusion (chat shape = `messages` array + no `input` + no native pck).

**Proxy (src/server.ts)** — make the anthropic wire consume the field deliberately, because the plugin cannot tell the wires apart by shape (both carry `max_tokens`):

- anthropic path mirrors the openai pck promotion: `preferPromptCacheKeyIdentity` over the content fingerprint (session id becomes the omp sid verbatim, `clientProvided=true`), plus the conversation mapping is now recorded for `responses | openai | anthropic`.
- `prepareAnthropic` **strips `prompt_cache_key`** from the outgoing body — it is a proxy-internal identity marker, not part of the Anthropic Messages API, so the real upstream never sees a field it doesn't know (same pattern as the existing `prompt_cache_retention` strip in `prepareOpenai`).

### Why not ship the one-line plugin patch alone

The patch alone would also stamp the anthropic wire (indistinguishable by shape — `BeforeProviderRequestEvent` carries only `{type, payload}`, no URL to scope on). The pck would then be forwarded to api.anthropic.com as an unknown top-level field: zero benefit (the proxy ignored body-pck on that wire) and an unverified upstream-rejection risk. With the proxy half, the anthropic wire is *also* fixed (`/acp` works for omp + Claude models) with no unknown field reaching the real Anthropic.

### Other report claims, checked

- ✅ omp has no `before_provider_headers` (header path is dead code on omp) — confirmed in the 18.0.6 type defs.
- ✅ register-consumption timing deadlock (`!anonAffinity` / `requests === 0` gates) — confirmed; the pck path bypasses it since the first request now carries identity.
- ❌ "omp natively sends `x-session-id` on every model request" — not supported: in the 18.0.6 dist, `x-session-id` appears only in Codex-Live WebSocket signaling and the auth-broker header allowlist, never in the normal model-request path. The reporter's own observed `anonymousPrefixAffinity: true` session metadata proves it (that flag is only set when the request carries no client identity). Consequence: the header-identity route is dead on omp too — pck is the only route, which is what this PR fixes.

## Tests

- `tests/plugin-agent.test.ts` — injection matrix: new real-world case (chat-completions **with** `max_tokens` → stamped), anthropic-shape case flipped to stamped (documents the proxy strip contract).
- `tests/anthropic-pck-identity.test.ts` (new) — mapping recorded by pck on the anthropic wire, field stripped upstream, identity register + pck binds pluginMode (wire injection suppressed), anonymous no-pck requests unchanged.

Checks: `npm run typecheck`, `npm test` (827 pass), `npm run build` — all green.
