### PR TITLE
feat: surface compress rejection reasons to the model (#362 ③) + acp-kernel 0.0.47

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 .env
 *.tgz
 .bili-coop-build-stamp
+tmp/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.57",
+  "version": "0.1.65",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.57",
+      "version": "0.1.65",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@types/node": "^22.0.0",
         "@types/node-forge": "^1.3.14",
-        "acp-kernel": "0.0.46",
+        "acp-kernel": "0.0.47",
         "fzstd": "0.1.1",
         "node-forge": "^1.4.0",
         "tar": "^7.5.22",
@@ -988,9 +988,9 @@
       }
     },
     "node_modules/acp-kernel": {
-      "version": "0.0.46",
-      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.46.tgz",
-      "integrity": "sha512-LE0qif1XmfGHVF39vNIIaRVzi+W/ZPaxmIo+rtGxgT//U03dJhgI8CfzF9thUlHVqM8NSw5uRrTYwWrAgDVcoQ==",
+      "version": "0.0.47",
+      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.47.tgz",
+      "integrity": "sha512-XxC8y/w1wPiaCA/euGb74XsWy9ndlZL+cHttKYCwAlmxHy9L9d2bY+Ed/h9cTctT4LI7EnpuKfJ3r3zSirq/yQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/node-forge": "^1.3.14",
-    "acp-kernel": "0.0.46",
+    "acp-kernel": "0.0.47",
     "fzstd": "0.1.1",
     "node-forge": "^1.4.0",
     "tar": "^7.5.22",

--- a/src/compress-tool.ts
+++ b/src/compress-tool.ts
@@ -51,9 +51,9 @@ export { ACP_TOOL_NAMES as PROXY_TOOL_NAMES, ACP_MUTATING_TOOLS as MUTATING_PROX
 export function parseCompressInput(input: unknown, callId?: string) {
     const { ranges, diagnostics } = parseCompressArgs(input, { callId });
     if (!diagnostics.ok && diagnostics.kind !== "ok") {
-        loggerLog("warn", `[acp-compress-input] rejected: kind=${diagnostics.kind} invalidItems=${diagnostics.invalidItems}${diagnostics.keys ? ` keys=[${diagnostics.keys.join(",")}]` : ""}${diagnostics.length !== undefined ? ` len=${diagnostics.length}` : ""}`);
+        loggerLog("warn", `[acp-compress-input] rejected: kind=${diagnostics.kind} invalidItems=${diagnostics.invalidItems}${diagnostics.keys ? ` keys=[${diagnostics.keys.join(",")}]` : ""}${diagnostics.length !== undefined ? ` len=${diagnostics.length}` : ""}${diagnostics.invalidReasons && diagnostics.invalidReasons.length > 0 ? ` reasons=[${diagnostics.invalidReasons.join(" | ")}]` : ""}`);
     }
-    return ranges;
+    return { ranges, diagnostics };
 }
 
 // #189 staged-compression / prefix-survival guidance, appended to the nudge

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -225,10 +225,13 @@ function refNum(ref: string): number {
     return Number(ref.replace(/\D/g, "")) || 0;
 }
 
-export function applyRanges(ranges: ReturnType<typeof parseCompressInput>, ctx: RewriteCtx): string {
+export function applyRanges(parsed: ReturnType<typeof parseCompressInput>, ctx: RewriteCtx): string {
+    const { ranges, diagnostics } = parsed;
     if (ranges.length === 0) {
         ctx.log("[acp-proxy: compress call had no valid ranges; nothing compressed.]");
-        return "[Compression FAILED: no valid ranges parsed. compress requires a non-empty 'content' array of {startId, endId, summary} ranges, where startId/endId are mNNNNN message refs from the conversation. Re-issue the compress call with a valid content array.]";
+        const reasons = diagnostics.invalidReasons?.slice(0, 8).map((r) => (r.length > 200 ? r.slice(0, 200) + "..." : r)) ?? [];
+        const why = reasons.length > 0 ? ` Rejected entries:\n${reasons.map((r) => `- ${r}`).join("\n")}` : "";
+        return `[Compression FAILED: no valid ranges parsed (kind=${diagnostics.kind}, dropped=${diagnostics.invalidItems}).${why} compress requires a non-empty 'content' array of {startId, endId, summary} ranges, where startId/endId are mNNNNN message refs from the conversation. Re-issue the compress call with a valid content array.]`;
     }
     ctx.log(`[acp-proxy: compress requested ${ranges.length} range(s): ${ranges.map((r) => `${r.startRef}–${r.endRef}`).join(", ")}]`);
     ctx.log(`[acp-proxy: ctx has ${ctx.messages.length} message(s), state has ${ctx.session.state.messageRefs?.byRef?.size ?? "?"} ref(s) mapped]`);

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -231,7 +231,7 @@ export function applyRanges(parsed: ReturnType<typeof parseCompressInput>, ctx: 
         ctx.log("[acp-proxy: compress call had no valid ranges; nothing compressed.]");
         const reasons = diagnostics.invalidReasons?.slice(0, 8).map((r) => (r.length > 200 ? r.slice(0, 200) + "..." : r)) ?? [];
         const why = reasons.length > 0 ? ` Rejected entries:\n${reasons.map((r) => `- ${r}`).join("\n")}` : "";
-        return `[Compression FAILED: no valid ranges parsed (kind=${diagnostics.kind}, dropped=${diagnostics.invalidItems}).${why} compress requires a non-empty 'content' array of {startId, endId, summary} ranges, where startId/endId are mNNNNN message refs from the conversation. Re-issue the compress call with a valid content array.]`;
+        return `[Compression FAILED: no valid ranges parsed (kind=${diagnostics.kind}, dropped=${diagnostics.invalidItems}).${why}\n compress requires a non-empty 'content' array of {startId, endId, summary} ranges, where startId/endId are mNNNNN message refs from the conversation. Re-issue the compress call with a valid content array.]`;
     }
     ctx.log(`[acp-proxy: compress requested ${ranges.length} range(s): ${ranges.map((r) => `${r.startRef}–${r.endRef}`).join(", ")}]`);
     ctx.log(`[acp-proxy: ctx has ${ctx.messages.length} message(s), state has ${ctx.session.state.messageRefs?.byRef?.size ?? "?"} ref(s) mapped]`);

--- a/tests/basic.test.ts
+++ b/tests/basic.test.ts
@@ -119,7 +119,7 @@ test("parseCompressInput handles batch {content:[...]} form", () => {
             { startId: "m00001", endId: "m00010", summary: "first batch", topic: "intro" },
             { startId: "m00020", endId: "m00030", summary: "second batch" },
         ],
-    });
+    }).ranges;
     assert.equal(parsed.length, 2);
     assert.equal(parsed[0]?.startRef, "m00001");
     assert.equal(parsed[0]?.endRef, "m00010");
@@ -129,7 +129,7 @@ test("parseCompressInput handles batch {content:[...]} form", () => {
 });
 
 test("parseCompressInput handles single {startId,endId,summary} form", () => {
-    const parsed = parseCompressInput({ startId: "m00005", endId: "m00008", summary: "solo" });
+    const parsed = parseCompressInput({ startId: "m00005", endId: "m00008", summary: "solo" }).ranges;
     assert.equal(parsed.length, 1);
     assert.equal(parsed[0]?.startRef, "m00005");
     assert.equal(parsed[0]?.endRef, "m00008");
@@ -137,10 +137,10 @@ test("parseCompressInput handles single {startId,endId,summary} form", () => {
 });
 
 test("parseCompressInput returns empty for malformed input", () => {
-    assert.deepEqual(parseCompressInput(null), []);
-    assert.deepEqual(parseCompressInput("nope"), []);
-    assert.deepEqual(parseCompressInput({ content: "not-an-array" }), []);
-    assert.deepEqual(parseCompressInput({ content: [{ startId: "m1" }] }), []);
+    assert.deepEqual(parseCompressInput(null).ranges, []);
+    assert.deepEqual(parseCompressInput("nope").ranges, []);
+    assert.deepEqual(parseCompressInput({ content: "not-an-array" }).ranges, []);
+    assert.deepEqual(parseCompressInput({ content: [{ startId: "m1" }] }).ranges, []);
 });
 
 test("parseCompressInput accepts JSON-string content (non-strict providers stringify arrays)", () => {
@@ -149,7 +149,7 @@ test("parseCompressInput accepts JSON-string content (non-strict providers strin
             { startId: "m00001", endId: "m00010", summary: "first", topic: "intro" },
             { startId: "m00020", endId: "m00030", summary: "second" },
         ]),
-    });
+    }).ranges;
     assert.equal(parsed.length, 2);
     assert.equal(parsed[0]?.startRef, "m00001");
     assert.equal(parsed[0]?.endRef, "m00010");
