### PR TITLE
feat: categorize compress-reject log + include callId (#366 observability)

### DIFF
--- a/src/compress-tool.ts
+++ b/src/compress-tool.ts
@@ -8,7 +8,7 @@
  *    kernel's ACP_* names ("proxy" is a misnomer once shared);
  *  - parseCompressInput wires the kernel's onWarn hook into the proxy logger.
  */
-import { parseCompressArgs } from "acp-kernel";
+import { parseCompressArgs, type CompressParseKind } from "acp-kernel";
 import { log as loggerLog } from "./logger.js";
 import { maxShrinkPerCompress } from "./fetch-util.js";
 
@@ -48,10 +48,24 @@ export {
 export type { ParsedRange } from "acp-kernel";
 export { ACP_TOOL_NAMES as PROXY_TOOL_NAMES, ACP_MUTATING_TOOLS as MUTATING_PROXY_TOOLS, ACP_READONLY_TOOLS as READONLY_PROXY_TOOLS } from "acp-kernel";
 
+// #366: rejection categories by attribution — only stream-concat is
+// adapter-attributable; empty-call is a model empty call, validation is a
+// valid-range validation failure.
+const REJECT_CATEGORY: Record<CompressParseKind, string> = {
+    ok: "",
+    "empty-input": "empty-call",
+    "missing-content": "empty-call",
+    "malformed-json": "stream-concat",
+    "truncated": "stream-concat",
+    "no-valid-ranges": "validation",
+    "content-not-array": "validation",
+    "not-object": "validation",
+};
+
 export function parseCompressInput(input: unknown, callId?: string) {
     const { ranges, diagnostics } = parseCompressArgs(input, { callId });
     if (!diagnostics.ok && diagnostics.kind !== "ok") {
-        loggerLog("warn", `[acp-compress-input] rejected: kind=${diagnostics.kind} invalidItems=${diagnostics.invalidItems}${diagnostics.keys ? ` keys=[${diagnostics.keys.join(",")}]` : ""}${diagnostics.length !== undefined ? ` len=${diagnostics.length}` : ""}`);
+        loggerLog("warn", `[acp-compress-input] rejected: kind=${diagnostics.kind} category=${REJECT_CATEGORY[diagnostics.kind]}${callId ? ` callId=${callId}` : ""} invalidItems=${diagnostics.invalidItems}${diagnostics.keys ? ` keys=[${diagnostics.keys.join(",")}]` : ""}${diagnostics.length !== undefined ? ` len=${diagnostics.length}` : ""}`);
     }
     return ranges;
 }

--- a/tests/compress-observability.test.ts
+++ b/tests/compress-observability.test.ts
@@ -8,6 +8,7 @@ import { maxShrinkPerCompress } from "../src/fetch-util.ts";
 import { withStagedCompressGuidance } from "../src/compress-tool.ts";
 import { parseCompressInput } from "../src/compress-tool.ts";
 import { applyRanges, type RewriteCtx } from "../src/stream.ts";
+import { setLogCapture } from "../src/logger.ts";
 
 type Ctx = Omit<RewriteCtx, "log"> & { log: (m: string) => void; logs: string[] };
 
@@ -188,6 +189,55 @@ test("#189: maxShrinkPerCompress parses the env fraction; rejects out-of-range",
     } finally {
         if (prev === undefined) delete process.env.BILI_MAX_SHRINK_PER_COMPRESS;
         else process.env.BILI_MAX_SHRINK_PER_COMPRESS = prev;
+    }
+});
+
+test("#366: rejected log carries category by kind (all 7 kinds) and none on success", () => {
+    const captured: { level: string; msg: string }[] = [];
+    setLogCapture((level, msg) => captured.push({ level, msg }));
+    try {
+        const cases: Array<[label: string, input: unknown, kind: string, category: string]> = [
+            ["empty-input", null, "empty-input", "empty-call"],
+            ["missing-content", {}, "missing-content", "empty-call"],
+            ["malformed-json", "nope", "malformed-json", "stream-concat"],
+            ["truncated", '{"content":[{"startId":"m1","endId":"m2","summar', "truncated", "stream-concat"],
+            ["no-valid-ranges", { content: [{ startId: "m1" }] }, "no-valid-ranges", "validation"],
+            ["content-not-array", { content: 42 }, "content-not-array", "validation"],
+            ["not-object", 42, "not-object", "validation"],
+        ];
+        for (const [label, input, kind, category] of cases) {
+            captured.length = 0;
+            parseCompressInput(input);
+            const line = captured.find((c) => c.msg.includes("[acp-compress-input] rejected"));
+            assert.ok(line, `rejected line logged for ${label}`);
+            assert.ok(line!.msg.includes(`kind=${kind} `), `${label}: kind=${kind} in log: ${line!.msg}`);
+            assert.ok(line!.msg.includes(`category=${category}`), `${label}: category=${category} in log: ${line!.msg}`);
+            assert.equal(line!.level, "warn", `${label}: logged at warn level`);
+        }
+        captured.length = 0;
+        parseCompressInput({ content: [{ startId: "m1", endId: "m2", summary: "a valid summary" }] });
+        assert.equal(captured.filter((c) => c.msg.includes("[acp-compress-input] rejected")).length, 0, "no rejected line on success");
+    } finally {
+        setLogCapture(null);
+    }
+});
+
+test("#366: rejected log includes callId when the path supplies one, omits it otherwise", () => {
+    const captured: { level: string; msg: string }[] = [];
+    setLogCapture((level, msg) => captured.push({ level, msg }));
+    try {
+        parseCompressInput(null, "call_abc123");
+        let line = captured.find((c) => c.msg.includes("[acp-compress-input] rejected"));
+        assert.ok(line, "rejected line logged with callId");
+        assert.ok(line!.msg.includes("callId=call_abc123"), `callId in log: ${line!.msg}`);
+
+        captured.length = 0;
+        parseCompressInput(null);
+        line = captured.find((c) => c.msg.includes("[acp-compress-input] rejected"));
+        assert.ok(line, "rejected line logged without callId");
+        assert.ok(!line!.msg.includes("callId="), `no callId field: ${line!.msg}`);
+    } finally {
+        setLogCapture(null);
     }
 });
 


