### PR TITLE
fix: banner raw-HTTP-capture reflects ACP_DUMP_BODY real state (#413)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -380,7 +380,7 @@ export async function startServer(opts: ProxyOptions): Promise<http.Server> {
             );
         }
         if (opts.debug) {
-            log("info", `[debug] build features: raw-HTTP-capture(on) | remote_compaction_v2-strip(on) | cert-MITM-launcher(on) | strip-acp-summary(on) — seeing this line confirms the launcher build (not registry 0.1.34)`);
+            log("info", `[debug] build features: raw-HTTP-capture(${bodyDumpEnabled() ? "on" : "off"}) | remote_compaction_v2-strip(on) | cert-MITM-launcher(on) | strip-acp-summary(on) — seeing this line confirms the launcher build (not registry 0.1.34)`);
         }
     });
     // Listen errors (EADDRINUSE port taken, EACCES privileged port, EAFNOSUPPORT


### PR DESCRIPTION
Fixes #413.

## What

The launcher startup banner hardcoded `raw-HTTP-capture(on)` even though the real switch is the independent env `ACP_DUMP_BODY` (decoupled from `--debug` since #276, default **off**). The banner therefore always lied — forensics was once misled into suspecting a #362-type EPERM write failure when the dump-fail warn count was actually 0.

## Root cause

`src/server.ts:383` logged a constant string and never consulted `bodyDumpEnabled()` (`src/server.ts:77-79`, `process.env.ACP_DUMP_BODY === "1"`). `ACP_DUMP_BODY` also has no config-file persistence (config only has `debug`/`dumpSse`), so it dies with the startup shell env.

## Fix

One line (the issue's suggested fix):

```
- raw-HTTP-capture(on)
+ raw-HTTP-capture(${bodyDumpEnabled() ? "on" : "off"})
```

## Same-source check on the other banner fields

Verified the remaining feature flags are honest **build features** (unconditionally compiled in), so their `on` is accurate:
- `remote_compaction_v2-strip(on)` — strip at `src/server.ts:2001-2009`, unconditional
- `cert-MITM-launcher(on)` — `setupMitm` always present
- `strip-acp-summary(on)` — `stripAcpTags` always present

No new hardcoded `on` introduced.

## Not done (optional, out of scope)

The issue's optional suggestion to unify `ACP_DUMP_BODY` with file config (env→file→default off) is **not** included — it's marked optional ("可顺手"), not in the acceptance criteria, and keeping the change minimal. Happy to follow up if wanted.

## Pre-flight

- `npm run typecheck` — clean
- `npm test` — 868/868 pass
- `npm run build` — success
- Runtime: without env → banner shows `raw-HTTP-capture(off)`; with `ACP_DUMP_BODY=1` → `raw-HTTP-capture(on)`

## Acceptance criteria

- [x] Start without ACP_DUMP_BODY → banner contains `raw-HTTP-capture(off)`; with it set, `raw/*-REQ.txt` appears within one request (existing dump path, unchanged)
- [x] Other banner fields same-source verified (no new hardcoded "on")
