### PR TITLE
release v0.1.67

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.66",
+  "version": "0.1.67",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## v0.1.67

Version bump only (isolated release commit). CI will build, test, publish to npm, tag `v0.1.67`, and create the GitHub Release on merge.

### Changes since v0.1.66
- **fix: Windows overlay symlink EPERM fallback + fail-loudly + SQLite set merge** (#381, PR #382)
  - `bili omp`/`pi`/`hermes`/`dsh` overlay now works on unprivileged Windows (no Developer Mode): `symlinkSync` `EPERM` falls back to junction (dir) / hardlink / copy (file).
  - Hollow overlay (no entry resolvable) now fails loudly and aborts the launch instead of silently pointing the client at an empty home — the Windows root cause of #289.
  - SQLite three-piece set (`.db`/`.db-wal`/`.db-shm`) moves as a unit with rollback; write-through hardlinks are re-pointed, never merged back.

### Pre-flight (matches CI)
- `npm run typecheck` ✅
- `npm test` — 868 pass, 0 fail ✅
- `npm run build` ✅