### PR TITLE
chore: bump acp-kernel to 0.0.47 (Layer 1 spill/retry/throttle, #374)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.57",
+  "version": "0.1.65",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.57",
+      "version": "0.1.65",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@types/node": "^22.0.0",
         "@types/node-forge": "^1.3.14",
-        "acp-kernel": "0.0.46",
+        "acp-kernel": "0.0.47",
         "fzstd": "0.1.1",
         "node-forge": "^1.4.0",
         "tar": "^7.5.22",
@@ -546,9 +546,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -650,9 +647,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -667,9 +661,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -684,9 +675,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -701,9 +689,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -718,9 +703,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -735,9 +717,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -752,9 +731,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -769,9 +745,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -786,9 +759,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -803,9 +773,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -820,9 +787,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -837,9 +801,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -854,9 +815,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -988,9 +946,9 @@
       }
     },
     "node_modules/acp-kernel": {
-      "version": "0.0.46",
-      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.46.tgz",
-      "integrity": "sha512-LE0qif1XmfGHVF39vNIIaRVzi+W/ZPaxmIo+rtGxgT//U03dJhgI8CfzF9thUlHVqM8NSw5uRrTYwWrAgDVcoQ==",
+      "version": "0.0.47",
+      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.47.tgz",
+      "integrity": "sha512-XxC8y/w1wPiaCA/euGb74XsWy9ndlZL+cHttKYCwAlmxHy9L9d2bY+Ed/h9cTctT4LI7EnpuKfJ3r3zSirq/yQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/node-forge": "^1.3.14",
-    "acp-kernel": "0.0.46",
+    "acp-kernel": "0.0.47",
     "fzstd": "0.1.1",
     "node-forge": "^1.4.0",
     "tar": "^7.5.22",


### PR DESCRIPTION
## What

Bumps the pinned `acp-kernel` devDependency from `0.0.46` to `0.0.47` (exact pin, no `^`) and refreshes `package-lock.json`.

## Why

#374: acp-kernel PR #172 (Layer 1 resilience for the #362 persist EPERM storm) was merged to acp-kernel master (`a559247`) but was not in the previously-pinned stable `0.0.46`. `0.0.47` is now live on npm as `latest` and is the first stable containing it. Verified against the published `0.0.47` tarball (`dist/persist`):

1. **Exponential-backoff retry** — `renameWithRetry` on EPERM/EBUSY/EACCES (6 attempts, 50ms base, 1600ms cap, ~1.5s window).
2. **Final-failure spill** — the record spills to a `<name>.fb.json` side file instead of `unlink(tmp)` + data loss; one slot per id (overwritten each spill), `.json` suffix so `loadAll` discovers it and reconciles against the canonical record by `savedAt` (freshest wins); stale spill of the same id is removed after a successful canonical write.
3. **Error rate limiting** — `recordFailure` logs on the first failure and at each power-of-two count (1, 2, 4, 8, …), so a long lock yields ~log2(N) lines instead of one per write; the alert includes the spill path.

`0.0.47` adds no runtime dependencies (`dependencies: {}`), so the inlined `dist` bundle is unaffected beyond the persist module.

## Verification

- `npm view acp-kernel dist-tags.latest` → `0.0.47` (prerequisite from #374 step 2 satisfied).
- Grep of published `acp-kernel@0.0.47` tarball: `fb.json` / `spillPathFor` / `backoffMs` / `renameWithRetry` / `recordFailure` all present in `dist/persist`.
- Rebuilt `dist/index.js` contains the same spill code (inlined).
- Pre-flight (same checks CI runs): `npm run typecheck` clean · `npm test` 858/858 pass · `npm run build` OK.

## Notes

- Lockfile also picks up pre-existing drift fix (lockfile `version` field 0.1.57 → 0.1.65, matching `package.json`) and drops npm-version `libc` metadata on optional platform binaries — no functional impact on `npm ci`.
- No `version` change in `package.json` (content commit; release follows the standard flow after this lands).
- Closes #374 once merged + released.