### PR TITLE
fix: Windows overlay symlink EPERM fallback + fail-loudly + SQLite set merge

### DIFF
--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -644,6 +644,140 @@ function livePidHoldsOverlay(overlay: string): number | undefined {
     return pid;
 }
 
+/**
+ * Link one real-home entry into the overlay: plain symlink first (the Linux/
+ * macOS path, and the Windows path when Developer Mode grants
+ * SeCreateSymbolicLinkPrivilege). On EPERM/EACCES/EINVAL — the default for an
+ * unprivileged Windows process, #381 — fall back to privilege-free links so
+ * the overlay is populated instead of silently hollow: directories → junction
+ * (mklink /J), files → hardlink (same volume, write-through) → copy.
+ */
+function linkOverlayEntry(realHome: string, overlay: string, entry: string): boolean {
+    const target = path.join(realHome, entry);
+    const link = path.join(overlay, entry);
+    try {
+        fs.symlinkSync(target, link);
+        return true;
+    } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code !== "EPERM" && code !== "EACCES" && code !== "EINVAL") return false;
+    }
+    let st: fs.Stats;
+    try {
+        st = fs.lstatSync(target);
+    } catch {
+        return false;
+    }
+    if (st.isDirectory()) {
+        try {
+            fs.symlinkSync(target, link, "junction");
+            return true;
+        } catch {
+            return false;
+        }
+    }
+    try {
+        fs.linkSync(target, link);
+        return true;
+    } catch {
+        try {
+            fs.copyFileSync(target, link);
+            return true;
+        } catch {
+            return false;
+        }
+    }
+}
+
+/** True when overlayPath hardlinks realPath (same dev+ino, nlink>1) — the
+ *  Windows file fallback (#381). Its writes already reached the real home, so
+ *  on refresh it is re-pointed (drop + re-link), never merged back. */
+function isWriteThroughHardlink(overlayPath: string, realPath: string, st: fs.Stats): boolean {
+    if (st.isDirectory() || st.isSymbolicLink() || st.nlink <= 1) return false;
+    try {
+        const realSt = fs.lstatSync(realPath);
+        return st.dev === realSt.dev && st.ino === realSt.ino;
+    } catch {
+        return false;
+    }
+}
+
+/** SQLite three-piece set for a main-db name. A WAL is only valid against its
+ *  exact main db, so the set must move as a unit — splitting it corrupts the
+ *  database (#381). */
+function sqliteSetMembers(base: string): string[] {
+    return [base, `${base}-wal`, `${base}-shm`];
+}
+
+/** Move a SQLite set (see sqliteSetMembers) from overlay to real home as one
+ *  unit (#381): all present members move together, and if any rename fails
+ *  (real db open/locked on Windows) the moved ones roll back and the set stays
+ *  for the next launch. Per member mtime-newer wins (loser → .bili-conflict). */
+function mergeSqliteSet(overlay: string, realHome: string, base: string): boolean {
+    const members = sqliteSetMembers(base).filter((m) => {
+        try {
+            return fs.lstatSync(path.join(overlay, m)).isFile();
+        } catch {
+            return false;
+        }
+    });
+    if (members.length === 0) return true;
+    const undo: (() => void)[] = [];
+    const rollback = (): void => {
+        for (const step of undo.reverse()) {
+            try {
+                step();
+            } catch {}
+        }
+        undo.length = 0;
+    };
+    try {
+        for (const m of members) {
+            const src = path.join(overlay, m);
+            const dst = path.join(realHome, m);
+            let dstStat: fs.Stats | undefined;
+            try {
+                dstStat = fs.lstatSync(dst);
+            } catch {}
+            if (dstStat && dstStat.isDirectory()) {
+                rollback();
+                return false;
+            }
+            const srcStat = fs.lstatSync(src);
+            if (dstStat && dstStat.mtimeMs >= srcStat.mtimeMs) {
+                try {
+                    fs.renameSync(src, `${dst}.bili-conflict`);
+                } catch {
+                    rollback();
+                    return false;
+                }
+                undo.push(() => fs.renameSync(`${dst}.bili-conflict`, src));
+                continue;
+            }
+            if (dstStat) {
+                try {
+                    fs.renameSync(dst, `${dst}.bili-conflict`);
+                } catch {
+                    rollback();
+                    return false;
+                }
+                undo.push(() => fs.renameSync(`${dst}.bili-conflict`, dst));
+            }
+            try {
+                fs.renameSync(src, dst);
+            } catch {
+                rollback();
+                return false;
+            }
+            undo.push(() => fs.renameSync(dst, src));
+        }
+        return true;
+    } catch {
+        rollback();
+        return false;
+    }
+}
+
 function refreshOverlayHome(realHome: string, overlay: string, generatedFile: string): boolean {
     try {
         fs.mkdirSync(overlay, { recursive: true });
@@ -664,7 +798,36 @@ function refreshOverlayHome(realHome: string, overlay: string, generatedFile: st
         for (const entry of fs.readdirSync(realHome)) realEntries.add(entry);
     } catch {}
     try {
-        for (const entry of fs.readdirSync(overlay)) {
+        let overlayEntries: string[];
+        try {
+            overlayEntries = fs.readdirSync(overlay);
+        } catch {
+            overlayEntries = [];
+        }
+        // SQLite sets in the overlay root move as a unit (#381). A set whose
+        // main db is a write-through hardlink keeps its -wal/-shm in the
+        // overlay (SQLite recovers them in place on next open) and only
+        // re-points the db; any other set moves wholesale.
+        const dbSets: { base: string; keepSidecars: boolean }[] = [];
+        for (const entry of overlayEntries) {
+            if (!entry.endsWith(".db") || entry === generatedFile) continue;
+            const members = sqliteSetMembers(entry);
+            if (!members.some((m) => m !== entry && overlayEntries.includes(m))) continue;
+            let mainSt: fs.Stats | undefined;
+            try {
+                mainSt = fs.lstatSync(path.join(overlay, entry));
+            } catch {}
+            const keepSidecars =
+                mainSt !== undefined && isWriteThroughHardlink(path.join(overlay, entry), path.join(realHome, entry), mainSt);
+            dbSets.push({ base: entry, keepSidecars });
+        }
+        const skipEntries = new Set<string>();
+        for (const { base, keepSidecars } of dbSets) {
+            for (const m of sqliteSetMembers(base)) {
+                if (keepSidecars ? m !== base : true) skipEntries.add(m);
+            }
+        }
+        for (const entry of overlayEntries) {
             if (entry === generatedFile) continue;
             const overlayPath = path.join(overlay, entry);
             if (entry.startsWith(`.${generatedFile}.`) && entry.endsWith(".tmp")) {
@@ -673,6 +836,7 @@ function refreshOverlayHome(realHome: string, overlay: string, generatedFile: st
                 } catch {}
                 continue;
             }
+            if (skipEntries.has(entry)) continue;
             let st: fs.Stats;
             try {
                 st = fs.lstatSync(overlayPath);
@@ -691,7 +855,12 @@ function refreshOverlayHome(realHome: string, overlay: string, generatedFile: st
                     } catch {}
                 }
             } else if (realEntries.has(entry)) {
-                if (mergeOverlayEntry(overlayPath, path.join(realHome, entry))) {
+                const realPath = path.join(realHome, entry);
+                if (isWriteThroughHardlink(overlayPath, realPath, st)) {
+                    try {
+                        fs.unlinkSync(overlayPath);
+                    } catch {}
+                } else if (mergeOverlayEntry(overlayPath, realPath)) {
                     try {
                         fs.rmSync(overlayPath, { recursive: true, force: true });
                     } catch {}
@@ -700,11 +869,53 @@ function refreshOverlayHome(realHome: string, overlay: string, generatedFile: st
                 }
             }
         }
+        for (const { base, keepSidecars } of dbSets) {
+            if (keepSidecars) continue;
+            if (!mergeSqliteSet(overlay, realHome, base)) {
+                console.error(
+                    `bili: could not merge the SQLite set ${base} / ${base}-wal / ${base}-shm into ${realHome} ` +
+                        `(the real db is likely open/locked) — kept in the overlay, retry on the next launch.`,
+                );
+            }
+        }
+        let accessible = 0;
+        let total = 0;
+        const linkFailures: string[] = [];
         for (const entry of realEntries) {
             if (entry === generatedFile) continue;
+            total += 1;
+            const overlayPath = path.join(overlay, entry);
+            let present = false;
             try {
-                fs.symlinkSync(path.join(realHome, entry), path.join(overlay, entry));
+                fs.lstatSync(overlayPath);
+                present = true;
             } catch {}
+            // A correct link left in place by the per-entry loop (or a SQLite
+            // set that failed to merge and rolled back) already makes the entry
+            // accessible — re-linking would EEXIST, so skip it.
+            if (present) {
+                accessible += 1;
+                continue;
+            }
+            if (linkOverlayEntry(realHome, overlay, entry)) {
+                accessible += 1;
+            } else {
+                linkFailures.push(entry);
+            }
+        }
+        if (total > 0 && accessible === 0) {
+            console.error(
+                `bili: overlay ${overlay} is HOLLOW — none of ${total} real-home entries is reachable ` +
+                    `(on Windows, symlink creation is denied without Developer Mode and the junction/hardlink/copy fallbacks also failed). ` +
+                    `The client will start from its real home without the bili config rewrite.`,
+            );
+            return false;
+        }
+        if (linkFailures.length > 0) {
+            console.error(
+                `bili: overlay ${overlay} — could not link ${linkFailures.length} entr${linkFailures.length === 1 ? "y" : "ies"}: ${linkFailures.join(", ")}. ` +
+                    `The client may miss those (on Windows, enable Developer Mode for full symlink support).`,
+            );
         }
     } catch {}
     return true;

--- a/tests/launcher.test.ts
+++ b/tests/launcher.test.ts
@@ -1,6 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
+import type { PathLike, SymlinkType } from "node:fs";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
@@ -1131,6 +1132,189 @@ test("prepareOmpHttpRewrite: returns undefined when models.yml missing", () => {
         const rw = [{ key: "a", realUpstream: "http://example.com/v1" }];
         assert.equal(prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", rw, []), undefined);
     } finally {
+        fs.rmSync(home, { recursive: true, force: true });
+    }
+});
+
+// #381: Windows overlay symlink EPERM fallback. Unprivileged Windows
+// processes lack SeCreateSymbolicLinkPrivilege, so plain symlinkSync throws
+// EPERM and the overlay would be silently hollowed (fresh, unconfigured
+// client every launch). Simulated on Linux by denying fs.symlinkSync for
+// non-junction links (junctions stay allowed).
+function denyErr(code: string): NodeJS.ErrnoException {
+    const err = new Error(`${code}: operation not permitted`) as NodeJS.ErrnoException;
+    err.code = code;
+    return err;
+}
+
+test("prepareOmpHttpRewrite: EPERM fallback links dir→junction, file→hardlink, overlay not hollow (#381)", () => {
+    const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "bili-omphome-")));
+    fs.writeFileSync(path.join(home, "models.yml"), ["providers:", "  a:", "    baseUrl: http://example.com/v1"].join("\n"));
+    fs.mkdirSync(path.join(home, "sessions"));
+    fs.writeFileSync(path.join(home, "settings.json"), "real-settings");
+    const rw = [{ key: "a", realUpstream: "http://example.com/v1" }];
+    const realSymlinkSync = fs.symlinkSync;
+    fs.symlinkSync = ((target: PathLike, link: PathLike, type?: SymlinkType) => {
+        if (type === "junction") return realSymlinkSync(target, link, "junction");
+        throw denyErr("EPERM");
+    }) as typeof fs.symlinkSync;
+    let tmp: string | undefined;
+    try {
+        tmp = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", rw, []);
+        assert.equal(tmp, `${home}-bili`, "overlay returned, not hollow");
+        const overlay = tmp!;
+        assert.equal(fs.lstatSync(path.join(overlay, "sessions")).isSymbolicLink(), true, "dir linked via junction");
+        assert.equal(fs.realpathSync(path.join(overlay, "sessions")), path.join(home, "sessions"), "junction points at real dir");
+        const st = fs.lstatSync(path.join(overlay, "settings.json"));
+        const realSt = fs.lstatSync(path.join(home, "settings.json"));
+        assert.equal(st.isSymbolicLink(), false, "file is a hardlink, not a symlink");
+        assert.equal(st.nlink, 2, "hardlink has nlink 2");
+        assert.ok(st.dev === realSt.dev && st.ino === realSt.ino, "hardlink shares inode with real file");
+    } finally {
+        fs.symlinkSync = realSymlinkSync;
+        if (tmp) fs.rmSync(tmp, { recursive: true, force: true });
+        fs.rmSync(home, { recursive: true, force: true });
+    }
+});
+
+test("prepareOmpHttpRewrite: EPERM fallback copies file when hardlink also denied (#381)", () => {
+    const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "bili-omphome-")));
+    fs.writeFileSync(path.join(home, "models.yml"), ["providers:", "  a:", "    baseUrl: http://example.com/v1"].join("\n"));
+    fs.writeFileSync(path.join(home, "settings.json"), "real-settings");
+    const rw = [{ key: "a", realUpstream: "http://example.com/v1" }];
+    const realSymlinkSync = fs.symlinkSync;
+    const realLinkSync = fs.linkSync;
+    fs.symlinkSync = ((target: PathLike, link: PathLike, type?: SymlinkType) => {
+        if (type === "junction") return realSymlinkSync(target, link, "junction");
+        throw denyErr("EPERM");
+    }) as typeof fs.symlinkSync;
+    fs.linkSync = (() => { throw denyErr("EPERM"); }) as typeof fs.linkSync;
+    let tmp: string | undefined;
+    try {
+        tmp = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", rw, []);
+        assert.equal(tmp, `${home}-bili`);
+        const st = fs.lstatSync(path.join(tmp!, "settings.json"));
+        assert.equal(st.isSymbolicLink(), false, "file is a copy, not a symlink");
+        assert.equal(st.nlink, 1, "copy has nlink 1 (not a hardlink)");
+        assert.equal(fs.readFileSync(path.join(tmp!, "settings.json"), "utf8"), "real-settings", "copy content matches");
+    } finally {
+        fs.symlinkSync = realSymlinkSync;
+        fs.linkSync = realLinkSync;
+        if (tmp) fs.rmSync(tmp, { recursive: true, force: true });
+        fs.rmSync(home, { recursive: true, force: true });
+    }
+});
+
+test("prepareOmpHttpRewrite: all link fallbacks fail → hollow overlay → returns undefined (#381)", () => {
+    const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "bili-omphome-")));
+    fs.writeFileSync(path.join(home, "models.yml"), ["providers:", "  a:", "    baseUrl: http://example.com/v1"].join("\n"));
+    fs.mkdirSync(path.join(home, "sessions"));
+    fs.writeFileSync(path.join(home, "settings.json"), "real-settings");
+    const rw = [{ key: "a", realUpstream: "http://example.com/v1" }];
+    const realSymlinkSync = fs.symlinkSync;
+    const realLinkSync = fs.linkSync;
+    const realCopyFileSync = fs.copyFileSync;
+    fs.symlinkSync = (() => { throw denyErr("EPERM"); }) as typeof fs.symlinkSync;
+    fs.linkSync = (() => { throw denyErr("EPERM"); }) as typeof fs.linkSync;
+    fs.copyFileSync = (() => { throw denyErr("EPERM"); }) as typeof fs.copyFileSync;
+    try {
+        const tmp = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", rw, []);
+        assert.equal(tmp, undefined, "hollow overlay → undefined (fail loudly, not silent)");
+    } finally {
+        fs.symlinkSync = realSymlinkSync;
+        fs.linkSync = realLinkSync;
+        fs.copyFileSync = realCopyFileSync;
+        fs.rmSync(`${home}-bili`, { recursive: true, force: true });
+        fs.rmSync(home, { recursive: true, force: true });
+    }
+});
+
+test("prepareOmpHttpRewrite: SQLite three-piece set (.db/.db-wal/.db-shm) moves as a unit (#381)", () => {
+    const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "bili-omphome-")));
+    fs.writeFileSync(path.join(home, "models.yml"), ["providers:", "  a:", "    baseUrl: http://example.com/v1"].join("\n"));
+    const rw = [{ key: "a", realUpstream: "http://example.com/v1" }];
+    const overlay = `${home}-bili`;
+    let tmp: string | undefined;
+    try {
+        tmp = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", rw, []);
+        assert.equal(tmp, overlay);
+        fs.writeFileSync(path.join(overlay, "agent.db"), "db-content");
+        fs.writeFileSync(path.join(overlay, "agent.db-wal"), "wal-content");
+        fs.writeFileSync(path.join(overlay, "agent.db-shm"), "shm-content");
+        tmp = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", rw, []);
+        assert.equal(fs.readFileSync(path.join(home, "agent.db"), "utf8"), "db-content", "db moved to real home");
+        assert.equal(fs.readFileSync(path.join(home, "agent.db-wal"), "utf8"), "wal-content", "wal moved with the db");
+        assert.equal(fs.readFileSync(path.join(home, "agent.db-shm"), "utf8"), "shm-content", "shm moved with the db");
+        assert.equal(fs.existsSync(path.join(overlay, "agent.db")), false, "db left the overlay");
+        assert.equal(fs.existsSync(path.join(overlay, "agent.db-wal")), false, "wal left the overlay");
+        assert.equal(fs.existsSync(path.join(overlay, "agent.db-shm")), false, "shm left the overlay");
+    } finally {
+        if (tmp) fs.rmSync(tmp, { recursive: true, force: true });
+        fs.rmSync(home, { recursive: true, force: true });
+    }
+});
+
+test("prepareOmpHttpRewrite: SQLite set merge failure rolls back, keeps set in overlay (#381)", () => {
+    const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "bili-omphome-")));
+    fs.writeFileSync(path.join(home, "models.yml"), ["providers:", "  a:", "    baseUrl: http://example.com/v1"].join("\n"));
+    fs.writeFileSync(path.join(home, "agent.db"), "real-original-db");
+    const old = new Date(Date.now() - 60000);
+    fs.utimesSync(path.join(home, "agent.db"), old, old);
+    const rw = [{ key: "a", realUpstream: "http://example.com/v1" }];
+    const overlay = `${home}-bili`;
+    let tmp: string | undefined;
+    const realRenameSync = fs.renameSync;
+    try {
+        tmp = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", rw, []);
+        assert.equal(tmp, overlay);
+        fs.rmSync(path.join(overlay, "agent.db"));
+        fs.writeFileSync(path.join(overlay, "agent.db"), "overlay-db");
+        fs.writeFileSync(path.join(overlay, "agent.db-wal"), "overlay-wal");
+        fs.writeFileSync(path.join(overlay, "agent.db-shm"), "overlay-shm");
+        fs.renameSync = ((src: PathLike, dst: PathLike) => {
+            if (String(src).endsWith("agent.db-shm")) throw denyErr("EPERM");
+            return realRenameSync(src, dst);
+        }) as typeof fs.renameSync;
+        tmp = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", rw, []);
+        assert.equal(fs.readFileSync(path.join(home, "agent.db"), "utf8"), "real-original-db", "real db restored after rollback");
+        assert.equal(fs.existsSync(path.join(home, "agent.db-wal")), false, "wal rolled back to overlay");
+        assert.equal(fs.existsSync(path.join(home, "agent.db-shm")), false, "shm rolled back to overlay");
+        assert.equal(fs.readFileSync(path.join(overlay, "agent.db"), "utf8"), "overlay-db", "db stays in overlay");
+        assert.equal(fs.readFileSync(path.join(overlay, "agent.db-wal"), "utf8"), "overlay-wal", "wal stays in overlay");
+        assert.equal(fs.readFileSync(path.join(overlay, "agent.db-shm"), "utf8"), "overlay-shm", "shm stays in overlay");
+    } finally {
+        fs.renameSync = realRenameSync;
+        if (tmp) fs.rmSync(tmp, { recursive: true, force: true });
+        fs.rmSync(home, { recursive: true, force: true });
+    }
+});
+
+test("prepareOmpHttpRewrite: write-through hardlink is re-pointed, never merged back (#381)", () => {
+    const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "bili-omphome-")));
+    fs.writeFileSync(path.join(home, "models.yml"), ["providers:", "  a:", "    baseUrl: http://example.com/v1"].join("\n"));
+    fs.writeFileSync(path.join(home, "settings.json"), "real-settings");
+    const rw = [{ key: "a", realUpstream: "http://example.com/v1" }];
+    const overlay = `${home}-bili`;
+    const realSymlinkSync = fs.symlinkSync;
+    fs.symlinkSync = ((target: PathLike, link: PathLike, type?: SymlinkType) => {
+        if (type === "junction") return realSymlinkSync(target, link, "junction");
+        throw denyErr("EPERM");
+    }) as typeof fs.symlinkSync;
+    let tmp: string | undefined;
+    try {
+        tmp = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", rw, []);
+        assert.equal(tmp, overlay);
+        assert.equal(fs.lstatSync(path.join(overlay, "settings.json")).nlink, 2, "file linked as a hardlink");
+        fs.appendFileSync(path.join(overlay, "settings.json"), "-appended");
+        tmp = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", rw, []);
+        assert.equal(fs.readFileSync(path.join(home, "settings.json"), "utf8"), "real-settings-appended", "write-through reached the real file");
+        const st = fs.lstatSync(path.join(overlay, "settings.json"));
+        assert.equal(st.isSymbolicLink(), false, "re-pointed as a hardlink, not a symlink");
+        assert.equal(st.nlink, 2, "still a hardlink after re-point");
+        assert.equal(fs.existsSync(path.join(home, "settings.json.bili-conflict")), false, "not merged (no .bili-conflict)");
+    } finally {
+        fs.symlinkSync = realSymlinkSync;
+        if (tmp) fs.rmSync(tmp, { recursive: true, force: true });
         fs.rmSync(home, { recursive: true, force: true });
     }
 });


