### PR TITLE
release v0.1.66

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.65",
+  "version": "0.1.66",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Version bump only. Changes since v0.1.65:

- **#364** — dump observability: rate-limited `[dump]` failure logging + unrecognized-path warnings on all five raw-dump write sites; unrecognized-path keys now strip query strings before masking.
- **#372** — surface compress rejection reasons to the model (#362 ③): parse diagnostics (`kind`, `dropped`, per-entry `entry N: <reason>`) now flow from kernel 0.0.47 into the model-facing failure receipt, ending blind retry loops. Bumps `acp-kernel` to exactly `0.0.47` (backoff retry + spill files for EPERM, #362 ①).
- `3c778ab` — compress-reject boilerplate on its own line (cosmetic follow-up to #372).

Pre-flight (release branch, post-bump): typecheck ✓ / 862 tests 862 pass ✓ / build ✓ / E2E_CHECK gate present ✓