### PR TITLE
fix: 404 unknown /__bili/ paths + actionable MITM CA-rejection warning (#346)

### DIFF
--- a/src/mitm.ts
+++ b/src/mitm.ts
@@ -168,6 +168,7 @@ function tunnelThrough(
         if (head.length > 0) upstream.write(head);
         upstream.pipe(clientSocket);
         clientSocket.pipe(upstream);
+        log(`tunnel ${maskHostForLog(host)}:${port} established (blind TCP, not decrypted)`);
         const cleanup = (where: string, err: Error) => {
             log(`tunnel ${maskHostForLog(host)}:${port} ${where} closed: ${maskHostInText(err.message, host)}`);
             upstream.destroy();

--- a/src/mitm.ts
+++ b/src/mitm.ts
@@ -1,7 +1,7 @@
 import http from "node:http";
 import net from "node:net";
 import tls from "node:tls";
-import { ensureRootCA, getSecureContext } from "./ca.js";
+import { ensureRootCA, getSecureContext, rootCaPath } from "./ca.js";
 import { connectThroughProxy } from "./upstream-proxy.js";
 import { discoverMitmDomains } from "./discover.js";
 import { isLoopbackAddress } from "./util.js";
@@ -22,6 +22,23 @@ export const DEFAULT_MITM_DOMAINS = [
 /** Socket marker: when we MITM a CONNECT tunnel, we stash the original
  *  host the CONNECT tunnel targeted. */
 export const MITM_UPSTREAM_KEY = "__biliMitmUpstream";
+
+// A client that rejects our MITM cert (root CA not trusted) can flood the log
+// with hundreds of identical handshake failures. Warn once, with the fix.
+let warnedCertRejected = false;
+const CERT_REJECT_RE = /alert (?:certificate unknown|unknown ca|bad certificate|certificate expired|certificate revoked|unsupported certificate)/i;
+
+export function noteMitmTlsError(host: string, port: number, message: string, log: Logger): void {
+    log(`mitm ${maskHostForLog(host)}:${port} TLS error: ${message}`);
+    if (CERT_REJECT_RE.test(message) && !warnedCertRejected) {
+        warnedCertRejected = true;
+        log(`mitm ${maskHostForLog(host)}:${port} client REJECTED the MITM certificate — it does not trust bili's root CA. Install it in the client's/system trust store, then restart the client. CA: ${rootCaPath()}`);
+    }
+}
+
+export function _resetCertRejectionWarningForTest(): void {
+    warnedCertRejected = false;
+}
 
 /** Max ms to wait for a MITM client to finish the TLS handshake after we
  *  return CONNECT 200. Bounds slowloris-style resource hold (a client that
@@ -207,7 +224,7 @@ function doMitm(
     // it as an uncaught exception and crashes the whole proxy. Destroy the
     // underlying socket and log — mirrors tunnelThrough()'s error handling.
     tlsSocket.on("error", (err: Error) => {
-        log(`mitm ${maskHostForLog(host)}:${port} TLS error: ${err.message}`);
+        noteMitmTlsError(host, port, err.message, log);
         tlsSocket.destroy();
         clientSocket.destroy();
     });

--- a/src/server.ts
+++ b/src/server.ts
@@ -647,6 +647,14 @@ async function handle(
             return;
         }
     }
+    // Unknown /__bili/ or /__acp/ path → 404 locally. These are bili's own
+    // management prefixes; forwarding would leak the internal path to the
+    // upstream (which 403s it) — #346.
+    if (isAdminPath) {
+        res.writeHead(404, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: { type: "not_found", message: "no such management endpoint" } }));
+        return;
+    }
 
     // NOTE: WebSocket upgrades are answered by the dedicated 'upgrade' listener
     // in startServer() (above), which is the only reliable path — Node routes

--- a/tests/admin-origin.test.ts
+++ b/tests/admin-origin.test.ts
@@ -148,3 +148,59 @@ test("admin endpoints work with port: 0 (dynamic port assignment)", async () => 
         try { rmSync(root, { recursive: true, force: true }); } catch { /* best-effort */ }
     }
 });
