### PR TITLE
fix: actionable no-valid-ranges compress error + defensive object tool args

### DIFF
--- a/src/loop/adapter-openai.ts
+++ b/src/loop/adapter-openai.ts
@@ -335,7 +335,8 @@ export function createOpenaiAdapter(requestBody: Record<string, unknown>, client
                         const fn = tc.function as Record<string, unknown> | undefined;
                         const name = typeof fn?.name === "string" ? fn.name : "";
                         const id = typeof tc.id === "string" ? tc.id : "";
-                        const args = typeof fn?.arguments === "string" ? fn.arguments : "";
+                        const rawArgs = fn?.arguments;
+                        const args = typeof rawArgs === "string" ? rawArgs : (rawArgs !== null && typeof rawArgs === "object" ? JSON.stringify(rawArgs) : "");
                         let buf = pending.get(idx);
                         if (!buf) {
                             buf = { index: idx, id, name, arguments: args };

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -228,7 +228,7 @@ function refNum(ref: string): number {
 export function applyRanges(ranges: ReturnType<typeof parseCompressInput>, ctx: RewriteCtx): string {
     if (ranges.length === 0) {
         ctx.log("[acp-proxy: compress call had no valid ranges; nothing compressed.]");
-        return "[Compression FAILED: no valid ranges parsed from the tool call. Check your startId/endId parameters.]";
+        return "[Compression FAILED: no valid ranges parsed. compress requires a non-empty 'content' array of {startId, endId, summary} ranges, where startId/endId are mNNNNN message refs from the conversation. Re-issue the compress call with a valid content array.]";
     }
     ctx.log(`[acp-proxy: compress requested ${ranges.length} range(s): ${ranges.map((r) => `${r.startRef}–${r.endRef}`).join(", ")}]`);
     ctx.log(`[acp-proxy: ctx has ${ctx.messages.length} message(s), state has ${ctx.session.state.messageRefs?.byRef?.size ?? "?"} ref(s) mapped]`);

--- a/tests/compress-observability.test.ts
+++ b/tests/compress-observability.test.ts
@@ -111,6 +111,15 @@ test("#189: failed compress records no lastCompress", () => {
     assert.equal(ctx.session.lastCompress, undefined, "no lastCompress on failure");
 });
 
+test("#349: empty compress args → actionable no-valid-ranges message (missing-content)", () => {
+    const ctx = makeCompressibleCtx();
+    const out = runApply(ctx, {});
+    assert.ok(out.startsWith("[Compression FAILED"), `expected failure, got: ${out}`);
+    assert.ok(out.includes("non-empty 'content' array"), `steers to a content array: ${out}`);
+    assert.ok(out.includes("startId, endId, summary"), `names the required fields: ${out}`);
+    assert.ok(!out.includes("Check your startId/endId parameters"), "old misleading hint removed");
+});
+
 test("#189: staged-compress steering note appended when shrink exceeds the configured max", () => {
     const prev = process.env.BILI_MAX_SHRINK_PER_COMPRESS;
     process.env.BILI_MAX_SHRINK_PER_COMPRESS = "0.05";


### PR DESCRIPTION
Fixes #349.

Three low-risk changes (no compression-semantics change) addressing the "no
valid ranges" compress error and @liyangbing's runtime-verification
suggestions:

### 1. Actionable error message (`src/stream.ts`)

When `applyRanges` gets 0 ranges it returned:

> `[Compression FAILED: no valid ranges parsed from the tool call. Check your startId/endId parameters.]`

That hint is misleading for the most common cause — the model called `compress`
with **no arguments at all** (`kind=missing-content`, `keys=[]`), not with bad
startId/endId. The new message tells the model exactly what to do so it can
self-correct on the re-request round:

> `[Compression FAILED: no valid ranges parsed. compress requires a non-empty 'content' array of {startId, endId, summary} ranges, where startId/endId are mNNNNN message refs from the conversation. Re-issue the compress call with a valid content array.]`

Keeps the `[Compression FAILED` prefix so `preflight.ts` detection is unaffected.

### 2. Defensive object tool args (`src/loop/adapter-openai.ts`)

The OpenAI adapter only accepted `function.arguments` as a **string**; a
non-standard upstream that emits it as an **object** was silently dropped
(`""` → empty → the same `missing-content` failure). Now `JSON.stringify`
object args. Standard OpenAI (always a string) is unchanged.

### 3. Categorize the reject log + include callId (`src/compress-tool.ts`)

Per @liyangbing's suggestion to separately count the failure modes, the
`[acp-compress-input] rejected` log now carries a `category` field (by `kind`)
and the `callId` (when the path supplies one):

- `empty-call` = `missing-content` / `empty-input` — model empty call
- `stream-concat` = `malformed-json` / `truncated` — adapter-attributable
- `validation` = `no-valid-ranges` / `content-not-array` / `not-object`

So `grep "category=..." bili.log | wc -l` gives per-mode rates with no
session-structure change. With change #2, `missing-content` now maps cleanly to
"model empty call" (the adapter no longer swallows object args).

## Root cause note

Per the log analysis in #349, the primary trigger is **upstream/model** —
deepseek-v4-flash emits an empty `compress` call in some turns (10/12 calls in
the log succeeded, so proxy parsing is sound). These changes are the proxy-side
mitigation: clearer feedback, a hardened arg path, and better observability.

## Session-state safety (verified, no code change)

@liyangbing's concern that a failed compress might replace the original tool
result with an empty "success" placeholder does not hold:
- `src/stream.ts:229` — on `ranges.length===0`, `applyRanges` returns the error
  string without calling `ctx.core.applyCompression`; session state (blocks) is
  untouched. Log: `[acp-proxy: compress call had no valid ranges; nothing compressed.]`.
- `src/loop/core.ts:347-363` — the failed compress is written back as a
  `tool-call` (with the **original** `arguments`) + `tool` (with the error
  result), not an empty placeholder.
- `src/loop/core.ts:373-383` — on `anyCompressFailed`, `hideConsumedCompressCalls`
  is skipped, so the failure stays visible for the model to self-correct.

## Pre-flight

- New regression test `#349: empty compress args → actionable no-valid-ranges message (missing-content)` in `tests/compress-observability.test.ts`.
- `npm run typecheck` — clean.
- `npm test` — 824/824 pass.
- `npm run build` — ok.
