### PR TITLE
test: widen e2e mock pacing to keep streaming-span margin on slow CI runners

### DIFF
--- a/tests/e2e-proxy-smoke.test.ts
+++ b/tests/e2e-proxy-smoke.test.ts
@@ -23,7 +23,7 @@ function sseLine(obj: unknown): string {
     return `data: ${JSON.stringify(obj)}\n\n`;
 }
 
-const DELAY_MS = 40;
+const DELAY_MS = 80;
 
 test("e2e proxy smoke: compress tool-call -> re-request -> round-2 streams in real-time", async () => {
     _setStoreForTest(new SessionStore({ enabled: false }));

--- a/tests/e2e-responses-chat-relay.test.ts
+++ b/tests/e2e-responses-chat-relay.test.ts
@@ -26,7 +26,7 @@ function sseLine(obj: unknown): string {
     return `data: ${JSON.stringify(obj)}\n\n`;
 }
 
-const DELAY_MS = 40;
+const DELAY_MS = 80;
 
 function startMockChatRelay(script: ChatRelayScript, captured: Captured[]): http.Server {
     const server = http.createServer((req, res) => {


### PR DESCRIPTION
Model: glm-5.3 (vllm, via pi)

# What

The two streaming-latency e2e tests inject `DELAY_MS = 40` between mock SSE frames and assert the client-observed span is `>= 50ms` (guards against the proxy buffering deltas into one flush).

On a loaded CI runner (v0.1.63's ubuntu-22 job, run 33243362588) timer coalescing + socket merging compressed the span to 48ms — 2ms under the threshold — a pure timing flake. Both files:

- `tests/e2e-proxy-smoke.test.ts:26`
- `tests/e2e-responses-chat-relay.test.ts:29`

# Fix

`DELAY_MS 40 → 80` in both files. Expected span becomes ~160ms vs the unchanged 50ms threshold (>3x margin). The test still discriminates hard: a buffering regression collapses the span to ~0–10ms, far below 50ms.

Cost: each affected test takes ~200ms longer (8 tests in the two files, 8/8 pass locally).

# Pre-flight

- node --import tsx --test on both files: 8/8 ✓