### PR TITLE
fix: emit /acp panel as persistent custom message and strip it from the proxy model context (#359)

### DIFF
--- a/src/acp-panel.ts
+++ b/src/acp-panel.ts
@@ -1,0 +1,99 @@
+// ACP panel stripping for proxy mode (issue #359). The pi plugin's /acp emits
+// the status panel as a persistent custom_message; in proxy mode pi's
+// convertToLlm projects every custom message as an ordinary user message, so
+// the panel would ride the recent zone to the model as if it were real
+// conversation content. pi's projection drops the customType, so the proxy
+// (which generates the panel itself via buildStatusPanel) strips it by content
+// signature before it enters the compression state.
+//
+// The match must be WHOLE-MESSAGE, not a prefix: a user can copy a panel from
+// pi-web and append a follow-up question in the same message — a prefix match
+// would strip the user's question too (data loss, unrecoverable in-session).
+// Each renderer is therefore anchored on BOTH its start and its end:
+//  - buildStatusPanel (acp-kernel): starts with the U+256D top border + title
+//    "ACP Context Analysis", and always ends with the "Tag visibility: ..."
+//    footer (unconditional, last line pushed).
+//  - renderAcpStatus (plugin fallback): first line exactly "📊 ACP status",
+//    every other line an indented field.
+const PANEL_BOX_TOP = "\u256d";
+const PANEL_BOX_TITLE = "ACP Context Analysis";
+const PANEL_BOX_FOOTER = "Tag visibility: tags injected to LLM only (deep copy), not persisted in session, not shown in terminal.";
+const PANEL_FALLBACK_HEADER = "\u{1f4ca} ACP status";
+
+export function isAcpPanelText(text: string): boolean {
+    const t = text.trim();
+    if (t.length === 0) return false;
+    return isBoxPanel(t) || isFallbackPanel(t);
+}
+
+function isBoxPanel(t: string): boolean {
+    return t.startsWith(PANEL_BOX_TOP) && t.includes(PANEL_BOX_TITLE) && t.endsWith(PANEL_BOX_FOOTER);
+}
+
+function isFallbackPanel(t: string): boolean {
+    const lines = t.split("\n");
+    if (lines[0] !== PANEL_FALLBACK_HEADER) return false;
+    for (let i = 1; i < lines.length; i++) {
+        const line = lines[i];
+        if (line.length > 0 && !line.startsWith("  ")) return false;
+    }
+    return true;
+}
+
+// Plain text of a message's content (string or text-block array). Returns
+// undefined for mixed/multimodal content — such a message can never be a
+// panel, so it is preserved.
+function messageText(content: unknown): string | undefined {
+    if (typeof content === "string") return content;
+    if (Array.isArray(content)) {
+        let joined = "";
+        for (const part of content) {
+            const p = part as Record<string, unknown> | null;
+            if (p === null || typeof p !== "object") return undefined;
+            const pt = p.type;
+            if (pt !== undefined && pt !== "text" && pt !== "input_text") return undefined;
+            if (typeof p.text === "string") joined += p.text;
+        }
+        return joined;
+    }
+    return undefined;
+}
+
+// Strip ACP panel user messages from an anthropic/openai messages array (in
+// place); returns the count removed.
+export function stripAcpPanelMessages(messages: unknown): number {
+    if (!Array.isArray(messages)) return 0;
+    let stripped = 0;
+    for (let i = messages.length - 1; i >= 0; i--) {
+        const rec = messages[i] as Record<string, unknown> | null;
+        if (rec === null || typeof rec !== "object") continue;
+        if (rec.role !== "user") continue;
+        const text = messageText(rec.content);
+        if (text !== undefined && isAcpPanelText(text)) {
+            messages.splice(i, 1);
+            stripped++;
+        }
+    }
+    return stripped;
+}
+
+// Strip ACP panel user messages from a Responses input array (in place);
+// returns the count removed. Type-less user items (omp wire form) count as
+// messages, mirroring dropWhitespaceResponsesMessages.
+export function stripAcpPanelResponsesInput(input: unknown): number {
+    if (!Array.isArray(input)) return 0;
+    let stripped = 0;
+    for (let i = input.length - 1; i >= 0; i--) {
+        const rec = input[i] as Record<string, unknown> | null;
+        if (rec === null || typeof rec !== "object") continue;
+        const type = rec.type;
+        if (type !== "message" && type !== undefined) continue;
+        if (rec.role !== "user") continue;
+        const text = messageText(rec.content);
+        if (text !== undefined && isAcpPanelText(text)) {
+            input.splice(i, 1);
+            stripped++;
+        }
+    }
+    return stripped;
+}

--- a/src/agent/pi.ts
+++ b/src/agent/pi.ts
@@ -48,6 +48,10 @@ type ExtensionAPI = {
     // session model, so the extension must re-pin it via setModel (see the
     // session_start handler below). Optional because pi hosts lack it.
     setModel?: (model: Record<string, unknown> & { baseUrl?: string }) => Promise<boolean | void> | boolean | void;
+    // Persistent transcript output (rendered by TUI and web hosts like
+    // pi-web); notify() is a transient toast — only the fallback for hosts
+    // without sendMessage (issue #359).
+    sendMessage?: (message: { customType: string; content: string; display: boolean }) => void;
 };
 
 function agentName(override: string | undefined): string {
@@ -363,7 +367,21 @@ export function createBiliPlugin(agentOverride?: string, opts?: { retryIntervalM
                         return;
                     }
                     const panel = typeof status.panel === "string" ? status.panel : undefined;
-                    notify(panel ?? renderAcpStatus(status), "info");
+                    const text = panel ?? renderAcpStatus(status);
+                    // Persistent transcript output (TUI + web hosts like pi-web).
+                    // The proxy strips this message from the model context by
+                    // content signature (src/acp-panel.ts), so it never reaches
+                    // the LLM; notify() is the fallback for hosts without
+                    // sendMessage (older pi).
+                    if (typeof pi.sendMessage === "function") {
+                        try {
+                            pi.sendMessage({ customType: "bili-acp-status", content: text, display: true });
+                            return;
+                        } catch (err) {
+                            console.error(`bili-plugin(${agent}): sendMessage failed (${err instanceof Error ? err.message : String(err)}) — falling back to notify`);
+                        }
+                    }
+                    notify(text, "info");
                 },
             });
         }