### PR DESCRIPTION
## What

Follow-up to #349 (observability), per @liyangbing's runtime-verification suggestions. The error-message + defensive-object-args changes already landed via #350; this is the remaining observability piece.

The `[acp-compress-input] rejected` log now carries a `category` field (by `kind`) and the `callId` (when the path supplies one):

- `empty-call` = `missing-content` / `empty-input` — model empty call
- `stream-concat` = `malformed-json` / `truncated` — adapter-attributable
- `validation` = `no-valid-ranges` / `content-not-array` / `not-object`

So `grep "category=..." bili.log | wc -l` gives per-mode rates with no session-structure change. With #350's object-args hardening, `missing-content` now maps cleanly to "model empty call" (the adapter no longer swallows object args), so attribution is unambiguous.

### Changes

- `src/compress-tool.ts` — `REJECT_CATEGORY` maps all 7 non-ok `CompressParseKind` values to a category; the rejected log line gains `category=...` and `callId=...` (only when the caller supplies one — the loop path `src/loop/core.ts:106` does).
- `tests/compress-observability.test.ts` — two new tests: (1) every kind logs at warn with the correct `kind=` + `category=` pair, and success logs nothing; (2) `callId=` appears when supplied, absent otherwise.

## Session-state safety (verified, no code change)

@liyangbing's concern that a failed compress might replace the original tool result with an empty "success" placeholder does not hold:
- `src/stream.ts` — on `ranges.length===0`, `applyRanges` returns the error string without calling `ctx.core.applyCompression`; session state (blocks) is untouched.
- `src/loop/core.ts:347-363` — the failed compress is written back as a `tool-call` (with the **original** `arguments`) + `tool` (with the error result), not an empty placeholder.
- `src/loop/core.ts:373-383` — on `anyCompressFailed`, `hideConsumedCompressCalls` is skipped, so the failure stays visible for the model to self-correct.

## Pre-flight

- `npm run typecheck` — clean.
- `npm test` — 852/852 pass (850 + 2 new).
- `npm run build` — ok.