### PR TITLE
fix: acp_status derives ranges/nudge from live state, not the prepare-time snapshot (#389)

### DIFF
--- a/src/acp-status.ts
+++ b/src/acp-status.ts
@@ -1,0 +1,66 @@
+import {
+    buildStatusReport,
+    defaultCountTokens,
+    formatRanges,
+    viableRanges,
+    type CompressionCore,
+    type Config,
+    type CoreMessage,
+} from "acp-kernel";
+import { preCompactionArchiveOf, type Session } from "./session.js";
+
+export interface AcpStatusCtx {
+    core: CompressionCore;
+    config: Config;
+    messages: CoreMessage[];
+    session: Session;
+}
+
+// The ranges/nudge section is recomputed from live session state on every
+// call instead of reading the prepare-time nudge snapshot: a successful
+// compress mutates state mid-turn without re-running prepare, so the snapshot
+// goes stale and lists already-compressed refs as compressible (#389).
+// processTurn is pure (nodes return new objects), so the returned state is
+// intentionally NOT adopted — this is a read-only recompute.
+export function handleAcpStatus(args: Record<string, unknown>, ctx: AcpStatusCtx): string {
+    const scope = typeof args.scope === "string" ? (args.scope as "compressed" | "uncompressed") : undefined;
+    const view = typeof args.view === "string" ? (args.view as "ranges" | "messages") : undefined;
+    const tool = typeof args.tool === "string" ? args.tool : undefined;
+    const sort = typeof args.sort === "string" ? (args.sort as "size" | "time" | "tool" | "age") : undefined;
+    const limit = typeof args.limit === "number" ? args.limit : undefined;
+    const base = buildStatusReport(ctx.session.state, ctx.messages, defaultCountTokens, { scope, view, tool, sort, limit });
+    if (scope) return base;
+    const extra: string[] = [];
+    try {
+        const turn = ctx.core.processTurn({
+            messages: ctx.messages,
+            state: ctx.session.state,
+            config: ctx.config,
+            tokenCount: ctx.session.stats.lastInputTokens,
+            renderTags: "none",
+        });
+        const nudge = turn.nudge;
+        if (nudge) {
+            extra.push("");
+            extra.push(nudge.shouldInject ? `Nudge: ACTIVE — ${nudge.reason}` : `Nudge: idle — ${nudge.reason}`);
+            const ranges = viableRanges(nudge.compressibleRanges);
+            const protectedRanges = nudge.protectedRanges ?? [];
+            if (ranges.length > 0 || protectedRanges.length > 0) {
+                extra.push("");
+                extra.push(formatRanges(ranges, protectedRanges));
+            }
+        }
+    } catch {
+        // Base-only report; never fall back to a stale snapshot.
+    }
+    const archive = preCompactionArchiveOf(ctx.session);
+    const archivedIds = Object.keys(archive);
+    if (archivedIds.length > 0) {
+        extra.push("");
+        extra.push(`PRE-COMPACTION ARCHIVE — ${archivedIds.length} block(s): content was replaced by the client's native compaction summary, so it is no longer in the session history and decompress is unavailable.`);
+        for (const id of archivedIds) {
+            extra.push(`  ${id} — ${archive[id].reason}`);
+        }
+    }
+    return extra.length > 0 ? `${base}\n${extra.join("\n")}` : base;
+}

--- a/src/compress-loop-responses.ts
+++ b/src/compress-loop-responses.ts
@@ -1,10 +1,9 @@
 import {
-    buildStatusReport,
-    defaultCountTokens,
     type CompressionCore,
     type Config,
     type CoreMessage,
 } from "acp-kernel";
+import { handleAcpStatus } from "./acp-status.js";
 import { lastCompressSuffix, type Session } from "./session.js";
 import { parseCompressInput, PROXY_TOOL_NAMES, MUTATING_PROXY_TOOLS, COMPRESS_TOOL_NAME, ACP_TEXT_OPEN, ACP_TEXT_CLOSE } from "./compress-tool.js";
 import { log as loggerLog } from "./logger.js";
@@ -102,7 +101,7 @@ function executeProxyTool(
         return `Found ${blocks.length} block(s) for "${query}":\n\n${lines.join("\n\n")}`;
     }
     if (toolName === "acp_status") {
-        return buildStatusReport(ctx.session.state, ctx.messages, defaultCountTokens);
+        return handleAcpStatus(args, ctx);
     }
     return `[Unknown proxy tool: ${toolName}]`;
 }

