### PR TITLE
fix: hoist mid-conversation system messages to the leading prefix on the OpenAI wire (#355)

### DIFF
--- a/src/loop/adapter-openai.ts
+++ b/src/loop/adapter-openai.ts
@@ -3,6 +3,7 @@ import { coreToOpenai, injectOpenaiSystem } from "acp-kernel/wire";
 import { buildVisibilityMarker } from "../compress-loop.js";
 import { createTagEchoFilter } from "./tag-echo-filter.js";
 import { log as loggerLog } from "../logger.js";
+import { hoistMidSystemMessages } from "../util.js";
 
 import type {
     CompressLoopAdapter,
@@ -171,7 +172,7 @@ export function createOpenaiAdapter(requestBody: Record<string, unknown>, client
             // runtime state), so coreMessages no longer carries it — re-inject
             // the CLIENT's original system ahead of the compress prompt,
             // mirroring the anthropic adapter's anthropicSystem path.
-            const messages = coreToOpenai(coreMessages);
+            const messages = hoistMidSystemMessages(coreToOpenai(coreMessages));
             const withSys = injectOpenaiSystem(messages, [clientSystem, systemPrompt].filter((p): p is string => typeof p === "string" && p.length > 0));
             return { ...body, messages: withSys };
         },

--- a/src/server.ts
+++ b/src/server.ts
@@ -64,7 +64,7 @@ import { prefixAffinity, type AnonymousAffinity } from "./prefix-affinity.js";
 import { consumePluginRegisterFor, flushConversations, handlePluginManifest, handlePluginRegister, handlePluginStatus, handlePluginTool, loadConversations, pipePluginJson, pipePluginResponsesWithStrip, pipeThroughWithUsage, pluginAgentHeader, pluginConversationHeader, pluginReportedContextWindow, recordPluginSession, rememberPluginMessages, takePendingPluginRegister } from "./plugin.js";
 import { setupMitm, readMitmUpstream } from "./mitm.js";
 import type { BiliMessage } from "acp-kernel/wire";
-import { isLoopbackAddress, inspectContextOverflow, reserveOutputHeadroom, shouldReserveOutputHeadroom, usageTotals } from "./util.js";
+import { hoistMidSystemMessages, isLoopbackAddress, inspectContextOverflow, reserveOutputHeadroom, shouldReserveOutputHeadroom, usageTotals } from "./util.js";
 
 import { decodeRequestBody } from "./content-encoding.js";
 
@@ -1354,7 +1354,7 @@ function prepareOpenai(
         log("info", diagNudge(turn, sessionId, tokenCount, config.modelContextLimit, parsed.model));
         processedMessages = stripKernelSummaries(turn.messages, turn.state);
         reapOrphanBlocks(session, msgs, deactivateBlock);
-        rebuiltMessages = coreToOpenai(processedMessages as BiliMessage[]);
+        rebuiltMessages = hoistMidSystemMessages(coreToOpenai(processedMessages as BiliMessage[]));
 
         // ONLY the static compress prompt goes into the system message — the
         // system prompt is the prefix-cache anchor and must be byte-stable

--- a/src/util.ts
+++ b/src/util.ts
@@ -175,6 +175,40 @@ export function reserveOutputHeadroom(window: number, maxOutput: number): number
 }
 
 /**
+ * Move mid-conversation system/developer messages to the leading system-prefix
+ * position, preserving relative order. acp-kernel renders compressed summaries
+ * as role:"system" anchored at the earliest message their block covered; when
+ * that anchor sits after an uncompressed message (multi-segment compress with
+ * an uncovered user message between segments), the OpenAI wire carries a
+ * system message mid-conversation, which strict OpenAI-compatible backends
+ * (sglang: "System message must be at the beginning") reject with 400 (#355).
+ * A summary is a stand-in for the folded history, so moving it to the head
+ * preserves semantics. Messages stay SEPARATE (not merged into the head) so
+ * the head system message — the prefix-cache anchor — keeps its bytes stable
+ * across compress turns. No-op (same array) when there is nothing to hoist.
+ */
+export function hoistMidSystemMessages<T extends { role: string }>(messages: T[]): T[] {
+    let lead = 0;
+    while (lead < messages.length && (messages[lead].role === "system" || messages[lead].role === "developer")) lead++;
+    if (lead === messages.length) return messages;
+    let midCount = 0;
+    for (let i = lead; i < messages.length; i++) {
+        const r = messages[i].role;
+        if (r === "system" || r === "developer") midCount++;
+    }
+    if (midCount === 0) return messages;
+    const head = messages.slice(0, lead);
+    const mid: T[] = [];
+    const rest: T[] = [];
+    for (let i = lead; i < messages.length; i++) {
+        const r = messages[i].role;
+        if (r === "system" || r === "developer") mid.push(messages[i]);
+        else rest.push(messages[i]);
+    }
+    return [...head, ...mid, ...rest];
+}
+
+/**
  * Whether the OUTPUT budget should be reserved from the context window at all.
  * Anthropic's Messages API enforces the input limit INDEPENDENTLY of
  * max_tokens (the output budget is separate — input up to the window works

--- a/tests/e2e-mid-system.test.ts
+++ b/tests/e2e-mid-system.test.ts
@@ -1,0 +1,207 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import { once } from "node:events";
+import { defaultConfig } from "acp-kernel";
+import { startServer } from "../src/server.ts";
+import { SessionStore, _setStoreForTest } from "../src/persist.ts";
+import type { ProxyOptions } from "../src/config.ts";
+import { _setForTest as setRegistryForTest } from "../src/registry.ts";
+
+// Regression for #355: a multi-segment compress whose segments are separated
+// by an uncovered user message made the kernel render a compressed summary
+// (role:"system") mid-conversation on the OpenAI wire; strict OpenAI-compatible
+// backends (sglang: "System message must be at the beginning") then reject
+// EVERY subsequent request for that provider with 400.
+//
+// Repro shape, driven through the REAL proxy (startServer) against a mock
+// upstream that captures every forwarded body:
+//   compress #1: single segment anchored at the conversation head (m00001–m00020)
+//                → summary lands in the leading system prefix (always safe).
+//   compress #2: TWO segments (m00016–m00018 + m00020–m00022) with m00019, a
+//                USER message, uncovered between them → both blocks' anchors
+//                sit after an uncovered user message → mid-conversation system
+//                on the wire before the fix.
+//
+// Range choices are load-bearing: the kernel NEVER folds the first user
+// message (rebuildMessages preserves firstUserIndex), so after compress #1
+// refs[0] is still m00001; and the protected zone (preserveRecentTokens)
+// excludes the last ~11 visible messages from compression at any point, so
+// compress #2 must fire once enough NEW messages have accumulated past the
+// zone (refs.length >= 25 ⇒ zone starts at m00029, ranges end at m00022).
+// The assertion is sglang's exact validation: in every upstream request, all
+// system/developer messages must form a contiguous leading prefix.
+
+const TURN_COUNT = 23;
+
+function listen(server: http.Server): Promise<void> {
+    if (server.listening) return Promise.resolve();
+    return once(server, "listening").then(() => undefined);
+}
+
+function close(server: http.Server): Promise<void> {
+    return new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+}
+
+function userText(i: number): string {
+    return `user turn ${i}: ${"the quick brown fox jumps over the lazy dog. ".repeat(12)}`;
+}
+
+// Refs attached to CONVERSATION messages only (index 0 is the injected
+// compress-prompt system message, which contains literal <acp> tag EXAMPLES
+// in its prose and would pollute a whole-body scan).
+function parseMessageRefIds(sent: { messages: Array<{ role: string; content?: unknown }> }): string[] {
+    const ids: string[] = [];
+    const re = /<(?:acp|dcp-message-id)[^>]*>\s*(m\d+)\s*<\/(?:acp|dcp-message-id)>/g;
+    for (let i = 1; i < sent.messages.length; i++) {
+        const c = typeof sent.messages[i]!.content === "string" ? sent.messages[i]!.content : JSON.stringify(sent.messages[i]!.content ?? "");
+        re.lastIndex = 0;
+        let m: RegExpExecArray | null;
+        while ((m = re.exec(c)) !== null) ids.push(m[1]!);
+    }
+    return ids;
+}
+
+function compressArgs(ranges: Array<{ startId: string; endId: string; summary: string }>): string {
+    return JSON.stringify({ content: ranges.map((r) => ({ startId: r.startId, endId: r.endId, topic: "mid-system e2e", summary: r.summary })) });
+}
+
+function chatJson(message: Record<string, unknown>, finishReason: string): string {
+    return JSON.stringify({
+        id: "r1",
+        object: "chat.completion",
+        choices: [{ index: 0, message, finish_reason: finishReason }],
+        usage: { prompt_tokens: 100, completion_tokens: 5 },
+    });
+}
+
+test("e2e #355: multi-segment compress never puts a system message mid-conversation on the OpenAI wire", async () => {
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    setRegistryForTest({});
+
+    const captured: string[] = [];
+    let didCompress1 = false;
+    let didCompress2 = false;
+
+    const upstream = http.createServer((req, res) => {
+        const chunks: Buffer[] = [];
+        req.on("data", (chunk: Buffer) => chunks.push(chunk));
+        req.on("end", () => {
+            const body = Buffer.concat(chunks).toString("utf8");
+            captured.push(body);
+            const refs = parseMessageRefIds(JSON.parse(body) as { messages: Array<{ role: string; content?: unknown }> });
+            res.writeHead(200, { "content-type": "application/json" });
+            if (!didCompress1 && refs.length >= 25 && refs[0] === "m00001") {
+                didCompress1 = true;
+                res.end(chatJson(
+                    { role: "assistant", content: "", tool_calls: [{ id: "call_c1", type: "function", function: { name: "compress", arguments: compressArgs([{ startId: "m00001", endId: "m00020", summary: "SUMMARY-ONE-MARKER head-anchored single segment" }]) } }] },
+                    "tool_calls",
+                ));
+                return;
+            }
+            if (didCompress1 && !didCompress2 && refs.length >= 25) {
+                didCompress2 = true;
+                res.end(chatJson(
+                    {
+                        role: "assistant",
+                        content: "",
+                        tool_calls: [{
+                            id: "call_c2",
+                            type: "function",
+                            function: {
+                                name: "compress",
+                                arguments: compressArgs([
+                                    { startId: "m00016", endId: "m00018", summary: "SUMMARY-TWO-A-MARKER first segment, anchored after preserved first user m00001" },
+                                    { startId: "m00020", endId: "m00022", summary: "SUMMARY-TWO-B-MARKER second segment, anchored after uncovered user m00019" },
+                                ]),
+                            },
+                        }],
+                    },
+                    "tool_calls",
+                ));
+                return;
+            }
+            res.end(chatJson({ role: "assistant", content: `assistant reply ${captured.length}` }, "stop"));
+        });
+    });
+    upstream.listen(0, "127.0.0.1");
+    await listen(upstream);
+    const upstreamPort = (upstream.address() as { port: number }).port;
+
+    const opts: ProxyOptions = {
+        port: 0,
+        host: "127.0.0.1",
+        upstream: "http://127.0.0.1",
+        routes: {
+            [`http://127.0.0.1:${upstreamPort}`]: { models: { "gpt-test": { context: 400_000 } } },
+        },
+        modelContextLimit: 400_000,
+        kernelConfig: defaultConfig(400_000, {
+            preserveRecentMessages: 3,
+            preserveRecentTokens: 800,
+            compress: { minCompressRange: 1, maxSummaryLength: 20000, minSummaryLength: 1 },
+        }),
+        compress: { injectTool: true, injectNudge: true },
+        promptCache: { routing: "auto" },
+        sessionHeader: "x-acp-session",
+        log: false,
+        debug: false,
+        passthrough: false,
+        autoUpdate: false,
+        mitm: { enabled: false, domains: [] },
+    };
+    const proxy = await startServer(opts);
+    await listen(proxy);
+    const proxyPort = (proxy.address() as { port: number }).port;
+    const url = `http://127.0.0.1:${proxyPort}/bili/http://127.0.0.1:${upstreamPort}/v1/chat/completions`;
+
+    const history: Array<{ role: string; content: string }> = [];
+    try {
+        for (let i = 1; i <= TURN_COUNT; i++) {
+            history.push({ role: "user", content: userText(i) });
+            const res = await fetch(url, {
+                method: "POST",
+                headers: { "content-type": "application/json", "x-acp-session": "mid-system-e2e" },
+                body: JSON.stringify({ model: "gpt-test", stream: false, messages: history }),
+            });
+            if (!res.ok) assert.fail(`turn ${i}: HTTP ${res.status}: ${await res.text()}`);
+            const json = (await res.json()) as { choices: Array<{ message: { content?: string } }> };
+            const content = json.choices[0]?.message?.content ?? "";
+            assert.ok(!content.includes("Compression FAILED"), `turn ${i}: compress tool call failed: ${content}`);
+            history.push({ role: "assistant", content });
+        }
+
+        assert.ok(didCompress1, "mock upstream never fired compress #1 (head-anchored) — ref layout unexpected");
+        assert.ok(didCompress2, "mock upstream never fired compress #2 (two segments, user msg between) — ref layout unexpected");
+        assert.equal(captured.length, TURN_COUNT, `expected ${TURN_COUNT} upstream requests, got ${captured.length}`);
+
+        for (let i = 0; i < captured.length; i++) {
+            const sent = JSON.parse(captured[i]!) as { messages: Array<{ role: string; content?: unknown }> };
+            let firstNonSystem = -1;
+            for (let j = 0; j < sent.messages.length; j++) {
+                const r = sent.messages[j]!.role;
+                if (r !== "system" && r !== "developer") { firstNonSystem = j; break; }
+            }
+            if (firstNonSystem === -1) continue;
+            for (let j = firstNonSystem; j < sent.messages.length; j++) {
+                const r = sent.messages[j]!.role;
+                assert.ok(
+                    r !== "system" && r !== "developer",
+                    `upstream request ${i + 1}: role "${r}" at index ${j} AFTER the leading system prefix — sglang would 400 "System message must be at the beginning"`,
+                );
+            }
+        }
+
+        const last = JSON.parse(captured[captured.length - 1]!) as { messages: Array<{ role: string; content?: unknown }> };
+        const leadingSystems = last.messages
+            .filter((m) => m.role === "system" || m.role === "developer")
+            .map((m) => (typeof m.content === "string" ? m.content : JSON.stringify(m.content)))
+            .join("\n");
+        assert.ok(leadingSystems.includes("SUMMARY-ONE-MARKER"), "head-anchored summary missing from the leading system prefix");
+        assert.ok(leadingSystems.includes("SUMMARY-TWO-A-MARKER"), "first mid segment summary missing from the leading system prefix");
+        assert.ok(leadingSystems.includes("SUMMARY-TWO-B-MARKER"), "second mid segment summary (the #355 offender) missing from the leading system prefix");
+    } finally {
+        await close(proxy);
+        await close(upstream);
+    }
+});

--- a/tests/hoist-mid-system.test.ts
+++ b/tests/hoist-mid-system.test.ts
@@ -1,0 +1,95 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { hoistMidSystemMessages } from "../src/util.ts";
+
+type Msg = { role: string; content: string };
+
+test("hoistMidSystemMessages: no-op (same array) when all system messages are already a leading prefix", () => {
+    const msgs: Msg[] = [
+        { role: "system", content: "head" },
+        { role: "system", content: "summary-b1" },
+        { role: "user", content: "u1" },
+        { role: "assistant", content: "a1" },
+    ];
+    assert.equal(hoistMidSystemMessages(msgs), msgs, "clean input must return the same array (no allocation)");
+});
+
+test("hoistMidSystemMessages: no-op (same array) for an empty list", () => {
+    const msgs: Msg[] = [];
+    assert.equal(hoistMidSystemMessages(msgs), msgs);
+});
+
+test("hoistMidSystemMessages: no-op (same array) when there is no system message at all", () => {
+    const msgs: Msg[] = [
+        { role: "user", content: "u1" },
+        { role: "assistant", content: "a1" },
+    ];
+    assert.equal(hoistMidSystemMessages(msgs), msgs);
+});
+
+test("hoistMidSystemMessages: a single mid-conversation system moves to the leading prefix", () => {
+    const msgs: Msg[] = [
+        { role: "system", content: "head" },
+        { role: "user", content: "u1" },
+        { role: "system", content: "summary-b3" },
+        { role: "user", content: "u2" },
+    ];
+    const out = hoistMidSystemMessages(msgs);
+    assert.deepEqual(out.map((m) => m.role), ["system", "system", "user", "user"]);
+    assert.deepEqual(out.map((m) => m.content), ["head", "summary-b3", "u1", "u2"]);
+});
+
+test("hoistMidSystemMessages: no leading system — mid systems become the new leading prefix", () => {
+    const msgs: Msg[] = [
+        { role: "user", content: "u1" },
+        { role: "system", content: "summary-b1" },
+        { role: "user", content: "u2" },
+        { role: "system", content: "summary-b2" },
+    ];
+    const out = hoistMidSystemMessages(msgs);
+    assert.deepEqual(out.map((m) => m.role), ["system", "system", "user", "user"]);
+    assert.deepEqual(out.map((m) => m.content), ["summary-b1", "summary-b2", "u1", "u2"]);
+});
+
+test("hoistMidSystemMessages: multiple mid systems keep their relative order and land after the existing head", () => {
+    const msgs: Msg[] = [
+        { role: "system", content: "head" },
+        { role: "system", content: "b1" },
+        { role: "user", content: "u1" },
+        { role: "system", content: "b2" },
+        { role: "user", content: "u2" },
+        { role: "developer", content: "dev-mid" },
+        { role: "assistant", content: "a1" },
+    ];
+    const out = hoistMidSystemMessages(msgs);
+    assert.deepEqual(out.map((m) => m.role), ["system", "system", "system", "developer", "user", "user", "assistant"]);
+    assert.deepEqual(out.map((m) => m.content), ["head", "b1", "b2", "dev-mid", "u1", "u2", "a1"]);
+});
+
+test("hoistMidSystemMessages: an all-system list is unchanged in order (returned as-is when no mid exists past the prefix)", () => {
+    const msgs: Msg[] = [
+        { role: "system", content: "s1" },
+        { role: "developer", content: "d1" },
+        { role: "system", content: "s2" },
+    ];
+    assert.equal(hoistMidSystemMessages(msgs), msgs);
+});
+
+test("hoistMidSystemMessages: the issue #355 wire shape — [system, system, system, user, system, user] becomes a clean leading prefix", () => {
+    const msgs: Msg[] = [
+        { role: "system", content: "sysprompt" },
+        { role: "system", content: "b1" },
+        { role: "system", content: "b2" },
+        { role: "user", content: "m00240" },
+        { role: "system", content: "b3" },
+        { role: "user", content: "m00329" },
+    ];
+    const out = hoistMidSystemMessages(msgs);
+    const firstNonSystem = out.findIndex((m) => m.role !== "system" && m.role !== "developer");
+    assert.ok(firstNonSystem > 0, "there is a non-system message");
+    for (let i = firstNonSystem; i < out.length; i++) {
+        assert.notEqual(out[i].role, "system", `system at index ${i} after the first non-system message`);
+        assert.notEqual(out[i].role, "developer", `developer at index ${i} after the first non-system message`);
+    }
+    assert.deepEqual(out.map((m) => m.content), ["sysprompt", "b1", "b2", "b3", "m00240", "m00329"]);
+});


### PR DESCRIPTION
Fixes #355.

## Root cause

acp-kernel renders compressed summaries as `role:"system"` messages anchored at the earliest message their block covered (`collectSummaryAnchors`/`rebuildMessages` in `prune.ts`). When a block's anchor sits AFTER an uncompressed message — the minimal condition is a multi-segment compress with an uncovered user message between segments — the OpenAI wire carries a system message mid-conversation. `coreToOpenai` serializes it verbatim, and strict OpenAI-compatible backends (sglang: `400 System message must be at the beginning`) reject every subsequent request for that provider.

Head-anchored single-segment compresses never triggered it (anchor = index 0 = still inside the leading system prefix), which is why the bug stayed hidden.

## Fix

New `hoistMidSystemMessages()` in `src/util.ts`: moves any mid-conversation `system`/`developer` messages to the leading system-prefix position, preserving relative order. Applied at both OpenAI-wire build sites:

- `src/server.ts:1357` (`prepareOpenai` — the main request pipeline)
- `src/loop/adapter-openai.ts:175` (`buildRequest` — the compress loop's re-requests, which also fixes the `acp_loop_r*` visibility-marker system messages)

Design choices:

- **Separate messages, not merged into the head** — the head system message is the prefix-cache anchor and must stay byte-stable across compress turns; merging would change its bytes on every compress.
- **Semantics preserved** — a summary is a stand-in for the folded history; moving it to the head changes no information. sglang (and OpenAI) accept a contiguous leading system prefix.
- **Wire-layer, not kernel** — keeps this fix self-contained in billion-context (no acp-kernel release dependency). The kernel-level clamp (`insertAt = Math.min(earliest ?? 0, firstUserIndex)` in `collectSummaryAnchors`) is filed separately against acp-kernel so in-process hosts (pi/opencode) get the root fix too.

## Tests

- `tests/hoist-mid-system.test.ts` — 8 unit tests: mid-system hoisting, order preservation, no-op cases (clean list, all-system list, empty list), developer-role handling.
- `tests/e2e-mid-system.test.ts` — full-proxy regression (real `startServer` + mock upstream capturing every forwarded body): head-anchored compress #1 (m00001–m00020), then two-segment compress #2 (m00016–m00018 + m00020–m00022) with uncovered USER m00019 between them — the exact #355 shape. Asserts sglang's validation on EVERY upstream request (all system/developer messages form a contiguous leading prefix) plus that all three summaries land in the final leading prefix. Verified the test FAILS without the fix (`role "system" at index 3 AFTER the leading system prefix`) and passes with it.

## Pre-flight

- `npm run typecheck` ✓
- `npm test` — 832/832 ✓ (was 823; +9 new)
- `npm run build` ✓