### PR TITLE
release v0.1.64

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.63",
+  "version": "0.1.64",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Release **v0.1.64**.

Bumps the version to 0.1.64. Merging this branch triggers `.github/workflows/release.yml` (branch name matches `*_release-v*`), which runs typecheck + test + build, tags `v0.1.64`, publishes to npm (`latest`), and creates the GitHub Release.

## Changes since v0.1.63

- **#346 fix** (PR #357): unset upstream-proxy mode now means **direct** (not env auto-detect) — fixes the silent-proxy / IP-bound-OAuth 401s + slowness; adds the gost-style `-F <url>` forward flag for the launcher; adds a deduped `[upstream-proxy] <host> via <proxy> (source=…)` log line (non-public hosts masked per #255).
- Generate real changelog in GitHub Releases via `generate_release_notes` (#339).
- Widen e2e mock pacing to keep streaming-span margin on slow CI runners.