--- a/src/server.ts
+++ b/src/server.ts
@@ -59,6 +59,7 @@ import { containsToolCallXmlFragment } from "./loop/tag-echo-filter.js";
 import { isFakeCompletion, injectFakeCompletionHint, maxFakeCompletionRetries, fakeBufCap } from "./fake-completion.js";
 import { sanitizeResponsesInputIds, dropWhitespaceResponsesMessages, normalizeResponsesMessageItems } from "./loop/adapter-responses.js";
 import { codexCompactMode, isCodexClient, hasCompactionTrigger, stripBiliCompactionItems, replaceBiliCompactionItems, codexCompactGate, codexCompactGatePre, buildTriggerForgeBody, mergeForgedSummaries } from "./codex-compact.js";
+import { stripAcpPanelMessages, stripAcpPanelResponsesInput } from "./acp-panel.js";
 import { rewriteOpenaiJsonResponse } from "./stream-openai.js";
 import { rewriteResponsesJsonResponse } from "./stream-responses.js";
 import { observeResponsesTerminalState } from "./stream-terminal.js";
@@ -1566,6 +1567,13 @@ function prepareAnthropic(
     let systemOut = parsed.system;
     let toolsOut = parsed.tools;
 
+    // The classifier passthrough above and prepareResponsesCompact return before
+    // this strip; no client emits an ACP panel on those paths, so that's safe.
+    const strippedPanels = stripAcpPanelMessages(parsed.messages);
+    if (strippedPanels > 0) {
+        log("info", `[${sessionId}] stripped ${strippedPanels} ACP panel message(s) before projection (UI-only, issue #359)`);
+    }
+
     try {
         const { msgs, cacheControls } = anthropicToCore(parsed);
         originalMessages = msgs;
@@ -1737,6 +1745,11 @@ function prepareOpenai(
     const shouldInject = opts.compress.injectTool && !isTitleGen;
     const injectTools = shouldInject && !pluginMode;
 
+    const strippedPanels = stripAcpPanelMessages(parsed.messages);
+    if (strippedPanels > 0) {
+        log("info", `[${sessionId}] stripped ${strippedPanels} ACP panel message(s) before projection (UI-only, issue #359)`);
+    }
+
     try {
         // Kernel 0.0.37 hoists the contiguous leading system/developer prefix
         // OUT of the fold space: system content is host runtime state and
@@ -1888,6 +1901,11 @@ function prepareResponses(
     const droppedEmpty = dropWhitespaceResponsesMessages(parsed.input);
     if (droppedEmpty > 0) {
         log("info", `[${sessionId}] dropped ${droppedEmpty} whitespace-only message item(s) before projection (flattened-turn artifact)`);
+    }
+
+    const strippedPanels = stripAcpPanelResponsesInput(parsed.input);
+    if (strippedPanels > 0) {
+        log("info", `[${sessionId}] stripped ${strippedPanels} ACP panel message(s) before projection (UI-only, issue #359)`);
     }
 
     const shouldInject = opts.compress.injectTool;

--- a/tests/acp-panel.test.ts
+++ b/tests/acp-panel.test.ts
@@ -1,0 +1,110 @@
+import assert from "node:assert";
+import test from "node:test";
+import { createInitialState } from "acp-kernel";
+import { buildStatusPanel } from "acp-kernel/panel";
+import { isAcpPanelText, stripAcpPanelMessages, stripAcpPanelResponsesInput } from "../src/acp-panel.ts";
+
+// Generate the REAL panel the proxy produces (handlePluginStatus →
+// buildStatusPanel), so the signature test tracks acp-kernel's actual output
+// rather than a hand-typed copy that could drift.
+function realPanel(): string {
+    return buildStatusPanel({
+        version: "billion-context@0.1.64",
+        tokenCount: 100000,
+        systemPromptTokens: 0,
+        state: createInitialState(),
+        nudge: undefined,
+        modelContextLimit: 200000,
+    });
+}
+
+const FALLBACK = "📊 ACP status\n  context: 12.3K / 200.0K (6.2%)\n  requests: 7";
+
+test("isAcpPanelText detects the buildStatusPanel box", () => {
+    const panel = realPanel();
+    assert.ok(panel.startsWith("\u256d"), "sanity: box starts with the top border");
+    assert.equal(isAcpPanelText(panel), true);
+});
+
+test("isAcpPanelText detects the renderAcpStatus fallback header", () => {
+    assert.equal(isAcpPanelText(FALLBACK), true);
+});
+
+test("isAcpPanelText tolerates surrounding whitespace", () => {
+    assert.equal(isAcpPanelText(`\n  ${realPanel()}  \n`), true);
+});
+
+test("isAcpPanelText rejects normal user content", () => {
+    assert.equal(isAcpPanelText("hello world"), false);
+    assert.equal(isAcpPanelText(""), false);
+    assert.equal(isAcpPanelText("   "), false);
+});
+
+test("isAcpPanelText rejects a message that merely quotes the panel", () => {
+    const panel = realPanel();
+    assert.equal(isAcpPanelText(`here is the panel:\n${panel}`), false, "quoted panel is a real user message");
+    assert.equal(isAcpPanelText('I saw "ACP Context Analysis" today'), false, "title alone is not a panel");
+});
+
+test("isAcpPanelText rejects a panel with a follow-up appended (suffix case)", () => {
+    const panel = realPanel();
+    assert.equal(isAcpPanelText(`${panel}\n\nmy follow-up question`), false, "panel + follow-up is a real user message");
+    assert.equal(isAcpPanelText(`${panel} and what about X?`), false, "panel + inline follow-up preserved");
+    assert.equal(isAcpPanelText(`${FALLBACK}\nmy follow-up question`), false, "fallback + follow-up is a real user message");
+});
+
+test("isAcpPanelText tolerates surrounding whitespace on the fallback", () => {
+    assert.equal(isAcpPanelText(`\n  ${FALLBACK}  \n`), true);
+});
+
+test("stripAcpPanelMessages removes panel user messages (string + block content)", () => {
+    const panel = realPanel();
+    const messages = [
+        { role: "user", content: "hi" },
+        { role: "assistant", content: "hello" },
+        { role: "user", content: panel },
+        { role: "user", content: [{ type: "text", text: FALLBACK }] },
+        { role: "assistant", content: [{ type: "text", text: panel }] },
+        { role: "user", content: "next question" },
+    ];
+    const stripped = stripAcpPanelMessages(messages);
+    assert.equal(stripped, 2, "two panel user messages removed");
+    assert.deepEqual(messages.map((m) => m.role), ["user", "assistant", "assistant", "user"]);
+});
+
+test("stripAcpPanelMessages preserves multimodal and non-user content", () => {
+    const panel = realPanel();
+    const messages = [
+        { role: "user", content: [{ type: "text", text: "look" }, { type: "image", source: { type: "base64", data: "x" } }] },
+        { role: "user", content: [{ type: "tool_result", content: panel }] },
+        { role: "assistant", content: panel },
+    ];
+    const stripped = stripAcpPanelMessages(messages);
+    assert.equal(stripped, 0, "no plain-text panel user message here");
+    assert.equal(messages.length, 3);
+});
+
+test("stripAcpPanelMessages is a no-op on non-array input", () => {
+    assert.equal(stripAcpPanelMessages("not an array"), 0);
+    assert.equal(stripAcpPanelMessages(undefined), 0);
+});
+
+test("stripAcpPanelResponsesInput removes panel user items, keeps others", () => {
+    const panel = realPanel();
+    const input = [
+        { type: "message", role: "user", content: "hi" },
+        { type: "message", role: "assistant", content: "hello" },
+        { type: "message", role: "user", content: panel },
+        { type: "function_call", name: "compress", arguments: "{}", id: "fc1" },
+        { type: "message", role: "user", content: [{ type: "input_text", text: FALLBACK }] },
+        { role: "user", content: panel },
+    ];
+    const stripped = stripAcpPanelResponsesInput(input);
+    assert.equal(stripped, 3, "three panel user items removed (typed + type-less)");
+    assert.deepEqual(input.map((i) => i.type ?? "message"), ["message", "message", "function_call"]);
+});
+
+test("stripAcpPanelResponsesInput is a no-op on string input and non-arrays", () => {
+    assert.equal(stripAcpPanelResponsesInput(realPanel()), 0);
+    assert.equal(stripAcpPanelResponsesInput(undefined), 0);
+});

--- a/tests/launcher.test.ts
+++ b/tests/launcher.test.ts
@@ -246,7 +246,20 @@ tools.web_search = false
 });
 
 test("findFreePort: returns preferred when it is free", async () => {
-    const port = 50000 + Math.floor(Math.random() * 1000);
+    // Ask the OS for a port (listen 0), release it, then verify findFreePort
+    // prefers it. A random pick from a fixed range races the OS: on Windows
+    // the ephemeral range (49152-65535) covers 50000-50999, so an unrelated
+    // outbound connection can occupy the "free" port mid-test.
+    const probe = net.createServer();
+    const port = await new Promise<number>((resolve, reject) => {
+        probe.once("error", reject);
+        probe.listen(0, LAUNCHER_DEFAULT_HOST, () => {
+            const addr = probe.address();
+            if (addr && typeof addr === "object") resolve(addr.port);
+            else reject(new Error("no port"));
+        });
+    });
+    await new Promise<void>((resolve) => probe.close(() => resolve()));
     const got = await findFreePort(port, LAUNCHER_DEFAULT_HOST);
     assert.equal(got, port);
 });

--- a/tests/plugin-agent.test.ts
+++ b/tests/plugin-agent.test.ts
@@ -555,6 +555,104 @@ test("/acp shows armed info when the proxy is live but the session is unknown", 
     }
 });
 
+test("/acp emits a persistent custom message via pi.sendMessage when available (issue #359)", async () => {
+    const server = http.createServer((req, res) => {
+        if (req.url?.startsWith("/__bili/plugin/status")) {
+            res.writeHead(200, { "content-type": "application/json" });
+            res.end(JSON.stringify({ ok: true, panel: "PANEL-BODY", contextTokens: 12345 }));
+            return;
+        }
+        res.writeHead(404);
+        res.end("{}");
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const origin = `http://127.0.0.1:${(server.address() as { port: number }).port}`;
+    try {
+        const sent: Array<{ customType: string; content: string; display: boolean }> = [];
+        const notes: string[] = [];
+        const pi = { ...makeFakePi(), sendMessage: (m: { customType: string; content: string; display: boolean }) => sent.push(m) };
+        biliPlugin(pi as never);
+        const cmd = pi.commands.get("acp")!;
+        const ctx = {
+            sessionManager: { getSessionId: () => "sess-send" },
+            model: { baseUrl: `${origin}/bili/https://api.example.com/v1` },
+            ui: { notify: (msg: string) => notes.push(msg) },
+        };
+        await cmd.handler("", ctx);
+        assert.equal(sent.length, 1, "one custom message sent");
+        assert.equal(notes.length, 0, "notify must not fire when sendMessage is available");
+        assert.equal(sent[0]!.customType, "bili-acp-status");
+        assert.equal(sent[0]!.display, true);
+        assert.equal(sent[0]!.content, "PANEL-BODY");
+    } finally {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+});
+
+test("/acp sends renderAcpStatus fallback content via sendMessage when no panel string", async () => {
+    const server = http.createServer((req, res) => {
+        if (req.url?.startsWith("/__bili/plugin/status")) {
+            res.writeHead(200, { "content-type": "application/json" });
+            res.end(JSON.stringify({ ok: true, contextLimit: 200000, contextTokens: 12345, inputTokens: 10000, outputTokens: 1234, cachedTokens: 8000, requests: 7, blocks: [{ id: "b1", tier: 1, active: true }] }));
+            return;
+        }
+        res.writeHead(404);
+        res.end("{}");
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const origin = `http://127.0.0.1:${(server.address() as { port: number }).port}`;
+    try {
+        const sent: Array<{ customType: string; content: string; display: boolean }> = [];
+        const pi = { ...makeFakePi(), sendMessage: (m: { customType: string; content: string; display: boolean }) => sent.push(m) };
+        biliPlugin(pi as never);
+        const cmd = pi.commands.get("acp")!;
+        const ctx = {
+            sessionManager: { getSessionId: () => "sess-send2" },
+            model: { baseUrl: `${origin}/bili/https://api.example.com/v1` },
+            ui: { notify: () => { throw new Error("notify must not fire"); } },
+        };
+        await cmd.handler("", ctx);
+        assert.equal(sent.length, 1);
+        assert.equal(sent[0]!.customType, "bili-acp-status");
+        assert.match(sent[0]!.content, /📊 ACP status/);
+    } finally {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+});
+
+test("/acp falls back to notify when pi.sendMessage throws", async () => {
+    const server = http.createServer((req, res) => {
+        if (req.url?.startsWith("/__bili/plugin/status")) {
+            res.writeHead(200, { "content-type": "application/json" });
+            res.end(JSON.stringify({ ok: true, panel: "PANEL-BODY", contextTokens: 1 }));
+            return;
+        }
+        res.writeHead(404);
+        res.end("{}");
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const origin = `http://127.0.0.1:${(server.address() as { port: number }).port}`;
+    try {
+        const notes: string[] = [];
+        const pi = { ...makeFakePi(), sendMessage: () => { throw new Error("host sendMessage failed"); } };
+        biliPlugin(pi as never);
+        const cmd = pi.commands.get("acp")!;
+        const ctx = {
+            sessionManager: { getSessionId: () => "sess-send3" },
+            model: { baseUrl: `${origin}/bili/https://api.example.com/v1` },
+            ui: { notify: (msg: string) => notes.push(msg) },
+        };
+        await cmd.handler("", ctx);
+        assert.equal(notes.length, 1, "notify fallback fires");
+        assert.equal(notes[0], "PANEL-BODY");
+    } finally {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+});
+
 test("omp entry reports x-bili-plugin: omp without env vars", async () => {
     const proxy = await startFakeProxy();
     try {


### PR DESCRIPTION
## What

The pi plugin's `/acp` command rendered the status panel through `ctx.ui.notify()`, which web hosts like `agegr/pi-web` show as a **transient toast** instead of a persistent transcript entry (same class as [billion-context-pi#255](https://github.com/ranxianglei/billion-context-pi/issues/255), fixed there in PR #256).

This is a **two-part fix** — a plugin-only port is *not* safe in proxy mode:

### 1. Plugin (`src/agent/pi.ts`)
`/acp` now emits `pi.sendMessage({ customType: "bili-acp-status", content, display: true })` when `sendMessage` is available, falling back to `ctx.ui.notify()` for older pi. `sendMessage` produces a persistent `custom_message` session entry that TUI and web hosts render in the transcript.

### 2. Proxy (`src/acp-panel.ts` + the three prepare paths)
Strip panel user-messages from the request **before** the `*ToCore` conversion, so the panel never enters the compression state / recent zone and is never forwarded to the model.

**Why the proxy side is required:** in extension mode (billion-context-pi) the ACP transform runs *inside* pi and filters `acp-status` panels out of the sent view by `customType`. In **proxy mode** pi's `convertToLlm` projects every custom message as an ordinary **user message** and *drops the `customType`* — so the panel arrives as indistinguishable real conversation content and would sit in the recent zone, forwarded to the model on every turn. The proxy generates the panel itself (`handlePluginStatus` → `buildStatusPanel`), so it matches its own **content signature** (the `buildStatusPanel` box — `╭` border + `ACP Context Analysis` title — or the plugin's `renderAcpStatus` fallback header `📊 ACP status`) rather than the type. Applied in `prepareAnthropic` / `prepareOpenai` / `prepareResponses`.

## Files

- `src/acp-panel.ts` (new): `isAcpPanelText` + `stripAcpPanelMessages` / `stripAcpPanelResponsesInput`. Plain-text-only matching — mixed/multimodal, assistant, and function-call items are never touched; a message that merely *quotes* a panel is preserved.
- `src/server.ts`: strip calls wired into the three prepare paths (before projection) + import.
- `src/agent/pi.ts`: `sendMessage` on `ExtensionAPI` + `/acp` handler uses it with `notify` fallback.
- `tests/acp-panel.test.ts` (new): 10 tests against the **real** `buildStatusPanel` output + fallback + edge cases.
- `tests/plugin-agent.test.ts`: 3 tests for the `sendMessage` path (panel string, `renderAcpStatus` fallback, `sendMessage` throws → `notify`).

## Pre-flight

- `npm run typecheck` — clean
- `npm test` — **842 pass, 0 fail**
- `npm run build` — success

> **E2E note:** `tests/e2e/e2e-codex.test.ts` could not be run here (no `codex` binary, no local upstream). It drives **codex**, not pi, so it never injects a panel — the strip is a no-op for those requests. The full unit suite (all anthropic/openai/responses round-trip + stream tests) plus the new tests already verify the strip is a no-op for legitimate messages and correctly removes panels.

Closes #359.