### PR TITLE
fix: acp_status breakdown uses the CJK-aware estimator (issue #390)

### DIFF
--- a/src/compress-loop-responses.ts
+++ b/src/compress-loop-responses.ts
@@ -1,6 +1,6 @@
 import {
     buildStatusReport,
-    estimateTokensFast,
+    defaultCountTokens,
     type CompressionCore,
     type Config,
     type CoreMessage,
@@ -102,7 +102,7 @@ function executeProxyTool(
         return `Found ${blocks.length} block(s) for "${query}":\n\n${lines.join("\n\n")}`;
     }
     if (toolName === "acp_status") {
-        return buildStatusReport(ctx.session.state, ctx.messages, estimateTokensFast);
+        return buildStatusReport(ctx.session.state, ctx.messages, defaultCountTokens);
     }
     return `[Unknown proxy tool: ${toolName}]`;
 }

--- a/src/loop/core.ts
+++ b/src/loop/core.ts
@@ -1,6 +1,6 @@
 import {
     buildStatusReport,
-    estimateTokensFast,
+    defaultCountTokens,
     formatRanges,
     hideConsumedCompressCalls,
     type CompressionCore,
@@ -145,7 +145,7 @@ function handleAcpStatus(args: Record<string, unknown>, ctx: LoopCtx): string {
     const tool = typeof args.tool === "string" ? args.tool : undefined;
     const sort = typeof args.sort === "string" ? (args.sort as "size" | "time" | "tool" | "age") : undefined;
     const limit = typeof args.limit === "number" ? args.limit : undefined;
-    const base = buildStatusReport(ctx.session.state, ctx.messages, estimateTokensFast, { scope, view, tool, sort, limit });
+    const base = buildStatusReport(ctx.session.state, ctx.messages, defaultCountTokens, { scope, view, tool, sort, limit });
     if (scope) return base;
     const nudge = ctx.nudge;
     const ranges = nudge?.compressibleRanges ?? [];

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,7 +1,7 @@
 import http from "node:http";
 import fs from "node:fs";
 import { randomUUID } from "node:crypto";
-import { createCore, type CompressionCore, type CompressionState, type Config, type CoreMessage, type NudgeDecision, type Prompts, defaultPrompts, defaultCountTokens, estimateTokensFast, renderNudgeText, deactivateBlock, viableRanges } from "acp-kernel";
+import { createCore, type CompressionCore, type CompressionState, type Config, type CoreMessage, type NudgeDecision, type Prompts, defaultPrompts, defaultCountTokens, renderNudgeText, deactivateBlock, viableRanges } from "acp-kernel";
 import { resolveCompress, resolveCompressPrompts, resolveRequestConfig } from "./compress-settings.js";
 import type { ProxyOptions } from "./config.js";
 import { loadOptions, loadRoutes } from "./config.js";

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1,4 +1,4 @@
-import { buildStatusReport, collectBlockContent, estimateTokensFast, type CompressionCore, type Config, type CoreMessage, type CompressionState } from "acp-kernel";
+import { buildStatusReport, collectBlockContent, defaultCountTokens, type CompressionCore, type Config, type CoreMessage, type CompressionState } from "acp-kernel";
 import { type Session, cacheBlockContent } from "./session.js";
 import { COMPRESS_TOOL_NAME, parseCompressInput, PROXY_TOOL_NAMES } from "./compress-tool.js";
 import { resolveDecompress } from "./decompress-shared.js";
@@ -43,7 +43,7 @@ function executeAnthropicProxyTool(toolName: string, args: Record<string, unknow
         return `Found ${blocks.length} block(s) for "${query}":\n\n${lines.join("\n\n")}`;
     }
     if (toolName === "acp_status") {
-        return buildStatusReport(ctx.session.state, ctx.messages, estimateTokensFast);
+        return buildStatusReport(ctx.session.state, ctx.messages, defaultCountTokens);
     }
     return `[Unknown proxy tool: ${toolName}]`;
 }

--- a/tests/loop-core.test.ts
+++ b/tests/loop-core.test.ts
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import type { Config, CoreMessage } from "acp-kernel";
-import { createCore, createInitialState } from "acp-kernel";
+import { assignRefs, createCore, createInitialState } from "acp-kernel";
 import type { Session } from "../src/session.ts";
 import { runCompressLoop, createResponsesAdapter } from "../src/loop/index.ts";
 import { buildCompressSystemPrompt } from "../src/compress-tool.ts";
@@ -87,6 +87,43 @@ test("loop #1: acp_status-only round → marker surfaced + re-request (avoids to
         assert.ok(out.includes("[ACP]"), "acp_status visibility marker surfaced to client");
         assert.ok(/response\.completed/.test(out), "graceful completion present (no 炸锅)");
         assert.equal(fetchCalls, 1, "re-request after acp_status so model can continue (not finish_reason=tool_calls with no body)");
+    } finally {
+        globalThis.fetch = orig;
+    }
+});
+
+test("loop #390: acp_status breakdown uses the CJK-aware scale (no 4x underestimate)", async () => {
+    // 4000 CJK chars = 4000 tokens on defaultCountTokens (the nudge's scale),
+    // 1000 on estimateTokensFast — the old acp_status scale (issue #390).
+    const messages: CoreMessage[] = [
+        { id: "m1", role: "user", contentType: "text", text: "中".repeat(4_000) },
+    ];
+    const ctx = makeCtx(messages, "responses");
+    ctx.session.state.messageRefs = assignRefs(messages, {
+        existing: ctx.session.state.messageRefs,
+        nextIndex: 1,
+    }).map;
+    const round1 = [
+        sse("response.created", { response: { id: "resp_1", status: "in_progress" } }),
+        fcEvents(0, "call_status", "acp_status", "{}"),
+        COMPLETED,
+    ].join("");
+    let captured = "";
+    const orig = globalThis.fetch;
+    globalThis.fetch = (async (_url: unknown, init?: RequestInit) => {
+        captured = typeof init?.body === "string" ? init.body : "";
+        return new Response(COMPLETED, { status: 200 });
+    }) as typeof fetch;
+    try {
+        await drain(
+            new Response(round1, { status: 200 }).body!,
+            ctx,
+            { model: "gpt-4o", input: [], stream: true },
+            { url: "http://mock", headers: {} },
+        );
+        assert.ok(captured, "re-request after acp_status carries the report");
+        assert.match(captured, /4\.0K text \(100%\)/, "CJK counted 1:1, not chars/4");
+        assert.doesNotMatch(captured, /1\.0K text \(100%\)/, "chars/4 scale must not appear");
     } finally {
         globalThis.fetch = orig;
     }


### PR DESCRIPTION
## What

Issue #390, bili-side half. The `acp_status` CONTEXT BREAKDOWN passed `estimateTokensFast` (chars/4) to `buildStatusReport` while the nudge-side breakdown (same session, same report output) runs on the core's CJK-aware `defaultCountTokens` — so in Chinese sessions the report systematically underestimated ~4×, and the two surfaces in one `acp_status` answer used different scales without any label.

- `src/loop/core.ts` (unified-loop `handleAcpStatus`), `src/stream.ts`, `src/compress-loop-responses.ts`: pass `defaultCountTokens` instead of `estimateTokensFast` to `buildStatusReport` — one scale for the whole report, matching the nudge and the panel's Session-only contract.
- `src/server.ts`: drop the now-unused `estimateTokensFast` import.
- No `src/plugin.ts` arithmetic change: `unprunedTokens` already uses `defaultCountTokens`, same estimator as the nudge breakdown (`createCore()` is called without injected ports) — the #18-family defect there was the kernel's `panel.ts` docstring claiming "chars/4"; fixed in acp-kernel PR #177.

## Tests

- `tests/loop-core.test.ts`: new regression — an acp_status round over a 4000-CJK-char message must print `4.0K text (100%)` (CJK 1:1), and the old chars/4 scale (`1.0K`) must not appear.

## Pre-flight

- `npm run typecheck` — clean
- `npm test` — 869/869 pass
- `npm run build` — clean

## Companion PR (kernel-side half of #390)

acp-kernel#177 fixes the remaining defects: tool-results misclassified as text in the breakdown (field-selection bug), the two conflicting "tool" definitions (now one shared `isToolMessage`), the pct 1% floor, and the panel scale-contract comments. **Follow-up after acp-kernel#177 releases**: bump `acp-kernel` here to the new version (exact pin, per AGENTS.md §5 cross-repo rule) so the bundled dist picks up the tool-bucket fix.