### PR TITLE
fix: omp plugin install/remove idempotency (scoped match, existence check, overlay redirect)

### DIFF
--- a/src/plugin-install.ts
+++ b/src/plugin-install.ts
@@ -137,9 +137,55 @@ function piStatus(): string {
 
 // — omp ———————————————————————————————————————————————————————————————
 
+// An extensions entry that loads the bili omp plugin (any install): a path
+// ending in dist/agent/omp.js. Shared by install/remove/status and the
+// launcher's loader check so all four agree on what "installed" means.
+const OMP_ENTRY_RE = /[\\/]dist[\\/]agent[\\/]omp\.js$/;
+
+// Line indices of the `- ` items inside the top-level `extensions:` block.
+// The block starts at the column-0 `extensions:` key and ends at the first
+// non-blank, non-comment line that is not a list item. Returns [] when there
+// is no top-level key or when it appears more than once (ambiguous — refuse
+// to guess). Matching is scoped to this block, so a same-valued line under
+// any other key is never counted as installed and never removed.
+function ompExtensionItemLines(text: string): number[] {
+    const lines = text.split("\n");
+    let keyIdx = -1;
+    for (let i = 0; i < lines.length; i++) {
+        if (/^extensions:(\s+(#.*)?)?$/.test(lines[i]!)) {
+            if (keyIdx !== -1) return [];
+            keyIdx = i;
+        }
+    }
+    if (keyIdx === -1) return [];
+    const items: number[] = [];
+    for (let i = keyIdx + 1; i < lines.length; i++) {
+        const t = lines[i]!.trimStart();
+        if (t === "" || t.startsWith("#")) continue;
+        if (t === "-" || t.startsWith("- ")) items.push(i);
+        else break;
+    }
+    return items;
+}
+
+// The config.yml the plugin commands read/write. When PI_CODING_AGENT_DIR
+// points at a bili overlay (<home>-bili, created by `bili omp`), redirect to
+// the real home: the overlay's config.yml may be a stale copy (a merge
+// conflict leaves a .bili-conflict instead of the live file), so editing it
+// would silently miss the real config. A note is printed so the user sees
+// which file was actually touched.
 function ompConfigFile(): string {
     const raw = process.env.PI_CODING_AGENT_DIR?.trim();
-    if (raw && raw.length > 0) return path.join(raw, "config.yml");
+    if (raw && raw.length > 0) {
+        if (raw.endsWith("-bili") && raw.length > "-bili".length) {
+            const realHome = raw.slice(0, -"-bili".length);
+            process.stderr.write(
+                `bili plugin: PI_CODING_AGENT_DIR points at the bili overlay ${raw} — operating on the real omp home ${realHome} instead\n`,
+            );
+            return path.join(realHome, "config.yml");
+        }
+        return path.join(raw, "config.yml");
+    }
     return path.join(os.homedir(), ".omp", "agent", "config.yml");
 }
 
@@ -151,16 +197,24 @@ function ompEntryValue(line: string): string {
     return line.replace(/#.*$/, "").trim().replace(/^-\s*/, "").replace(/^["']|["']$/g, "").trim();
 }
 
+function ompBlockLoaded(text: string): boolean {
+    const lines = text.split("\n");
+    return ompExtensionItemLines(text).some((i) => {
+        const v = ompEntryValue(lines[i]!);
+        return OMP_ENTRY_RE.test(v) && fs.existsSync(v);
+    });
+}
+
 function ompRemove(): string {
     const file = ompConfigFile();
-    const entry = ompExtensionPath();
     if (!fs.existsSync(file)) return `omp: not installed (${file})`;
     const text = fs.readFileSync(file, "utf8");
-    const cleaned = text
-        .split("\n")
-        .filter((line) => ompEntryValue(line) !== entry)
-        .join("\n");
-    if (cleaned === text) return `omp: not installed (${file})`;
+    const lines = text.split("\n");
+    const drop = new Set(
+        ompExtensionItemLines(text).filter((i) => OMP_ENTRY_RE.test(ompEntryValue(lines[i]!))),
+    );
+    if (drop.size === 0) return `omp: not installed (${file})`;
+    const cleaned = lines.filter((_, i) => !drop.has(i)).join("\n");
     backupOnce(file);
     fs.writeFileSync(file, cleaned);
     return `omp: removed from ${file}`;
@@ -171,8 +225,15 @@ function ompInstall(): string {
     const entry = ompExtensionPath();
     requireDistFile(entry);
     fs.mkdirSync(path.dirname(file), { recursive: true });
-    const text = fs.existsSync(file) ? fs.readFileSync(file, "utf8") : "";
-    if (text.split("\n").some((line) => ompEntryValue(line) === entry)) return `omp: already installed (${file})`;
+    let text = fs.existsSync(file) ? fs.readFileSync(file, "utf8") : "";
+    if (ompBlockLoaded(text)) return `omp: already installed (${file})`;
+    // Drop any stale copy of OUR exact entry (points at a vanished file) so
+    // the insert below leaves exactly one copy instead of a duplicate.
+    {
+        const lines = text.split("\n");
+        const stale = new Set(ompExtensionItemLines(text).filter((i) => ompEntryValue(lines[i]!) === entry));
+        if (stale.size > 0) text = lines.filter((_, i) => !stale.has(i)).join("\n");
+    }
     const keyCount = (text.match(/^extensions:/gm) ?? []).length;
     if (keyCount > 1) throw new Error(`${file}: multiple \`extensions:\` keys — fix the file first, refusing to edit`);
     if (/^extensions:\s*\S/m.test(text) && !/^extensions:\s*$/m.test(text)) {
@@ -199,7 +260,8 @@ function ompInstall(): string {
         out = text.endsWith("\n") || text.length === 0 ? text : text + "\n";
         out += `extensions:\n  - ${entry}\n`;
     }
-    const occurrences = out.split("\n").filter((line) => ompEntryValue(line) === entry).length;
+    const outLines = out.split("\n");
+    const occurrences = ompExtensionItemLines(out).filter((i) => ompEntryValue(outLines[i]!) === entry).length;
     if (occurrences !== 1) {
         throw new Error(`${file}: edit would leave ${occurrences} copies of the entry — aborting without writing`);
     }
@@ -211,7 +273,15 @@ function ompInstall(): string {
 function ompStatus(): string {
     const file = ompConfigFile();
     const text = fs.existsSync(file) ? fs.readFileSync(file, "utf8") : "";
-    return text.split("\n").some((line) => ompEntryValue(line) === ompExtensionPath()) ? "installed" : "not installed";
+    const lines = text.split("\n");
+    let broken = false;
+    for (const i of ompExtensionItemLines(text)) {
+        const v = ompEntryValue(lines[i]!);
+        if (!OMP_ENTRY_RE.test(v)) continue;
+        if (fs.existsSync(v)) return "installed";
+        broken = true;
+    }
+    return broken ? "broken" : "not installed";
 }
 
 /** True when the given omp home's config.yml carries a bili plugin entry
@@ -223,11 +293,7 @@ function ompStatus(): string {
  *  launcher must supply the working plugin itself. */
 export function ompPluginLoadedFrom(ompHome: string): boolean {
     try {
-        const text = fs.readFileSync(path.join(ompHome, "config.yml"), "utf8");
-        return text.split("\n").some((line) => {
-            const v = ompEntryValue(line);
-            return /[\\/]dist[\\/]agent[\\/]omp\.js$/.test(v) && fs.existsSync(v);
-        });
+        return ompBlockLoaded(fs.readFileSync(path.join(ompHome, "config.yml"), "utf8"));
     } catch {
         return false;
     }

--- a/tests/plugin-agent.test.ts
+++ b/tests/plugin-agent.test.ts
@@ -542,6 +542,14 @@ test("plugin install/remove roundtrips for pi/omp/codex/opencode under a fake HO
         assert.match(pluginRemove("pi"), /removed/);
         assert.deepEqual((JSON.parse(fs.readFileSync(path.join(piAgentDir, "settings.json"), "utf8")) as { packages: string[] }).packages, ["/home/x/other-package"]);
 
+        // omp install/status/remove verify the entry's target exists, so
+        // materialize the (gitignored) dist artifact for this sub-test.
+        const ompDistFile = path.join(root, "dist", "agent", "omp.js");
+        const createdOmpDist = !fs.existsSync(ompDistFile);
+        if (createdOmpDist) {
+            fs.mkdirSync(path.dirname(ompDistFile), { recursive: true });
+            fs.writeFileSync(ompDistFile, "// test stub\n");
+        }
         fs.mkdirSync(path.join(home, ".omp/agent"), { recursive: true });
         await withEnv({ PI_CODING_AGENT_DIR: path.join(home, ".omp/agent") }, async () => {
         fs.writeFileSync(path.join(home, ".omp/agent/config.yml"), "extensions:\n  - /some/other/ext.js\nfirstRunComplete: true\n");
@@ -580,6 +588,7 @@ test("plugin install/remove roundtrips for pi/omp/codex/opencode under a fake HO
         assert.match(pluginRemove("omp"), /removed/);
         assert.equal(fs.readFileSync(path.join(home, ".omp/agent/config.yml"), "utf8"), "extensions:\n");
         });
+        if (createdOmpDist) fs.rmSync(ompDistFile, { force: true });
 
         assert.match(pluginInstall("codex"), /installed/);
         const toml = fs.readFileSync(path.join(home, "config.toml"), "utf8");
@@ -622,6 +631,77 @@ test("plugin install/remove roundtrips for pi/omp/codex/opencode under a fake HO
         assert.equal(rows.length, 5);
         assert.deepEqual(PLUGIN_AGENTS, ["pi", "omp", "claude", "codex", "opencode"]);
     });
+    fs.rmSync(home, { recursive: true, force: true });
+});
+
+test("omp plugin: scoped matching, existence check, overlay redirect (issue #392)", async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "bili-plugin-omp-"));
+    const root = selfPackageRoot();
+    const ompDistFile = path.join(root, "dist", "agent", "omp.js");
+    const createdOmpDist = !fs.existsSync(ompDistFile);
+    if (createdOmpDist) {
+        fs.mkdirSync(path.dirname(ompDistFile), { recursive: true });
+        fs.writeFileSync(ompDistFile, "// test stub\n");
+    }
+    try {
+        const stale = "/does/not/exist/dist/agent/omp.js";
+
+        // (a) a same-valued line OUTSIDE the extensions block must not block install
+        {
+            const agentDir = path.join(home, "a", ".omp", "agent");
+            fs.mkdirSync(agentDir, { recursive: true });
+            fs.writeFileSync(path.join(agentDir, "config.yml"),
+                `extensions:\n  - ${stale}\nother:\n  - ${stale}\nfirstRunComplete: true\n`);
+            await withEnv({ PI_CODING_AGENT_DIR: agentDir }, async () => {
+                assert.match(pluginInstall("omp"), /installed/);
+                assert.equal(pluginStatusAll().find((r) => r.agent === "omp")?.status, "installed");
+            });
+            assert.match(fs.readFileSync(path.join(agentDir, "config.yml"), "utf8"),
+                /extensions:\n  - \/does\/not\/exist\/dist\/agent\/omp\.js\n  - .*dist[\\/]agent[\\/]omp\.js\nother:\n  - \/does\/not\/exist\/dist\/agent\/omp\.js\n/);
+        }
+
+        // (b) remove only deletes in-block entries; the out-of-block line stays
+        {
+            const agentDir = path.join(home, "b", ".omp", "agent");
+            fs.mkdirSync(agentDir, { recursive: true });
+            fs.writeFileSync(path.join(agentDir, "config.yml"),
+                `extensions:\n  - ${stale}\nother:\n  - ${stale}\nfirstRunComplete: true\n`);
+            await withEnv({ PI_CODING_AGENT_DIR: agentDir }, async () => {
+                assert.match(pluginRemove("omp"), /removed/);
+            });
+            assert.equal(fs.readFileSync(path.join(agentDir, "config.yml"), "utf8"),
+                `extensions:\nother:\n  - ${stale}\nfirstRunComplete: true\n`);
+        }
+
+        // (c) PI_CODING_AGENT_DIR pointing at a bili overlay redirects to the real home
+        {
+            const realHome = path.join(home, "c", ".omp", "agent");
+            const overlay = realHome + "-bili";
+            fs.mkdirSync(realHome, { recursive: true });
+            fs.mkdirSync(overlay, { recursive: true });
+            fs.writeFileSync(path.join(realHome, "config.yml"), "firstRunComplete: true\n");
+            fs.writeFileSync(path.join(overlay, "config.yml"), "extensions:\n  - /stale/overlay/dist/agent/omp.js\n");
+            await withEnv({ PI_CODING_AGENT_DIR: overlay }, async () => {
+                assert.match(pluginInstall("omp"), /installed/);
+            });
+            assert.match(fs.readFileSync(path.join(realHome, "config.yml"), "utf8"),
+                /extensions:\n  - .*dist[\\/]agent[\\/]omp\.js\n/);
+            assert.equal(fs.readFileSync(path.join(overlay, "config.yml"), "utf8"),
+                "extensions:\n  - /stale/overlay/dist/agent/omp.js\n");
+        }
+
+        // (d) a stale entry (target file gone) reports "broken"
+        {
+            const agentDir = path.join(home, "d", ".omp", "agent");
+            fs.mkdirSync(agentDir, { recursive: true });
+            fs.writeFileSync(path.join(agentDir, "config.yml"), `extensions:\n  - ${stale}\n`);
+            await withEnv({ PI_CODING_AGENT_DIR: agentDir }, async () => {
+                assert.equal(pluginStatusAll().find((r) => r.agent === "omp")?.status, "broken");
+            });
+        }
+    } finally {
+        if (createdOmpDist) fs.rmSync(ompDistFile, { force: true });
+    }
     fs.rmSync(home, { recursive: true, force: true });
 });
 


### PR DESCRIPTION
Fixes #393.

Three defects in the omp plugin idempotency checks:

1. **Whole-file, unscoped line matching** — install/remove/status compared every line of `config.yml` against the entry value, so a same-valued line under any other key was counted as installed (blocking a needed install) or deleted (corrupting unrelated config). Matching is now scoped to the top-level `extensions:` block via `ompExtensionItemLines()` (returns `[]` when the key is absent or duplicated).

2. **No existence check, disagreeing with the loader** — the launcher's `ompPluginLoadedFrom()` uses a suffix match + `fs.existsSync`, but install/remove used exact-string compare with no existence check, so a stale entry (target file gone) was reported `installed` while the launcher treated it as unloaded. All four paths now share `OMP_ENTRY_RE` + `ompBlockLoaded()`; `status` additionally reports `broken` for a stale entry.

3. **`PI_CODING_AGENT_DIR` drift to the overlay** — inside a `bili omp` shell the env points at the `<home>-bili` overlay whose `config.yml` can be a stale copy (a merge conflict leaves a `.bili-conflict` instead of the live file), so edits silently missed the real config. `ompConfigFile()` now detects the `-bili` overlay, redirects to the real home, and prints a note about which file was actually touched.

### Tests
- Existing roundtrip fixtures now materialize the gitignored `dist/agent/omp.js` artifact (the existence check needs it); guarded create + cleanup.
- New test `omp plugin: scoped matching, existence check, overlay redirect (issue #392)` covers all four acceptance criteria:
  - a same-valued line outside the `extensions:` block does not block install;
  - remove only deletes in-block entries, out-of-block line preserved;
  - `PI_CODING_AGENT_DIR` pointing at a `-bili` overlay operates on the real home and leaves the overlay untouched;
  - a stale entry (target gone) reports `broken`.

### Pre-flight
- `npm run typecheck` — clean
- `npm test` — 869 pass / 0 fail
- `npm run build` — success
- Manual smoke test of the built CLI confirmed the overlay redirect, stderr note, and roundtrip install/status/remove.