### PR TITLE
fix: /bili/ tunnel destination admission + management-plane tunnel block (#409)

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -353,6 +353,7 @@ Environment variables take precedence over the config file. They are useful for 
 | `BILI_UPSTREAM_PROXY` | Upstream proxy for the proxy's own outbound connections — highest priority, above per-URL/per-provider config. See the README *Upstream proxy* section. |
 | `BILI_PERSIST` | Set `0` to disable session persistence (in-memory only, lost on restart). |
 | `BILI_PERSIST_DEBOUNCE_MS` | Debounce window for persistence writes to disk, in ms (default `500`). |
+| `BILI_TUNNEL_ALLOWED_HOSTS` | `/bili/<absolute-url>` tunnel admission for **remote clients** (#409): comma-separated `host` or `host:port` entries that unlock loopback/private destinations (e.g. a LAN relay or the machine's own sglang) for non-loopback clients. The proxy itself and link-local/metadata addresses are always denied; local (loopback) clients always pass. |
 | `BILI_MAX_SESSIONS` | Max sessions held in memory (default `256`; LRU eviction — disk is the source of truth). |
 | `BILI_SESSIONS_DIR` | Directory for persisted session state (default XDG data dir). |
 | `BILLION_CONTEXT_PROXY` | Exported by the launcher; client-side bili plugins/extensions detect it and self-disable their own compression (no double compression). |

--- a/README.md
+++ b/README.md
@@ -162,6 +162,15 @@ bili --host 0.0.0.0           # all interfaces (or use your LAN IP)
 - MITM-mode `CONNECT` then also accepts remote clients — for **whitelisted
   model hosts only**. Blind tunnels to arbitrary hosts stay loopback-only, so
   the proxy can never be used as an open relay.
+- The `/bili/<absolute-url>` tunnel has destination admission (#409): the
+  proxy itself and link-local/metadata addresses are **always denied**;
+  loopback/private destinations are allowed for local clients (self-hosted
+  upstreams) and **denied for remote clients** unless listed in
+  `BILI_TUNNEL_ALLOWED_HOSTS` (`host` or `host:port`, comma-separated) — a
+  remote peer must not use the proxy as an SSRF pivot into your LAN, and the
+  management plane is unreachable through the tunnel even via NAT hairpin
+  (tunneled requests carry an internal `x-bili-tunnel` marker that `/__bili/`
+  rejects).
 - There is **no authentication**: only do this on a trusted LAN or behind a
   firewall. The `/__bili/` management endpoints remain loopback-only.
 - A startup `[security]` warning reminds you of the above.

--- a/src/server.ts
+++ b/src/server.ts
@@ -67,6 +67,7 @@ import { consumePluginRegisterFor, flushConversations, handlePluginManifest, han
 import { setupMitm, readMitmUpstream } from "./mitm.js";
 import type { BiliMessage } from "acp-kernel/wire";
 import { hoistMidSystemMessages, isLoopbackAddress, inspectContextOverflow, reserveOutputHeadroom, shouldReserveOutputHeadroom, usageTotals } from "./util.js";
+import { BILI_TUNNEL_HEADER, checkTunnelDestination, tunnelAllowlistFromEnv } from "./tunnel-guard.js";
 
 import { decodeRequestBody } from "./content-encoding.js";
 
@@ -232,7 +233,7 @@ function buildForwardHeaders(headers: Record<string, string>): Record<string, st
     return out;
 }
 
-export function resolveUpstream(_opts: ProxyOptions, reqUrl: string, req?: http.IncomingMessage): { upstream: string; rewrittenUrl: string; explicitProtocol?: "openai" | "anthropic" | "responses" } | undefined {
+export function resolveUpstream(_opts: ProxyOptions, reqUrl: string, req?: http.IncomingMessage): { upstream: string; rewrittenUrl: string; explicitProtocol?: "openai" | "anthropic" | "responses"; tunnel?: boolean } | undefined {
     // MITM mode: the request arrived over a CONNECT tunnel we terminated
     // locally (client set HTTP_PROXY and issued CONNECT host:443). The socket
     // carries the real upstream origin; the request path has no /bili/ prefix
@@ -273,7 +274,7 @@ export function resolveUpstream(_opts: ProxyOptions, reqUrl: string, req?: http.
         if (rest.startsWith("http://") || rest.startsWith("https://")) {
             try {
                 const u = new URL(rest);
-                return { upstream: `${u.protocol}//${u.host}`, rewrittenUrl: rest, explicitProtocol };
+                return { upstream: `${u.protocol}//${u.host}`, rewrittenUrl: rest, explicitProtocol, tunnel: true };
             } catch {
                 // malformed embedded URL
             }
@@ -301,6 +302,11 @@ export async function startServer(opts: ProxyOptions): Promise<http.Server> {
     await initSessions();
     loadConversations();
     log("info", `[persist] ${getStore().enabled ? "enabled" : "disabled"}`);
+    // #405 (silent env knobs): the tunnel allowlist is security-relevant —
+    // surface it at startup so a remote-client deployment shows WHY private
+    // destinations pass or fail.
+    const tunnelAllowlist = tunnelAllowlistFromEnv();
+    if (tunnelAllowlist.length > 0) log("info", `[tunnel] remote-client allowlist: ${tunnelAllowlist.join(", ")}`);
     if (filePath) {
         log("info", `[log] writing to ${filePath}`);
     }
@@ -593,6 +599,18 @@ async function handle(
     // in that case we still must NOT expose management to the LAN. Only the
     // proxy /bili/ and CONNECT (model traffic) endpoints remain open to all.
     const isAdminPath = req.url === "/__bili/" || req.url?.startsWith("/__bili/") || req.url === "/__acp/" || req.url?.startsWith("/__acp/");
+    // #409: management must never be reachable THROUGH the bili tunnel, not
+    // even from a loopback client: the tunnel's inner connection originates
+    // from the proxy itself, so the remoteAddress gate alone is satisfied and
+    // a `--host 0.0.0.0` peer could otherwise PUT /__bili/config over the
+    // tunnel. forward() stamps this marker on every /bili/ absolute-URL
+    // forward; clients have no legitimate reason to send it, and a spoofed
+    // value only locks the spoofer out of admin paths.
+    if (isAdminPath && headerValue(req, BILI_TUNNEL_HEADER) !== undefined) {
+        res.writeHead(403, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: "management endpoints are not reachable through the bili tunnel" }));
+        return;
+    }
     if (isAdminPath && !isLoopbackAddress(req.socket.remoteAddress)) {
         res.writeHead(403, { "content-type": "application/json" });
         res.end(JSON.stringify({ error: "management endpoints are loopback-only; access denied for " + (req.socket.remoteAddress ?? "unknown") }));
@@ -754,6 +772,23 @@ async function handle(
         urlPath = url.split("?", 2)[0];
         responsesCompact = urlPath.endsWith("/responses/compact");
         route = resolveUpstream(opts, req.url ?? "", req);
+        // #409: destination admission for the zero-config /bili/ absolute-URL
+        // tunnel. CONNECT has its own gates (mitm.ts); this is the /bili/
+        // counterpart — self-proxy, link-local/metadata always denied;
+        // loopback/private denied for remote clients unless allowlisted.
+        if (route?.tunnel) {
+            const verdict = await checkTunnelDestination(route.upstream, {
+                selfPort: req.socket.localPort ?? undefined,
+                clientLoopback: isLoopbackAddress(req.socket.remoteAddress),
+                allowlist: tunnelAllowlistFromEnv(),
+            });
+            if (!verdict.ok) {
+                log("warn", `[tunnel] denied ${maskUrlsInText(route.upstream)}: ${verdict.message}`);
+                res.writeHead(403, { "content-type": "application/json" });
+                res.end(JSON.stringify({ error: verdict.message, code: "tunnel_destination_denied", detail: verdict.code }));
+                return;
+            }
+        }
         upstreamOrigin = route ? route.upstream : /^https?:\/\//i.test(url) ? new URL(url).origin : opts.upstream;
         protocol =
             route?.explicitProtocol
@@ -2041,6 +2076,10 @@ function buildForwardTarget(
     // request; a passthrough leaves the inbound marker — if any — intact so it
     // keeps propagating down the chain).
     if (hopMarker !== undefined) headers[BILI_HOP_HEADER] = hopMarker;
+    // #409: mark every /bili/ absolute-URL forward so a management plane
+    // reached through this tunnel (self, NAT hairpin, chained bili) can
+    // recognize and reject it — see the admin gate in handle().
+    if (route?.tunnel) headers[BILI_TUNNEL_HEADER] = "1";
     headers["host"] = new URL(upstreamUrl).host;
     // codex advertises its own server-side context compaction via this beta
     // feature. It conflicts with bili's client-side compress (bili IS the

--- a/src/tunnel-guard.ts
+++ b/src/tunnel-guard.ts
@@ -1,0 +1,168 @@
+import { lookup } from "node:dns/promises";
+import { networkInterfaces } from "node:os";
+
+/**
+ * Tunnel admission for the `/bili/<absolute-url>` zero-config branch (#409).
+ *
+ * The CONNECT/MITM side has destination admission (mitm.ts — whitelisted
+ * hosts, loopback-only blind tunnels). The /bili/ absolute-URL side had none:
+ * it would happily forward to the proxy's OWN /__bili/ management plane (the
+ * inner connection originates from the proxy, so the loopback admin gate
+ * passes), to link-local metadata addresses, or — on a `--host 0.0.0.0`
+ * deployment — to anything reachable from this machine, turning bili into a
+ * LAN-reachable SSRF pivot despite the "management stays loopback-only"
+ * promise.
+ *
+ * Policy (destination × client):
+ *   - the proxy itself (same port, own addresses incl. 127/8) → always deny
+ *   - link-local / metadata ranges → always deny (no legitimate use through
+ *     a model-traffic tunnel)
+ *   - loopback/private destinations → allowed for loopback clients (the
+ *     self-hosted-upstream case: sglang on 127.0.0.1:8199, ollama on
+ *     11434, a LAN relay — the httpRewrites launcher flow DEPENDS on this),
+ *     denied for remote clients unless the destination is on the explicit
+ *     allowlist (BILI_TUNNEL_ALLOWED_HOSTS, "host" or "host:port" entries)
+ *   - public destinations → allowed
+ *
+ * Hostnames are resolved before the verdict (an attacker must not bypass the
+ * range checks with "metadata.google.internal" or a rebind-friendly name);
+ * unresolvable names are denied outright. A DNS-rebinding race between the
+ * check and the connect remains theoretically possible and accepted — the
+ * `x-bili-tunnel` marker + management-plane rejection below is the second
+ * layer that still holds when it happens.
+ */
+
+export const BILI_TUNNEL_HEADER = "x-bili-tunnel";
+
+export type IpClass = "loopback" | "linkLocal" | "private" | "public";
+
+/** Parse a v4 quad or v6 literal (incl. ::ffff: mapped); null for names. */
+export function parseIpLiteral(s: string): string | null {
+    const t = s.trim().toLowerCase();
+    if (/^\d{1,3}(\.\d{1,3}){3}$/.test(t)) return t;
+    if (t.includes(":")) return t; // v6 literal (possibly mapped); names never contain ':'
+    return null;
+}
+
+export function classifyIp(ip: string): IpClass {
+    const lit = parseIpLiteral(ip);
+    if (!lit) return "public";
+    // v6 (incl. ::ffff:a.b.c.d mapped — normalize BEFORE the v4 branch, which
+    // would otherwise split on the dots of a mapped literal and NaN out).
+    if (lit.includes(":")) {
+        if (lit === "::1" || lit === "::") return "loopback";
+        const mapped = lit.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+        if (mapped) return classifyIp(mapped[1]);
+        if (lit.startsWith("fe8") || lit.startsWith("fe9") || lit.startsWith("fea") || lit.startsWith("feb")) return "linkLocal";
+        if (lit.startsWith("fc") || lit.startsWith("fd")) return "private"; // fc00::/7 ULA
+        return "public";
+    }
+    const parts = lit.split(".").map(Number);
+    const [a, b] = parts;
+    if (a === 127) return "loopback";
+    if (a === 169 && b === 254) return "linkLocal";
+    if (a === 10 || a === 0) return "private";
+    if (a === 172 && b >= 16 && b <= 31) return "private";
+    if (a === 192 && b === 168) return "private";
+    if (a === 100 && b >= 64 && b <= 127) return "private"; // CGNAT shared space
+    return "public";
+}
+
+export type ResolveHost = (host: string) => Promise<string[]>;
+
+export const dnsResolveHost: ResolveHost = async (host) => {
+    const res = await lookup(host, { all: true, family: 0 });
+    return res.map((r) => r.address);
+};
+
+let localAddrCache: { at: number; ips: Set<string> } | undefined;
+/** All addresses considered "this machine": 127/8 + ::1 + every interface unicast addr. */
+export function localMachineIps(): Set<string> {
+    const now = Date.now();
+    if (!localAddrCache || now - localAddrCache.at > 30_000) {
+        const ips = new Set<string>(["127.0.0.1", "::1"]);
+        for (const list of Object.values(networkInterfaces())) {
+            for (const ni of list ?? []) {
+                if (ni.address) ips.add(ni.address.toLowerCase());
+            }
+        }
+        // The whole 127/8 loopback range routes to this machine.
+        for (let i = 0; i <= 255; i++) ips.add(`127.0.0.${i}`);
+        localAddrCache = { at: now, ips };
+    }
+    return localAddrCache.ips;
+}
+
+export interface TunnelCheckContext {
+    /** Port this proxy is actually serving on (server.address()). */
+    selfPort: number | undefined;
+    clientLoopback: boolean;
+    allowlist: string[];
+    resolveHost?: ResolveHost;
+    localIps?: () => Set<string>;
+}
+
+export type TunnelVerdict = { ok: true } | { ok: false; code: "self" | "linkLocal" | "privateRemote" | "unresolvable"; message: string };
+
+function allowlistHit(host: string, port: number, allowlist: string[]): boolean {
+    const h = host.toLowerCase();
+    const hp = `${h}:${port}`;
+    return allowlist.some((e) => e === h || e === hp);
+}
+
+export async function checkTunnelDestination(origin: string, ctx: TunnelCheckContext): Promise<TunnelVerdict> {
+    let u: URL;
+    try {
+        u = new URL(origin);
+    } catch {
+        return { ok: false, code: "unresolvable", message: `invalid tunnel destination ${origin}` };
+    }
+    const host = u.hostname.replace(/^\[|\]$/g, "").toLowerCase();
+    const port = u.port ? Number(u.port) : u.protocol === "https:" ? 443 : 80;
+    let ips: string[];
+    const literal = parseIpLiteral(host);
+    if (literal) {
+        ips = [literal];
+    } else {
+        try {
+            ips = await (ctx.resolveHost ?? dnsResolveHost)(host);
+        } catch {
+            return { ok: false, code: "unresolvable", message: `cannot resolve tunnel destination ${host}` };
+        }
+        if (ips.length === 0) return { ok: false, code: "unresolvable", message: `no addresses for tunnel destination ${host}` };
+    }
+    // Layer 1: the proxy itself — the /__bili/ management plane must never be
+    // reachable through the tunnel, from any client.
+    if (ctx.selfPort !== undefined && port === ctx.selfPort) {
+        const mine = (ctx.localIps ?? localMachineIps)();
+        if (ips.some((ip) => mine.has(ip.toLowerCase()) || mine.has(`::ffff:${ip.toLowerCase()}`))) {
+            return { ok: false, code: "self", message: "the bili tunnel may not target the proxy itself" };
+        }
+    }
+    // Layer 2: link-local / metadata — no legitimate model upstream lives there.
+    const classes = ips.map((ip) => classifyIp(ip));
+    if (classes.includes("linkLocal")) {
+        return { ok: false, code: "linkLocal", message: "link-local / metadata destinations are blocked from the bili tunnel" };
+    }
+    // Layer 3: loopback / private — fine for local clients (self-hosted
+    // upstreams), denied for remote clients unless explicitly allowlisted.
+    if (!classes.every((c) => c === "public")) {
+        if (ctx.clientLoopback) return { ok: true };
+        if (allowlistHit(host, port, ctx.allowlist)) return { ok: true };
+        return {
+            ok: false,
+            code: "privateRemote",
+            message: `tunnel destination ${host} resolves to a loopback/private address; remote clients may only reach it via BILI_TUNNEL_ALLOWED_HOSTS`,
+        };
+    }
+    return { ok: true };
+}
+
+/** Parse BILI_TUNNEL_ALLOWED_HOSTS ("host" / "host:port", comma-separated). */
+export function tunnelAllowlistFromEnv(env: NodeJS.ProcessEnv = process.env): string[] {
+    const raw = env.BILI_TUNNEL_ALLOWED_HOSTS ?? "";
+    return raw
+        .split(",")
+        .map((s) => s.trim().toLowerCase())
+        .filter((s) => s.length > 0);
+}

--- a/tests/tunnel-guard.test.ts
+++ b/tests/tunnel-guard.test.ts
@@ -1,0 +1,258 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import { once } from "node:events";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { defaultConfig } from "acp-kernel";
+import { startServer } from "../src/server.ts";
+import type { ProxyOptions } from "../src/config.ts";
+import { SessionStore, _setStoreForTest } from "../src/persist.ts";
+import { _setForTest as setRegistryForTest } from "../src/registry.ts";
+import { classifyIp, checkTunnelDestination, tunnelAllowlistFromEnv, parseIpLiteral, type ResolveHost } from "../src/tunnel-guard.ts";
+
+/** #409: the /bili/<absolute-url> tunnel must not reach the proxy's own
+ *  management plane, link-local metadata, or (for remote clients) any
+ *  loopback/private destination — while LOCAL clients keep the self-hosted
+ *  upstream case (sglang/ollama on 127.0.0.1:<other port>). */
+
+test("parseIpLiteral: quads, v6, mapped; names are not literals", () => {
+    assert.equal(parseIpLiteral("127.0.0.1"), "127.0.0.1");
+    assert.equal(parseIpLiteral("FE80::1"), "fe80::1");
+    assert.equal(parseIpLiteral("::ffff:192.168.0.1"), "::ffff:192.168.0.1");
+    assert.equal(parseIpLiteral("metadata.google.internal"), null);
+    assert.equal(parseIpLiteral("localhost"), null);
+});
+
+test("classifyIp: range matrix", () => {
+    assert.equal(classifyIp("127.0.0.1"), "loopback");
+    assert.equal(classifyIp("127.9.9.9"), "loopback");
+    assert.equal(classifyIp("::1"), "loopback");
+    assert.equal(classifyIp("169.254.169.254"), "linkLocal");
+    assert.equal(classifyIp("fe80::1"), "linkLocal");
+    assert.equal(classifyIp("10.1.2.3"), "private");
+    assert.equal(classifyIp("172.16.0.1"), "private");
+    assert.equal(classifyIp("172.31.255.255"), "private");
+    assert.equal(classifyIp("192.168.1.1"), "private");
+    assert.equal(classifyIp("100.64.0.1"), "private");
+    assert.equal(classifyIp("fd00:ec2::254"), "private");
+    assert.equal(classifyIp("::ffff:10.0.0.1"), "private");
+    assert.equal(classifyIp("8.8.8.8"), "public");
+    assert.equal(classifyIp("2606:4700::1111"), "public");
+});
+
+const localIps = () => new Set(["127.0.0.1", "::1", "192.168.1.5", "127.0.0.2"]);
+const stubResolve = (map: Record<string, string[]>): ResolveHost => async (h) => map[h] ?? [];
+
+test("checkTunnelDestination: self always denied, any client", async () => {
+    for (const clientLoopback of [true, false]) {
+        const v = await checkTunnelDestination("http://127.0.0.1:8787", { selfPort: 8787, clientLoopback, allowlist: ["127.0.0.1:8787"], localIps });
+        assert.equal(v.ok, false);
+        assert.equal(v.code, "self", "allowlist must not exempt the proxy itself");
+        const lan = await checkTunnelDestination("http://192.168.1.5:8787", { selfPort: 8787, clientLoopback, allowlist: [], localIps });
+        assert.equal(lan.ok, false);
+        assert.equal(lan.code, "self", "interface address on the serving port is self");
+    }
+    const otherPort = await checkTunnelDestination("http://127.0.0.1:8199", { selfPort: 8787, clientLoopback: true, allowlist: [], localIps });
+    assert.equal(otherPort.ok, true, "loopback client reaching a DIFFERENT local service is the self-hosted upstream case");
+});
+
+test("checkTunnelDestination: link-local/metadata always denied, incl. via DNS names", async () => {
+    const direct = await checkTunnelDestination("http://169.254.169.254/latest/meta-data/", { selfPort: 8787, clientLoopback: true, allowlist: [], localIps });
+    assert.equal(direct.ok, false);
+    assert.equal(direct.code, "linkLocal");
+    const byName = await checkTunnelDestination("http://metadata.google.internal/", {
+        selfPort: 8787,
+        clientLoopback: true,
+        allowlist: ["metadata.google.internal"],
+        localIps,
+        resolveHost: stubResolve({ "metadata.google.internal": ["169.254.169.254"] }),
+    });
+    assert.equal(byName.ok, false, "names resolving into link-local are denied even when allowlisted");
+    assert.equal(byName.code, "linkLocal");
+});
+
+test("checkTunnelDestination: private destinations — local allow, remote needs allowlist", async () => {
+    const local = await checkTunnelDestination("http://127.0.0.1:8199/v1", { selfPort: 8787, clientLoopback: true, allowlist: [], localIps });
+    assert.equal(local.ok, true);
+    const remote = await checkTunnelDestination("http://127.0.0.1:8199/v1", { selfPort: 8787, clientLoopback: false, allowlist: [], localIps });
+    assert.equal(remote.ok, false);
+    assert.equal(remote.code, "privateRemote");
+    const remoteLan = await checkTunnelDestination("http://192.168.1.9:9000/v1", { selfPort: 8787, clientLoopback: false, allowlist: [], localIps });
+    assert.equal(remoteLan.ok, false);
+    assert.equal(remoteLan.code, "privateRemote");
+    const allowPort = await checkTunnelDestination("http://127.0.0.1:8199/v1", { selfPort: 8787, clientLoopback: false, allowlist: ["127.0.0.1:8199"], localIps });
+    assert.equal(allowPort.ok, true, "host:port allowlist entry unlocks the remote client");
+    const allowHost = await checkTunnelDestination("http://192.168.1.9:9000/v1", { selfPort: 8787, clientLoopback: false, allowlist: ["192.168.1.9"], localIps });
+    assert.equal(allowHost.ok, true, "bare-host allowlist entry matches any port on that host");
+    const wrongPort = await checkTunnelDestination("http://127.0.0.1:9000/v1", { selfPort: 8787, clientLoopback: false, allowlist: ["127.0.0.1:8199"], localIps });
+    assert.equal(wrongPort.ok, false, "host:port entry must not unlock other ports");
+});
+
+test("checkTunnelDestination: public destinations pass for any client; unresolvable denied", async () => {
+    for (const clientLoopback of [true, false]) {
+        const pub = await checkTunnelDestination("https://api.example.com/v1", {
+            selfPort: 8787,
+            clientLoopback,
+            allowlist: [],
+            localIps,
+            resolveHost: stubResolve({ "api.example.com": ["93.184.216.34"] }),
+        });
+        assert.equal(pub.ok, true);
+    }
+    const dead = await checkTunnelDestination("https://no-such-host.invalid/v1", {
+        selfPort: 8787,
+        clientLoopback: true,
+        allowlist: [],
+        localIps,
+        resolveHost: async () => {
+            throw new Error("ENOTFOUND");
+        },
+    });
+    assert.equal(dead.ok, false);
+    assert.equal(dead.code, "unresolvable");
+});
+
+test("checkTunnelDestination: default ports by scheme", async () => {
+    const httpsNoPort = await checkTunnelDestination("https://169.254.169.254/", { selfPort: 8787, clientLoopback: true, allowlist: [], localIps });
+    assert.equal(httpsNoPort.ok, false);
+    assert.equal(httpsNoPort.code, "linkLocal", "scheme-default 443 still classified");
+});
+
+test("tunnelAllowlistFromEnv: comma parsing, case normalization, blanks dropped", () => {
+    assert.deepEqual(tunnelAllowlistFromEnv({ BILI_TUNNEL_ALLOWED_HOSTS: "127.0.0.1:8199, LANRELAY.EXAMPLE , ,10.0.0.5" }), ["127.0.0.1:8199", "lanrelay.example", "10.0.0.5"]);
+    assert.deepEqual(tunnelAllowlistFromEnv({}), []);
+    assert.deepEqual(tunnelAllowlistFromEnv({ BILI_TUNNEL_ALLOWED_HOSTS: "  " }), []);
+});
+
+// ---------------------------------------------------------------------------
+// Integration: real server, real sockets.
+
+function close(server: http.Server): Promise<void> {
+    return new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+}
+
+function get(port: number, reqPath: string, headers: Record<string, string> = {}): Promise<{ status: number; body: string }> {
+    const { promise, resolve, reject } = Promise.withResolvers<{ status: number; body: string }>();
+    const req = http.request({ host: "127.0.0.1", port, path: reqPath, headers }, (res) => {
+        let body = "";
+        res.on("data", (c: Buffer) => { body += c.toString("utf8"); });
+        res.on("end", () => resolve({ status: res.statusCode ?? 0, body }));
+    });
+    req.once("error", reject);
+    req.end();
+    return promise;
+}
+
+test("integration: tunnel cannot reach the proxy's own management plane (#409 PoC)", async () => {
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    setRegistryForTest({});
+    const root = path.join(tmpdir(), `bili-tunnel-self-${process.pid}-${Date.now()}`);
+    mkdirSync(root, { recursive: true });
+    const biliConfig = path.join(root, "billion-context.json");
+    writeFileSync(biliConfig, '{"providers":{}}\n', "utf8");
+    const prevConfig = process.env.BILI_CONFIG_FILE;
+    process.env.BILI_CONFIG_FILE = biliConfig;
+    const opts: ProxyOptions = {
+        port: 0,
+        host: "127.0.0.1",
+        upstream: "http://127.0.0.1:1",
+        routes: {},
+        proxy: "",
+        proxyMode: "direct",
+        proxySource: "direct",
+        modelContextLimit: 400_000,
+        kernelConfig: defaultConfig(400_000),
+        compress: { injectTool: true, injectNudge: true },
+        promptCache: { routing: "auto" },
+        sessionHeader: "x-acp-session",
+        log: false,
+        debug: false,
+        passthrough: false,
+        autoUpdate: false,
+        mitm: { enabled: false, domains: [] },
+    };
+    const proxy = await startServer(opts);
+    if (!proxy.listening) await once(proxy, "listening");
+    const selfPort = (proxy.address() as { port: number }).port;
+    try {
+        const poc = await get(selfPort, `/bili/http://127.0.0.1:${selfPort}/__bili/config`);
+        assert.equal(poc.status, 403, "the issue's PoC GET must be denied");
+        assert.match(poc.body, /tunnel_destination_denied/);
+        const pocPut = await get(selfPort, `/bili/http://127.0.0.1:${selfPort}/__bili/config`);
+        assert.equal(pocPut.status, 403);
+        // Direct loopback management access still works (marker not present).
+        const direct = await get(selfPort, "/__bili/config", { host: `127.0.0.1:${selfPort}` });
+        assert.equal(direct.status, 200);
+        // Spoofed marker on a direct request only locks the spoofer out.
+        const spoof = await get(selfPort, "/__bili/config", { host: `127.0.0.1:${selfPort}`, "x-bili-tunnel": "1" });
+        assert.equal(spoof.status, 403, "admin gate rejects any request carrying the tunnel marker");
+    } finally {
+        process.env.BILI_CONFIG_FILE = prevConfig;
+        proxy.closeAllConnections?.();
+        await close(proxy);
+        try { rmSync(root, { recursive: true, force: true }); } catch { /* best-effort */ }
+    }
+});
+
+test("integration: metadata destination never contacted (403 before any socket); local upstream still proxied + marker stamped", async () => {
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    setRegistryForTest({});
+    const root = path.join(tmpdir(), `bili-tunnel-meta-${process.pid}-${Date.now()}`);
+    mkdirSync(root, { recursive: true });
+    const biliConfig = path.join(root, "billion-context.json");
+    writeFileSync(biliConfig, '{"providers":{}}\n', "utf8");
+    const prevConfig = process.env.BILI_CONFIG_FILE;
+    process.env.BILI_CONFIG_FILE = biliConfig;
+
+    // Echo upstream: captures headers, replies 200.
+    let sawMarker: string | string[] | undefined;
+    const echo = http.createServer((req, res) => {
+        sawMarker = req.headers["x-bili-tunnel"];
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ ok: true }));
+    });
+    echo.listen(0, "127.0.0.1");
+    await once(echo, "listening");
+    const echoPort = (echo.address() as { port: number }).port;
+
+    const opts: ProxyOptions = {
+        port: 0,
+        host: "127.0.0.1",
+        upstream: "http://127.0.0.1:1",
+        routes: {},
+        proxy: "",
+        proxyMode: "direct",
+        proxySource: "direct",
+        modelContextLimit: 400_000,
+        kernelConfig: defaultConfig(400_000),
+        compress: { injectTool: true, injectNudge: true },
+        promptCache: { routing: "auto" },
+        sessionHeader: "x-acp-session",
+        log: false,
+        debug: false,
+        passthrough: false,
+        autoUpdate: false,
+        mitm: { enabled: false, domains: [] },
+    };
+    const proxy = await startServer(opts);
+    if (!proxy.listening) await once(proxy, "listening");
+    const selfPort = (proxy.address() as { port: number }).port;
+    try {
+        const meta = await get(selfPort, "/bili/http://169.254.169.254/latest/meta-data/");
+        assert.equal(meta.status, 403);
+        assert.match(meta.body, /"detail":"linkLocal"/);
+        // Self-hosted upstream on a DIFFERENT port still works for the local client.
+        const local = await get(selfPort, `/bili/http://127.0.0.1:${echoPort}/v1/models`);
+        assert.equal(local.status, 200, `loopback client → loopback upstream must pass (got ${local.status}: ${local.body})`);
+        assert.equal(sawMarker, "1", "tunnel forward stamps x-bili-tunnel: 1");
+    } finally {
+        process.env.BILI_CONFIG_FILE = prevConfig;
+        proxy.closeAllConnections?.();
+        await close(proxy);
+        echo.closeAllConnections?.();
+        await close(echo);
+        try { rmSync(root, { recursive: true, force: true }); } catch { /* best-effort */ }
+    }
+});

--- a/tests/upstream-proxy-routing.test.ts
+++ b/tests/upstream-proxy-routing.test.ts
@@ -34,21 +34,25 @@ test("/bili/ resolves upstream host and full path from embedded URL", () => {
         upstream: "https://relay.example",
         rewrittenUrl: "https://relay.example/openai/v1/responses?foo=a%2Fb",
         explicitProtocol: undefined,
+        tunnel: true,
     });
     assert.deepEqual(resolveUpstream(opts, "/bili/https://relay.example/openai/v1/future/unknown?x=1"), {
         upstream: "https://relay.example",
         rewrittenUrl: "https://relay.example/openai/v1/future/unknown?x=1",
         explicitProtocol: undefined,
+        tunnel: true,
     });
     assert.deepEqual(resolveUpstream(opts, "/bili/responses/https://relay.example/custom-path"), {
         upstream: "https://relay.example",
         rewrittenUrl: "https://relay.example/custom-path",
         explicitProtocol: "responses",
+        tunnel: true,
     });
     assert.deepEqual(resolveUpstream(opts, "/bili/anthropic/https://relay.example/api/generate"), {
         upstream: "https://relay.example",
         rewrittenUrl: "https://relay.example/api/generate",
         explicitProtocol: "anthropic",
+        tunnel: true,
     });
     assert.equal(resolveUpstream(opts, "/bili-not-owned/responses"), undefined);
 });


### PR DESCRIPTION
Fixes #409.

## The hole

`/bili/<absolute-url>` had **zero destination admission** (CONNECT had gates; the tunnel branch had none):

1. `GET /bili/http://127.0.0.1:PORT/__bili/config` → **200** — the tunnel's inner connection originates from the proxy itself, so the loopback admin gate passes and the no-Origin origin gate passes too (issue PoC).
2. `169.254.169.254` — outbound connection really attempted.
3. On `--host 0.0.0.0`, a LAN peer could `PUT /__bili/config` over the tunnel → rewrite upstream routing → MITM all subsequent agent traffic and credentials, voiding the loopback-only promise.

## The fix (destination × client admission, keeps self-hosted upstreams working)

| destination | local (loopback) client | remote client |
|---|---|---|
| the proxy itself (same port, any local address incl. 127/8, NAT-reachable interfaces) | **403 always** | **403 always** |
| link-local / metadata (literal **or resolved via DNS name**) | **403 always** | **403 always** |
| loopback / private | allow (sglang `127.0.0.1:8199`, ollama `11434`, LAN relays — the launcher httpRewrites flow depends on this) | **403** unless in `BILI_TUNNEL_ALLOWED_HOSTS` (`host` / `host:port`) |
| public | allow | allow |

Plus defense in depth: every tunnel forward is stamped `x-bili-tunnel: 1`, and `/__bili/*` rejects any request carrying the marker — the management plane stays unreachable through the tunnel even when self-detection misses (NAT hairpin, DNS-rebinding race between check and connect, chained bili). A spoofed marker only locks the spoofer out of admin paths.

Names are resolved before the verdict (`metadata.google.internal` cannot bypass); unresolvable destinations are denied. The allowlist is logged at startup when set (#405's silent-knob lesson). README + CONFIGURATION document the policy alongside the existing CONNECT gates.

## What does NOT change

- Local clients → self-hosted loopback upstreams: unchanged (this is the launcher's core flow).
- Direct-config upstream mode (`opts.upstream`, operator-chosen): unaffected.
- CONNECT/MITM: already gated (mitm.ts), untouched.
- Authorization/cookie headers: still forwarded on admitted destinations — stripping auth would break the actual model upstreams; admission already blocks the destinations where header leakage mattered.

## Verification

- typecheck ✓ / **891 tests, 891 pass** ✓ (10 new: unit matrix for classify/admission/allowlist + 2 real-socket integration) / build ✓
- Integration reproduces the issue PoC → now 403; `169.254.169.254` → 403 with `detail:"linkLocal"` before any socket; loopback→loopback upstream still proxies and the upstream observes `x-bili-tunnel: 1`.

## Accepted residual risk

- DNS rebinding between the check and the connect (TOCTOU) — the `x-bili-tunnel` marker still blocks the management plane in that window; model-traffic SSRF to a rebound public host is equivalent to normal proxying of a public destination.
- The guard classifies CGNAT `100.64/10` and `0/8` as private (denied for remote clients) — conservative, no known impact.