### PR TITLE
fix: warn on tool-call XML fragments + close-side truncated acp echo (#361)

### DIFF
--- a/src/loop/tag-echo-filter.ts
+++ b/src/loop/tag-echo-filter.ts
@@ -16,10 +16,13 @@ const LONE_CLOSE = /<\/acp(?=[\s>])[^<>]{0,32}>/;
 // A suffix of the buffer that could still grow into a render tag: either an
 // unterminated `\x3cacp …` opening (attrs so far, no `>` yet) or a short
 // ambiguous prefix like `<`, `<a`, `</ac`, …
-const PARTIAL_TAIL = /(\x3cacp\s[^<>]*|<\/?a?c?p?)$/;
+const PARTIAL_TAIL = /(\x3cacp\s[^<>]*|\x3c\/acp(?:\s[^<>]*)?|<\/?a?c?p?)$/;
 // An unterminated render-tag opening at the end of a string: `<acp ` plus
 // attrs, no `>` — a truncated imitation, never prose (triggers use `<acp_`).
 const TRUNC_OPEN = /\x3cacp\s[^<>]*$/;
+// A truncated render-tag CLOSE at the end of a string: `` or `` —
+// a truncated imitation close, never prose. Mirrors TRUNC_OPEN on the close side.
+const TRUNC_CLOSE = /\x3c\/acp(?:\s[^<>]*)?$/;
 const CLOSE_TAG = "\x3c/acp";
 const HOLD_LIMIT = 128;
 // Hold cap for a definite unterminated opening tail — far beyond any real tag
@@ -40,15 +43,27 @@ export function stripAcpTags(text: string): string {
         .replace(new RegExp(PAIRED.source, "g"), "")
         .replace(new RegExp(LONE_OPEN.source, "g"), "")
         .replace(new RegExp(LONE_CLOSE.source, "g"), "")
-        .replace(new RegExp(TRUNC_OPEN.source), "");
+        .replace(new RegExp(TRUNC_OPEN.source), "")
+        .replace(new RegExp(TRUNC_CLOSE.source), "");
 }
 
 // Cheap pre-check on a raw wire string (SSE event or JSON body): does it
 // contain anything that looks like a render tag (literal or JSON-escaped
 // `\u003c` form)? Callers use this to skip re-serializing chunks that need
 // no stripping, preserving byte-identical passthrough.
+const RENDER_TAG_DETECT = /\x3c\/?acp(?=[\s>])|\\u003c\/?acp(?=[\s>\\])/;
 export function containsRenderTagText(s: string): boolean {
-    return /\x3c\/?acp(?=[\s>])/.test(s) || /\\u003c\/?acp(?=[\s>\\])/.test(s);
+    return RENDER_TAG_DETECT.test(s);
+}
+
+// #361: tool-call XML template fragments a model may echo from the context
+// (same source as acp tag echo — the model "writes the tool call as text").
+// Detected + warned for attribution, NOT stripped: a closing tool-XML tag
+// cannot be distinguished from legitimate prose discussing tool-call code,
+// so stripping would corrupt real content (see #295 review).
+const TOOL_CALL_XML = /\x3c\/?(?:antml:)?(invoke|tool_calls|tool_call|parameter|parameters)\b[^<>]*\x3e|\\u003c\/?(?:antml:)?(invoke|tool_calls|tool_call|parameter|parameters)\b|\x3c\/?antml:[a-z_]+/i;
+export function containsToolCallXmlFragment(s: string): boolean {
+    return TOOL_CALL_XML.test(s);
 }
 
 export function createTagEchoFilter(onDrop?: (snippet: string) => void): TagEchoFilter {
@@ -102,7 +117,7 @@ export function createTagEchoFilter(onDrop?: (snippet: string) => void): TagEcho
                     // past HOLD_LIMIT (drop it past TAG_OPEN_CAP); a short
                     // ambiguous prefix stays on the small hold cap so prose
                     // is never delayed or lost.
-                    const definite = /^\x3cacp\s/.test(t[0]);
+                    const definite = /^\x3cacp\s/.test(t[0]) || /^\x3c\/acp/.test(t[0]);
                     const cap = definite ? TAG_OPEN_CAP : HOLD_LIMIT;
                     if (t[0].length <= cap) {
                         held = t[0];
@@ -153,6 +168,11 @@ export function createTagEchoFilter(onDrop?: (snippet: string) => void): TagEcho
             if (t) {
                 drop(t[0]);
                 return rest.slice(0, t.index);
+            }
+            const tc = new RegExp(TRUNC_CLOSE.source).exec(rest);
+            if (tc) {
+                drop(tc[0]);
+                return rest.slice(0, tc.index);
             }
             return rest;
         },

--- a/src/server.ts
+++ b/src/server.ts
@@ -53,6 +53,7 @@ import { log as loggerLog, configureLogger, getLogPath, closeLogger } from "./lo
 import { defaultLogFile, stateDir, proxyOriginFile } from "./paths.js";
 import { compressLoopResponsesJson } from "./compress-loop-responses.js";
 import { runCompressLoop, pickAdapter } from "./loop/index.js";
+import { containsToolCallXmlFragment } from "./loop/tag-echo-filter.js";
 import { sanitizeResponsesInputIds, dropWhitespaceResponsesMessages, normalizeResponsesMessageItems } from "./loop/adapter-responses.js";
 import { codexCompactMode, isCodexClient, hasCompactionTrigger, stripBiliCompactionItems, replaceBiliCompactionItems, codexCompactGate, buildTriggerForgeBody, mergeForgedSummaries } from "./codex-compact.js";
 import { rewriteOpenaiJsonResponse } from "./stream-openai.js";
@@ -2462,12 +2463,16 @@ async function forward(
                 systemPrompt,
                 clientAbort.signal,
             );
+            let protocolFragmentWarned = false;
             for await (const chunk of loop) {
                 if (res.destroyed || res.writableEnded) break;
                 {
                     const s = chunk.toString("utf8");
                     if (s.includes("\x3cacp ") || s.includes("\x3c/acp")) {
                         log("warn", `[${prepared.session.id}] tag echo: ${prepared.protocol} response stream contains \x3cacp tag`);
+                    } else if (!protocolFragmentWarned && containsToolCallXmlFragment(s)) {
+                        protocolFragmentWarned = true;
+                        log("warn", `[${prepared.session.id}] tag echo: ${prepared.protocol} response stream contains tool-call XML fragment (possible tag echo; not stripped)`);
                     }
                 }
                 res.write(chunk);

--- a/tests/tag-echo.test.ts
+++ b/tests/tag-echo.test.ts
@@ -4,7 +4,7 @@ import type { Config, CoreMessage } from "acp-kernel";
 import { createCore, createInitialState } from "acp-kernel";
 import type { Session } from "../src/session.ts";
 import { runCompressLoop, createOpenaiAdapter, createAnthropicAdapter, createResponsesAdapter } from "../src/loop/index.ts";
-import { stripAcpTags, createTagEchoFilter, containsRenderTagText } from "../src/loop/tag-echo-filter.ts";
+import { stripAcpTags, createTagEchoFilter, containsRenderTagText, containsToolCallXmlFragment } from "../src/loop/tag-echo-filter.ts";
 import { rewriteJsonResponse } from "../src/stream.ts";
 import { rewriteOpenaiJsonResponse } from "../src/stream-openai.ts";
 import { buildCompressSystemPrompt } from "../src/compress-tool.ts";
@@ -328,7 +328,13 @@ test("stripAcpTags drops arbitrary truncated open fragments, keeps ambiguous pre
     assert.equal(stripAcpTags(`text ${OPEN}type="text" tokens=`), "text ");
     assert.equal(stripAcpTags(`text ${OPEN}tok`), "text ");
     assert.equal(stripAcpTags(`text ${LT}acp`), `text ${LT}acp`);
-    assert.equal(stripAcpTags(`text ${LT}/acp`), `text ${LT}/acp`);
+    assert.equal(stripAcpTags(`text ${LT}/ac`), `text ${LT}/ac`);
+});
+
+test("stripAcpTags drops truncated close fragments (close side of #361)", () => {
+    assert.equal(stripAcpTags(`text ${LT}/acp`), "text ");
+    assert.equal(stripAcpTags(`text ${LT}/acp x="y"`), "text ");
+    assert.equal(stripAcpTags(`text ${CLOSE}`), "text ");
 });
 
 test("streaming flush drops arbitrary truncated open fragments", () => {
@@ -338,6 +344,17 @@ test("streaming flush drops arbitrary truncated open fragments", () => {
     const g = createTagEchoFilter();
     assert.equal(g.push(`text ${LT}acp`), "text ");
     assert.equal(g.flush(), `${LT}acp`);
+});
+
+test("streaming filter drops truncated close fragments (close side of #361)", () => {
+    const f = createTagEchoFilter();
+    assert.equal(f.push(`text ${LT}/acp`) + f.flush(), "text ");
+    const g = createTagEchoFilter();
+    assert.equal(g.push(`text ${LT}/acp `), "text ");
+    assert.ok(g.pending());
+    assert.equal(g.push(`x="y">`) + g.flush(), "");
+    const h = createTagEchoFilter();
+    assert.equal(h.push(`text ${LT}/acp `) + h.push(`>`) + h.flush(), "text ");
 });
 
 test("streaming flush drops content of a tag left unclosed at end of stream", () => {
@@ -364,4 +381,21 @@ test("prose with a tag-like opening beyond the attr bound survives intact", () =
     assert.equal(stripAcpTags(prose), prose);
     const f = createTagEchoFilter();
     assert.equal(f.push(prose) + f.flush(), prose);
+});
+
+test("containsToolCallXmlFragment detects tool-call XML fragments, not prose", () => {
+    assert.equal(containsToolCallXmlFragment(`done ${LT}/invoke>`), true);
+    assert.equal(containsToolCallXmlFragment(`x ${LT}/tool_calls> y`), true);
+    assert.equal(containsToolCallXmlFragment(`x ${LT}/parameter> y`), true);
+    assert.equal(containsToolCallXmlFragment(`x ${LT}antml:invoke name="t"> y`), true);
+    assert.equal(containsToolCallXmlFragment(`x ${LT}/antml:invoke> y`), true);
+    assert.equal(containsToolCallXmlFragment("escaped \\u003c/invoke\\u003e"), true);
+    assert.equal(containsToolCallXmlFragment(`plain text with ${LT} b and invoke() calls`), false);
+    assert.equal(containsToolCallXmlFragment(`the ${LT}/abcd> tag`), false);
+});
+
+test("tag-echo filter does not strip tool-call XML fragments (warn-only, #361)", () => {
+    const f = createTagEchoFilter();
+    const out = f.push(`done ${LT}/invoke> ${LT}/tool_calls>`) + f.flush();
+    assert.equal(out, `done ${LT}/invoke> ${LT}/tool_calls>`);
 });


### PR DESCRIPTION
Fixes #361.

## What changed

The 0.1.63 leak had two fragment classes reaching the final message. This
addresses both, plus the flush-path question:

1. **Non-acp tool-call XML fragments (the main gap).** </invoke>,
   </tool_calls>, </parameter> (and `antml:`-namespaced / JSON-escaped
   forms) matched nothing in the filter and always passed through. Added a
   `containsToolCallXmlFragment` detector for this family and a **once-per-stream
   warn** in the server streaming loop, so a "fake completion" (model wrote the
   tool call as text, no `tool_use` block) is attributable in `bili.log`.
   **Warn-only, not stripped** — these fragments are indistinguishable from
   legitimate prose discussing tool-call code (the #295 review deliberately did
   not strip them; stripping would corrupt real content).

2. **Close-side truncated acp tags.** `TRUNC_OPEN` only handled the open side
   (`<acp …`); a truncated close (`</acp`, `</acp …`) held at
   stream end was re-emitted verbatim. Added `TRUNC_CLOSE` mirroring
   `TRUNC_OPEN` (strip at flush + drop in the streaming filter), and extended
   `PARTIAL_TAIL` / the `definite` check so the close side is held instead of
   leaking.

3. **Regression fix.** A dangling `RENDER_TAG_DETECT` reference (left by an
   earlier uncommitted refactor) broke `tsc`; restored the constant.

## On the "TAG_OPEN_CAP flush path" question (#361 ask 3)

A truncated open **with attributes** (`<acp …`) is already dropped at flush by
`TRUNC_OPEN` — that path works. The residue that survived was the **close side**
(fixed above) and the non-acp tool-call fragments (now warned, ask 1/2). A bare
`<acp` (no space) remains an intentional conservative pass-through (covered
by existing tests) and is not changed here.

## Pre-flight

- `npm run typecheck` — exit 0
- `npm test` — 835/835 pass (833 baseline + 2 new; 1 previously-failing assertion fixed)
- `npm run build` — exit 0

No `version` bump (content branch).