@@ -157,7 +157,7 @@ test("parseCompressInput accepts JSON-string content (non-strict providers strin
     assert.equal(parsed[0]?.topic, "intro");
     assert.equal(parsed[1]?.startRef, "m00020");
     assert.equal(parsed[1]?.endRef, "m00030");
-    assert.deepEqual(parseCompressInput({ content: "not-json" }), []);
+    assert.deepEqual(parseCompressInput({ content: "not-json" }).ranges, []);
 });
 
 test("buildCompressSystemPrompt includes compression philosophy", () => {

--- a/tests/compress-reject-reasons.test.ts
+++ b/tests/compress-reject-reasons.test.ts
@@ -1,0 +1,69 @@
+// #362诉求③: compress 参数被拒时, 拒绝原因(kernel invalidReasons)必须进入
+// 模型可见的错误回执 — 否则模型只看到通用样板, 盲目重试同样的坏形状.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { CoreMessage } from "acp-kernel";
+import { createCore, createInitialState, defaultConfig } from "acp-kernel";
+import { parseCompressInput } from "../src/compress-tool.ts";
+import { applyRanges, type RewriteCtx } from "../src/stream.ts";
+
+type Ctx = Omit<RewriteCtx, "log"> & { log: (m: string) => void; logs: string[] };
+
+function makeCtx(): Ctx {
+    const logs: string[] = [];
+    return {
+        core: createCore(),
+        config: defaultConfig(200000),
+        messages: [] as CoreMessage[],
+        session: {
+            id: "reject-reasons-test",
+            meta: {},
+            stats: { requests: 0, tokensSaved: 0, inputTokens: 0, cachedTokens: 0, outputTokens: 0, cacheSamples: 0, lastInputTokens: 0, compressCreditTokens: 0, contextTokens: 0 },
+            metadata: {},
+            state: createInitialState(),
+            createdAt: Date.now(),
+            lastSeen: Date.now(),
+            blockContents: new Map(),
+            inFlight: 0,
+            persisted: false,
+        },
+        log: (m: string) => { logs.push(m); },
+        logs,
+    };
+}
+
+test("#362: parse-level rejections surface per-entry reasons in the model-facing error", () => {
+    const out = applyRanges(
+        parseCompressInput({ content: [{ summary: "no bounds" }, { startId: "m00001", endId: "m00002" }] }),
+        makeCtx(),
+    );
+    assert.ok(out.startsWith("[Compression FAILED"), `expected failure, got: ${out}`);
+    assert.ok(out.includes("kind=no-valid-ranges"), `kind reported, got: ${out}`);
+    assert.ok(out.includes("dropped=2"), `dropped count reported, got: ${out}`);
+    assert.ok(out.includes("- entry 0: missing range bounds"), "reason for entry 0 present");
+    assert.ok(out.includes("- entry 1: missing summary"), "reason for entry 1 present");
+});
+
+test("#362: shape drift (content vs ranges key) reports kind=missing-content", () => {
+    const out = applyRanges(
+        parseCompressInput({ ranges: [{ startId: "m00001", endId: "m00002", summary: "s" }] }),
+        makeCtx(),
+    );
+    assert.ok(out.includes("kind=missing-content"), `kind reported, got: ${out}`);
+    assert.ok(!out.includes("Rejected entries"), "no per-entry reasons for shape-level failure");
+});
+
+test("#362: truncated gateway-stringified args salvage complete entries, kind=truncated", () => {
+    const complete = JSON.stringify({ startId: "m00001", endId: "m00002", summary: "complete entry" });
+    const json = '{"content": [' + complete + ',{"startId":"m00003","sum';
+    const parsed = parseCompressInput(json);
+    assert.equal(parsed.ranges.length, 1, "complete entry salvaged");
+    assert.equal(parsed.diagnostics.kind, "truncated");
+});
+
+test("#362: diagnostics flow — valid parse returns ranges + ok diagnostics", () => {
+    const parsed = parseCompressInput({ content: [{ startId: "m00001", endId: "m00002", summary: "s" }] });
+    assert.equal(parsed.ranges.length, 1);
+    assert.equal(parsed.diagnostics.ok, true);
+    assert.equal(parsed.diagnostics.kind, "ok");
+});

--- a/tests/proxy-basic.test.ts
+++ b/tests/proxy-basic.test.ts
@@ -87,7 +87,7 @@ test("parseCompressInput handles batch {content:[...]} form", () => {
             { startId: "m00001", endId: "m00010", summary: "first batch", topic: "intro" },
             { startId: "m00020", endId: "m00030", summary: "second batch" },
         ],
-    });
+    }).ranges;
     assert.equal(parsed.length, 2);
     assert.equal(parsed[0]?.startRef, "m00001");
     assert.equal(parsed[0]?.endRef, "m00010");
