### PR TITLE
docs: align per-model context declaration precedence with actual resolution order

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -146,7 +146,9 @@ A shallow key (`https://open.bigmodel.cn`) matches every path on that host. A de
 - **Type:** `Record<string, { context?: number; output?: number; compress?: CompressSettings }>`
 - **Default:** *(none)*
 - **Status:** ACTIVE
-- **Description:** Maps a model name to its context-window declaration. The LLM `/models` endpoint does **not** return context windows (verified across OpenAI, Anthropic, zhipu, comfly), so the proxy cannot discover them at runtime — you must declare them here. `context` is the model's context window in tokens; `output` is the max output size. When a model is not declared, the proxy falls back to its built-in context table or the models.dev registry. Each model entry may also carry a per-model `compress` block (see [Compression Tuning](#compression-tuning)).
+- **Description:** Maps a model name to its context-window declaration. The LLM `/models` endpoint does **not** return context windows (verified across OpenAI, Anthropic, zhipu, comfly), so the proxy cannot discover them at runtime. `context` is the model's context window in tokens; `output` is the max output size.
+
+  **Resolution order (first match wins):** (1) per-request sources — the client's `anthropic-beta` larger-context negotiation, a cooperative plugin's report, and the launcher's per-model windows; (2) the **warm** models.dev registry cache, when the model is listed (relay/private hosts match the bare model name against the registry's provider-prefixed entries); (3) this per-model `context` declaration; (4) the built-in context table. So when the models.dev registry already lists the model, the registry value **outranks this declaration** — this matters for relay/private deployments, where the registry's standard window can differ from the window the relay actually serves. To pin the effective window reliably, set `compress.modelContextLimit` instead (highest-priority source, always wins). Each model entry may also carry a per-model `compress` block (see [Compression Tuning](#compression-tuning)).
 
 ### `proxy`
 


### PR DESCRIPTION
## What

Docs-only fix for the docs-vs-code contradiction surfaced by #351.

`CONFIGURATION.md` (per-model `models` section) claimed the per-model `context` declaration is **primary** and the models.dev registry is only a **fallback for undeclared models**. The code does the opposite: in the native-window resolution chain (`src/server.ts:791-796`), the **warm** models.dev registry (`peekWindow`) is checked **before** the per-model declaration (`configuredWindow`). For a relay/private host whose model is listed in the registry (matched by bare name against provider-prefixed entries via the relay fallback in `src/registry.ts:271-282`), the registry value silently **outranks** the user's declaration.

This is exactly what bit the #351 reporter: their `deepseek-v4-flash` deployment serves a 200K window, but the registry lists 1M, so the effective window resolved to 967232 (1M − 32768 output headroom) and the 75%/95% compression thresholds were unreachable — no compression until the upstream died.

## Change

Rewrite the `models` description in `CONFIGURATION.md` to document the **actual** resolution order (per-request sources → warm registry → per-model `context` declaration → built-in table) and steer users to `compress.modelContextLimit` (highest-priority source, always wins) for reliably pinning the effective window — especially for relay/private deployments where the registry's standard window differs from the served window.

**Behavior-preserving** (markdown only; no code touched).

## Why docs and not code

The code order is deliberate (detailed comment at `src/server.ts:767-784`). Whether the per-model declaration *should* outrank the warm registry (at least for relay/private hosts, where the declaration is the only source of truth about the served window) is a design decision. This PR resolves the contradiction on the docs side; the code-side option (host-dependent precedence) is left to your call — happy to follow up if you want it.

## Minor note (not fixed here)

The committed `package-lock.json` is stale: it records version `0.1.57` while `package.json` is `0.1.63`. Per the release flow the lockfile should be kept in sync — flagging for the next release commit.

## Pre-flight

Docs-only change; no typecheck/test/build impact. Verified the resolution-order claim against `src/server.ts:785-808`, `src/registry.ts:255-284`, and `src/compress-settings.ts:16-25`.

Closes the docs half of #351.