### PR TITLE
fix: pass through Claude auto-mode classifier requests untouched (#353)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1225,6 +1225,11 @@ function prepareAnthropic(
     ++session.stats.requests;
     const injectTools = opts.compress.injectTool && !pluginMode;
 
+    if (isAutoModeClassifier(parsed)) {
+        log("info", `[${sessionId}] auto-mode classifier passthrough (skipping compress injection)`);
+        return { body: JSON.stringify(parsed), session, processedMessages: [], originalMessages: [], anthropicSystem: parsed.system, protocol: "anthropic", stream, compressInjected: false, pluginMode, nudge: undefined, prompts } as Prepared;
+    }
+
     let processedMessages: CoreMessage[] = [];
     let originalMessages: CoreMessage[] = [];
     let nudge: NudgeDecision | undefined;
@@ -1791,6 +1796,20 @@ export function resolvePromptCacheKey(
     if (explicit?.trim()) return explicit;
     if (!identity.clientProvided || !shouldInjectPromptCacheKey(routing, upstream)) return undefined;
     return identity.value;
+}
+
+// Claude Code's auto-mode safety classifier one-shots expect a strict XML
+// verdict — the default `xml_2stage` mode stops the response at `</severity>`
+// or `</block>`. These are not compressible conversations: the compress
+// system-prompt + ACP tools (or the kernel round-trip) derailed the small model
+// from that verdict, so the classifier reported "could not evaluate" (#353).
+// The magic stop sequences are the only in-body signal; forward them untouched.
+const AUTO_MODE_CLASSIFIER_STOPS = new Set(["</severity>", "</block>"]);
+
+function isAutoModeClassifier(parsed: AnthropicRequestBody): boolean {
+    const stops = parsed.stop_sequences;
+    if (!Array.isArray(stops)) return false;
+    return stops.some((s) => typeof s === "string" && AUTO_MODE_CLASSIFIER_STOPS.has(s));
 }
 
 function injectSystem(

--- a/tests/e2e-anthropic.test.ts
+++ b/tests/e2e-anthropic.test.ts
@@ -321,3 +321,42 @@ test("e2e anthropic: compress tool_use round-trip — 2nd upstream request carri
         await h.close();
     }
 });
+
+test("e2e anthropic: auto-mode classifier (stop_sequences </severity>/</block>) bypasses compress injection (#353)", async () => {
+    const h = await startHarness([textScript()]);
+    try {
+        const resp = await fetch(`http://127.0.0.1:${h.proxyPort}/bili/http://127.0.0.1:${h.upstreamPort}/v1/messages`, {
+            method: "POST",
+            headers: { "content-type": "application/json", "x-acp-session": "e2e-classifier" },
+            body: JSON.stringify({
+                model: "claude-test",
+                max_tokens: 64,
+                stream: true,
+                system: "You are a safety classifier. Respond with <severity>N</severity>.",
+                messages: [{ role: "user", content: "Is this command safe? rm -rf /" }],
+                stop_sequences: ["</severity>"],
+            }),
+        });
+        assert.equal(resp.status, 200);
+        const raw = await resp.text();
+
+        const upstreamReq = JSON.parse(h.captured[0]!.body) as {
+            tools?: Array<{ name: string }>;
+            system?: string | Array<{ type: string; text?: string }>;
+            stop_sequences?: string[];
+        };
+        assert.deepEqual(upstreamReq.stop_sequences, ["</severity>"], "classifier stop_sequences must reach the upstream verbatim");
+        const toolNames = upstreamReq.tools?.map((t) => t.name) ?? [];
+        for (const banned of ["compress", "decompress", "search_context", "acp_status"]) {
+            assert.ok(!toolNames.includes(banned), `classifier request must not carry the ${banned} tool: ${JSON.stringify(toolNames)}`);
+        }
+        const sysText = typeof upstreamReq.system === "string" ? upstreamReq.system : (upstreamReq.system ?? []).map((b) => b.text ?? "").join("\n");
+        assert.ok(!/compress/i.test(sysText), `classifier system must not gain the compress prompt: ${JSON.stringify(sysText)}`);
+        assert.match(sysText, /safety classifier/);
+
+        const events = parseAnthropicSse(raw);
+        assert.equal(events.filter((e) => e.event === "message_stop").length, 1, "classifier verdict stream must reach the client unrewritten");
+    } finally {
+        await h.close();
+    }
+});


### PR DESCRIPTION
## What
`bili claude` broke Claude Code's **auto-mode safety classifier**: it reported "Auto mode could not evaluate this action and is blocking it for safety" and blocked consecutive actions (#353).

## Root cause
The auto-mode classifier is a throwaway one-shot API call (not a compressible conversation). Reverse-engineered from the `@anthropic-ai/claude-code` v2.1.251 binary, its default `xml_2stage` mode expects a **strict XML verdict** and terminates the response with `stop_sequences: ["</severity>"]` (or `"</block>"`), e.g. `<severity>72</severity><category>Data Exfiltration</category>`.

bili's `prepareAnthropic` injects the compress system-prompt + the 4 ACP tools into **every** anthropic request unconditionally (and runs the kernel round-trip). For the classifier that derailed the small model away from the expected XML verdict → "could not evaluate" → blocked actions.

## Fix
Detect the classifier by its in-body signal — `stop_sequences` containing `</severity>` or `</block>` — and forward the request **byte-for-byte**: no compress system-prompt, no ACP tools, no kernel round-trip, and `compressInjected: false` so the response is piped through unrewritten (the verdict reaches the client intact).

Normal conversation requests never carry those stop sequences, so they are unaffected (the existing e2e tests that assert injection on plain turn-1 requests still pass).

## Tests
- New e2e test: a classifier request (`stop_sequences: ["</severity>"]`) reaches the upstream with **no** compress tools and **no** compress prompt appended, and the verdict stream reaches the client unrewritten.
- `npm run typecheck` clean · `npm test` 824/824 · `npm run build` clean.

## Known limitations (follow-up)
- The `twoStageClassifier: "fast"` mode (opt-in) omits `stop_sequences`, so it is not detected by this signal. The default `both`/`thinking` modes are covered.
- The separate "sub-agent exceptions" mentioned in #353 are a distinct path (sub-agents don't use these stop sequences) and are not addressed here.