### PR TITLE
fix: break the small-model same-parameter compress failure loop early (#156)

### DIFF
--- a/src/loop/core.ts
+++ b/src/loop/core.ts
@@ -34,6 +34,27 @@ function stripLoopThinking(messages: CoreMessage[]): CoreMessage[] {
     return messages.filter((m) => !isLoopThinking(m));
 }
 
+// Canonical args for repeat-detection: key-order/whitespace differences must not
+// defeat an identical-call match, so parse + re-stringify with sorted keys.
+function canonicalArgs(args: string): string {
+    try {
+        return JSON.stringify(sortKeys(JSON.parse(args)));
+    } catch {
+        return args;
+    }
+}
+
+function sortKeys(v: unknown): unknown {
+    if (Array.isArray(v)) return v.map(sortKeys);
+    if (v !== null && typeof v === "object") {
+        const src = v as Record<string, unknown>;
+        const out: Record<string, unknown> = {};
+        for (const k of Object.keys(src).sort()) out[k] = sortKeys(src[k]);
+        return out;
+    }
+    return v;
+}
+
 export interface LoopCtx {
     core: CompressionCore;
     config: Config;
@@ -242,6 +263,11 @@ export async function* runCompressLoop(
                 loggerLog("warn", `[acp-loop] upstream rejected replay (HTTP ${info.status}); retrying in ${info.delayMs}ms (attempt ${info.attempt}/${info.maxAttempts})${lc}`);
             },
         );
+
+    // #156: compress/decompress calls already failed this loop. Validation is
+    // deterministic (identical args → identical failure), so a byte-identical
+    // re-submission can never succeed — break early instead of at MAX_LOOP_ROUNDS.
+    const failedSignatures = new Set<string>();
 
     try {
         for (let round = 1; round <= MAX_LOOP_ROUNDS; round++) {
@@ -561,6 +587,23 @@ export async function* runCompressLoop(
                 yield adapter.emitCompletion({ finishReason: "length", usage });
                 return;
             }
+
+            // #156: if this round is only failed compress/decompress and one of
+            // them re-submits args that already failed, the model is stuck in a
+            // deterministic failure loop — break early instead of burning rounds.
+            const failedMutating = proxyResults.filter(
+                (pr) => (pr.name === "compress" || pr.name === "decompress") && pr.result.includes("FAILED"),
+            );
+            if (reRequest && failedMutating.length > 0 && failedMutating.length === proxyResults.length) {
+                const repeated = failedMutating.some((pr) => failedSignatures.has(`${pr.name}\u0000${canonicalArgs(pr.arguments)}`));
+                if (repeated) {
+                    ctx.log(`[acp-loop] round ${round}: model re-submitted an already-failed compress with identical arguments; stopping after ${round} round(s) instead of ${MAX_LOOP_ROUNDS}`);
+                    loggerLog("warn", `[acp-loop] repeated identical compress failure at round ${round}; breaking early (#156)`);
+                    yield adapter.emitCompletion({ finishReason: "length", usage });
+                    return;
+                }
+            }
+            for (const pr of failedMutating) failedSignatures.add(`${pr.name}\u0000${canonicalArgs(pr.arguments)}`);
 
             ctx.log(`[acp-loop] round ${round}: proxy tool executed; re-requesting so the model sees the result`);
 

--- a/tests/fix-stream.test.ts
+++ b/tests/fix-stream.test.ts
@@ -112,7 +112,18 @@ test("client-abort: signal aborted during a re-request stops further re-requests
 test("client-abort control: without a signal, mutating rounds keep re-requesting up to the loop limit", async () => {
     let fetchCalls = 0;
     const orig = globalThis.fetch;
-    globalThis.fetch = (() => { fetchCalls++; return new Response(mutatingRound(), { status: 200 }); }) as typeof fetch;
+    globalThis.fetch = (() => {
+        fetchCalls++;
+        // Vary the summary each round so no two are byte-identical — the #156
+        // early-break must not fire; this control is about the abort signal, not
+        // the loop limit.
+        const round = [
+            sse("response.created", { response: { id: "resp_1", status: "in_progress" } }),
+            fcEvents(0, "call_c", "compress", JSON.stringify({ content: [{ startId: "m00001", endId: "m00002", summary: `s${fetchCalls}` }] })),
+            COMPLETED,
+        ].join("");
+        return new Response(round, { status: 200 });
+    }) as typeof fetch;
     try {
         await drainSig(new Response(mutatingRound(), { status: 200 }).body!, makeCtx(), undefined);
         assert.ok(fetchCalls > 1, `control path re-requested multiple times (fetchCalls=${fetchCalls}); abort is what stops it`);

--- a/tests/loop-core.test.ts
+++ b/tests/loop-core.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import type { Config, CoreMessage } from "acp-kernel";
 import { createCore, createInitialState } from "acp-kernel";
 import type { Session } from "../src/session.ts";
-import { runCompressLoop, createResponsesAdapter } from "../src/loop/index.ts";
+import { runCompressLoop, createResponsesAdapter, MAX_LOOP_ROUNDS } from "../src/loop/index.ts";
 import { buildCompressSystemPrompt } from "../src/compress-tool.ts";
 import type { WireProtocol } from "../src/util.ts";
 import { isTransientUpstreamError, REPLAY_MAX_ATTEMPTS, replayBackoffMs, replayMaxAttempts } from "../src/fetch-util.ts";
@@ -190,6 +190,57 @@ test("loop #5: limit-hit graceful — 10 mutating rounds never degenerate empty,
         assert.ok(!/^data: \[\]\n\n$/.test(out), "no degenerate empty payload");
         const completedCount = (out.match(/event: response\.completed/g) || []).length;
         assert.equal(completedCount, 1, "exactly one completion event (one SSE event line)");
+    } finally {
+        globalThis.fetch = orig;
+    }
+});
+
+// #156: identical failing compress re-submitted every round is a deterministic
+// failure — re-requesting only burns real upstream calls, so break early.
+test("loop #156: identical failing compress re-submitted → breaks early, not MAX_LOOP_ROUNDS", async () => {
+    const failingRound = [
+        sse("response.created", { response: { id: "resp_1", status: "in_progress" } }),
+        fcEvents(0, "call_c", "compress", JSON.stringify({ content: [{ startId: "m00001", endId: "m00002", summary: "s" }] })),
+        COMPLETED,
+    ].join("");
+    let fetchCalls = 0;
+    const orig = globalThis.fetch;
+    globalThis.fetch = (async () => { fetchCalls++; return new Response(failingRound, { status: 200 }); }) as typeof fetch;
+    try {
+        const out = await drain(
+            new Response(failingRound, { status: 200 }).body!,
+            makeCtx(),
+            { model: "gpt-4o", input: [], stream: true },
+            { url: "http://mock", headers: {} },
+        );
+        assert.ok(/response\.completed/.test(out), "graceful completion present (not degenerate empty)");
+        assert.ok(fetchCalls < MAX_LOOP_ROUNDS - 1, `broke early (fetchCalls=${fetchCalls} < ${MAX_LOOP_ROUNDS - 1}) instead of burning all rounds`);
+    } finally {
+        globalThis.fetch = orig;
+    }
+});
+
+// #156 guard: a failing compress that is NOT the model's only action this round
+// must not trigger the early break (the model may still be making progress).
+test("loop #156 guard: failing compress + other proxy call → no early break", async () => {
+    const mixedRound = [
+        sse("response.created", { response: { id: "resp_1", status: "in_progress" } }),
+        fcEvents(0, "call_c", "compress", JSON.stringify({ content: [{ startId: "m00001", endId: "m00002", summary: "s" }] })),
+        fcEvents(1, "call_status", "acp_status", "{}"),
+        COMPLETED,
+    ].join("");
+    let fetchCalls = 0;
+    const orig = globalThis.fetch;
+    globalThis.fetch = (async () => { fetchCalls++; return new Response(mixedRound, { status: 200 }); }) as typeof fetch;
+    try {
+        const out = await drain(
+            new Response(mixedRound, { status: 200 }).body!,
+            makeCtx(),
+            { model: "gpt-4o", input: [], stream: true },
+            { url: "http://mock", headers: {} },
+        );
+        assert.ok(/response\.completed/.test(out), "graceful completion present");
+        assert.equal(fetchCalls, MAX_LOOP_ROUNDS - 1, "NOT broken early: ran to the normal loop limit");
     } finally {
         globalThis.fetch = orig;
     }


### PR DESCRIPTION
## What

Fixes the **most serious** part of #156: a small model (~2B) getting stuck re-submitting the *exact same failing* `compress` call (identical args) every round, burning all `MAX_LOOP_ROUNDS` (10) real upstream calls with zero success before completing gracefully.

Compress validation is **deterministic** — byte-identical args fail identically. So a re-submission of an already-failed call can never succeed; re-requesting only burns a real upstream call for an identical result.

## How

`runCompressLoop` (`src/loop/core.ts`) now tracks the canonical args of every `compress`/`decompress` that fails this loop (`failedSignatures`). If a round is **only** failed compress/decompress calls and one of them re-submits args that already failed in a prior round, the loop breaks early (graceful completion) instead of running to the limit.

Safety properties:
- Match is on **canonicalized** args (parsed + recursively key-sorted), so key-order/whitespace differences between two attempts do not defeat the match.
- Fires **only** when the model is doing nothing but repeating failures. A successful compress, or any other proxy call (e.g. `acp_status`) in the same round, suppresses the break — so a model that is making progress is never cut off.
- The model still gets one full chance to see a failure and correct it (the break fires on the *second* identical submission, not the first).

This directly stops the `round 4→10 连续 7 轮` pattern from the issue, and also stops the loop from burning rounds on repeated identical hallucinated refs (#156 part 2) / repeated too-short-summary failures (part 3).

## Files

- `src/loop/core.ts` — `canonicalArgs`/`sortKeys` helpers, `failedSignatures` set, early-break after the `MAX_LOOP_ROUNDS` check.
- `tests/loop-core.test.ts` — regression test (identical failing compress → breaks early, `fetchCalls < MAX_LOOP_ROUNDS-1`) + guard test (failing compress alongside another proxy call → does NOT break early, runs to the limit).
- `tests/fix-stream.test.ts` — the abort-signal *control* test now varies the summary per round so it does not trip the new early-break (its intent is to prove the abort signal, not loop logic, stops re-requests).

## Pre-flight

- `npm run typecheck` (src, tsconfig.build.json): **pass**
- `npm test`: **852/852 pass**
- `npm run build`: **pass** (dist self-contained)
- No new type errors in the touched test files (verified against clean master — the 6 pre-existing test-file errors are unchanged and not part of the CI gate).

## E2E note

`tests/e2e/e2e-codex.test.ts` could not be run in this environment (no `codex` binary — `spawn codex ENOENT` — and no local upstream at `127.0.0.1:8199`). The change is in `src/loop/`, so please run the E2E (or the manual-dispatch CI e2e) before merging. The unit tests exercise the modified `runCompressLoop` directly via `createResponsesAdapter()` (the same Responses path the E2E drives), and all pass.

## Out of scope (model-quality, not proxy-fixable)

#156 parts 2–4 (hallucinated refs, numeric-constraint memory, tag echo) are small-model capability issues. The proxy already surfaces clear validation errors and a tag-echo warning; this PR adds the missing piece — not wasting upstream calls on futile identical retries.