--- a/src/loop/core.ts
+++ b/src/loop/core.ts
@@ -1,14 +1,11 @@
 import {
-    buildStatusReport,
-    defaultCountTokens,
-    formatRanges,
     hideConsumedCompressCalls,
     type CompressionCore,
     type Config,
     type CoreMessage,
-    type NudgeDecision,
 } from "acp-kernel";
-import { lastCompressSuffix, preCompactionArchiveOf, type Session } from "../session.js";
+import { handleAcpStatus } from "../acp-status.js";
+import { lastCompressSuffix, type Session } from "../session.js";
 import type { BiliMessage } from "acp-kernel/wire";
 import {
     parseCompressInput,
@@ -66,7 +63,6 @@ export interface LoopCtx {
     proxyUrl?: string;
     textProtocol?: boolean;
     debug?: boolean;
-    nudge?: NudgeDecision;
     /** #422: host hook that re-runs the kernel fold (processTurn) on the
      *  original messages with the CURRENT session state, re-attaching this
      *  loop's round records. Called after a successful compress so the
@@ -155,41 +151,6 @@ export function executeProxyTool(
         return handleAcpStatus(args, ctx);
     }
     return `[Unknown proxy tool: ${toolName}]`;
-}
-
-// Aligns with billion-context-pi's handleStatus: appends compressible ranges
-// to the default overview so the model picks valid refs (else it guesses
-// covered/protected refs → 0-char compress failures).
-function handleAcpStatus(args: Record<string, unknown>, ctx: LoopCtx): string {
-    const scope = typeof args.scope === "string" ? (args.scope as "compressed" | "uncompressed") : undefined;
-    const view = typeof args.view === "string" ? (args.view as "ranges" | "messages") : undefined;
-    const tool = typeof args.tool === "string" ? args.tool : undefined;
-    const sort = typeof args.sort === "string" ? (args.sort as "size" | "time" | "tool" | "age") : undefined;
-    const limit = typeof args.limit === "number" ? args.limit : undefined;
-    const base = buildStatusReport(ctx.session.state, ctx.messages, defaultCountTokens, { scope, view, tool, sort, limit });
-    if (scope) return base;
-    const nudge = ctx.nudge;
-    const ranges = nudge?.compressibleRanges ?? [];
-    const protectedRanges = nudge?.protectedRanges ?? [];
-    const archive = preCompactionArchiveOf(ctx.session);
-    const archivedIds = Object.keys(archive);
-    const extra: string[] = [];
-    if (nudge) {
-        extra.push("");
-        extra.push(nudge.shouldInject ? `Nudge: ACTIVE — ${nudge.reason}` : `Nudge: idle — ${nudge.reason}`);
-    }
-    if (ranges.length > 0 || protectedRanges.length > 0) {
-        extra.push("");
-        extra.push(formatRanges(ranges, protectedRanges));
-    }
-    if (archivedIds.length > 0) {
-        extra.push("");
-        extra.push(`PRE-COMPACTION ARCHIVE — ${archivedIds.length} block(s): content was replaced by the client's native compaction summary, so it is no longer in the session history and decompress is unavailable.`);
-        for (const id of archivedIds) {
-            extra.push(`  ${id} — ${archive[id].reason}`);
-        }
-    }
-    return extra.length > 0 ? `${base}\n${extra.join("\n")}` : base;
 }
 
 function recordUsage(

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -471,7 +471,6 @@ export async function handlePluginTool(
                 messages,
                 session,
                 log: (m) => deps.log("info", `[${session.id}] [plugin] ${m}`),
-                nudge: mem?.nudge,
             }, callId);
         });
     } catch (err) {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -355,7 +355,7 @@ export type PluginToolDeps = {
 
 /** Context-level visibility for plugin UIs (status bars / slash commands):
  *  the same usage the nudge decision sees, keyed by conversation id. */
-export function handlePluginStatus(conversationId: string, res: import("node:http").ServerResponse, fallbackLatest = false): void {
+export function handlePluginStatus(conversationId: string, res: import("node:http").ServerResponse, deps: PluginToolDeps, fallbackLatest = false): void {
     let entry = conversations.get(conversationId);
     let session = entry ? peekSession(entry.sessionId) : undefined;
     let viaFallback = false;
@@ -385,6 +385,28 @@ export function handlePluginStatus(conversationId: string, res: import("node:htt
     const limit = session.metadata.effectiveContextLimit;
     const mem = remembered.get(session.id);
     const modelContextLimit = typeof limit === "number" && limit > 0 ? limit : 0;
+    // #387: the remembered nudge is a prepare-time snapshot. A compress tool
+    // executed after the last model request mutates state without re-running
+    // prepare, so that snapshot would list already-compressed refs as
+    // compressible next to the new blocks (stale ranges + live blocks in one
+    // panel). Recompute from live state on every status read — same pattern
+    // as acp_status; on failure omit the nudge/ranges sections instead of
+    // serving the stale snapshot.
+    let nudge: NudgeDecision | undefined;
+    try {
+        const messages = mem ? (mem.processed.length > 0 ? mem.processed : mem.original) : [];
+        if (messages.length > 0) {
+            nudge = deps.core.processTurn({
+                messages,
+                state: session.state,
+                config: deps.config,
+                tokenCount: session.stats.lastInputTokens,
+                renderTags: "none",
+            }).nudge;
+        }
+    } catch {
+        nudge = undefined;
+    }
     let panel: string | undefined;
     try {
         panel = buildStatusPanel({
@@ -392,7 +414,7 @@ export function handlePluginStatus(conversationId: string, res: import("node:htt
             tokenCount: session.stats.lastInputTokens,
             systemPromptTokens: 0,
             state: session.state,
-            nudge: mem?.nudge,
+            nudge,
             modelContextLimit,
             unprunedTokens: mem && mem.original.length > 0
                 ? mem.original.reduce((sum, m) => sum + defaultCountTokens(m.text ?? ""), 0)

--- a/src/server.ts
+++ b/src/server.ts
@@ -856,7 +856,7 @@ async function handle(
             res.end(JSON.stringify({ ok: false, error: "conversationId query parameter is required" }));
             return;
         }
-        return handlePluginStatus(conversationId, res, params.get("fallback") === "latest");
+        return handlePluginStatus(conversationId, res, { core, config, log }, params.get("fallback") === "latest");
     }
     if (req.method === "POST" && req.url === "/__bili/plugin/tool") {
         try {

--- a/src/server.ts
+++ b/src/server.ts
@@ -3089,7 +3089,7 @@ async function forward(
             };
             const loop = runCompressLoop(
                 streamToRead,
-                { core, config, messages: prepared.processedMessages.length > 0 ? prepared.processedMessages : prepared.originalMessages, compressMessages: prepared.originalMessages, session: prepared.session, log: ctx.log, proxyUrl, protocol: prepared.protocol, textProtocol, debug: opts.debug, nudge: prepared.nudge, refreshFolded },
+                { core, config, messages: prepared.processedMessages.length > 0 ? prepared.processedMessages : prepared.originalMessages, compressMessages: prepared.originalMessages, session: prepared.session, log: ctx.log, proxyUrl, protocol: prepared.protocol, textProtocol, debug: opts.debug, refreshFolded },
                 parsedReq,
                 { url: upstreamUrl, headers: reqHeaders },
                 adapter,

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1,4 +1,5 @@
-import { buildStatusReport, collectBlockContent, defaultCountTokens, type CompressionCore, type Config, type CoreMessage, type CompressionState } from "acp-kernel";
+import { collectBlockContent, type CompressionCore, type Config, type CoreMessage, type CompressionState } from "acp-kernel";
+import { handleAcpStatus } from "./acp-status.js";
 import { type Session, cacheBlockContent } from "./session.js";
 import { COMPRESS_TOOL_NAME, parseCompressInput, PROXY_TOOL_NAMES } from "./compress-tool.js";
 import { resolveDecompress } from "./decompress-shared.js";
@@ -43,7 +44,7 @@ function executeAnthropicProxyTool(toolName: string, args: Record<string, unknow
         return `Found ${blocks.length} block(s) for "${query}":\n\n${lines.join("\n\n")}`;
     }
     if (toolName === "acp_status") {
-        return buildStatusReport(ctx.session.state, ctx.messages, defaultCountTokens);
+        return handleAcpStatus(args, ctx);
     }
     return `[Unknown proxy tool: ${toolName}]`;
 }

--- a/tests/acp-status.test.ts
+++ b/tests/acp-status.test.ts
@@ -1,0 +1,127 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { Config, CoreMessage } from "acp-kernel";
+import { createCore, createInitialState, assignRefs, emptyRefMap, defaultConfig } from "acp-kernel";
+import type { Session } from "../src/session.ts";
+import { handleAcpStatus } from "../src/acp-status.ts";
+import { applyRanges } from "../src/stream.ts";
+import { parseCompressInput, buildCompressSystemPrompt } from "../src/compress-tool.ts";
+import { runCompressLoop, createResponsesAdapter } from "../src/loop/index.ts";
+
+function textMsg(id: string, role: "user" | "assistant", text: string): CoreMessage {
+    return { id, role, contentType: "text", text };
+}
+
+function makeCtx(messages: CoreMessage[]): {
+    core: ReturnType<typeof createCore>;
+    config: Config;
+    messages: CoreMessage[];
+    session: Session;
+    log: (m: string) => void;
+} {
+    return {
+        core: createCore(),
+        config: defaultConfig(200000),
+        messages,
+        session: {
+            id: "acp-status-test",
+            meta: {},
+            stats: { requests: 0, tokensSaved: 0, inputTokens: 0, cachedTokens: 0, outputTokens: 0, cacheSamples: 0, lastInputTokens: 15000, compressCreditTokens: 0, contextTokens: 0 },
+            metadata: {},
+            state: createInitialState(),
+            createdAt: Date.now(),
+            lastSeen: Date.now(),
+            blockContents: new Map(),
+            inFlight: 0,
+            persisted: false,
+        },
+        log: () => {},
+    };
+}
+
+function withRefs(ctx: ReturnType<typeof makeCtx>): ReturnType<typeof makeCtx> {
+    const res = assignRefs(ctx.messages, { existing: emptyRefMap(), nextIndex: 0 });
+    ctx.session.state.messageRefs = res.map;
+    return ctx;
+}
+
+function makeCtx12(): ReturnType<typeof makeCtx> {
+    const msgs: CoreMessage[] = [];
+    for (let i = 1; i <= 12; i++) {
+        msgs.push(textMsg(`raw_${i}`, i % 2 === 1 ? "user" : "assistant", "x".repeat(5000)));
+    }
+    return withRefs(makeCtx(msgs));
+}
+
+const COMPRESS_ARGS = JSON.stringify({ content: [{ startId: "m00001", endId: "m00006", summary: "ACP-STATUS-TEST-SUMMARY-PAYLOAD-LONG-ENOUGH-FOR-THE-KERNEL-MIN-LENGTH-CHECK" }] });
+
+function rangesSection(report: string): string {
+    const idx = report.indexOf("Compressible ranges");
+    return idx === -1 ? "" : report.slice(idx);
+}
+
+test("#389: acp_status after compress lists no already-compressed refs, without a new prepare", () => {
+    const ctx = makeCtx12();
+    const before = handleAcpStatus({}, ctx);
+    assert.ok(rangesSection(before).includes("m00001"), "pre-compress report lists m00001 as compressible (fixture sanity)");
+
+    const result = applyRanges(parseCompressInput(JSON.parse(COMPRESS_ARGS)), ctx);
+    assert.ok(!result.startsWith("[Compression FAILED"), `compress succeeded (got: ${result.slice(0, 80)})`);
+    assert.ok(ctx.session.state.blocks.some((b) => b.blockId === "b1" && b.active), "block b1 active after compress");
+
+    // No new prepare between the compress and this status call — the exact
+    // #389 scenario. The report must derive ranges/nudge from live state.
+    const after = handleAcpStatus({}, ctx);
+    assert.ok(after.includes("b1"), "base report shows the new active block");
+    assert.ok(!rangesSection(after).includes("m00001"), "compressed refs must not reappear in Compressible ranges");
+    assert.ok(!rangesSection(after).includes("m00006"), "compressed refs must not reappear in Compressible ranges");
+    assert.ok(after.includes("Nudge: "), "Nudge line present and derived from live state");
+});
+
+test("#389: scope= short-circuit returns the live base report only", () => {
+    const ctx = makeCtx12();
+    const out = handleAcpStatus({ scope: "uncompressed" }, ctx);
+    assert.ok(out.includes("UNCOMPRESSED"), "scope= base report present");
+    assert.ok(!out.includes("Compressible ranges"), "scope= output carries no ranges section");
+    assert.ok(!out.includes("Nudge:"), "scope= output carries no nudge line");
+});
+
+function sse(type: string, data: unknown): string {
+    return `event: ${type}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+function fcEvents(outputIndex: number, callId: string, name: string, args: string): string {
+    return [
+        sse("response.output_item.added", { item: { type: "function_call", id: `fc_${callId}`, call_id: callId, name }, output_index: outputIndex }),
+        sse("response.function_call_arguments.delta", { item_id: `fc_${callId}`, delta: args }),
+        sse("response.output_item.done", { item: { type: "function_call", id: `fc_${callId}`, call_id: callId, name, arguments: args }, output_index: outputIndex }),
+    ].join("");
+}
+
+test("#389: same-turn loop — acp_status after compress in one round shows live ranges", async () => {
+    const ctx = makeCtx12();
+    const round1 = [
+        sse("response.created", { response: { id: "resp_1", status: "in_progress" } }),
+        fcEvents(0, "call_c", "compress", COMPRESS_ARGS),
+        fcEvents(1, "call_s", "acp_status", "{}"),
+        sse("response.completed", { response: { id: "resp_1", status: "completed", output: [] } }),
+    ].join("");
+    const refetch = sse("response.completed", { response: { id: "resp_refetch", status: "completed", output: [], usage: { input_tokens: 8000, output_tokens: 5 } } });
+    const orig = globalThis.fetch;
+    globalThis.fetch = (async () => new Response(refetch, { status: 200, headers: { "content-type": "text/event-stream" } })) as typeof fetch;
+    try {
+        const chunks: Buffer[] = [];
+        for await (const chunk of runCompressLoop(new Response(round1, { status: 200 }).body!, ctx, { model: "gpt-4o", input: [], stream: true }, { url: "http://mock", headers: {} }, createResponsesAdapter(), buildCompressSystemPrompt())) {
+            chunks.push(chunk);
+        }
+        const out = Buffer.concat(chunks).toString("utf8");
+        const markerIdx = out.indexOf("acp_status result:");
+        assert.ok(markerIdx !== -1, "acp_status marker emitted");
+        const statusPart = out.slice(markerIdx);
+        assert.ok(statusPart.includes("Compressible ranges"), "responses loop acp_status now carries the ranges section");
+        assert.ok(statusPart.includes("b1"), "status marker shows the newly created block");
+        assert.ok(!statusPart.includes("m00001–m00006"), "compressed range must not be listed as compressible in the same-turn status");
+    } finally {
+        globalThis.fetch = orig;
+    }
+});

--- a/tests/issue404-restore-timestamps.test.ts
+++ b/tests/issue404-restore-timestamps.test.ts
@@ -5,7 +5,7 @@ import { createHash } from "node:crypto";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import { createInitialState } from "acp-kernel";
+import { createCore, createInitialState, defaultConfig } from "acp-kernel";
 import { SessionStore, _setStoreForTest } from "../src/persist.ts";
 import { _resetSessionsForTest, getSession, initSessions, peekSession, type Session } from "../src/session.ts";
 import { handlePluginStatus } from "../src/plugin.ts";
@@ -98,8 +98,9 @@ await test("boot restore: lastSeen=savedAt, restored flag, freshness-keyed trunc
         // activity, never a restored one — the 245-way-tie regression.
         const active = getSession("sess-active", { protocol: "anthropic", label: "ACTIVE" });
         assert.notEqual(active.restored, true, "a session created by a live request is not restored");
+        const statusDeps = { core: createCore(), config: defaultConfig(200000), log: (_l: string, _m: string) => {} };
         const res1 = mockRes();
-        handlePluginStatus("never-seen", res1.res, true);
+        handlePluginStatus("never-seen", res1.res, statusDeps, true);
         const body1 = JSON.parse(res1.body) as { ok: boolean; fallback?: boolean; label: string | null };
         assert.equal(res1.status, 200);
         assert.equal(body1.ok, true);
@@ -109,7 +110,7 @@ await test("boot restore: lastSeen=savedAt, restored flag, freshness-keyed trunc
         // All sessions restored (no activity since boot): refuse to guess.
         _resetSessionsForTest();
         const res2 = mockRes();
-        handlePluginStatus("never-seen", res2.res, true);
+        handlePluginStatus("never-seen", res2.res, statusDeps, true);
         assert.equal(res2.status, 404);
         assert.ok(res2.body.includes("since boot"), "explicit no-post-boot-activity error instead of a readdir-order guess");
     } finally {

--- a/tests/plugin-protocol.test.ts
+++ b/tests/plugin-protocol.test.ts
@@ -330,6 +330,54 @@ test("plugin tool API executes compress under the session lock; next request fol
     }
 });
 
+test("plugin status panel recomputes the nudge after a mid-turn compress (#387)", async () => {
+    const h = await startHarness([compressToolScript(), textScript()]);
+    try {
+        const conv = "plug-conv-panel-fresh";
+        // Same sizing as the tool-API test: the head exceeds
+        // minCompressibleChars while the tail stays inside the
+        // preserveRecentTokens protected zone.
+        const headFiller = "lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. ".repeat(28);
+        const tailFiller = "enim ad minim veniam quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat duis aute irure dolor in reprehenderit in voluptate. ".repeat(28);
+        const history: AnthropicMessage[] = [];
+        for (let i = 1; i <= 2; i++) {
+            history.push({ role: "user", content: `turn-${i}-marker question: ${headFiller}` });
+            history.push({ role: "assistant", content: `turn-${i}-marker answer: ${headFiller}` });
+        }
+        for (let i = 3; i <= 5; i++) {
+            history.push({ role: "user", content: `turn-${i} padding question: ${tailFiller}` });
+            history.push({ role: "assistant", content: `turn-${i} padding answer: ${tailFiller}` });
+        }
+        await callPluginAnthropic(h, conv, history);
+
+        const before = (await (await fetch(`http://127.0.0.1:${h.proxyPort}/__bili/plugin/status?conversationId=${conv}`)).json()) as { panel?: string };
+        assert.match(before.panel ?? "", /m00001/, "pre-compress panel recommends the head range");
+
+        // Compress the head through the plugin tool API — it mutates session
+        // state WITHOUT re-running prepare, which is exactly the window where
+        // the remembered prepare-time nudge goes stale: the old panel mixed
+        // the (live) new block with (stale) already-compressed ranges.
+        const toolResp = await fetch(`http://127.0.0.1:${h.proxyPort}/__bili/plugin/tool`, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+                conversationId: conv,
+                tool: "compress",
+                args: { content: [{ topic: "panel-fresh-topic", startId: "m00001", endId: "m00002", summary: "panel freshness probe compressing the two early lorem-ipsum turns so the status nudge must be recomputed from live state" }] },
+            }),
+        });
+        const toolJson = (await toolResp.json()) as { ok: boolean; result: string };
+        assert.equal(toolJson.ok, true, `compress tool failed: ${toolJson.result}`);
+
+        const after = (await (await fetch(`http://127.0.0.1:${h.proxyPort}/__bili/plugin/status?conversationId=${conv}`)).json()) as { panel?: string };
+        const panel = after.panel ?? "";
+        assert.match(panel, /panel-fresh-topic/, "live state: the new block is listed");
+        assert.doesNotMatch(panel, /m00001\.\.m00002/, "fresh nudge: the just-compressed range is no longer recommended");
+    } finally {
+        await h.close();
+    }
+});
+
 test("plugin tool API error paths: bad JSON, unknown tool, unknown conversation", async () => {
     const h = await startHarness([textScript()]);
     try {


### PR DESCRIPTION
## Problem (#389)

`acp_status` stitched two freshness levels into one report: the base report read live `ctx.session.state`, while the appended "Compressible ranges" + "Nudge:" lines read `ctx.nudge` — a snapshot frozen at request-prepare time and never re-assigned inside the loop. After a successful `compress`, the same-turn `acp_status` still listed the just-compressed range as compressible with the stale nudge value, inviting duplicate/mis-targeted compress calls.

## Fix (issue option 1)

- **New `src/acp-status.ts`** — shared `handleAcpStatus(args, ctx)`. After the base report (and the existing `scope=` short-circuit, which already carried no stale data), it re-runs the kernel's **pure** `processTurn` over `ctx.session.state + ctx.messages` (verified: every pipeline node returns new objects; `syncBlocks` deep-copies state) with `tokenCount = session.stats.lastInputTokens` — the same estimate the next prepare uses — and derives `compressibleRanges` (through the same one-shot `viableRanges` filter the prepare path applies) + `protectedRanges` + the Nudge line from the fresh decision. `turn.state` is intentionally NOT adopted, so nudge cadence bookkeeping is untouched; a recompute failure degrades to the base-only report rather than serving stale data.
- **Converged all three dispatcher copies** (issue acceptance #3): `src/stream.ts` (`executeAnthropicProxyTool`) and `src/compress-loop-responses.ts` (`executeProxyTool`) previously called bare `buildStatusReport` and ignored every option — they now delegate to the shared handler, so all protocols emit the same output shape and honor `scope`/`view`/`tool`/`sort`/`limit`.
- **Removed `LoopCtx.nudge`** and its setters (`src/server.ts`, `src/plugin.ts`) — the frozen snapshot can no longer leak into the report, and the plugin tool path gets the live behavior for free.

## Tests (`tests/acp-status.test.ts`, 3 new)

1. **Acceptance #2**: state change (real `applyRanges` compress) → immediate `handleAcpStatus` with NO new prepare → compressed refs absent from "Compressible ranges", b1 active, Nudge line state-derived.
2. `scope=` short-circuit: base-only, no ranges/Nudge section.
3. **Acceptance #1** end-to-end through `runCompressLoop` + responses adapter: `compress` + `acp_status` in the same round — the acp_status marker no longer lists the just-compressed range.

## Pre-flight

- `npm run typecheck` — clean
- `npm test` — 871/871 pass (868 existing + 3 new)
- `npm run build` — success
- E2E (`tests/e2e/e2e-codex.test.ts`) could NOT run in this environment (no `codex` binary / no local upstream); CI manual-dispatch e2e is available. The loop-level same-turn test above covers the changed pipeline path.

## Also fixed (commit 1a1178d): the plugin /acp panel path

`handlePluginStatus` (src/plugin.ts) built the panel from the nudge remembered at the last model request (prepare-time snapshot). A compress executed through the plugin tool API mutates session.state without re-running prepare, so the panel mixed live blocks with stale, already-consumed ranges. The panel now recomputes the nudge on every status request (`processTurn` over the remembered pre-fold view against the CURRENT session.state; on failure the nudge/ranges sections are omitted instead of falling back to the stale snapshot). `server.ts` passes `{ core, config, log }` as deps. New e2e in `tests/plugin-protocol.test.ts` ("plugin status panel recomputes the nudge after a mid-turn compress") fails pre-fix.

Pre-flight after the panel fix: typecheck clean · 1069 tests, 1067 pass (2 known env fails in plugin-agent.test.ts, unrelated) · build success.
