### PR TITLE
feat: detect + retry fake completions (tool call written as text, #371)

### DIFF
--- a/src/fake-completion.ts
+++ b/src/fake-completion.ts
@@ -1,0 +1,124 @@
+import type { WireProtocol } from "./util.js";
+import { containsToolCallXmlFragment } from "./loop/tag-echo-filter.js";
+
+// #371 (root-cause follow-up to #361): a small model can WRITE a tool call as
+// plain text (echoing the tool-call XML template from the context) instead of
+// emitting a real tool block. With no tool block the agent ends the turn early
+// — a "fake completion": the tool never ran but the client shows success. The
+// proxy detects this shape (tool-call structure present + no real tool block)
+// and retries once with a corrective hint, bounded per turn and per session.
+
+export const FAKE_COMPLETION_HINT =
+    "[billion-context] Your last reply described a tool call as plain text instead of invoking it, so no tool actually ran. " +
+    "To act, invoke the tool through the proper tool-calling mechanism (emit a tool_use / tool_calls / function_call block). " +
+    "Do not write tool-call markup as text in your reply.";
+
+// One value serves two bounds: max retries within a single request, and the
+// consecutive-fake-completion-turn cap after which a session stops retrying.
+//
+// DISABLED BY DEFAULT (0): the fallback must buffer the whole response before
+// the client sees it (a fake completion is only knowable at end-of-stream),
+// which defeats incremental streaming. That cost is only worth paying for the
+// low-frequency fake-completion case (small models via gateways), so it is
+// opt-in: set BILI_FAKE_COMPLETION_RETRIES=2 to enable. 0 = pre-#371 passthrough.
+export function maxFakeCompletionRetries(): number {
+    const n = Number.parseInt(process.env.BILI_FAKE_COMPLETION_RETRIES ?? "0", 10);
+    return Number.isFinite(n) && n >= 0 ? n : 0;
+}
+
+// OOM guard for a pathological upstream; LLM responses are bounded by max_tokens
+// and normally well under 1 MiB.
+export function fakeBufCap(): number {
+    const n = Number.parseInt(process.env.BILI_FAKE_BUF_CAP ?? String(16 * 1024 * 1024), 10);
+    return Number.isFinite(n) && n > 0 ? n : 16 * 1024 * 1024;
+}
+
+// "Does this raw response (full SSE stream or JSON body) carry a REAL tool
+// block?" A real block means the model actually invoked a tool → not a fake
+// completion. Each protocol marks its tool block differently on the wire.
+const ANTHROPIC_TOOL_BLOCK = /"type"\s*:\s*"tool_use"/;
+const OPENAI_TOOL_BLOCK = /"tool_calls"\s*:\s*\[\s*\{/;
+const RESPONSES_TOOL_BLOCK = /"type"\s*:\s*"function_call"/;
+
+export function hasToolBlock(protocol: WireProtocol, rawText: string): boolean {
+    switch (protocol) {
+        case "anthropic":
+            return ANTHROPIC_TOOL_BLOCK.test(rawText);
+        case "openai":
+            return OPENAI_TOOL_BLOCK.test(rawText);
+        case "responses":
+            return RESPONSES_TOOL_BLOCK.test(rawText);
+    }
+}
+
+// Opening tool tag (no leading '/'): the model started writing a call as text —
+// the strongest signal. Literal '<' or JSON-escaped '\u003c'; optional antml:
+// namespace; case-insensitive, matching containsToolCallXmlFragment.
+const TOOL_OPEN =
+    /\x3c(?!\s*\/)(?:antml:)?(invoke|tool_calls|tool_call|parameter|parameters)\b|\\u003c(?!\s*\/)(?:antml:)?(invoke|tool_calls|tool_call|parameter|parameters)\b/i;
+
+// Closing tool tags (global): an echoed template tail carries 2+ distinct
+// closers (</invoke> + </tool_calls>) even when the openers were folded away
+// earlier in the context (the #361 shape).
+const TOOL_CLOSE_GLOBAL =
+    /\x3c\/(?:antml:)?(invoke|tool_calls|tool_call|parameter|parameters)\b|\\u003c\/(?:antml:)?(invoke|tool_calls|tool_call|parameter|parameters)\b/gi;
+
+// Structural guard on top of containsToolCallXmlFragment: require an opening
+// tool tag OR 2+ distinct closing tags. A LONE closing tag in prose (a model
+// discussing tool-call code) does not qualify — that is the false positive the
+// plain fragment detector would otherwise trigger on.
+export function hasToolCallStructure(text: string): boolean {
+    if (!containsToolCallXmlFragment(text)) return false;
+    if (TOOL_OPEN.test(text)) return true;
+    const closes = new Set<string>();
+    for (const m of text.matchAll(TOOL_CLOSE_GLOBAL)) {
+        const name = m[1] ?? m[2];
+        if (name) closes.add(name.toLowerCase());
+    }
+    return closes.size >= 2;
+}
+
+export function isFakeCompletion(protocol: WireProtocol, rawText: string): boolean {
+    return hasToolCallStructure(rawText) && !hasToolBlock(protocol, rawText);
+}
+
+// Appends the hint as a trailing user message, merged into the last user
+// message when present (avoids back-to-back user turns on strict providers).
+// Returns the hinted JSON, or null if the body is unparseable (skip the retry).
+export function injectFakeCompletionHint(protocol: WireProtocol, body: string | Buffer): string | null {
+    const raw = typeof body === "string" ? body : body.toString("utf8");
+    let obj: Record<string, unknown>;
+    try {
+        obj = JSON.parse(raw) as Record<string, unknown>;
+    } catch {
+        return null;
+    }
+    if (protocol === "responses") {
+        const input = obj.input;
+        if (!Array.isArray(input)) return null;
+        const arr = input as Record<string, unknown>[];
+        const last = arr[arr.length - 1];
+        if (last && typeof last === "object" && last.role === "user") {
+            const c = last.content;
+            if (typeof c === "string") last.content = `${c}\n\n${FAKE_COMPLETION_HINT}`;
+            else if (Array.isArray(c)) last.content = [...c, { type: "input_text", text: FAKE_COMPLETION_HINT }];
+            else last.content = FAKE_COMPLETION_HINT;
+        } else {
+            arr.push({ role: "user", content: [{ type: "input_text", text: FAKE_COMPLETION_HINT }] });
+        }
+        return JSON.stringify(obj);
+    }
+    const messages = obj.messages;
+    if (!Array.isArray(messages)) return null;
+    const arr = messages as Record<string, unknown>[];
+    const last = arr[arr.length - 1];
+    if (last && typeof last === "object" && last.role === "user") {
+        const c = last.content;
+        if (typeof c === "string") last.content = `${c}\n\n${FAKE_COMPLETION_HINT}`;
+        else if (Array.isArray(c)) last.content = [...c, { type: "text", text: FAKE_COMPLETION_HINT }];
+        else last.content = FAKE_COMPLETION_HINT;
+    } else {
+        arr.push({ role: "user", content: FAKE_COMPLETION_HINT });
+    }
+    return JSON.stringify(obj);
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -2623,9 +2623,9 @@ async function forward(
             const p = prepared;
             const tagLog = (msg: string) => log("info", `[${p.session.id}] ${msg}`);
             if (p.protocol === "responses") {
-                await pipePluginResponsesWithStrip(upstream.body as ReadableStream<Uint8Array>, res, undefined, tagLog);
+                await pipePluginResponsesWithStrip(responseBody, res, undefined, tagLog);
             } else {
-                await pipePluginChatWithStrip(upstream.body as ReadableStream<Uint8Array>, res, p.protocol, undefined, tagLog);
+                await pipePluginChatWithStrip(responseBody, res, p.protocol, undefined, tagLog);
             }
             clearUpstreamTimer();
         } else {

--- a/src/server.ts
+++ b/src/server.ts
@@ -55,6 +55,7 @@ import { atomicWriteInstanceFile, clearProxyInstanceFile, isPidAlive, registerIn
 import { compressLoopResponsesJson } from "./compress-loop-responses.js";
 import { runCompressLoop, pickAdapter } from "./loop/index.js";
 import { containsToolCallXmlFragment } from "./loop/tag-echo-filter.js";
+import { isFakeCompletion, injectFakeCompletionHint, maxFakeCompletionRetries, fakeBufCap } from "./fake-completion.js";
 import { sanitizeResponsesInputIds, dropWhitespaceResponsesMessages, normalizeResponsesMessageItems } from "./loop/adapter-responses.js";
 import { codexCompactMode, isCodexClient, hasCompactionTrigger, stripBiliCompactionItems, replaceBiliCompactionItems, codexCompactGate, buildTriggerForgeBody, mergeForgedSummaries } from "./codex-compact.js";
 import { rewriteOpenaiJsonResponse } from "./stream-openai.js";
@@ -66,7 +67,7 @@ import { prefixAffinity, type AnonymousAffinity } from "./prefix-affinity.js";
 import { consumePluginRegisterFor, flushConversations, handlePluginManifest, handlePluginRegister, handlePluginStatus, handlePluginTool, loadConversations, pipePluginChatWithStrip, pipePluginJson, pipePluginResponsesWithStrip, pluginAgentHeader, pluginConversationHeader, pluginReportedContextWindow, recordPluginSession, rememberPluginMessages, takePendingPluginRegister } from "./plugin.js";
 import { setupMitm, readMitmUpstream } from "./mitm.js";
 import type { BiliMessage } from "acp-kernel/wire";
-import { systemToUser, isLoopbackAddress, inspectContextOverflow, reserveOutputHeadroom, shouldReserveOutputHeadroom, usageTotals } from "./util.js";
+import { systemToUser, isLoopbackAddress, inspectContextOverflow, reserveOutputHeadroom, shouldReserveOutputHeadroom, usageTotals, type WireProtocol } from "./util.js";
 import { BILI_TUNNEL_HEADER, checkTunnelDestination, tunnelAllowlistFromEnv } from "./tunnel-guard.js";
 
 import { decodeRequestBody } from "./content-encoding.js";
@@ -2569,6 +2570,23 @@ async function forward(
         clearUpstreamTimer();
         return;
     }
+    // #371: detect + retry a fake completion for every non-plugin streaming
+    // response (any turn, not just compress-injected). Buffering is required:
+    // the retry re-requests before the client sees the fake completion.
+    let responseBody: ReadableStream<Uint8Array> = upstream.body;
+    if (prepared !== null && prepared.stream && maxFakeCompletionRetries() > 0) {
+        const resolvedBuf = await resolveFakeCompletion(upstream.body, {
+            protocol: prepared.protocol,
+            body,
+            upstreamUrl,
+            reqHeaders: buildForwardHeaders(headers),
+            proxyUrl,
+            signal: clientAbort.signal,
+            session: prepared.session,
+            log,
+        });
+        responseBody = bufferToStream(resolvedBuf);
+    }
     // We only rewrite when THIS request actually had the compress tool
     // injected (per-request). For the OpenAI title-gen path
     // (`compressInjected === false`) we must NOT route the stream into a
@@ -2581,7 +2599,7 @@ async function forward(
         prepared.processedMessages.length > 0;
     if (!useRewriter || prepared === null) {
         if (prepared && prepared.resetAfterSuccess) {
-            const [toClient, toObserve] = upstream.body.tee();
+            const [toClient, toObserve] = responseBody.tee();
             const observed = observeResponsesTerminalState(toObserve, prepared.stream);
             await pipeThrough(toClient, res);
             clearUpstreamTimer();
@@ -2593,7 +2611,7 @@ async function forward(
                 log("warn", `[${prepared.session.id}] native compact response terminal=${terminal}; rebase NOT scheduled`);
             }
         } else {
-            await pipeThrough(upstream.body, res);
+            await pipeThrough(responseBody, res);
             clearUpstreamTimer();
         }
         return;
@@ -2607,10 +2625,10 @@ async function forward(
         debug: opts.debug,
     };
     if (prepared.stream) {
-        let streamToRead = upstream.body as ReadableStream<Uint8Array>;
+        let streamToRead = responseBody;
         let dumpRaw: Promise<void> | undefined;
         if (opts.dumpSse) {
-            const [a, b] = (upstream.body as ReadableStream<Uint8Array>).tee();
+            const [a, b] = responseBody.tee();
             streamToRead = a;
             dumpRaw = dumpStreamToFile(b, opts.dumpSse, `${Date.now()}-${safeSessionId(prepared.session.id)}-raw.sse`);
         }
@@ -2774,6 +2792,78 @@ async function readStreamToBuffer(stream: ReadableStream<Uint8Array>, maxBytes =
         reader.releaseLock();
     }
     return Buffer.concat(chunks);
+}
+
+function bufferToStream(buf: Buffer): ReadableStream<Uint8Array> {
+    return new ReadableStream<Uint8Array>({
+        start(controller) {
+            controller.enqueue(new Uint8Array(buf));
+            controller.close();
+        },
+    });
+}
+
+// #371: buffer the raw upstream response, detect a fake completion (tool-call
+// XML, no real tool block), and — bounded per turn and per session — re-request
+// upstream with a corrective hint. Returns the bytes to stream to the client
+// (the retry's response when a retry recovered, else the original). The session
+// streak (metadata.fakeCompletionStreak) counts consecutive fake-completion
+// turns: it gates retries (skip once >= cap) and resets to 0 on a clean turn.
+async function resolveFakeCompletion(
+    stream: ReadableStream<Uint8Array>,
+    opts: {
+        protocol: WireProtocol;
+        body: string | Buffer;
+        upstreamUrl: string;
+        reqHeaders: Record<string, string>;
+        proxyUrl?: string;
+        signal: AbortSignal;
+        session: Session;
+        log: (level: string, msg: string) => void;
+    },
+): Promise<Buffer> {
+    let buffer = await readStreamToBuffer(stream, fakeBufCap());
+    const max = maxFakeCompletionRetries();
+    const sid = opts.session.id;
+    const priorStreak = (opts.session.metadata.fakeCompletionStreak as number | undefined) ?? 0;
+    if (max > 0 && priorStreak < max && isFakeCompletion(opts.protocol, buffer.toString("utf8"))) {
+        for (let attempt = 1; attempt <= max && !opts.signal.aborted; attempt++) {
+            const hinted = injectFakeCompletionHint(opts.protocol, opts.body);
+            if (hinted === null) break;
+            opts.log("warn", `[${sid}] fake completion (tool-call XML, no tool block); retry ${attempt}/${max} with corrective hint`);
+            let r: Awaited<ReturnType<typeof fetchWithTimeout>>;
+            try {
+                r = await fetchWithTimeout(
+                    opts.upstreamUrl,
+                    {
+                        method: "POST",
+                        headers: opts.reqHeaders,
+                        body: hinted,
+                        ...(opts.proxyUrl ? { dispatcher: proxyDispatcher(opts.proxyUrl) } : {}),
+                    },
+                    undefined,
+                    opts.signal,
+                );
+            } catch (e) {
+                opts.log("warn", `[${sid}] fake-completion retry failed: ${String(e)}; presenting original`);
+                break;
+            }
+            try {
+                if (!r.response.ok || !r.response.body) {
+                    opts.log("warn", `[${sid}] fake-completion retry rejected (HTTP ${r.response.status}); presenting original`);
+                    break;
+                }
+                buffer = await readStreamToBuffer(r.response.body, fakeBufCap());
+            } finally {
+                r.clearTimer();
+            }
+            if (!isFakeCompletion(opts.protocol, buffer.toString("utf8"))) break;
+        }
+    }
+    const stillFake = isFakeCompletion(opts.protocol, buffer.toString("utf8"));
+    opts.session.metadata.fakeCompletionStreak = stillFake ? priorStreak + 1 : 0;
+    markDirty(opts.session);
+    return buffer;
 }
 
 async function pipeThrough(stream: ReadableStream<Uint8Array>, res: http.ServerResponse): Promise<void> {

--- a/tests/fake-completion.test.ts
+++ b/tests/fake-completion.test.ts
@@ -1,0 +1,273 @@
+import assert from "node:assert";
+import http from "node:http";
+import { once } from "node:events";
+import test from "node:test";
+
+process.env.NODE_ENV = "test";
+// The fake-completion fallback is opt-in (disabled by default to preserve
+// incremental streaming); these tests exercise it, so enable it explicitly.
+process.env.BILI_FAKE_COMPLETION_RETRIES = "2";
+
+import { defaultConfig } from "acp-kernel";
+import { startServer, type ProxyOptions } from "../src/server.ts";
+import { SessionStore, _setStoreForTest } from "../src/persist.ts";
+import { _setForTest as setRegistryForTest } from "../src/registry.ts";
+import {
+    isFakeCompletion,
+    hasToolBlock,
+    hasToolCallStructure,
+    injectFakeCompletionHint,
+} from "../src/fake-completion.ts";
+
+// Hex escapes so no literal tag sequence appears in this file's source.
+const LT = "\x3c";
+const GT = "\x3e";
+
+// The #361 shape: the model echoed a tool call as TEXT — an opening invoke
+// plus closing tags — with no real tool block. A distinctive marker lets the
+// integration tests prove this text is discarded on retry.
+const FAKE_XML = `${LT}invoke name="read_file"${GT}\n${LT}parameter name="path"${GT}/fake/completion/marker${LT}/parameter${GT}\n${LT}/invoke${GT}\n${LT}/tool_calls${GT}`;
+
+test("hasToolBlock: anthropic detects a tool_use block", () => {
+    assert.equal(hasToolBlock("anthropic", '{"type":"tool_use","name":"x"}'), true);
+    assert.equal(hasToolBlock("anthropic", '{"type":"text","text":"hi"}'), false);
+});
+
+test("hasToolBlock: openai detects a non-empty tool_calls array", () => {
+    assert.equal(hasToolBlock("openai", '{"choices":[{"delta":{"tool_calls":[{"index":0}]}}]}'), true);
+    assert.equal(hasToolBlock("openai", '{"choices":[{"delta":{"content":"hi"}}]}'), false);
+});
+
+test("hasToolBlock: responses detects a function_call item", () => {
+    assert.equal(hasToolBlock("responses", '{"type":"function_call","name":"x"}'), true);
+    assert.equal(hasToolBlock("responses", '{"type":"message"}'), false);
+});
+
+test("hasToolCallStructure: an opening tool tag is a structure", () => {
+    assert.equal(hasToolCallStructure(`${LT}invoke name="x"${GT}`), true);
+});
+
+test("hasToolCallStructure: two distinct closing tags (the #361 shape) is a structure", () => {
+    assert.equal(hasToolCallStructure(`${LT}/invoke${GT} ${LT}/tool_calls${GT}`), true);
+});
+
+test("hasToolCallStructure: a single closing tag is NOT a structure (legit prose)", () => {
+    assert.equal(hasToolCallStructure(`the ${LT}/invoke${GT} tag closes a call`), false);
+});
+
+test("hasToolCallStructure: plain text with no tool XML is not a structure", () => {
+    assert.equal(hasToolCallStructure("just plain text about tools"), false);
+});
+
+test("isFakeCompletion: anthropic tool-XML with no tool_use block is a fake completion", () => {
+    assert.equal(isFakeCompletion("anthropic", FAKE_XML), true);
+});
+
+test("isFakeCompletion: openai tool-XML with no tool_calls is a fake completion", () => {
+    assert.equal(isFakeCompletion("openai", FAKE_XML), true);
+});
+
+test("isFakeCompletion: responses tool-XML with no function_call is a fake completion", () => {
+    assert.equal(isFakeCompletion("responses", FAKE_XML), true);
+});
+
+test("isFakeCompletion: tool-XML WITH a real tool block is NOT a fake completion", () => {
+    assert.equal(isFakeCompletion("anthropic", `${FAKE_XML} {"type":"tool_use"}`), false);
+    assert.equal(isFakeCompletion("openai", `${FAKE_XML} "tool_calls":[{`), false);
+    assert.equal(isFakeCompletion("responses", `${FAKE_XML} {"type":"function_call"}`), false);
+});
+
+test("isFakeCompletion: legit prose with a single closing tag is NOT a fake completion", () => {
+    assert.equal(isFakeCompletion("anthropic", `the ${LT}/invoke${GT} tag closes a call`), false);
+});
+
+test("isFakeCompletion: plain text is not a fake completion", () => {
+    assert.equal(isFakeCompletion("anthropic", "all done, nothing to do"), false);
+});
+
+test("injectFakeCompletionHint: anthropic merges the hint into the last user message", () => {
+    const body = JSON.stringify({ model: "m", messages: [{ role: "user", content: "hello" }] });
+    const out = injectFakeCompletionHint("anthropic", body);
+    assert.ok(out !== null);
+    const parsed = JSON.parse(out!) as { messages: Array<{ role: string; content: string }> };
+    assert.equal(parsed.messages.length, 1);
+    assert.ok(parsed.messages[0]!.content.includes("hello"));
+    assert.ok(parsed.messages[0]!.content.includes("tool-calling mechanism"));
+});
+
+test("injectFakeCompletionHint: anthropic appends a new user message when the last is assistant", () => {
+    const body = JSON.stringify({ model: "m", messages: [{ role: "user", content: "hi" }, { role: "assistant", content: "yo" }] });
+    const out = injectFakeCompletionHint("anthropic", body);
+    assert.ok(out !== null);
+    const parsed = JSON.parse(out!) as { messages: Array<{ role: string; content: string }> };
+    assert.equal(parsed.messages.length, 3);
+    assert.equal(parsed.messages[2]!.role, "user");
+    assert.ok(parsed.messages[2]!.content.includes("tool-calling mechanism"));
+});
+
+test("injectFakeCompletionHint: openai appends the hint to messages", () => {
+    const body = JSON.stringify({ model: "m", messages: [{ role: "user", content: "hi" }] });
+    const out = injectFakeCompletionHint("openai", body);
+    assert.ok(out !== null);
+    const parsed = JSON.parse(out!) as { messages: Array<{ role: string; content: string }> };
+    const last = parsed.messages[parsed.messages.length - 1]!;
+    assert.equal(last.role, "user");
+    assert.ok(last.content.includes("tool-calling mechanism"));
+});
+
+test("injectFakeCompletionHint: responses merges an input_text part into the last user input", () => {
+    const body = JSON.stringify({ model: "m", input: [{ role: "user", content: [{ type: "input_text", text: "hi" }] }] });
+    const out = injectFakeCompletionHint("responses", body);
+    assert.ok(out !== null);
+    const parsed = JSON.parse(out!) as { input: Array<{ role: string; content: Array<{ type: string; text?: string }> }> };
+    const last = parsed.input[parsed.input.length - 1]!;
+    const texts = last.content.map((c) => c.text ?? "").join("");
+    assert.ok(texts.includes("hi"));
+    assert.ok(texts.includes("tool-calling mechanism"));
+});
+
+test("injectFakeCompletionHint: returns null for an unparseable body", () => {
+    assert.equal(injectFakeCompletionHint("anthropic", "not json"), null);
+});
+
+interface Harness {
+    proxyPort: number;
+    upstreamPort: number;
+    captured: { body: string }[];
+    close(): Promise<void>;
+}
+
+function anthropicSse(event: string, data: unknown): string {
+    return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+function startHarness(scripts: string[][]): Promise<Harness> {
+    const captured: { body: string }[] = [];
+    let call = 0;
+    const upstream = http.createServer((req, res) => {
+        const chunks: Buffer[] = [];
+        req.on("data", (c: Buffer) => chunks.push(c));
+        req.on("end", () => {
+            captured.push({ body: Buffer.concat(chunks).toString() });
+            res.writeHead(200, { "content-type": "text/event-stream" });
+            const script = scripts[Math.min(call, scripts.length - 1)]!;
+            call += 1;
+            for (const line of script) res.write(line);
+            res.end();
+        });
+    });
+    upstream.listen(0, "127.0.0.1");
+    return (async () => {
+        await once(upstream, "listening");
+        const upstreamPort = upstream.address().port;
+        _setStoreForTest(new SessionStore({ enabled: false }));
+        setRegistryForTest({});
+        const proxy = await startServer({
+            port: 0,
+            host: "127.0.0.1",
+            upstream: "http://127.0.0.1",
+            routes: { [`http://127.0.0.1:${upstreamPort}`]: { models: { "claude-test": { context: 400_000 } } } },
+            modelContextLimit: 400_000,
+            kernelConfig: defaultConfig(400_000),
+            compress: { injectTool: false, injectNudge: false },
+            sessionHeader: "x-acp-session",
+            log: false,
+            debug: false,
+            passthrough: false,
+            autoUpdate: false,
+            mitm: { enabled: false, domains: [] },
+        } as ProxyOptions);
+        await once(proxy, "listening");
+        const proxyPort = proxy.address().port;
+        return {
+            proxyPort,
+            upstreamPort,
+            captured,
+            close: async () => {
+                proxy.close();
+                await once(proxy, "close");
+                upstream.close();
+                await once(upstream, "close");
+            },
+        };
+    })();
+}
+
+async function callAnthropic(h: Harness, session: string, messages: Array<{ role: string; content: string }>): Promise<string> {
+    const resp = await fetch(`http://127.0.0.1:${h.proxyPort}/bili/http://127.0.0.1:${h.upstreamPort}/v1/messages`, {
+        method: "POST",
+        headers: { "content-type": "application/json", "x-acp-session": session },
+        body: JSON.stringify({ model: "claude-test", max_tokens: 1024, stream: true, system: "You are a test assistant.", messages }),
+    });
+    assert.equal(resp.status, 200);
+    let raw = "";
+    for await (const chunk of resp.body) raw += Buffer.from(chunk).toString("utf8");
+    return raw;
+}
+
+function fakeCompletionScript(): string[] {
+    return [
+        anthropicSse("message_start", { type: "message_start", message: { id: "msg_fc_1", role: "assistant", usage: { input_tokens: 10 } } }),
+        anthropicSse("content_block_start", { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } }),
+        anthropicSse("content_block_delta", { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: FAKE_XML } }),
+        anthropicSse("content_block_stop", { type: "content_block_stop", index: 0 }),
+        anthropicSse("message_delta", { type: "message_delta", delta: { stop_reason: "end_turn", stop_sequence: null }, usage: { output_tokens: 5 } }),
+        anthropicSse("message_stop", { type: "message_stop" }),
+    ];
+}
+
+function realToolUseScript(): string[] {
+    return [
+        anthropicSse("message_start", { type: "message_start", message: { id: "msg_fc_2", role: "assistant", usage: { input_tokens: 10 } } }),
+        anthropicSse("content_block_start", { type: "content_block_start", index: 0, content_block: { type: "tool_use", id: "toolu_fc_1", name: "read_file", input: {} } }),
+        anthropicSse("content_block_delta", { type: "content_block_delta", index: 0, delta: { type: "input_json_delta", partial_json: '{"path":"/foo"}' } }),
+        anthropicSse("content_block_stop", { type: "content_block_stop", index: 0 }),
+        anthropicSse("message_delta", { type: "message_delta", delta: { stop_reason: "tool_use", stop_sequence: null }, usage: { output_tokens: 5 } }),
+        anthropicSse("message_stop", { type: "message_stop" }),
+    ];
+}
+
+test("e2e #371: fake completion triggers a retry that yields a real tool call", async () => {
+    const h = await startHarness([fakeCompletionScript(), realToolUseScript()]);
+    try {
+        const raw = await callAnthropic(h, "fc-retry", [{ role: "user", content: "read the file" }]);
+        assert.equal(h.captured.length, 2, `expected exactly 2 upstream requests (original + 1 retry), got ${h.captured.length}`);
+        assert.ok(raw.includes('"type":"tool_use"'), "client should receive the real tool_use block from the retry");
+        assert.ok(!raw.includes("/fake/completion/marker"), "the fake-completion text must not leak to the client");
+    } finally {
+        await h.close();
+    }
+});
+
+test("e2e #371: retry cap — always-fake upstream exhausts retries, then the session streak blocks further retries", async () => {
+    const h = await startHarness([fakeCompletionScript()]);
+    try {
+        await callAnthropic(h, "fc-cap", [{ role: "user", content: "t1" }]);
+        assert.equal(h.captured.length, 3, `turn 1: expected 3 requests (1 + 2 retries), got ${h.captured.length}`);
+        await callAnthropic(h, "fc-cap", [{ role: "user", content: "t2" }]);
+        assert.equal(h.captured.length, 6, `turn 2: expected 6 total (1 + 2 retries), got ${h.captured.length}`);
+        await callAnthropic(h, "fc-cap", [{ role: "user", content: "t3" }]);
+        assert.equal(h.captured.length, 7, `turn 3: expected 7 total (streak cap blocks the retry), got ${h.captured.length}`);
+    } finally {
+        await h.close();
+    }
+});
+
+test("e2e #371: legit prose with a single closing tag does NOT trigger a retry", async () => {
+    const legitScript = [
+        anthropicSse("message_start", { type: "message_start", message: { id: "msg_legit", role: "assistant", usage: { input_tokens: 10 } } }),
+        anthropicSse("content_block_start", { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } }),
+        anthropicSse("content_block_delta", { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: `The ${LT}/invoke${GT} tag closes a tool call in the template.` } }),
+        anthropicSse("content_block_stop", { type: "content_block_stop", index: 0 }),
+        anthropicSse("message_delta", { type: "message_delta", delta: { stop_reason: "end_turn", stop_sequence: null }, usage: { output_tokens: 5 } }),
+        anthropicSse("message_stop", { type: "message_stop" }),
+    ];
+    const h = await startHarness([legitScript]);
+    try {
+        const raw = await callAnthropic(h, "fc-legit", [{ role: "user", content: "explain the template" }]);
+        assert.equal(h.captured.length, 1, `legit prose must NOT trigger a retry, got ${h.captured.length} requests`);
+        assert.ok(raw.includes("closes a tool call"), "legit prose must pass through to the client");
+    } finally {
+        await h.close();
+    }
+});


### PR DESCRIPTION
## What

Fixes the "fake completion" from #371 (root-cause follow-up to #361): a small model (e.g. MiniMax-M3 via a gateway) can WRITE a tool call as plain text — echoing the tool-call XML template from the context — instead of emitting a real tool block. With no tool block the agent ends the turn early and shows success, but the tool never ran.

This adds a proxy-side **detect + retry** fallback:

- **Detect**: a response carrying a complete tool-call structure (an opening `<invoke>`-style tag, or 2+ distinct closing tags like `</invoke>` + `</tool_calls>`) AND no real tool block for the wire protocol (Anthropic `tool_use` / OpenAI `tool_calls` / Responses `function_call`). Reuses PR #365's `containsToolCallXmlFragment` detector; the structural guard (opening tag OR 2+ distinct closers) avoids false-positives on legit prose that merely mentions a single closing tag.
- **Retry**: re-request upstream with a corrective hint appended as a trailing user message ("you wrote the tool call as text; use the real tool-calling mechanism"). Bounded per turn (max retries) and per session (`session.metadata.fakeCompletionStreak` — consecutive fake-completion turns; resets on a clean turn).

## Opt-in (disabled by default)

The fallback must **buffer the whole response** before the client sees it (a fake completion is only knowable at end-of-stream), which defeats incremental streaming. That cost is only worth paying for the low-frequency fake-completion case, so it is **opt-in**:

- `BILI_FAKE_COMPLETION_RETRIES=2` — enable (2 retries/turn + 2 consecutive-turn cap).
- Default `0` — pre-#371 passthrough (streaming untouched).

This matches the issue's "先收集数据…确认频率后再决定是否上重试（避免为低频问题加复杂逻辑）" guidance: detection is already observable (PR #365's warn), and the retry can be turned on for the models/scenarios where it is confirmed to help.

## Trade-off (documented)

When enabled, streaming responses are buffered before being sent to the client (the client waits for the complete response before seeing tokens). This is the price of being able to retry before the client sees a fake completion.

## Tests

`tests/fake-completion.test.ts` (21 tests):
- Detection per protocol (anthropic/openai/responses): tool-XML + no tool block → fake; tool-XML + tool block → not fake.
- `hasToolCallStructure`: opening tag / 2+ distinct closers → structure; single closer (legit prose) → not.
- `injectFakeCompletionHint` per protocol (merge into last user msg / append).
- Integration (full proxy vs scripted mock upstream):
  - fake → retry → real `tool_use` reaches the client (fake text discarded).
  - retry cap: always-fake upstream → 3 requests turn 1, 6 turn 2, 7 turn 3 (streak cap blocks the retry).
  - legit prose (single closing tag) → NO retry.

## Pre-flight

- `npm run typecheck` — green
- `npm test` — 883 passing (all green)
- `npm run build` — green

Rebased onto latest master (v0.1.66).