### PR DESCRIPTION
## Fixes #381 (the Windows root cause of #289)

Unprivileged Windows processes lack `SeCreateSymbolicLinkPrivilege`, so `fs.symlinkSync` throws `EPERM`. `refreshOverlayHome` wrapped every link in a bare `catch {}` and **returned `true` unconditionally** — so the `bili omp`/`pi`/`hermes`/`dsh` overlay came out hollow (only the generated config + pid marker, zero links) and the client read an empty home, launching fresh/unconfigured every time.

### Changes (`src/launcher.ts`)
- **`linkOverlayEntry`** — on `EPERM`/`EACCES`/`EINVAL`, fall back per entry type: dir → `symlink 'junction'` (no privilege needed), file → hardlink (same volume) → copy. The overlay now works without Developer Mode.
- **`refreshOverlayHome`** — track link success/failure per entry. When the overlay comes out hollow (no entry resolvable), log a loud warning and `return false` so the launcher aborts instead of pointing the client at an empty home. Partial failures are reported, not silently dropped. (Also fixed an `EEXIST` bug: entries already correctly linked by the per-entry loop / left by a SQLite rollback are counted as present, not re-linked.)
- **`mergeSqliteSet`** — move the SQLite three-piece set (`.db`/`.db-wal`/`.db-shm`) as a unit with two-phase rollback, so a locked/half-migrated set can no longer corrupt the real home db.
- A write-through hardlink (`nlink>1`, same `dev`+`ino` as the real file) is re-pointed on refresh, never merged back (data-loss guard).

### Tests (`tests/launcher.test.ts`, +6)
Simulate the Windows `EPERM` condition on Linux by denying `fs.symlinkSync` for non-junction links: dir→junction, file→hardlink, file→copy, all-fail→hollow→`undefined`, SQLite set unit-move, SQLite set rollback, write-through hardlink re-point.

### Pre-flight
- `npm run typecheck` ✅
- `npm test` — 868 pass, 0 fail ✅
- `npm run build` ✅

Note: I could not exercise a real Windows host from this environment; the fallback paths are unit-tested by simulating the `EPERM`/`EACCES` behavior on Linux. A real-Windows smoke test of `bili omp` is recommended before release.