### PR TITLE
release v0.1.65

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.64",
+  "version": "0.1.65",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Release v0.1.65.

Bumps package.json 0.1.64 → 0.1.65. The release workflow (triggered by this merge commit's branch name) runs typecheck+test+build, tags v0.1.65, npm publish --tag latest, and creates the GitHub Release.

Contents: all changes in CHANGELOG [Unreleased] since v0.1.64 (verified locally: 850/850 tests, typecheck + build green).