### PR TITLE
feat: categorize compress-reject log + include callId (#349 observability)

### DIFF
--- a/src/compress-tool.ts
+++ b/src/compress-tool.ts
@@ -51,7 +51,12 @@ export { ACP_TOOL_NAMES as PROXY_TOOL_NAMES, ACP_MUTATING_TOOLS as MUTATING_PROX
 export function parseCompressInput(input: unknown, callId?: string) {
     const { ranges, diagnostics } = parseCompressArgs(input, { callId });
     if (!diagnostics.ok && diagnostics.kind !== "ok") {
-        loggerLog("warn", `[acp-compress-input] rejected: kind=${diagnostics.kind} invalidItems=${diagnostics.invalidItems}${diagnostics.keys ? ` keys=[${diagnostics.keys.join(",")}]` : ""}${diagnostics.length !== undefined ? ` len=${diagnostics.length}` : ""}`);
+        const category = diagnostics.kind === "missing-content" || diagnostics.kind === "empty-input"
+            ? "empty-call"
+            : diagnostics.kind === "malformed-json" || diagnostics.kind === "truncated"
+                ? "stream-concat"
+                : "validation";
+        loggerLog("warn", `[acp-compress-input] rejected: category=${category} kind=${diagnostics.kind} invalidItems=${diagnostics.invalidItems}${diagnostics.keys ? ` keys=[${diagnostics.keys.join(",")}]` : ""}${diagnostics.length !== undefined ? ` len=${diagnostics.length}` : ""}${callId ? ` callId=${callId}` : ""}`);
     }
     return ranges;
 }


### PR DESCRIPTION
Follow-up to #349 (observability), per @liyangbing's runtime-verification
suggestions. The error-message + defensive-object-args changes already landed
via #350 (merged); this is the remaining observability piece.

## What

The `[acp-compress-input] rejected` log now carries a `category` field (by
`kind`) and the `callId` (when the path supplies one):

- `empty-call` = `missing-content` / `empty-input` — model empty call
- `stream-concat` = `malformed-json` / `truncated` — adapter-attributable
- `validation` = `no-valid-ranges` / `content-not-array` / `not-object`

So `grep "category=..." bili.log | wc -l` gives per-mode rates with no
session-structure change. With #350's object-args hardening, `missing-content`
now maps cleanly to "model empty call" (the adapter no longer swallows object
args), so attribution is unambiguous.

## Why

@liyangbing asked to separately count (1) model empty calls, (2) streaming
parameter concatenation failures, and (3) valid-range validation failures —
only (2) is adapter-attributable. The `category` field makes that split
directly greppable from the log, and `callId` lets a rejection be correlated to
the specific tool call.

## Session-state safety (verified, no code change)

@liyangbing's concern that a failed compress might replace the original tool
result with an empty "success" placeholder does not hold:
- `src/stream.ts` — on `ranges.length===0`, `applyRanges` returns the error
  string without calling `ctx.core.applyCompression`; session state (blocks) is
  untouched. Log: `[acp-proxy: compress call had no valid ranges; nothing compressed.]`.
- `src/loop/core.ts:347-363` — the failed compress is written back as a
  `tool-call` (with the **original** `arguments`) + `tool` (with the error
  result), not an empty placeholder.
- `src/loop/core.ts:373-383` — on `anyCompressFailed`, `hideConsumedCompressCalls`
  is skipped, so the failure stays visible for the model to self-correct.

## Pre-flight

- `npm run typecheck` — clean.
- `npm test` — 850/850 pass.
- `npm run build` — ok.