@@ -97,7 +97,7 @@ test("parseCompressInput handles batch {content:[...]} form", () => {
 });
 
 test("parseCompressInput handles single {startId,endId,summary} form", () => {
-    const parsed = parseCompressInput({ startId: "m00005", endId: "m00008", summary: "solo" });
+    const parsed = parseCompressInput({ startId: "m00005", endId: "m00008", summary: "solo" }).ranges;
     assert.equal(parsed.length, 1);
     assert.equal(parsed[0]?.startRef, "m00005");
     assert.equal(parsed[0]?.endRef, "m00008");
@@ -105,10 +105,10 @@ test("parseCompressInput handles single {startId,endId,summary} form", () => {
 });
 
 test("parseCompressInput returns empty for malformed input", () => {
-    assert.deepEqual(parseCompressInput(null), []);
-    assert.deepEqual(parseCompressInput("nope"), []);
-    assert.deepEqual(parseCompressInput({ content: "not-an-array" }), []);
-    assert.deepEqual(parseCompressInput({ content: [{ startId: "m1" }] }), []);
+    assert.deepEqual(parseCompressInput(null).ranges, []);
+    assert.deepEqual(parseCompressInput("nope").ranges, []);
+    assert.deepEqual(parseCompressInput({ content: "not-an-array" }).ranges, []);
+    assert.deepEqual(parseCompressInput({ content: [{ startId: "m1" }] }).ranges, []);
 });
 
 test("buildCompressSystemPrompt includes compression philosophy", () => {


### PR DESCRIPTION
## What

Closes诉求③ of #362: when the model calls `compress` with invalid arguments, the tool receipt said only "no valid ranges parsed" + boilerplate — the model could not tell WHICH entry was rejected or WHY, and blind-retried the same shape 5×.

- `parseCompressInput` now returns `{ranges, diagnostics}` (was: bare ranges array); the warn log gains `reasons=[...]`
- `applyRanges` failure receipt now includes:
  - `kind=` (no-valid-ranges / missing-content / malformed-json / truncated …)
  - `dropped=N`
  - per-entry reasons from kernel 0.0.47 `invalidReasons` ("entry 0: missing range bounds …"), max 8 entries, 200 chars each
- `acp-kernel` bumped 0.0.46 → **0.0.47** (exact pin): persist retry backoff, spill files, tmp-name-per-attempt, invalidReasons diagnostics — the EPERM-storm treatment for #362 ①/②
- `.gitignore`: `tmp/` (e2e sandbox dirs — one leaked into a branch earlier today)
- call sites unchanged (all 7 pass `parseCompressInput(...)` straight into `applyRanges(...)`; composition types flow through)
- two existing test files updated for the new return shape

## Preflight

- typecheck ✓
- 858/858 tests ✓ (4 new in tests/compress-reject-reasons.test.ts)
- build ✓

## Example receipt

```
[Compression FAILED: no valid ranges parsed (kind=no-valid-ranges, dropped=2). Rejected entries:
- entry 0: missing range bounds (need startRef/startId and endRef/endId)
- entry 1: missing summary
 compress requires a non-empty 'content' array of {startId, endId, summary} ranges, …]\n```