+
+test("unknown /__bili/ path → 404 locally, not forwarded to upstream (#346)", async () => {
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    setRegistryForTest({});
+    const root = path.join(tmpdir(), `bili-admin-404-${process.pid}-${Date.now()}`);
+    mkdirSync(root, { recursive: true });
+    const biliConfig = path.join(root, "billion-context.json");
+    writeFileSync(biliConfig, '{"providers":{}}\n', "utf8");
+    const prevConfig = process.env.BILI_CONFIG_FILE;
+    process.env.BILI_CONFIG_FILE = biliConfig;
+
+    // Dead upstream: if the unknown /__bili/ path were (wrongly) forwarded,
+    // this would 502/hang instead of answering 404 immediately.
+    const opts: ProxyOptions = {
+        port: 0,
+        host: "127.0.0.1",
+        upstream: "http://127.0.0.1:1",
+        routes: {},
+        proxy: "",
+        proxyMode: "direct",
+        proxySource: "direct",
+        modelContextLimit: 400_000,
+        kernelConfig: defaultConfig(400_000),
+        compress: { injectTool: true, injectNudge: true },
+        promptCache: { routing: "auto" },
+        sessionHeader: "x-acp-session",
+        log: false,
+        debug: false,
+        passthrough: false,
+        autoUpdate: false,
+        mitm: { enabled: false, domains: [] },
+    };
+    const proxy = await startServer(opts);
+    if (!proxy.listening) await once(proxy, "listening");
+    const actualPort = (proxy.address() as { port: number }).port;
+    try {
+        const res = await new Promise<{ status: number; body: string }>((resolve, reject) => {
+            const req = http.request(
+                { host: "127.0.0.1", port: actualPort, path: "/__bili/api/sessions", headers: { host: `127.0.0.1:${actualPort}` } },
+                (r) => {
+                    let body = "";
+                    r.on("data", (c: Buffer) => { body += c.toString("utf8"); });
+                    r.on("end", () => resolve({ status: r.statusCode ?? 0, body }));
+                },
+            );
+            req.once("error", reject);
+            req.end();
+        });
+        assert.equal(res.status, 404, "unknown /__bili/ path must 404 locally, not be forwarded to the upstream");
+    } finally {
+        process.env.BILI_CONFIG_FILE = prevConfig;
+        proxy.closeAllConnections?.();
+        await close(proxy);
+        try { rmSync(root, { recursive: true, force: true }); } catch { /* best-effort */ }
+    }
+});

--- a/tests/mitm.test.ts
+++ b/tests/mitm.test.ts
@@ -290,6 +290,50 @@ await test("setupMitm e2e: remote CONNECT policy (#77, #240)", async (t) => {
     });
 });
 
+await test("setupMitm e2e: blind TCP tunnel to a non-whitelisted host passes bytes both ways (#346)", async () => {
+    await withTmpCa(async () => {
+        const upstream = net.createServer((sock) => {
+            sock.on("data", (c) => sock.write("UPSTREAM-SAW:" + c.toString("utf8")));
+        });
+        upstream.listen(0, "127.0.0.1");
+        await once(upstream, "listening");
+        const upPort = (upstream.address() as { port: number }).port;
+
+        const logs: string[] = [];
+        const server = http.createServer((_req, res) => { res.writeHead(500); res.end(); });
+        setupMitm(server, [], (msg) => { logs.push(msg); });
+        server.listen(0, "127.0.0.1");
+        await once(server, "listening");
+        const port = (server.address() as { port: number }).port;
+        try {
+            // 127.0.0.1 is an IP, not a domain → isMitmHost is false → blind tunnel.
+            const { statusLine, socket } = await rawConnect(port, "127.0.0.1", `127.0.0.1:${upPort}`);
+            assert.match(statusLine, /^HTTP\/1\.1 200/, "blind tunnel must answer CONNECT with 200");
+            const reply = Promise.withResolvers<string>();
+            let out = "";
+            let settled = false;
+            socket.on("data", (c: Buffer) => {
+                out += c.toString("utf8");
+                if (!settled && out.includes("UPSTREAM-SAW:")) { settled = true; reply.resolve(out); }
+            });
+            socket.once("close", () => { if (!settled) reply.reject(new Error("tunnel closed before reply")); });
+            socket.write("hello-zcode");
+            const body = await reply.promise;
+            assert.match(body, /UPSTREAM-SAW:hello-zcode/, "bytes must flow client→tunnel→upstream and back");
+            assert.ok(
+                logs.some((l) => /tunnel .* established \(blind TCP, not decrypted\)/.test(l)),
+                "established blind tunnel must be logged for diagnostics",
+            );
+            socket.destroy();
+        } finally {
+            server.close();
+            server.closeAllConnections?.();
+            upstream.close();
+            upstream.closeAllConnections?.();
+        }
+    });
+});
+
 // A real client (e.g. ZCode, #346) that does not trust the root CA sends a
 // TLS "certificate unknown" alert; the handler must turn that into exactly ONE
 // actionable "install the root CA" warning, deduplicated across the hundreds

--- a/tests/mitm.test.ts
+++ b/tests/mitm.test.ts
@@ -7,7 +7,7 @@ import tls from "node:tls";
 import net from "node:net";
 import { once } from "node:events";
 import http from "node:http";
