### PR TITLE
fix: per-route model context declaration outranks the models.dev registry (#344)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -775,24 +775,28 @@ async function handle(
             // windows (BILI_LAUNCHER_MODEL_WINDOWS — the client's own
             // models.json/models.yml contextWindow, authoritative for this
             // deployment, no header trust needed since only the launcher
-            // sets the env); (2) a WARM models.dev registry
+            // sets the env); (2) the user's per-route per-model declaration —
+            // operator-controlled and deployment-specific: the same model name
+            // can have different windows behind different relays (a private
+            // relay may serve gpt-5.6-sol at 272K while models.dev lists the
+            // official 1M), so an explicit declaration always outranks the
+            // auto-fetched registry (#344); (3) a WARM models.dev registry
             // cache (daily refresh — outranks the static table whenever
-            // already resident; peek never fetches, cold start skips to (3)
-            // without blocking); (3) resolveContextLimit = user's per-route
-            // per-model declaration, then the built-in CONTEXT_LIMIT_TABLE
+            // already resident; peek never fetches, cold start skips to (4)
+            // without blocking); (4) the built-in CONTEXT_LIMIT_TABLE
             // fallback. Operator tuning via compress.modelContextLimit still
             // outranks everything inside resolveRequestConfig.
             const host = (() => { try { return embeddedUrl ? new URL(embeddedUrl).host : undefined; } catch { return undefined; } })();
             const betaWindow = anthropicBetaContextWindow(req.headers);
             const pluginWindow = pluginReportedContextWindow(req.headers);
             const launcherWindow = launcherContextWindow(model);
-            const peekWindow = host ? peekRegistryContext(model, host) : undefined;
             const configuredWindow = resolveConfiguredContextLimit(opts.routes, embeddedUrl, model);
+            const peekWindow = host ? peekRegistryContext(model, host) : undefined;
             let native = betaWindow
                 ?? pluginWindow
                 ?? launcherWindow
-                ?? peekWindow
                 ?? configuredWindow
+                ?? peekWindow
                 ?? lookupContextLimit(model);
             // Fallback = no authoritative source AND the operator did not
             // explicitly tune the window via compress.modelContextLimit (an

--- a/tests/configured-window-outranks-registry.test.ts
+++ b/tests/configured-window-outranks-registry.test.ts
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import { once } from "node:events";
+import test from "node:test";
+
+process.env.NODE_ENV = "test";
+
+import { defaultConfig } from "acp-kernel";
+import { startServer, type ProxyOptions } from "../src/server.ts";
+import { SessionStore, _setStoreForTest } from "../src/persist.ts";
+import { _setForTest as setRegistryForTest } from "../src/registry.ts";
+import { listSessions } from "../src/session.ts";
+
+// #344: gpt-5.6-sol behind a private relay (host absent from the registry
+// host table) — models.dev lists openai/gpt-5.6-sol at 1,050,000, but the
+// relay serves it at 272K and the user declared context=272000 on the route.
+// The warm-registry peek must NOT outrank the user's explicit per-route
+// per-model declaration (config.ts contract: "The per-route declaration
+// (which the user controls) always wins"). Regression: the #212 priority
+// change put peekRegistryContext above resolveConfiguredContextLimit, so the
+// nudge denominator became 1,050,000 − max_tokens (922000 / 988782 in the
+// issue log) instead of 272000 − max_tokens.
+
+const MODEL = "gpt-5.6-sol"; // table /^gpt-5/i → 400K; registry → 1,050,000; declared → 272K
+const DECLARED = 272_000;
+const REGISTRY = 1_050_000;
+
+function okSse(inputTokens: number): string {
+    return (
+        `event: message_start\ndata: ${JSON.stringify({ type: "message_start", message: { id: "m1", role: "assistant", usage: { input_tokens: inputTokens } } })}\n\n` +
+        `event: content_block_start\ndata: ${JSON.stringify({ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } })}\n\n` +
+        `event: content_block_delta\ndata: ${JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "ok" } })}\n\n` +
+        `event: content_block_stop\ndata: ${JSON.stringify({ type: "content_block_stop", index: 0 })}\n\n` +
+        `event: message_delta\ndata: ${JSON.stringify({ type: "message_delta", delta: { stop_reason: "end_turn", stop_sequence: null }, usage: { output_tokens: 3 } })}\n\n` +
+        `event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`
+    );
+}
+
+interface Rig {
+    proxyPort: number;
+    upstreamPort: number;
+    proxy: http.Server;
+    upstream: http.Server;
+}
+
+async function startRig(models?: Record<string, { context?: number }>): Promise<Rig> {
+    const upstream = http.createServer((req, res) => {
+        const chunks: Buffer[] = [];
+        req.on("data", (c: Buffer) => chunks.push(c));
+        req.on("end", () => {
+            res.writeHead(200, { "content-type": "text/event-stream" });
+            res.end(okSse(500));
+        });
+    });
+    upstream.listen(0, "127.0.0.1");
+    await once(upstream, "listening");
+    const upstreamPort = upstream.address().port;
+
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    setRegistryForTest({ [`openai/${MODEL}`]: { limit: { context: REGISTRY } } });
+    const proxy = await startServer({
+        port: 0,
+        host: "127.0.0.1",
+        upstream: "http://127.0.0.1",
+        routes: { [`http://127.0.0.1:${upstreamPort}`]: models ? { models } : {} },
+        modelContextLimit: 200_000,
+        kernelConfig: defaultConfig(200_000),
+        compress: { injectTool: true, injectNudge: true },
+        promptCache: { routing: "auto" },
+        sessionHeader: "x-acp-session",
+        log: false,
+        debug: false,
+        passthrough: false,
+        autoUpdate: false,
+        mitm: { enabled: false, domains: [] },
+    } as ProxyOptions);
+    await once(proxy, "listening");
+    const proxyPort = proxy.address().port;
+    return { proxyPort, upstreamPort, proxy, upstream };
+}
+
+function url(rig: Rig): string {
+    return `http://127.0.0.1:${rig.proxyPort}/bili/http://127.0.0.1:${rig.upstreamPort}/v1/messages`;
+}
+
+async function closeRig(rig: Rig): Promise<void> {
+    rig.proxy.close();
+    await once(rig.proxy, "close");
+    rig.upstream.close();
+    await once(rig.upstream, "close");
+}
+
+test("#344: per-route model declaration outranks the warm models.dev registry", async () => {
+    const rig = await startRig({ [MODEL]: { context: DECLARED } });
+    try {
+        const headers: Record<string, string> = {
+            "content-type": "application/json",
+            "x-acp-session": "declared-sess",
+            "x-bili-plugin": "test-agent",
+        };
+        const r = await fetch(url(rig), { method: "POST", headers, body: JSON.stringify({ model: MODEL, max_tokens: 1024, stream: true, messages: [{ role: "user", content: "hi" }] }) });
+        assert.equal(r.status, 200);
+        await r.text();
+        // The declared 272K must win over the registry's 1,050,000 (which
+        // itself outranks the built-in table's 400K).
+        assert.equal(listSessions()[0]?.metadata.effectiveContextLimit, DECLARED, "declared context outranks the registry");
+    } finally {
+        await closeRig(rig);
+    }
+});
+
+test("#344: without a declaration the warm registry still outranks the built-in table", async () => {
+    const rig = await startRig();
+    try {
+        const headers: Record<string, string> = {
+            "content-type": "application/json",
+            "x-acp-session": "registry-sess",
+            "x-bili-plugin": "test-agent",
+        };
+        const r = await fetch(url(rig), { method: "POST", headers, body: JSON.stringify({ model: MODEL, max_tokens: 1024, stream: true, messages: [{ role: "user", content: "hi" }] }) });
+        assert.equal(r.status, 200);
+        await r.text();
+        assert.equal(listSessions()[0]?.metadata.effectiveContextLimit, REGISTRY, "registry 1,050,000 outranks the table's 400K when nothing is declared");
+    } finally {
+        await closeRig(rig);
+    }
+});


### PR DESCRIPTION
## Problem (#344)

ZCode (MITM, private relay) on `gpt-5.6-sol` with a route-declared `context: 272000` — but the nudge logs show denominators of **922000** and **988782**, i.e. the proxy sized the window from **models.dev** (`openai/gpt-5.6-sol` = 1,050,000) minus the per-request `max_tokens` headroom (1,050,000 − 128,000 = 922,000; 1,050,000 − 61,218 = 988,782), ignoring the user's declaration.

## Root cause

`src/server.ts` native-window resolution order was:

```
beta ?? plugin ?? launcher ?? peekRegistry ?? configured ?? table
```

The warm models.dev registry peek (`peekRegistryContext`) sat **above** the user's explicit per-route per-model declaration (`resolveConfiguredContextLimit`). The #212 priority change intended "registry > static table" but landed above the whole `configured ?? table` chain. For a private relay host (absent from the registry host table) the lookup falls back to scanning all providers, so the official `openai/gpt-5.6-sol` 1M window was adopted over the relay's real 272K window.

This contradicts the documented contract in `src/config.ts` ("The per-route declaration (which the user controls) always wins, because the same model name can have different windows behind different relays") and `CONFIGURATION.md` ("When a model is not declared, the proxy falls back to its built-in context table or the models.dev registry").

## Fix

Swap the two sources — an explicit declaration now outranks the auto-fetched registry:

```
beta ?? plugin ?? launcher ?? configured ?? peekRegistry ?? table
```

Registry still beats the built-in table when nothing is declared (unchanged behavior).

## Tests

New `tests/configured-window-outranks-registry.test.ts` (regression for #344, exact issue numbers):
1. route declares `context: 272000` + registry lists 1,050,000 → effective window is **272,000** (fails on master: 1,050,000)
2. no declaration → registry 1,050,000 still outranks the built-in table's 400K (pins the registry path)

## Pre-flight

- `npm run typecheck` — clean
- `npm test` — 825/825 pass
- `npm run build` — success
