### PR TITLE
fix: wire search_context to the kernel search engine (blocks + visible messages, CJK)

### DIFF
--- a/src/compress-loop-responses.ts
+++ b/src/compress-loop-responses.ts
@@ -90,7 +90,7 @@ function executeProxyTool(
         return resolveDecompress(args, ctx);
     }
     if (toolName === "search_context") {
-        return handleSearchContext(args, ctx.session.state, ctx.messages);
+        return handleSearchContext(args, ctx.session, ctx.messages);
     }
     if (toolName === "acp_status") {
         return buildStatusReport(ctx.session.state, ctx.messages, estimateTokensFast);

--- a/src/compress-loop-responses.ts
+++ b/src/compress-loop-responses.ts
@@ -10,6 +10,7 @@ import { parseCompressInput, PROXY_TOOL_NAMES, MUTATING_PROXY_TOOLS, COMPRESS_TO
 import { log as loggerLog } from "./logger.js";
 import { applyRanges } from "./stream.js";
 import { resolveDecompress } from "./decompress-shared.js";
+import { handleSearchContext } from "./search-context.js";
 import { buildVisibilityMarker } from "./compress-loop.js";
 import { MAX_LOOP_ROUNDS } from "./loop/index.js";
 import { stripResponsesText } from "./loop/tag-echo-filter.js";
@@ -89,17 +90,7 @@ function executeProxyTool(
         return resolveDecompress(args, ctx);
     }
     if (toolName === "search_context") {
-        const query = typeof args.query === "string" ? args.query : "";
-        if (query.length === 0) return "[search_context FAILED: query is required]";
-        const limit = typeof args.limit === "number" && args.limit > 0 ? Math.floor(args.limit) : 5;
-        const blocks = ctx.core.search(query, ctx.session.state).slice(0, limit);
-        if (blocks.length === 0) return `[No blocks matched "${query}"]`;
-        const lines = blocks.map((b) => {
-            const topic = b.topic ?? "(no topic)";
-            const preview = b.summary.length > 200 ? b.summary.slice(0, 200) + "..." : b.summary;
-            return `${b.blockId} (T${b.tier}) "${topic}"\n  ${preview}`;
-        });
-        return `Found ${blocks.length} block(s) for "${query}":\n\n${lines.join("\n\n")}`;
+        return handleSearchContext(args, ctx.session.state, ctx.messages);
     }
     if (toolName === "acp_status") {
         return buildStatusReport(ctx.session.state, ctx.messages, estimateTokensFast);

--- a/src/compress-tool.ts
+++ b/src/compress-tool.ts
@@ -71,13 +71,12 @@ export {
     buildCompressHybridSystemPrompt,
 } from "acp-kernel";
 
-// The proxy's search_context indexes the FOLDED ORIGINALS of active blocks
-// (error text, paths, variable names that summaries drop) with each summary
-// as a secondary signal (src/search-context.ts); the kernel schema only
-// promises block summaries, so the description is overridden to match the
-// implementation.
+// The proxy's search_context indexes the ORIGINAL text of folded-away
+// messages across ALL blocks (active or inactive) plus block summaries as a
+// secondary signal (src/search-context.ts); the kernel schema only promises
+// summaries, so the description is overridden to match the implementation.
 const SEARCH_CONTEXT_DESCRIPTION =
-    "Searches the FOLDED ORIGINAL CONTENT of compressed blocks — error text, file paths, and variable names that summaries drop — plus each block's summary as a secondary signal (English + Chinese/CJK). Use BEFORE decompressing to find the right block; every hit is a decompressable blockId. Hits marked [summary-only] mean the block's originals are gone from every payload and only its summary was searched.";
+    "Searches the ORIGINAL text of folded-away messages across ALL compressed blocks (any tier, active or archived) plus block summaries as a secondary signal (English + Chinese/CJK). Visible messages are not indexed — they are already in context. Use to locate which block holds a detail (an exact error string, a path, a value); message hits name the owning block, then decompress it. Hits marked summary-only mean the block's originals are gone from every payload and only its summary was searched.";
 
 export const SEARCH_CONTEXT_TOOL = { ..._SEARCH_CONTEXT_TOOL, description: SEARCH_CONTEXT_DESCRIPTION };
 export const SEARCH_CONTEXT_TOOL_OPENAI = {

--- a/src/compress-tool.ts
+++ b/src/compress-tool.ts
@@ -71,11 +71,13 @@ export {
     buildCompressHybridSystemPrompt,
 } from "acp-kernel";
 
-// The proxy's search_context searches active summary blocks AND the visible
-// conversation (src/search-context.ts); the kernel schema only promises
-// blocks, so the description is overridden to match the implementation.
+// The proxy's search_context indexes the FOLDED ORIGINALS of active blocks
+// (error text, paths, variable names that summaries drop) with each summary
+// as a secondary signal (src/search-context.ts); the kernel schema only
+// promises block summaries, so the description is overridden to match the
+// implementation.
 const SEARCH_CONTEXT_DESCRIPTION =
-    "Searches compressed block summaries AND visible conversation messages by keyword (English + Chinese/CJK). Use BEFORE decompressing to find the right block, or to locate content still in context.";
+    "Searches the FOLDED ORIGINAL CONTENT of compressed blocks — error text, file paths, and variable names that summaries drop — plus each block's summary as a secondary signal (English + Chinese/CJK). Use BEFORE decompressing to find the right block; every hit is a decompressable blockId. Hits marked [summary-only] mean the block's originals are gone from every payload and only its summary was searched.";
 
 export const SEARCH_CONTEXT_TOOL = { ..._SEARCH_CONTEXT_TOOL, description: SEARCH_CONTEXT_DESCRIPTION };
 export const SEARCH_CONTEXT_TOOL_OPENAI = {

--- a/src/compress-tool.ts
+++ b/src/compress-tool.ts
@@ -11,7 +11,39 @@
 import { parseCompressArgs } from "acp-kernel";
 import { log as loggerLog } from "./logger.js";
 import { maxShrinkPerCompress } from "./fetch-util.js";
+import {
+    ACP_READONLY_TOOLS_RESPONSES as _ACP_READONLY_TOOLS_RESPONSES,
+    ACP_STATUS_TOOL,
+    ACP_STATUS_TOOL_NAME,
+    ACP_STATUS_TOOL_OPENAI,
+    ACP_STATUS_TOOL_RESPONSES,
+    ACP_TEXT_OPEN,
+    ACP_TEXT_CLOSE,
+    ACP_STATUS_OPEN,
+    ACP_STATUS_CLOSE,
+    ACP_SEARCH_OPEN,
+    ACP_SEARCH_CLOSE,
+    ACP_DECOMPRESS_OPEN,
+    ACP_DECOMPRESS_CLOSE,
+    ACP_TOOLS_ANTHROPIC as _ACP_TOOLS_ANTHROPIC,
+    ACP_TOOLS_OPENAI as _ACP_TOOLS_OPENAI,
+    ACP_TOOLS_RESPONSES as _ACP_TOOLS_RESPONSES,
+    COMPRESS_TOOL,
+    COMPRESS_TOOL_NAME,
+    COMPRESS_TOOL_OPENAI,
+    COMPRESS_TOOL_RESPONSES,
+    DECOMPRESS_TOOL,
+    DECOMPRESS_TOOL_NAME,
+    DECOMPRESS_TOOL_OPENAI,
+    DECOMPRESS_TOOL_RESPONSES,
+    SEARCH_CONTEXT_TOOL as _SEARCH_CONTEXT_TOOL,
+    SEARCH_CONTEXT_TOOL_NAME,
+    SEARCH_CONTEXT_TOOL_OPENAI as _SEARCH_CONTEXT_TOOL_OPENAI,
+    SEARCH_CONTEXT_TOOL_RESPONSES as _SEARCH_CONTEXT_TOOL_RESPONSES,
+} from "acp-kernel";
 
+export type { ParsedRange } from "acp-kernel";
+export { ACP_TOOL_NAMES as PROXY_TOOL_NAMES, ACP_MUTATING_TOOLS as MUTATING_PROXY_TOOLS, ACP_READONLY_TOOLS as READONLY_PROXY_TOOLS } from "acp-kernel";
 export {
     COMPRESS_TOOL_NAME,
     DECOMPRESS_TOOL_NAME,
@@ -31,22 +63,41 @@ export {
     DECOMPRESS_TOOL,
     DECOMPRESS_TOOL_OPENAI,
     DECOMPRESS_TOOL_RESPONSES,
-    SEARCH_CONTEXT_TOOL,
-    SEARCH_CONTEXT_TOOL_OPENAI,
-    SEARCH_CONTEXT_TOOL_RESPONSES,
     ACP_STATUS_TOOL,
     ACP_STATUS_TOOL_OPENAI,
     ACP_STATUS_TOOL_RESPONSES,
-    ACP_TOOLS_OPENAI,
-    ACP_TOOLS_ANTHROPIC,
-    ACP_TOOLS_RESPONSES,
-    ACP_READONLY_TOOLS_RESPONSES,
     buildCompressSystemPrompt,
     buildCompressTextSystemPrompt,
     buildCompressHybridSystemPrompt,
 } from "acp-kernel";
-export type { ParsedRange } from "acp-kernel";
-export { ACP_TOOL_NAMES as PROXY_TOOL_NAMES, ACP_MUTATING_TOOLS as MUTATING_PROXY_TOOLS, ACP_READONLY_TOOLS as READONLY_PROXY_TOOLS } from "acp-kernel";
+
+// The proxy's search_context searches active summary blocks AND the visible
+// conversation (src/search-context.ts); the kernel schema only promises
+// blocks, so the description is overridden to match the implementation.
+const SEARCH_CONTEXT_DESCRIPTION =
+    "Searches compressed block summaries AND visible conversation messages by keyword (English + Chinese/CJK). Use BEFORE decompressing to find the right block, or to locate content still in context.";
+
+export const SEARCH_CONTEXT_TOOL = { ..._SEARCH_CONTEXT_TOOL, description: SEARCH_CONTEXT_DESCRIPTION };
+export const SEARCH_CONTEXT_TOOL_OPENAI = {
+    ..._SEARCH_CONTEXT_TOOL_OPENAI,
+    function: { ..._SEARCH_CONTEXT_TOOL_OPENAI.function, description: SEARCH_CONTEXT_DESCRIPTION },
+};
+export const SEARCH_CONTEXT_TOOL_RESPONSES = { ..._SEARCH_CONTEXT_TOOL_RESPONSES, description: SEARCH_CONTEXT_DESCRIPTION };
+
+export const ACP_TOOLS_OPENAI = _ACP_TOOLS_OPENAI.map((t) =>
+    t.function.name === SEARCH_CONTEXT_TOOL_NAME
+        ? { ...t, function: { ...t.function, description: SEARCH_CONTEXT_DESCRIPTION } }
+        : t,
+);
+export const ACP_TOOLS_ANTHROPIC = _ACP_TOOLS_ANTHROPIC.map((t) =>
+    t.name === SEARCH_CONTEXT_TOOL_NAME ? { ...t, description: SEARCH_CONTEXT_DESCRIPTION } : t,
+);
+export const ACP_TOOLS_RESPONSES = _ACP_TOOLS_RESPONSES.map((t) =>
+    t.name === SEARCH_CONTEXT_TOOL_NAME ? { ...t, description: SEARCH_CONTEXT_DESCRIPTION } : t,
+);
+export const ACP_READONLY_TOOLS_RESPONSES = _ACP_READONLY_TOOLS_RESPONSES.map((t) =>
+    t.name === SEARCH_CONTEXT_TOOL_NAME ? { ...t, description: SEARCH_CONTEXT_DESCRIPTION } : t,
+);
 
 export function parseCompressInput(input: unknown, callId?: string) {
     const { ranges, diagnostics } = parseCompressArgs(input, { callId });

--- a/src/loop/core.ts
+++ b/src/loop/core.ts
@@ -110,7 +110,7 @@ export function executeProxyTool(
         return resolveDecompress(args, ctx);
     }
     if (toolName === "search_context") {
-        return handleSearchContext(args, ctx.session.state, ctx.messages);
+        return handleSearchContext(args, ctx.session, ctx.messages);
     }
     if (toolName === "acp_status") {
         return handleAcpStatus(args, ctx);

--- a/src/loop/core.ts
+++ b/src/loop/core.ts
@@ -16,6 +16,7 @@ import {
 } from "../compress-tool.js";
 import { applyRanges } from "../stream.js";
 import { resolveDecompress } from "../decompress-shared.js";
+import { handleSearchContext } from "../search-context.js";
 import { buildVisibilityMarker } from "../compress-loop.js";
 import { fetchWithRetry, UpstreamHttpError } from "../fetch-util.js";
 import { proxyDispatcher } from "../upstream-proxy.js";
@@ -109,17 +110,7 @@ export function executeProxyTool(
         return resolveDecompress(args, ctx);
     }
     if (toolName === "search_context") {
-        const query = typeof args.query === "string" ? args.query : "";
-        if (query.length === 0) return "[search_context FAILED: query is required]";
-        const limit = typeof args.limit === "number" && args.limit > 0 ? Math.floor(args.limit) : 5;
-        const blocks = ctx.core.search(query, ctx.session.state).slice(0, limit);
-        if (blocks.length === 0) return `[No blocks matched "${query}"]`;
-        const lines = blocks.map((b) => {
-            const topic = b.topic ?? "(no topic)";
-            const preview = b.summary.length > 200 ? b.summary.slice(0, 200) + "..." : b.summary;
-            return `${b.blockId} (T${b.tier}) "${topic}"\n  ${preview}`;
-        });
-        return `Found ${blocks.length} block(s) for "${query}":\n\n${lines.join("\n\n")}`;
+        return handleSearchContext(args, ctx.session.state, ctx.messages);
     }
     if (toolName === "acp_status") {
         return handleAcpStatus(args, ctx);

--- a/src/search-context.ts
+++ b/src/search-context.ts
@@ -1,0 +1,72 @@
+// search_context handler shared by all three compress loops. Deliberately
+// bypasses core.search (active-only corpus, exact-substring scorer whose
+// 0.1 threshold a single summary hit could never reach) in favor of the
+// kernel's published engine: hybrid BM25+fuzzy, CJK-aware, corpus =
+// active blocks + visible messages.
+import {
+    blockDocs,
+    messageDocs,
+    searchBlocks,
+    type CompressionState,
+    type CoreMessage,
+    type MessageInput,
+} from "acp-kernel";
+
+export function parseSearchContextArgs(args: Record<string, unknown>): { query: string; limit: number } {
+    const query = typeof args.query === "string" ? args.query : "";
+    const limit = typeof args.limit === "number" && args.limit > 0 ? Math.floor(args.limit) : 5;
+    return { query, limit };
+}
+
+function visibleMessageInputs(state: CompressionState, messages: CoreMessage[]): MessageInput[] {
+    const byRaw = state.messageRefs.byRaw;
+    const out: MessageInput[] = [];
+    for (const m of messages) {
+        const ref = byRaw[m.id];
+        if (typeof ref !== "string" || ref.length === 0) continue;
+        if (m.role === "system") continue;
+        const text = m.text ?? "";
+        if (text.length === 0) continue;
+        const role =
+            m.role === "tool" || m.contentType === "tool-call" || m.contentType === "tool-result"
+                ? "tool"
+                : m.role;
+        out.push({ ref, role, text });
+    }
+    return out;
+}
+
+export function handleSearchContext(
+    args: Record<string, unknown>,
+    state: CompressionState,
+    messages: CoreMessage[],
+): string {
+    const { query, limit } = parseSearchContextArgs(args);
+    if (query.length === 0) return "[search_context FAILED: query is required]";
+
+    const activeBlockIds = new Set(state.blocks.filter((b) => b.active).map((b) => b.blockId));
+    const blockCorpus = blockDocs(state).filter((d) => activeBlockIds.has(d.ref));
+    const messageInputs = visibleMessageInputs(state, messages);
+    const results = searchBlocks([...blockCorpus, ...messageDocs(messageInputs)], query, { limit });
+
+    if (results.length === 0) {
+        return `[No matches for "${query}" — searched ${blockCorpus.length} block(s) and ${messageInputs.length} visible message(s). Compressed content is searchable only through its summary; try a broader term, or decompress the block you suspect holds it.]`;
+    }
+
+    const lines = results.map((r) => {
+        if (r.kind === "block") {
+            const topic = r.title === r.ref ? "(no topic)" : r.title;
+            return `${r.ref} (T${r.tier}) "${topic}"\n  ${r.preview}`;
+        }
+        return `${r.ref} (${r.role ?? "message"})\n  ${r.preview}`;
+    });
+    const blockHits = results.filter((r) => r.kind === "block").length;
+    const messageHits = results.length - blockHits;
+    const what = [
+        blockHits > 0 ? `${blockHits} block(s)` : "",
+        messageHits > 0 ? `${messageHits} message(s)` : "",
+    ]
+        .filter(Boolean)
+        .join(", ");
+    return `Found ${what} for "${query}":\n\n${lines.join("\n\n")}`;
+}

--- a/src/search-context.ts
+++ b/src/search-context.ts
@@ -1,16 +1,21 @@
-// search_context handler shared by all three compress loops. Deliberately
-// bypasses core.search (active-only corpus, exact-substring scorer whose
-// 0.1 threshold a single summary hit could never reach) in favor of the
-// kernel's published engine: hybrid BM25+fuzzy, CJK-aware, corpus =
-// active blocks + visible messages.
+// search_context handler shared by all three compress loops. Corpus = the
+// FOLDED ORIGINALS of active blocks (error text, paths, variable names that
+// summaries drop), via the kernel's published engine (hybrid BM25+fuzzy,
+// CJK-aware). Visible messages are NOT indexed — they are already in the
+// model's attention. Folding only rewrites the view forwarded upstream: the
+// client re-sends complete history every turn, so originals live in
+// session.lastMessages even though ctx.messages (folded view) has them
+// emptied; the blockContents cache (captured at compress time) is the fast
+// path and survives client-side history deletion (native compaction).
 import {
-    blockDocs,
-    messageDocs,
+    collectBlockContent,
     searchBlocks,
+    type CompressionBlock,
     type CompressionState,
     type CoreMessage,
-    type MessageInput,
+    type SearchDoc,
 } from "acp-kernel";
+import type { Session } from "./session.js";
 
 export function parseSearchContextArgs(args: Record<string, unknown>): { query: string; limit: number } {
     const query = typeof args.query === "string" ? args.query : "";
@@ -18,55 +23,70 @@ export function parseSearchContextArgs(args: Record<string, unknown>): { query: 
     return { query, limit };
 }
 
-function visibleMessageInputs(state: CompressionState, messages: CoreMessage[]): MessageInput[] {
-    const byRaw = state.messageRefs.byRaw;
-    const out: MessageInput[] = [];
-    for (const m of messages) {
-        const ref = byRaw[m.id];
-        if (typeof ref !== "string" || ref.length === 0) continue;
-        if (m.role === "system") continue;
-        const text = m.text ?? "";
-        if (text.length === 0) continue;
-        const role =
-            m.role === "tool" || m.contentType === "tool-call" || m.contentType === "tool-result"
-                ? "tool"
-                : m.role;
-        out.push({ ref, role, text });
-    }
-    return out;
+// Kernel prune empties folded messages (text: ""), so collectBlockContent on
+// the folded view renders role headers only — headers are not content.
+function hasSubstance(text: string): boolean {
+    return text.replace(/^\[[^\]]*\]\s*$/gm, "").trim().length > 0;
+}
+
+function collectFromSource(state: CompressionState, block: CompressionBlock, source: CoreMessage[] | undefined): string {
+    if (!source || source.length === 0) return "";
+    const collected = collectBlockContent(state, block, source, { full: true });
+    if (collected.count === 0 || !hasSubstance(collected.text)) return "";
+    return collected.text;
+}
+
+// "" when the originals are gone from every payload (then the caller falls
+// back to the summary and annotates the result).
+function blockOriginals(state: CompressionState, block: CompressionBlock, session: Session, messages: CoreMessage[]): string {
+    const cached = session.blockContents.get(block.blockId)?.full.text;
+    if (cached && hasSubstance(cached)) return cached;
+    return collectFromSource(state, block, session.lastMessages) || collectFromSource(state, block, messages);
 }
 
 export function handleSearchContext(
     args: Record<string, unknown>,
-    state: CompressionState,
+    session: Session,
     messages: CoreMessage[],
 ): string {
     const { query, limit } = parseSearchContextArgs(args);
     if (query.length === 0) return "[search_context FAILED: query is required]";
+    const state = session.state;
 
-    const activeBlockIds = new Set(state.blocks.filter((b) => b.active).map((b) => b.blockId));
-    const blockCorpus = blockDocs(state).filter((d) => activeBlockIds.has(d.ref));
-    const messageInputs = visibleMessageInputs(state, messages);
-    const results = searchBlocks([...blockCorpus, ...messageDocs(messageInputs)], query, { limit });
+    const docs: SearchDoc[] = [];
+    const summaryOnly = new Set<string>();
+    let withOriginals = 0;
+    for (const b of state.blocks) {
+        if (!b.active) continue;
+        const base: Omit<SearchDoc, "text"> = {
+            kind: "block",
+            ref: b.blockId,
+            title: b.topic ?? b.blockId,
+            blockId: b.blockId,
+            tier: b.tier ?? 1,
+            tokens: b.compressedTokens,
+        };
+        const originals = blockOriginals(state, b, session, messages);
+        if (originals) {
+            withOriginals++;
+            // Summary appended as a secondary signal, not the corpus.
+            docs.push({ ...base, text: `${originals}\n\n${b.topic ?? ""} ${b.summary ?? ""}`.trim() });
+        } else {
+            summaryOnly.add(b.blockId);
+            docs.push({ ...base, text: `${b.topic ?? ""} ${b.summary ?? ""}`.trim() });
+        }
+    }
+
+    const results = searchBlocks(docs, query, { limit });
 
     if (results.length === 0) {
-        return `[No matches for "${query}" — searched ${blockCorpus.length} block(s) and ${messageInputs.length} visible message(s). Compressed content is searchable only through its summary; try a broader term, or decompress the block you suspect holds it.]`;
+        return `[No matches for "${query}" — searched ${docs.length} active block(s) (${withOriginals} with folded originals, ${summaryOnly.size} summary-only). Try a broader term, or decompress the block you suspect holds it.]`;
     }
 
     const lines = results.map((r) => {
-        if (r.kind === "block") {
-            const topic = r.title === r.ref ? "(no topic)" : r.title;
-            return `${r.ref} (T${r.tier}) "${topic}"\n  ${r.preview}`;
-        }
-        return `${r.ref} (${r.role ?? "message"})\n  ${r.preview}`;
+        const topic = r.title === r.ref ? "(no topic)" : r.title;
+        const marker = summaryOnly.has(r.ref) ? " [summary-only]" : "";
+        return `${r.ref} (T${r.tier}) "${topic}"${marker}\n  ${r.preview}`;
     });
-    const blockHits = results.filter((r) => r.kind === "block").length;
-    const messageHits = results.length - blockHits;
-    const what = [
-        blockHits > 0 ? `${blockHits} block(s)` : "",
-        messageHits > 0 ? `${messageHits} message(s)` : "",
-    ]
-        .filter(Boolean)
-        .join(", ");
-    return `Found ${what} for "${query}":\n\n${lines.join("\n\n")}`;
+    return `Found ${results.length} block(s) for "${query}":\n\n${lines.join("\n\n")}`;
 }

--- a/src/search-context.ts
+++ b/src/search-context.ts
@@ -1,18 +1,28 @@
-// search_context handler shared by all three compress loops. Corpus = the
-// FOLDED ORIGINALS of active blocks (error text, paths, variable names that
-// summaries drop), via the kernel's published engine (hybrid BM25+fuzzy,
-// CJK-aware). Visible messages are NOT indexed — they are already in the
-// model's attention. Folding only rewrites the view forwarded upstream: the
-// client re-sends complete history every turn, so originals live in
-// session.lastMessages even though ctx.messages (folded view) has them
-// emptied; the blockContents cache (captured at compress time) is the fast
-// path and survives client-side history deletion (native compaction).
+// search_context handler shared by all three compress loops.
+//
+// Corpus (maintainer directive, PR#415 review):
+//   1. PRIMARY — the ORIGINAL text of folded-away messages, indexed
+//      per-message so role weighting works and each hit names the exact
+//      owning block. Coverage is decided by block effectiveMessageIds over
+//      ALL blocks (active or inactive): tier-2+ compression deactivates
+//      tier-1 blocks whose originals remain the finest-grained retrieval
+//      unit, and decompress ignores `active`. Originals ride in the log the
+//      client re-sends every turn (session.lastMessages snapshot).
+//   2. CACHE — blocks whose originals no longer appear in the log
+//      (client-side native compaction deleted them) fall back to the
+//      blockContents cache captured at compress time, indexed as one
+//      block-level doc of real original text.
+//   3. SUMMARY — every block's summary as a secondary signal; blocks with
+//      neither log originals nor cache are marked "summary only".
+//   Visible (uncovered) messages are NOT indexed: they are already in
+//   the model's attention, searching them is redundant.
 import {
-    collectBlockContent,
+    messageDocs,
     searchBlocks,
     type CompressionBlock,
     type CompressionState,
     type CoreMessage,
+    type MessageInput,
     type SearchDoc,
 } from "acp-kernel";
 import type { Session } from "./session.js";
@@ -23,25 +33,60 @@ export function parseSearchContextArgs(args: Record<string, unknown>): { query: 
     return { query, limit };
 }
 
-// Kernel prune empties folded messages (text: ""), so collectBlockContent on
-// the folded view renders role headers only — headers are not content.
+/** Most specific block covering `rawId`: deepest tier first, then smallest coverage. */
+function ownerOf(state: CompressionState, rawId: string): CompressionBlock | undefined {
+    let best: CompressionBlock | undefined;
+    for (const b of state.blocks) {
+        if (!b.effectiveMessageIds.includes(rawId)) continue;
+        if (
+            !best ||
+            b.tier < best.tier ||
+            (b.tier === best.tier && b.effectiveMessageIds.length < best.effectiveMessageIds.length)
+        ) {
+            best = b;
+        }
+    }
+    return best;
+}
+
+function foldedMessageInputs(state: CompressionState, log: CoreMessage[]): MessageInput[] {
+    const byRaw = state.messageRefs.byRaw;
+    const foldedRaw = new Set<string>();
+    for (const b of state.blocks) {
+        for (const id of b.effectiveMessageIds) foldedRaw.add(id);
+    }
+    const out: MessageInput[] = [];
+    const seen = new Set<string>();
+    for (const m of log) {
+        if (seen.has(m.id)) continue;
+        seen.add(m.id);
+        if (!foldedRaw.has(m.id)) continue;
+        if (m.role === "system") continue;
+        const text = m.text ?? "";
+        if (text.length === 0) continue;
+        const ref = byRaw[m.id];
+        if (typeof ref !== "string" || ref.length === 0) continue;
+        const owner = ownerOf(state, m.id);
+        const role =
+            m.role === "tool" || m.contentType === "tool-call" || m.contentType === "tool-result"
+                ? "tool"
+                : m.role;
+        out.push({ ref, role, text, blockId: owner?.blockId, tier: owner?.tier });
+    }
+    return out;
+}
+
+// Kernel prune empties folded messages (text: ""), so collected text that
+// renders role headers only carries no content.
 function hasSubstance(text: string): boolean {
     return text.replace(/^\[[^\]]*\]\s*$/gm, "").trim().length > 0;
 }
 
-function collectFromSource(state: CompressionState, block: CompressionBlock, source: CoreMessage[] | undefined): string {
-    if (!source || source.length === 0) return "";
-    const collected = collectBlockContent(state, block, source, { full: true });
-    if (collected.count === 0 || !hasSubstance(collected.text)) return "";
-    return collected.text;
-}
-
-// "" when the originals are gone from every payload (then the caller falls
-// back to the summary and annotates the result).
-function blockOriginals(state: CompressionState, block: CompressionBlock, session: Session, messages: CoreMessage[]): string {
-    const cached = session.blockContents.get(block.blockId)?.full.text;
-    if (cached && hasSubstance(cached)) return cached;
-    return collectFromSource(state, block, session.lastMessages) || collectFromSource(state, block, messages);
+function blockHasOriginals(blockId: string, byId: Map<string, CompressionBlock>, owners: Set<string>): boolean {
+    const b = byId.get(blockId);
+    if (!b) return false;
+    if (owners.has(blockId)) return true;
+    return b.directBlockIds.some((id) => blockHasOriginals(id, byId, owners));
 }
 
 export function handleSearchContext(
@@ -52,41 +97,64 @@ export function handleSearchContext(
     const { query, limit } = parseSearchContextArgs(args);
     if (query.length === 0) return "[search_context FAILED: query is required]";
     const state = session.state;
+    const log = session.lastMessages && session.lastMessages.length > 0 ? session.lastMessages : messages;
 
-    const docs: SearchDoc[] = [];
+    const messageInputs = foldedMessageInputs(state, log);
+    const owners = new Set(
+        messageInputs.map((m) => m.blockId).filter((b): b is string => typeof b === "string"),
+    );
+    const byId = new Map(state.blocks.map((b) => [b.blockId, b] as const));
+
+    const docs: SearchDoc[] = [...messageDocs(messageInputs)];
     const summaryOnly = new Set<string>();
-    let withOriginals = 0;
+    let cachedBlocks = 0;
     for (const b of state.blocks) {
-        if (!b.active) continue;
         const base: Omit<SearchDoc, "text"> = {
             kind: "block",
             ref: b.blockId,
             title: b.topic ?? b.blockId,
             blockId: b.blockId,
-            tier: b.tier ?? 1,
+            tier: b.tier,
             tokens: b.compressedTokens,
         };
-        const originals = blockOriginals(state, b, session, messages);
-        if (originals) {
-            withOriginals++;
-            // Summary appended as a secondary signal, not the corpus.
-            docs.push({ ...base, text: `${originals}\n\n${b.topic ?? ""} ${b.summary ?? ""}`.trim() });
+        const summaryText = `${b.topic ?? ""} ${b.summary ?? ""}`.trim();
+        if (blockHasOriginals(b.blockId, byId, owners)) {
+            docs.push({ ...base, text: summaryText });
+            continue;
+        }
+        const cached = session.blockContents.get(b.blockId)?.full;
+        if (cached && hasSubstance(cached.text)) {
+            cachedBlocks++;
+            docs.push({ ...base, text: `${cached.text}\n\n${summaryText}`.trim() });
         } else {
             summaryOnly.add(b.blockId);
-            docs.push({ ...base, text: `${b.topic ?? ""} ${b.summary ?? ""}`.trim() });
+            docs.push({ ...base, text: summaryText });
         }
     }
 
     const results = searchBlocks(docs, query, { limit });
 
     if (results.length === 0) {
-        return `[No matches for "${query}" — searched ${docs.length} active block(s) (${withOriginals} with folded originals, ${summaryOnly.size} summary-only). Try a broader term, or decompress the block you suspect holds it.]`;
+        return `[No matches for "${query}" — searched ${state.blocks.length} block(s) (${owners.size + cachedBlocks} with folded originals, ${summaryOnly.size} summary-only) and ${messageInputs.length} folded-away message(s). Folded originals are matched on full text. Try a broader term, or decompress the block you suspect holds it.]`;
     }
 
     const lines = results.map((r) => {
-        const topic = r.title === r.ref ? "(no topic)" : r.title;
-        const marker = summaryOnly.has(r.ref) ? " [summary-only]" : "";
-        return `${r.ref} (T${r.tier}) "${topic}"${marker}\n  ${r.preview}`;
+        if (r.kind === "block") {
+            const topic = r.title === r.ref ? "(no topic)" : r.title;
+            const mark = summaryOnly.has(r.ref) ? ", summary only" : "";
+            return `${r.ref} (T${r.tier}${mark}) "${topic}"\n  ${r.preview}`;
+        }
+        return r.blockId
+            ? `${r.ref} (${r.role ?? "message"}, in ${r.blockId})\n  ${r.preview}`
+            : `${r.ref} (${r.role ?? "message"})\n  ${r.preview}`;
     });
-    return `Found ${results.length} block(s) for "${query}":\n\n${lines.join("\n\n")}`;
+    const blockHits = results.filter((r) => r.kind === "block").length;
+    const messageHits = results.length - blockHits;
+    const what = [
+        blockHits > 0 ? `${blockHits} block(s)` : "",
+        messageHits > 0 ? `${messageHits} message(s)` : "",
+    ]
+        .filter(Boolean)
+        .join(", ");
+    return `Found ${what} for "${query}":\n\n${lines.join("\n\n")}`;
 }

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -202,7 +202,7 @@ function executeAnthropicProxyTool(toolName: string, args: Record<string, unknow
         return resolveDecompress(args, ctx);
     }
     if (toolName === "search_context") {
-        return handleSearchContext(args, ctx.session.state, ctx.messages);
+        return handleSearchContext(args, ctx.session, ctx.messages);
     }
     if (toolName === "acp_status") {
         return buildStatusReport(ctx.session.state, ctx.messages, estimateTokensFast);

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -2,6 +2,7 @@ import { buildStatusReport, collectBlockContent, estimateTokensFast, type Compre
 import { type Session, cacheBlockContent } from "./session.js";
 import { COMPRESS_TOOL_NAME, parseCompressInput, PROXY_TOOL_NAMES } from "./compress-tool.js";
 import { resolveDecompress } from "./decompress-shared.js";
+import { handleSearchContext } from "./search-context.js";
 import { normalizeSseLineEndings } from "./sse-util.js";
 import { containsRenderTagText, stripAcpTags } from "./loop/tag-echo-filter.js";
 import { maxShrinkPerCompress } from "./fetch-util.js";
@@ -201,17 +202,7 @@ function executeAnthropicProxyTool(toolName: string, args: Record<string, unknow
         return resolveDecompress(args, ctx);
     }
     if (toolName === "search_context") {
-        const query = typeof args.query === "string" ? args.query : "";
-        if (query.length === 0) return "[search_context FAILED: query is required]";
-        const limit = typeof args.limit === "number" && args.limit > 0 ? Math.floor(args.limit) : 5;
-        const blocks = ctx.core.search(query, ctx.session.state).slice(0, limit);
-        if (blocks.length === 0) return `[No blocks matched "${query}"]`;
-        const lines = blocks.map((b) => {
-            const topic = b.topic ?? "(no topic)";
-            const preview = b.summary.length > 200 ? b.summary.slice(0, 200) + "..." : b.summary;
-            return `${b.blockId} (T${b.tier}) "${topic}"\n  ${preview}`;
-        });
-        return `Found ${blocks.length} block(s) for "${query}":\n\n${lines.join("\n\n")}`;
+        return handleSearchContext(args, ctx.session.state, ctx.messages);
     }
     if (toolName === "acp_status") {
         return buildStatusReport(ctx.session.state, ctx.messages, estimateTokensFast);

--- a/tests/search-context.test.ts
+++ b/tests/search-context.test.ts
@@ -21,7 +21,7 @@ import {
 function block(
     blockId: string,
     summary: string,
-    opts: { active?: boolean; topic?: string; tier?: 1 | 2 | 3; effectiveMessageIds?: string[] } = {},
+    opts: { active?: boolean; topic?: string; tier?: 1 | 2 | 3; effective?: string[]; directBlocks?: string[] } = {},
 ): CompressionBlock {
     return {
         blockId,
@@ -29,9 +29,9 @@ function block(
         tier: opts.tier ?? 1,
         topic: opts.topic,
         summary,
-        directMessageIds: opts.effectiveMessageIds ?? [],
-        effectiveMessageIds: opts.effectiveMessageIds ?? [],
-        directBlockIds: [],
+        directMessageIds: opts.effective ?? [],
+        effectiveMessageIds: opts.effective ?? [],
+        directBlockIds: opts.directBlocks ?? [],
         compressedTokens: 100,
         createdAt: 0,
         survivedCount: 0,
@@ -44,14 +44,18 @@ function msg(id: string, role: CoreMessage["role"], text: string, contentType: C
     return { id, role, contentType, text };
 }
 
-function stateWith(blocks: CompressionBlock[]): CompressionState {
+function stateWith(blocks: CompressionBlock[], byRaw: Record<string, string> = {}): CompressionState {
     const state = createInitialState();
     state.blocks = blocks;
+    state.messageRefs.byRaw = byRaw;
     return state;
 }
 
 let sessionSeq = 0;
-function makeSession(state: CompressionState, opts: { lastMessages?: CoreMessage[]; cachedFull?: Record<string, string> } = {}): Session {
+function makeSession(
+    state: CompressionState,
+    opts: { lastMessages?: CoreMessage[]; cachedFull?: Record<string, string> } = {},
+): Session {
     const session = getSession(`search-ctx-test-${++sessionSeq}`);
     session.state = state;
     session.lastMessages = opts.lastMessages;
@@ -73,141 +77,196 @@ test("empty query fails loudly", () => {
     assert.equal(handleSearchContext({}, makeSession(stateWith([])), []), "[search_context FAILED: query is required]");
 });
 
-test("acceptance: folded original hits where the summary does not (EPERM)", () => {
-    const b1 = block("b1", "Deploy failed with a disk write error during the release", {
-        topic: "Deploy failure",
-        effectiveMessageIds: ["m1", "m2"],
-    });
-    const session = makeSession(stateWith([b1]), {
-        lastMessages: [
-            msg("m1", "user", "deploy the service to the staging cluster"),
-            msg("m2", "tool", "Error: EPERM: operation not permitted, open '/var/lib/data/db'"),
+test("visible (uncovered) messages are NOT indexed — they are already in context", () => {
+    const state = stateWith([], { m1: "m00001", m2: "m00002" });
+    const log = [
+        msg("m1", "user", "Please fix the gzip compression bug in the proxy"),
+        msg("m2", "assistant", "I will look at the compression code path now"),
+    ];
+    const out = handleSearchContext({ query: "gzip compression" }, makeSession(state, { lastMessages: log }), []);
+    assert.match(out, /^\[No matches for "gzip compression"/, out);
+    assert.ok(out.includes("and 0 folded-away message(s)"), out);
+});
+
+test("folded-away original text is the primary corpus (EPERM not in summary)", () => {
+    const state = stateWith(
+        [block("b1", "Deploy failed with a disk write error during the release", { effective: ["m1"] })],
+        { m1: "m00001" },
+    );
+    const log = [msg("m1", "assistant", "the daemon crashed: EPERM: operation not permitted, rename state.json")];
+    const out = handleSearchContext({ query: "EPERM" }, makeSession(state, { lastMessages: log }), []);
+    assert.ok(out.startsWith("Found"), out);
+    assert.ok(out.includes("m00001 (assistant, in b1)"), out);
+});
+
+test("acceptance: original under an INACTIVE tier-1 block is found and attributed to the tier-1 block", () => {
+    const state = stateWith(
+        [
+            block("b1", "routine config work", { active: false, tier: 1, effective: ["m1"] }),
+            block("b2", "batch of prior task summaries", { active: true, tier: 2, effective: ["m1"], directBlocks: ["b1"] }),
         ],
-    });
-    assert.ok(!JSON.stringify(b1).includes("EPERM"), "sanity: the summary must NOT contain EPERM");
-    const out = handleSearchContext({ query: "EPERM" }, session, []);
-    assert.match(out, /^Found 1 block\(s\) for "EPERM"/, out);
-    assert.ok(out.includes("b1"), out);
-    assert.ok(out.includes('"Deploy failure"'), out);
-    assert.ok(out.includes("EPERM"), out);
+        { m1: "m00001" },
+    );
+    const log = [msg("m1", "assistant", "EPERM: operation not permitted while renaming the state file")];
+    const out = handleSearchContext({ query: "EPERM" }, makeSession(state, { lastMessages: log }), []);
+    assert.ok(out.startsWith("Found"), out);
+    assert.ok(out.includes("in b1"), out);
+    assert.ok(!out.includes("in b2"), out);
 });
 
-test("blockContents cache is the fast path when the payload no longer has the originals", () => {
-    const b1 = block("b1", "raft tuning notes", { topic: "Raft", effectiveMessageIds: ["m1"] });
-    const session = makeSession(stateWith([b1]), {
-        cachedFull: { b1: "[assistant]\nSet the quorum size to five and raised the election timeout." },
-    });
-    const out = handleSearchContext({ query: "quorum" }, session, []);
-    assert.match(out, /^Found 1 block\(s\)/, out);
-    assert.ok(out.includes("b1"), out);
-    assert.ok(!out.includes("[summary-only]"), out);
+test("the messages argument is the log fallback when lastMessages is empty", () => {
+    const state = stateWith([block("b1", "routine work", { effective: ["m1"] })], { m1: "m00001" });
+    const out = handleSearchContext(
+        { query: "EPERM" },
+        makeSession(state),
+        [msg("m1", "user", "EPERM: operation not permitted")],
+    );
+    assert.ok(out.startsWith("Found"), out);
+    assert.ok(out.includes("in b1"), out);
 });
 
-test("CJK: Chinese query hits the folded original of a block", () => {
-    const b1 = block("b1", "Discussed the compression strategy for long sessions", {
-        topic: "Compression strategy",
-        effectiveMessageIds: ["m1"],
-    });
-    const session = makeSession(stateWith([b1]), {
-        lastMessages: [msg("m1", "user", "请帮我修复压缩上下文的问题，谢谢")],
-    });
-    const out = handleSearchContext({ query: "压缩 上下文" }, session, []);
-    assert.match(out, /^Found 1 block\(s\)/, out);
-    assert.ok(out.includes("b1"), out);
-    assert.ok(out.includes("压缩上下文"), out);
+test("CJK: Chinese query hits a Chinese folded original", () => {
+    const state = stateWith([block("b1", "早期讨论", { effective: ["m1"] })], { m1: "m00001" });
+    const log = [msg("m1", "user", "请帮我修复压缩上下文的问题，谢谢")];
+    const out = handleSearchContext({ query: "压缩 上下文" }, makeSession(state, { lastMessages: log }), []);
+    assert.ok(out.startsWith("Found"), out);
+    assert.ok(out.includes("m00001"), out);
 });
 
-test("CJK: Chinese query hits a Chinese block summary (secondary signal)", () => {
-    const b1 = block("b1", "讨论了压缩上下文的策略并决定采用分层方案", { topic: "压缩策略" });
-    const session = makeSession(stateWith([b1]));
-    const out = handleSearchContext({ query: "压缩 上下文" }, session, []);
-    assert.match(out, /^Found 1 block\(s\)/, out);
+test("CJK: Chinese query hits a Chinese block summary", () => {
+    const state = stateWith([block("b1", "讨论了压缩上下文的策略并决定采用分层方案", { topic: "压缩策略" })]);
+    const out = handleSearchContext({ query: "压缩 上下文" }, makeSession(state), []);
+    assert.ok(out.startsWith("Found"), out);
     assert.ok(out.includes("b1"), out);
-    assert.ok(out.includes("[summary-only]"), out);
 });
 
 test("a summary mentioning the query word ONCE passes the threshold", () => {
-    const b1 = block("b1", "Set the quorum size to five for the raft cluster.", { topic: "Raft" });
-    const out = handleSearchContext({ query: "quorum" }, makeSession(stateWith([b1])), []);
+    const state = stateWith([block("b1", "Set the quorum size to five for the raft cluster.", { topic: "Raft" })]);
+    const out = handleSearchContext({ query: "quorum" }, makeSession(state), []);
     assert.match(out, /^Found 1 block\(s\)/, out);
     assert.ok(out.includes("b1"), out);
     assert.ok(out.includes('"Raft"'), out);
 });
 
-test("inactive (consumed) blocks are excluded from the corpus", () => {
-    const dead = block("b1", "unrelated", { active: false, effectiveMessageIds: ["m1"] });
-    const live = block("b2", "unrelated content about caching");
-    const session = makeSession(stateWith([dead, live]), {
-        lastMessages: [msg("m1", "tool", "Error: EPERM: operation not permitted")],
-    });
-    const out = handleSearchContext({ query: "EPERM" }, session, []);
-    assert.match(out, /^\[No matches for "EPERM"/, out);
-    assert.ok(out.includes("searched 1 active block(s)"), out);
-});
-
-test("graceful degradation: originals gone from every payload → summary-only hit annotated", () => {
-    const b1 = block("b1", "the quorum protocol was tuned for the raft cluster", {
-        topic: "Raft",
-        effectiveMessageIds: ["m1"],
-    });
-    // lastMessages exists but no longer carries the block's messages (the
-    // client's native compaction deleted the history) and no cache.
-    const session = makeSession(stateWith([b1]), {
-        lastMessages: [msg("m9", "user", "unrelated later turn")],
-    });
-    const out = handleSearchContext({ query: "quorum" }, session, []);
+test("INACTIVE block summaries are also searched (tier-2 folds tier-1 away, not into oblivion)", () => {
+    const state = stateWith([block("b1", "quorum details", { active: false }), block("b2", "unrelated content about caching")]);
+    const out = handleSearchContext({ query: "quorum" }, makeSession(state), []);
     assert.match(out, /^Found 1 block\(s\)/, out);
     assert.ok(out.includes("b1"), out);
-    assert.ok(out.includes("[summary-only]"), out);
+});
+
+test("mixed corpus: block summary + folded original hits reported together", () => {
+    const state = stateWith(
+        [block("b1", "the quorum protocol summary", { effective: ["m1"] })],
+        { m1: "m00001" },
+    );
+    const log = [msg("m1", "user", "explain the quorum protocol to me")];
+    const out = handleSearchContext({ query: "quorum" }, makeSession(state, { lastMessages: log }), []);
+    assert.match(out, /Found 1 block\(s\), 1 message\(s\)/, out);
+    assert.ok(out.includes("b1"), out);
+    assert.ok(out.includes("m00001 (user, in b1)"), out);
+});
+
+test("blocks whose originals left the log are searched via the blockContents cache", () => {
+    const state = stateWith([block("b1", "Deploy failed with a disk write error", { effective: ["m1"] })], { m1: "m00001" });
+    const session = makeSession(state, {
+        cachedFull: { b1: "[assistant] the daemon crashed: EPERM: operation not permitted, rename state.json" },
+        lastMessages: [],
+    });
+    const out = handleSearchContext({ query: "EPERM" }, session, []);
+    assert.ok(out.startsWith("Found"), out);
+    assert.ok(out.includes("b1"), out);
+    assert.ok(!out.includes("summary only"), out);
+    assert.ok(!out.includes("summary-only"), out);
+});
+
+test("blocks with neither log originals nor cache are marked summary only", () => {
+    const withOriginals = stateWith([block("b1", "alpha config notes", { effective: ["m1"] })], { m1: "m00001" });
+    const out1 = handleSearchContext(
+        { query: "alpha" },
+        makeSession(withOriginals, { lastMessages: [msg("m1", "user", "unrelated filler text")] }),
+        [],
+    );
+    assert.ok(out1.includes("b1 (T1)"), out1);
+    assert.ok(!out1.includes("summary only"), out1);
+
+    const orphaned = stateWith([block("b2", "beta config notes")]);
+    const out2 = handleSearchContext({ query: "beta" }, makeSession(orphaned), []);
+    assert.ok(out2.includes("b2 (T1, summary only)"), out2);
+});
+
+test("a tier-2 block is NOT summary-only when its tier-1 children hold indexed originals", () => {
+    const state = stateWith(
+        [
+            block("b1", "routine work", { tier: 1, effective: ["m1"] }),
+            block("b2", "aggregated earlier work", { tier: 2, effective: ["m1"], directBlocks: ["b1"] }),
+        ],
+        { m1: "m00001" },
+    );
+    const log = [msg("m1", "user", "gamma ray burst detected in the data")];
+    const out = handleSearchContext({ query: "aggregated" }, makeSession(state, { lastMessages: log }), []);
+    assert.ok(out.includes("b2 (T2)"), out);
+    assert.ok(!out.includes("summary only"), out);
 });
 
 test("empty result states the searched corpus explicitly (no silent empty)", () => {
-    const b1 = block("b1", "alpha beta gamma", { effectiveMessageIds: ["m1"] });
-    const b2 = block("b2", "delta epsilon");
-    const session = makeSession(stateWith([b1, b2]), {
-        lastMessages: [msg("m1", "user", "hello world")],
-    });
-    const out = handleSearchContext({ query: "quixotic" }, session, []);
+    const state = stateWith([block("b1", "alpha beta gamma", { effective: ["m1"] })], { m1: "m00001" });
+    const out = handleSearchContext(
+        { query: "quixotic" },
+        makeSession(state, { lastMessages: [msg("m1", "user", "hello world")] }),
+        [],
+    );
     assert.match(out, /^\[No matches for "quixotic"/, out);
-    assert.ok(out.includes("searched 2 active block(s) (1 with folded originals, 1 summary-only)"), out);
+    assert.ok(out.includes("searched 1 block(s) (1 with folded originals, 0 summary-only) and 1 folded-away message(s)"), out);
 });
 
-test("visible (uncompressed) messages are NOT searchable", () => {
-    const session = makeSession(stateWith([]), {
-        lastMessages: [msg("m1", "user", "explain the quorum protocol to me")],
-    });
-    const out = handleSearchContext({ query: "quorum" }, session, [msg("m1", "user", "explain the quorum protocol to me")]);
+test("folded system messages are not searchable", () => {
+    const state = stateWith([block("b1", "misc", { effective: ["m1"] })], { m1: "m00001" });
+    const out = handleSearchContext(
+        { query: "quorum" },
+        makeSession(state, { lastMessages: [msg("m1", "system", "quorum quorum quorum")] }),
+        [],
+    );
     assert.match(out, /^\[No matches for "quorum"/, out);
-    assert.ok(out.includes("searched 0 active block(s)"), out);
+    assert.ok(out.includes("0 folded-away message(s)"), out);
 });
 
-test("limit caps the results", () => {
+test("folded tool-result messages are labeled (tool) and attributed", () => {
+    const state = stateWith([block("b1", "disk reads", { effective: ["m1"] })], { m1: "m00001" });
+    const out = handleSearchContext(
+        { query: "quorum" },
+        makeSession(state, { lastMessages: [msg("m1", "tool", "quorum config read from disk", "tool-result")] }),
+        [],
+    );
+    assert.ok(out.includes("m00001 (tool, in b1)"), out);
+});
+
+test("unmapped messages (no ref) are skipped even when blocks claim them", () => {
+    const state = stateWith([block("b1", "misc", { effective: ["m1"] })]);
+    const out = handleSearchContext(
+        { query: "quorum" },
+        makeSession(state, { lastMessages: [msg("m1", "user", "quorum quorum")] }),
+        [],
+    );
+    assert.match(out, /^\[No matches for "quorum"/, out);
+    assert.ok(out.includes("0 folded-away message(s)"), out);
+});
+
+test("the same message appearing twice in the log is indexed once", () => {
+    const state = stateWith([block("b1", "misc", { effective: ["m1"] })], { m1: "m00001" });
+    const log = [msg("m1", "user", "one"), msg("m1", "user", "two")];
+    const out = handleSearchContext({ query: "quixotic" }, makeSession(state, { lastMessages: log }), []);
+    assert.ok(out.includes("and 1 folded-away message(s)"), out);
+});
+
+test("limit caps the combined results", () => {
     const blocks = [
-        block("b1", "one", { effectiveMessageIds: ["m1"] }),
-        block("b2", "two", { effectiveMessageIds: ["m2"] }),
-        block("b3", "three", { effectiveMessageIds: ["m3"] }),
+        block("b1", "zebra one alpha"),
+        block("b2", "zebra two alpha"),
+        block("b3", "zebra three alpha"),
     ];
-    const session = makeSession(stateWith(blocks), {
-        lastMessages: [
-            msg("m1", "user", "zebra stripe one"),
-            msg("m2", "user", "zebra stripe two"),
-            msg("m3", "user", "zebra stripe three"),
-        ],
-    });
-    const out = handleSearchContext({ query: "zebra", limit: 2 }, session, []);
+    const out = handleSearchContext({ query: "zebra", limit: 2 }, makeSession(stateWith(blocks)), []);
     assert.equal((out.match(/\bb\d\b/g) ?? []).length, 2, out);
-});
-
-test("originals take precedence over the summary in the preview", () => {
-    const b1 = block("b1", "the quorum setting was changed", {
-        topic: "Raft",
-        effectiveMessageIds: ["m1"],
-    });
-    const session = makeSession(stateWith([b1]), {
-        lastMessages: [msg("m1", "assistant", "I raised the raft log index 42 quorum threshold to five")],
-    });
-    const out = handleSearchContext({ query: "quorum" }, session, []);
-    assert.ok(out.includes("raft log index 42"), out);
 });
 
 test("tool descriptions match the implementation (all wire formats)", () => {
@@ -216,17 +275,16 @@ test("tool descriptions match the implementation (all wire formats)", () => {
         SEARCH_CONTEXT_TOOL_OPENAI.function.description,
         SEARCH_CONTEXT_TOOL_RESPONSES.description,
     ]) {
-        assert.ok(desc.includes("FOLDED ORIGINAL"), desc);
-        assert.ok(desc.includes("secondary signal"), desc);
-        assert.ok(desc.includes("Chinese"), desc);
-        assert.ok(desc.includes("[summary-only]"), desc);
+        assert.ok(desc.includes("folded-away"), desc);
+        assert.ok(desc.includes("Chinese/CJK"), desc);
+        assert.ok(desc.includes("not indexed"), desc);
     }
     for (const tools of [ACP_TOOLS_ANTHROPIC, ACP_TOOLS_RESPONSES, ACP_READONLY_TOOLS_RESPONSES]) {
         const sc = tools.find((t) => t.name === "search_context");
         assert.ok(sc, "search_context present in tool array");
-        assert.ok(typeof sc.description === "string" && sc.description.includes("FOLDED ORIGINAL"), sc.description);
+        assert.ok(typeof sc.description === "string" && sc.description.includes("folded-away"), sc.description);
     }
     const scOpenai = ACP_TOOLS_OPENAI.find((t) => t.function?.name === "search_context");
     assert.ok(scOpenai, "search_context present in OpenAI tool array");
-    assert.ok(scOpenai.function.description.includes("FOLDED ORIGINAL"), scOpenai.function.description);
+    assert.ok(scOpenai.function.description.includes("folded-away"), scOpenai.function.description);
 });

--- a/tests/search-context.test.ts
+++ b/tests/search-context.test.ts
@@ -1,0 +1,168 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+    createInitialState,
+    type CompressionBlock,
+    type CompressionState,
+    type CoreMessage,
+} from "acp-kernel";
+import { handleSearchContext, parseSearchContextArgs } from "../src/search-context.js";
+import {
+    ACP_READONLY_TOOLS_RESPONSES,
+    ACP_TOOLS_ANTHROPIC,
+    ACP_TOOLS_OPENAI,
+    ACP_TOOLS_RESPONSES,
+    SEARCH_CONTEXT_TOOL,
+    SEARCH_CONTEXT_TOOL_OPENAI,
+    SEARCH_CONTEXT_TOOL_RESPONSES,
+} from "../src/compress-tool.js";
+
+function block(
+    blockId: string,
+    summary: string,
+    opts: { active?: boolean; topic?: string; tier?: 1 | 2 | 3 } = {},
+): CompressionBlock {
+    return {
+        blockId,
+        runId: "r1",
+        tier: opts.tier ?? 1,
+        topic: opts.topic,
+        summary,
+        directMessageIds: [],
+        effectiveMessageIds: [],
+        directBlockIds: [],
+        compressedTokens: 100,
+        createdAt: 0,
+        survivedCount: 0,
+        generation: "young",
+        active: opts.active ?? true,
+    };
+}
+
+function msg(id: string, role: CoreMessage["role"], text: string, contentType: CoreMessage["contentType"] = "text"): CoreMessage {
+    return { id, role, contentType, text };
+}
+
+function stateWith(blocks: CompressionBlock[], byRaw: Record<string, string>): CompressionState {
+    const state = createInitialState();
+    state.blocks = blocks;
+    state.messageRefs.byRaw = byRaw;
+    return state;
+}
+
+test("parseSearchContextArgs: defaults and validation", () => {
+    assert.deepEqual(parseSearchContextArgs({}), { query: "", limit: 5 });
+    assert.deepEqual(parseSearchContextArgs({ query: "x", limit: 3 }), { query: "x", limit: 3 });
+    assert.deepEqual(parseSearchContextArgs({ query: "x", limit: -1 }), { query: "x", limit: 5 });
+    assert.deepEqual(parseSearchContextArgs({ query: "x", limit: 2.9 }), { query: "x", limit: 2 });
+    assert.equal(parseSearchContextArgs({ query: 42 }).query, "");
+});
+
+test("empty query fails loudly", () => {
+    assert.equal(handleSearchContext({}, stateWith([], {}), []), "[search_context FAILED: query is required]");
+});
+
+test("zero-block session: query words from the current round hit visible messages", () => {
+    const state = stateWith([], { m1: "m00001", m2: "m00002" });
+    const messages = [
+        msg("m1", "user", "Please fix the gzip compression bug in the proxy"),
+        msg("m2", "assistant", "I will look at the compression code path now"),
+    ];
+    const out = handleSearchContext({ query: "gzip compression" }, state, messages);
+    assert.ok(out.startsWith("Found"), out);
+    assert.ok(out.includes("m00001"), out);
+    assert.ok(out.includes("m00002"), out);
+});
+
+test("CJK: Chinese query hits Chinese visible messages", () => {
+    const state = stateWith([], { m1: "m00001" });
+    const messages = [msg("m1", "user", "请帮我修复压缩上下文的问题，谢谢")];
+    const out = handleSearchContext({ query: "压缩 上下文" }, state, messages);
+    assert.ok(out.startsWith("Found"), out);
+    assert.ok(out.includes("m00001"), out);
+});
+
+test("CJK: Chinese query hits a Chinese block summary", () => {
+    const state = stateWith([block("b1", "讨论了压缩上下文的策略并决定采用分层方案", { topic: "压缩策略" })], {});
+    const out = handleSearchContext({ query: "压缩 上下文" }, state, []);
+    assert.ok(out.startsWith("Found"), out);
+    assert.ok(out.includes("b1"), out);
+});
+
+test("a summary mentioning the query word ONCE passes the threshold", () => {
+    const state = stateWith([block("b1", "Set the quorum size to five for the raft cluster.", { topic: "Raft" })], {});
+    const out = handleSearchContext({ query: "quorum" }, state, []);
+    assert.match(out, /^Found 1 block\(s\)/, out);
+    assert.ok(out.includes("b1"), out);
+    assert.ok(out.includes('"Raft"'), out);
+});
+
+test("mixed corpus: block + message hits reported together", () => {
+    const state = stateWith([block("b1", "the quorum protocol summary")], { m1: "m00001" });
+    const out = handleSearchContext({ query: "quorum" }, state, [msg("m1", "user", "explain the quorum protocol to me")]);
+    assert.match(out, /Found 1 block\(s\), 1 message\(s\)/, out);
+    assert.ok(out.includes("b1"), out);
+    assert.ok(out.includes("m00001"), out);
+});
+
+test("inactive (consumed) blocks are excluded from the corpus", () => {
+    const state = stateWith([block("b1", "quorum details", { active: false }), block("b2", "unrelated content about caching")], {});
+    const out = handleSearchContext({ query: "quorum" }, state, []);
+    assert.match(out, /^\[No matches for "quorum"/, out);
+    assert.ok(out.includes("searched 1 block(s)"), out);
+});
+
+test("empty result states the searched corpus explicitly (no silent empty)", () => {
+    const state = stateWith([block("b1", "alpha beta gamma")], { m1: "m00001" });
+    const out = handleSearchContext({ query: "quixotic" }, state, [msg("m1", "user", "hello world")]);
+    assert.match(out, /^\[No matches for "quixotic"/, out);
+    assert.ok(out.includes("searched 1 block(s) and 1 visible message(s)"), out);
+});
+
+test("system messages are not searchable", () => {
+    const state = stateWith([], { m1: "m00001" });
+    const out = handleSearchContext({ query: "quorum" }, state, [msg("m1", "system", "quorum quorum quorum")]);
+    assert.match(out, /^\[No matches for "quorum"/, out);
+});
+
+test("tool-result messages are labeled (tool)", () => {
+    const state = stateWith([], { m1: "m00001" });
+    const out = handleSearchContext({ query: "quorum" }, state, [msg("m1", "tool", "quorum config read from disk", "tool-result")]);
+    assert.ok(out.includes("m00001 (tool)"), out);
+});
+
+test("unmapped messages (no ref) are skipped", () => {
+    const state = stateWith([], {});
+    const out = handleSearchContext({ query: "quorum" }, state, [msg("m1", "user", "quorum quorum")]);
+    assert.match(out, /^\[No matches for "quorum"/, out);
+    assert.ok(out.includes("0 visible message(s)"), out);
+});
+
+test("limit caps the combined results", () => {
+    const blocks = [
+        block("b1", "zebra one alpha"),
+        block("b2", "zebra two alpha"),
+        block("b3", "zebra three alpha"),
+    ];
+    const out = handleSearchContext({ query: "zebra", limit: 2 }, stateWith(blocks, {}), []);
+    assert.equal((out.match(/\bb\d\b/g) ?? []).length, 2, out);
+});
+
+test("tool descriptions match the implementation (all wire formats)", () => {
+    for (const desc of [
+        SEARCH_CONTEXT_TOOL.description,
+        SEARCH_CONTEXT_TOOL_OPENAI.function.description,
+        SEARCH_CONTEXT_TOOL_RESPONSES.description,
+    ]) {
+        assert.ok(desc.includes("visible conversation"), desc);
+        assert.ok(desc.includes("Chinese"), desc);
+    }
+    for (const tools of [ACP_TOOLS_ANTHROPIC, ACP_TOOLS_RESPONSES, ACP_READONLY_TOOLS_RESPONSES]) {
+        const sc = tools.find((t) => t.name === "search_context");
+        assert.ok(sc, "search_context present in tool array");
+        assert.ok(typeof sc.description === "string" && sc.description.includes("visible conversation"), sc.description);
+    }
+    const scOpenai = ACP_TOOLS_OPENAI.find((t) => t.function?.name === "search_context");
+    assert.ok(scOpenai, "search_context present in OpenAI tool array");
+    assert.ok(scOpenai.function.description.includes("visible conversation"), scOpenai.function.description);
+});

--- a/tests/search-context.test.ts
+++ b/tests/search-context.test.ts
@@ -7,6 +7,7 @@ import {
     type CoreMessage,
 } from "acp-kernel";
 import { handleSearchContext, parseSearchContextArgs } from "../src/search-context.js";
+import { getSession, type Session } from "../src/session.js";
 import {
     ACP_READONLY_TOOLS_RESPONSES,
     ACP_TOOLS_ANTHROPIC,
@@ -20,7 +21,7 @@ import {
 function block(
     blockId: string,
     summary: string,
-    opts: { active?: boolean; topic?: string; tier?: 1 | 2 | 3 } = {},
+    opts: { active?: boolean; topic?: string; tier?: 1 | 2 | 3; effectiveMessageIds?: string[] } = {},
 ): CompressionBlock {
     return {
         blockId,
@@ -28,8 +29,8 @@ function block(
         tier: opts.tier ?? 1,
         topic: opts.topic,
         summary,
-        directMessageIds: [],
-        effectiveMessageIds: [],
+        directMessageIds: opts.effectiveMessageIds ?? [],
+        effectiveMessageIds: opts.effectiveMessageIds ?? [],
         directBlockIds: [],
         compressedTokens: 100,
         createdAt: 0,
@@ -43,11 +44,21 @@ function msg(id: string, role: CoreMessage["role"], text: string, contentType: C
     return { id, role, contentType, text };
 }
 
-function stateWith(blocks: CompressionBlock[], byRaw: Record<string, string>): CompressionState {
+function stateWith(blocks: CompressionBlock[]): CompressionState {
     const state = createInitialState();
     state.blocks = blocks;
-    state.messageRefs.byRaw = byRaw;
     return state;
+}
+
+let sessionSeq = 0;
+function makeSession(state: CompressionState, opts: { lastMessages?: CoreMessage[]; cachedFull?: Record<string, string> } = {}): Session {
+    const session = getSession(`search-ctx-test-${++sessionSeq}`);
+    session.state = state;
+    session.lastMessages = opts.lastMessages;
+    for (const [blockId, text] of Object.entries(opts.cachedFull ?? {})) {
+        session.blockContents.set(blockId, { one: { text, count: 1 }, full: { text, count: 1 } });
+    }
+    return session;
 }
 
 test("parseSearchContextArgs: defaults and validation", () => {
@@ -59,93 +70,144 @@ test("parseSearchContextArgs: defaults and validation", () => {
 });
 
 test("empty query fails loudly", () => {
-    assert.equal(handleSearchContext({}, stateWith([], {}), []), "[search_context FAILED: query is required]");
+    assert.equal(handleSearchContext({}, makeSession(stateWith([])), []), "[search_context FAILED: query is required]");
 });
 
-test("zero-block session: query words from the current round hit visible messages", () => {
-    const state = stateWith([], { m1: "m00001", m2: "m00002" });
-    const messages = [
-        msg("m1", "user", "Please fix the gzip compression bug in the proxy"),
-        msg("m2", "assistant", "I will look at the compression code path now"),
-    ];
-    const out = handleSearchContext({ query: "gzip compression" }, state, messages);
-    assert.ok(out.startsWith("Found"), out);
-    assert.ok(out.includes("m00001"), out);
-    assert.ok(out.includes("m00002"), out);
-});
-
-test("CJK: Chinese query hits Chinese visible messages", () => {
-    const state = stateWith([], { m1: "m00001" });
-    const messages = [msg("m1", "user", "请帮我修复压缩上下文的问题，谢谢")];
-    const out = handleSearchContext({ query: "压缩 上下文" }, state, messages);
-    assert.ok(out.startsWith("Found"), out);
-    assert.ok(out.includes("m00001"), out);
-});
-
-test("CJK: Chinese query hits a Chinese block summary", () => {
-    const state = stateWith([block("b1", "讨论了压缩上下文的策略并决定采用分层方案", { topic: "压缩策略" })], {});
-    const out = handleSearchContext({ query: "压缩 上下文" }, state, []);
-    assert.ok(out.startsWith("Found"), out);
+test("acceptance: folded original hits where the summary does not (EPERM)", () => {
+    const b1 = block("b1", "Deploy failed with a disk write error during the release", {
+        topic: "Deploy failure",
+        effectiveMessageIds: ["m1", "m2"],
+    });
+    const session = makeSession(stateWith([b1]), {
+        lastMessages: [
+            msg("m1", "user", "deploy the service to the staging cluster"),
+            msg("m2", "tool", "Error: EPERM: operation not permitted, open '/var/lib/data/db'"),
+        ],
+    });
+    assert.ok(!JSON.stringify(b1).includes("EPERM"), "sanity: the summary must NOT contain EPERM");
+    const out = handleSearchContext({ query: "EPERM" }, session, []);
+    assert.match(out, /^Found 1 block\(s\) for "EPERM"/, out);
     assert.ok(out.includes("b1"), out);
+    assert.ok(out.includes('"Deploy failure"'), out);
+    assert.ok(out.includes("EPERM"), out);
+});
+
+test("blockContents cache is the fast path when the payload no longer has the originals", () => {
+    const b1 = block("b1", "raft tuning notes", { topic: "Raft", effectiveMessageIds: ["m1"] });
+    const session = makeSession(stateWith([b1]), {
+        cachedFull: { b1: "[assistant]\nSet the quorum size to five and raised the election timeout." },
+    });
+    const out = handleSearchContext({ query: "quorum" }, session, []);
+    assert.match(out, /^Found 1 block\(s\)/, out);
+    assert.ok(out.includes("b1"), out);
+    assert.ok(!out.includes("[summary-only]"), out);
+});
+
+test("CJK: Chinese query hits the folded original of a block", () => {
+    const b1 = block("b1", "Discussed the compression strategy for long sessions", {
+        topic: "Compression strategy",
+        effectiveMessageIds: ["m1"],
+    });
+    const session = makeSession(stateWith([b1]), {
+        lastMessages: [msg("m1", "user", "请帮我修复压缩上下文的问题，谢谢")],
+    });
+    const out = handleSearchContext({ query: "压缩 上下文" }, session, []);
+    assert.match(out, /^Found 1 block\(s\)/, out);
+    assert.ok(out.includes("b1"), out);
+    assert.ok(out.includes("压缩上下文"), out);
+});
+
+test("CJK: Chinese query hits a Chinese block summary (secondary signal)", () => {
+    const b1 = block("b1", "讨论了压缩上下文的策略并决定采用分层方案", { topic: "压缩策略" });
+    const session = makeSession(stateWith([b1]));
+    const out = handleSearchContext({ query: "压缩 上下文" }, session, []);
+    assert.match(out, /^Found 1 block\(s\)/, out);
+    assert.ok(out.includes("b1"), out);
+    assert.ok(out.includes("[summary-only]"), out);
 });
 
 test("a summary mentioning the query word ONCE passes the threshold", () => {
-    const state = stateWith([block("b1", "Set the quorum size to five for the raft cluster.", { topic: "Raft" })], {});
-    const out = handleSearchContext({ query: "quorum" }, state, []);
+    const b1 = block("b1", "Set the quorum size to five for the raft cluster.", { topic: "Raft" });
+    const out = handleSearchContext({ query: "quorum" }, makeSession(stateWith([b1])), []);
     assert.match(out, /^Found 1 block\(s\)/, out);
     assert.ok(out.includes("b1"), out);
     assert.ok(out.includes('"Raft"'), out);
 });
 
-test("mixed corpus: block + message hits reported together", () => {
-    const state = stateWith([block("b1", "the quorum protocol summary")], { m1: "m00001" });
-    const out = handleSearchContext({ query: "quorum" }, state, [msg("m1", "user", "explain the quorum protocol to me")]);
-    assert.match(out, /Found 1 block\(s\), 1 message\(s\)/, out);
-    assert.ok(out.includes("b1"), out);
-    assert.ok(out.includes("m00001"), out);
+test("inactive (consumed) blocks are excluded from the corpus", () => {
+    const dead = block("b1", "unrelated", { active: false, effectiveMessageIds: ["m1"] });
+    const live = block("b2", "unrelated content about caching");
+    const session = makeSession(stateWith([dead, live]), {
+        lastMessages: [msg("m1", "tool", "Error: EPERM: operation not permitted")],
+    });
+    const out = handleSearchContext({ query: "EPERM" }, session, []);
+    assert.match(out, /^\[No matches for "EPERM"/, out);
+    assert.ok(out.includes("searched 1 active block(s)"), out);
 });
 
-test("inactive (consumed) blocks are excluded from the corpus", () => {
-    const state = stateWith([block("b1", "quorum details", { active: false }), block("b2", "unrelated content about caching")], {});
-    const out = handleSearchContext({ query: "quorum" }, state, []);
-    assert.match(out, /^\[No matches for "quorum"/, out);
-    assert.ok(out.includes("searched 1 block(s)"), out);
+test("graceful degradation: originals gone from every payload → summary-only hit annotated", () => {
+    const b1 = block("b1", "the quorum protocol was tuned for the raft cluster", {
+        topic: "Raft",
+        effectiveMessageIds: ["m1"],
+    });
+    // lastMessages exists but no longer carries the block's messages (the
+    // client's native compaction deleted the history) and no cache.
+    const session = makeSession(stateWith([b1]), {
+        lastMessages: [msg("m9", "user", "unrelated later turn")],
+    });
+    const out = handleSearchContext({ query: "quorum" }, session, []);
+    assert.match(out, /^Found 1 block\(s\)/, out);
+    assert.ok(out.includes("b1"), out);
+    assert.ok(out.includes("[summary-only]"), out);
 });
 
 test("empty result states the searched corpus explicitly (no silent empty)", () => {
-    const state = stateWith([block("b1", "alpha beta gamma")], { m1: "m00001" });
-    const out = handleSearchContext({ query: "quixotic" }, state, [msg("m1", "user", "hello world")]);
+    const b1 = block("b1", "alpha beta gamma", { effectiveMessageIds: ["m1"] });
+    const b2 = block("b2", "delta epsilon");
+    const session = makeSession(stateWith([b1, b2]), {
+        lastMessages: [msg("m1", "user", "hello world")],
+    });
+    const out = handleSearchContext({ query: "quixotic" }, session, []);
     assert.match(out, /^\[No matches for "quixotic"/, out);
-    assert.ok(out.includes("searched 1 block(s) and 1 visible message(s)"), out);
+    assert.ok(out.includes("searched 2 active block(s) (1 with folded originals, 1 summary-only)"), out);
 });
 
-test("system messages are not searchable", () => {
-    const state = stateWith([], { m1: "m00001" });
-    const out = handleSearchContext({ query: "quorum" }, state, [msg("m1", "system", "quorum quorum quorum")]);
+test("visible (uncompressed) messages are NOT searchable", () => {
+    const session = makeSession(stateWith([]), {
+        lastMessages: [msg("m1", "user", "explain the quorum protocol to me")],
+    });
+    const out = handleSearchContext({ query: "quorum" }, session, [msg("m1", "user", "explain the quorum protocol to me")]);
     assert.match(out, /^\[No matches for "quorum"/, out);
+    assert.ok(out.includes("searched 0 active block(s)"), out);
 });
 
-test("tool-result messages are labeled (tool)", () => {
-    const state = stateWith([], { m1: "m00001" });
-    const out = handleSearchContext({ query: "quorum" }, state, [msg("m1", "tool", "quorum config read from disk", "tool-result")]);
-    assert.ok(out.includes("m00001 (tool)"), out);
-});
-
-test("unmapped messages (no ref) are skipped", () => {
-    const state = stateWith([], {});
-    const out = handleSearchContext({ query: "quorum" }, state, [msg("m1", "user", "quorum quorum")]);
-    assert.match(out, /^\[No matches for "quorum"/, out);
-    assert.ok(out.includes("0 visible message(s)"), out);
-});
-
-test("limit caps the combined results", () => {
+test("limit caps the results", () => {
     const blocks = [
-        block("b1", "zebra one alpha"),
-        block("b2", "zebra two alpha"),
-        block("b3", "zebra three alpha"),
+        block("b1", "one", { effectiveMessageIds: ["m1"] }),
+        block("b2", "two", { effectiveMessageIds: ["m2"] }),
+        block("b3", "three", { effectiveMessageIds: ["m3"] }),
     ];
-    const out = handleSearchContext({ query: "zebra", limit: 2 }, stateWith(blocks, {}), []);
+    const session = makeSession(stateWith(blocks), {
+        lastMessages: [
+            msg("m1", "user", "zebra stripe one"),
+            msg("m2", "user", "zebra stripe two"),
+            msg("m3", "user", "zebra stripe three"),
+        ],
+    });
+    const out = handleSearchContext({ query: "zebra", limit: 2 }, session, []);
     assert.equal((out.match(/\bb\d\b/g) ?? []).length, 2, out);
+});
+
+test("originals take precedence over the summary in the preview", () => {
+    const b1 = block("b1", "the quorum setting was changed", {
+        topic: "Raft",
+        effectiveMessageIds: ["m1"],
+    });
+    const session = makeSession(stateWith([b1]), {
+        lastMessages: [msg("m1", "assistant", "I raised the raft log index 42 quorum threshold to five")],
+    });
+    const out = handleSearchContext({ query: "quorum" }, session, []);
+    assert.ok(out.includes("raft log index 42"), out);
 });
 
 test("tool descriptions match the implementation (all wire formats)", () => {
@@ -154,15 +216,17 @@ test("tool descriptions match the implementation (all wire formats)", () => {
         SEARCH_CONTEXT_TOOL_OPENAI.function.description,
         SEARCH_CONTEXT_TOOL_RESPONSES.description,
     ]) {
-        assert.ok(desc.includes("visible conversation"), desc);
+        assert.ok(desc.includes("FOLDED ORIGINAL"), desc);
+        assert.ok(desc.includes("secondary signal"), desc);
         assert.ok(desc.includes("Chinese"), desc);
+        assert.ok(desc.includes("[summary-only]"), desc);
     }
     for (const tools of [ACP_TOOLS_ANTHROPIC, ACP_TOOLS_RESPONSES, ACP_READONLY_TOOLS_RESPONSES]) {
         const sc = tools.find((t) => t.name === "search_context");
         assert.ok(sc, "search_context present in tool array");
-        assert.ok(typeof sc.description === "string" && sc.description.includes("visible conversation"), sc.description);
+        assert.ok(typeof sc.description === "string" && sc.description.includes("FOLDED ORIGINAL"), sc.description);
     }
     const scOpenai = ACP_TOOLS_OPENAI.find((t) => t.function?.name === "search_context");
     assert.ok(scOpenai, "search_context present in OpenAI tool array");
-    assert.ok(scOpenai.function.description.includes("visible conversation"), scOpenai.function.description);
+    assert.ok(scOpenai.function.description.includes("FOLDED ORIGINAL"), scOpenai.function.description);
 });


### PR DESCRIPTION
Fixes #391.

## What was broken

`search_context` had four compounding defects:

1. **Corpus = active summary blocks only.** Summaries drop exactly the details users search for — error text, file paths, variable names — so the folded originals sitting in the conversation were unfindable, and a session with zero compressed blocks always returned `[No blocks matched ...]`.
2. **Threshold unreachable.** The exact-substring scorer gave 0.04 per summary occurrence with a `> 0.1` filter, so a summary mentioning the query word *once* was always dropped.
3. **The kernel's published search engine was dead code.** `searchBlocks` / `blockDocs` / `messageDocs` (hybrid BM25 + fuzzy, CJK-aware tokenizer, doc-feature cache) are exported by acp-kernel but had zero call sites in the proxy.
4. **Description ≠ implementation.** The tool description promised "(and optionally visible messages)" that the implementation never had.

## Design (per maintainer review)

The corpus direction was corrected: visible messages do not need searching — they are already in the model's attention. What must be indexed is the **folded invisible originals** of active blocks. Folding only happens in the view forwarded upstream; the client's full per-turn payload still carries the originals (the same source the decompress fallback reads), so the proxy holds all folded originals — it just wasn't indexing them.

## What changed

- **New `src/search-context.ts`** — one shared handler for all three compress loops (`src/loop/core.ts`, `src/stream.ts`, `src/compress-loop-responses.ts`; the three duplicated inline implementations are removed). It searches **active blocks' folded original content** through the kernel's `searchBlocks` engine (hybrid BM25+fuzzy, CJK segmentation, bm25 score semantics — a single real hit scores ≈1.0, no arbitrary 0.1 gate); each block's summary stays in the doc as a secondary boost signal.
  - Originals resolution per block: `session.blockContents` cache (captured at compress time, fast path) → `session.lastMessages` (full client payload snapshot) via kernel `collectBlockContent(state, block, source, {full: true})` aligned on `effectiveMessageIds` → folded view as last resort.
  - A `hasSubstance()` guard discards role-header-only text (the kernel's prune empties folded messages' text, so `collectBlockContent` on a folded view renders `[role]` headers only — this also guards T2-block caches captured after T1 originals were folded).
  - **Visible messages are out of the index** (already in model attention); system messages excluded as before; inactive (consumed) blocks stay out — their content is folded into the parent tier's summary and decompressing them would fail.
  - **Graceful degradation:** when a block's originals are gone from every payload (e.g. client native compaction deleted the history), the block falls back to summary-only indexing and its result line is marked `[summary-only]`.
  - Result lines keep the existing block format (`b2 (T1) "topic"` + hit-centered preview); empty results state the searched corpus explicitly: `[No matches for "..." — searched N active block(s) (M with folded originals, K summary-only). ...]` — no more silent empty.
- **`src/compress-tool.ts`** — the `search_context` description is overridden in all three wire formats (Anthropic / OpenAI / Responses) and all tool arrays (`ACP_TOOLS_*`, `ACP_READONLY_TOOLS_RESPONSES`) to describe the actual corpus: folded originals + summary as secondary signal, English + Chinese/CJK. Until the kernel ships the same wording, the proxy's schema matches the proxy's behavior (acceptance criterion 4).
- **`tests/search-context.test.ts`** — 14 tests covering every acceptance criterion, including the acceptance scenario: a conversation containing an `EPERM` error original that the summary does NOT mention — `search_context("EPERM")` hits the block with its decompressable blockId (the old summary-only corpus could not find it). Plus: CJK query → CJK folded original and CJK summary (marked `[summary-only]`), cache fast path, single-occurrence summary hit passing, inactive-block exclusion, graceful-degradation annotation, visible-message exclusion, explicit empty-result corpus notice, limit, and description/implementation agreement across all wire formats.

## Pre-flight

- `npm run typecheck` — clean
- `npm test` — **882/882 pass** (incl. 14 new)
- `npm run build` — ok; bundle verified to carry the new handler + descriptions
- E2E (`tests/e2e/e2e-codex.test.ts`) not runnable in this environment (no local Responses upstream, no codex CLI); the changed dispatch path is covered by the new unit tests plus the existing loop tests (`tests/loop-core.test.ts` exercises search_context through the real loop).

## Note for the kernel

The same defect family lives in acp-kernel's `core.search` (`src/compress.ts`), which in-process hosts (billion-context-pi, pai-acp) use directly. Filed a separate issue there with the analysis; this PR is independent of it (the proxy bypasses `core.search` entirely).