-import { isMitmHost, readMitmUpstream, MITM_UPSTREAM_KEY, setupMitm } from "../src/mitm.js";
+import { isMitmHost, readMitmUpstream, MITM_UPSTREAM_KEY, setupMitm, noteMitmTlsError, _resetCertRejectionWarningForTest } from "../src/mitm.js";
 import { ensureRootCA, rootCaPath, getSecureContext, _resetForTest } from "../src/ca.js";
 import { _resetDiscoveryCacheForTest } from "../src/discover.js";
 
@@ -288,4 +288,32 @@ await test("setupMitm e2e: remote CONNECT policy (#77, #240)", async (t) => {
             openServer.closeAllConnections?.();
         }
     });
+});
+
+// A real client (e.g. ZCode, #346) that does not trust the root CA sends a
+// TLS "certificate unknown" alert; the handler must turn that into exactly ONE
+// actionable "install the root CA" warning, deduplicated across the hundreds
+// of identical failures a single misconfigured client produces.
+test("noteMitmTlsError: cert-rejection alert → one actionable CA warning, deduplicated (#346)", () => {
+    _resetCertRejectionWarningForTest();
+    const logs: string[] = [];
+    const log = (msg: string) => { logs.push(msg); };
+    const realAlert = "705F0000:error:0A000416:SSL routines:ssl3_read_bytes:ssl/tls alert certificate unknown:openssl\\ssl\\record\\rec_layer_s3.c:918:SSL alert number 46";
+    noteMitmTlsError("api.anthropic.com", 443, realAlert, log);
+    noteMitmTlsError("api.anthropic.com", 443, "ssl/tls alert certificate unknown", log);
+    noteMitmTlsError("api.anthropic.com", 443, "ssl/tls alert unknown ca", log);
+    const warnings = logs.filter((l) => l.includes("REJECTED the MITM certificate"));
+    assert.equal(warnings.length, 1, `expected exactly one CA warning, got ${warnings.length}: ${JSON.stringify(logs)}`);
+    assert.match(warnings[0], /root-ca\.pem/, "warning must point at the root CA file path");
+    assert.equal(logs.filter((l) => l.includes("TLS error")).length, 3, "the raw TLS error line is always logged");
+});
+
+test("noteMitmTlsError: non-cert TLS errors (reset/close) do NOT trigger the CA warning", () => {
+    _resetCertRejectionWarningForTest();
+    const logs: string[] = [];
+    const log = (msg: string) => { logs.push(msg); };
+    noteMitmTlsError("api.anthropic.com", 443, "socket hang up", log);
+    noteMitmTlsError("api.anthropic.com", 443, "read ECONNRESET", log);
+    assert.equal(logs.filter((l) => l.includes("REJECTED the MITM certificate")).length, 0);
+    assert.equal(logs.length, 2, "raw TLS error lines still logged");
 });


### PR DESCRIPTION
## Context (from #346 log analysis)

Analyzing the reporter's actual `bili.log` (ZCode 3.10.1, Windows, MITM via private relay) showed the session-loss symptom is **not** the #344 window bug (no overflow 400s; long sessions up to 290 msgs processed fine). The dominant signal was **160× `TLS error: ... ssl/tls alert certificate unknown`** — the client (ZCode) rejecting bili's MITM root CA on its non-model HTTP clients (session/telemetry/billing/config), which breaks ZCode's session management. The fix for the user is to install the root CA in the Windows trust store; these two changes make that failure **diagnosable at a glance** and stop a related path-leak.

## Changes

1. **`src/server.ts`** — unknown `/__bili/` or `/__acp/` management paths now return **404 locally** instead of falling through to the proxy and being forwarded to the upstream (which 403s it and leaks the internal path to a third party). The log showed `/__bili/api/sessions` / `/__bili/api/status` being forwarded to `api.anthropic.com` → 403.

2. **`src/mitm.ts`** — when a TLS handshake fails with a cert-rejection alert (`certificate unknown` / `unknown ca` / `bad certificate` / ...), log **one deduplicated, actionable warning** pointing at the root CA file path and the fix (install in the trust store, restart the client), instead of only 160 raw `[info] TLS error` lines. Extraction into `noteMitmTlsError()` keeps it unit-testable.

## Pre-flight
- `npm run typecheck` — clean
- `npm test` — 826/826 pass (added `tests/mitm.test.ts` cert-rejection dedup cases + `tests/admin-origin.test.ts` unknown-`/__bili/`-404 case)
- `npm run build` — success

No `version` bump (content change; release goes through the standard §5 flow).