### PR TITLE
fix: drive task-continuity across the compression boundary (#422)

### DIFF
--- a/src/loop/core.ts
+++ b/src/loop/core.ts
@@ -13,6 +13,7 @@ import type { BiliMessage } from "acp-kernel/wire";
 import {
     parseCompressInput,
     PROXY_TOOL_NAMES,
+    MUTATING_PROXY_TOOLS,
 } from "../compress-tool.js";
 import { applyRanges } from "../stream.js";
 import { resolveDecompress } from "../decompress-shared.js";
@@ -23,6 +24,17 @@ import { log as loggerLog } from "../logger.js";
 import type { WireProtocol } from "../util.js";
 
 export const MAX_LOOP_ROUNDS = 10;
+
+// #422: one-shot task-continuity driver for the re-request after a
+// context-mutating proxy tool — the compression boundary is where the model's
+// task-continuity is weakest (it stops, interrupting the in-progress task).
+// Injected into the re-request only; never persisted to session state. Text is
+// outcome-neutral (true for compress-success, compress-failure, and decompress
+// alike) and grants the model the right to stop if the task is actually done
+// (guards the reverse risk: over-driving a finished turn).
+export const CONTINUE_DRIVER_TEXT =
+    "[ACP] A context-management step (compress or decompress) just ran — that was housekeeping, not your task. " +
+    "Continue with your next planned action (the next tool call in your plan). If your task is in fact already complete, stop normally.";
 
 function isLoopThinking(m: CoreMessage): boolean {
     return m.contentType === "reasoning" && typeof m.id === "string" && m.id.startsWith("acp_loop_");
@@ -423,6 +435,21 @@ export async function* runCompressLoop(
                 loggerLog("warn", `[acp-loop] loop limit (${MAX_LOOP_ROUNDS}) reached; completing gracefully`);
                 yield adapter.emitCompletion({ finishReason: "length", usage });
                 return;
+            }
+
+            // #422: drive task-continuity across the compression boundary
+            // (mutating tools only — read-only queries don't replace context).
+            if (proxyResults.some((pr) => MUTATING_PROXY_TOOLS.has(pr.name))) {
+                const driverId = "acp_loop_continue_driver";
+                if (!coreMessages.some((m) => m.id === driverId)) {
+                    coreMessages.push({
+                        id: driverId,
+                        role: "user",
+                        contentType: "text",
+                        text: CONTINUE_DRIVER_TEXT,
+                    });
+                    ctx.log(`[acp-loop] round ${round}: injected continue-driver after context-mutating proxy tool (#422)`);
+                }
             }
 
             ctx.log(`[acp-loop] round ${round}: proxy tool executed; re-requesting so the model sees the result`);

--- a/tests/loop-compress.test.ts
+++ b/tests/loop-compress.test.ts
@@ -394,6 +394,67 @@ test("loop #9 (S2): responses round yields usage → session.stats populated (nu
     }
 });
 
+test("loop #422a: compress round → re-request body carries the one-shot continue-driver (task-continuity across the compression boundary)", async () => {
+    const ctx = withRefs(makeCtx([
+        textMsg("raw_1", "user", bigText(5000)),
+        textMsg("raw_2", "assistant", bigText(5000)),
+        textMsg("raw_3", "user", bigText(5000)),
+        textMsg("raw_4", "assistant", bigText(5000)),
+        textMsg("raw_5", "user", bigText(5000)),
+        textMsg("raw_6", "assistant", bigText(5000)),
+        textMsg("raw_7", "user", bigText(5000)),
+    ]));
+    const compressArgs = JSON.stringify({ content: [{ startId: "m00001", endId: "m00002", summary: "PAIR-SUMMARY-PAYLOAD-THAT-IS-LONG-ENOUGH-FOR-THE-KERNEL-MIN-LENGTH-CHECK" }] });
+    const round1 = [
+        sse("response.created", { response: { id: "resp_1", status: "in_progress" } }),
+        fcEvents(0, "call_c", "compress", compressArgs),
+        COMPLETED,
+    ].join("");
+    const probe = reFetchProbe();
+    try {
+        await drain(
+            new Response(round1, { status: 200 }).body!,
+            ctx,
+            { model: "gpt-4o", input: [], stream: true },
+            { url: "http://mock", headers: {} },
+        );
+        const bodies = probe.bodies();
+        assert.ok(bodies.length >= 1, "re-request fires after compress");
+        const body = bodies[0];
+        assert.ok(body.includes("housekeeping, not your task"), "re-request carries the one-shot continue-driver so the model resumes its in-progress task instead of stopping at the compression boundary (#422)");
+        assert.ok(body.includes("stop normally"), "driver grants the model the right to stop if the task is actually complete (reverse-risk guard)");
+    } finally {
+        probe.restore();
+    }
+});
+
+test("loop #422b: read-only acp_status round → re-request body does NOT carry the continue-driver (scoped to context-mutating tools)", async () => {
+    const ctx = makeCtx([
+        textMsg("m00001", "user", "hello"),
+        textMsg("m00002", "assistant", "hi"),
+    ]);
+    const round1 = [
+        sse("response.created", { response: { id: "resp_1", status: "in_progress" } }),
+        fcEvents(0, "call_s", "acp_status", "{}"),
+        COMPLETED,
+    ].join("");
+    const probe = reFetchProbe();
+    try {
+        await drain(
+            new Response(round1, { status: 200 }).body!,
+            ctx,
+            { model: "gpt-4o", input: [], stream: true },
+            { url: "http://mock", headers: {} },
+        );
+        const bodies = probe.bodies();
+        assert.ok(bodies.length >= 1, "re-request fires after acp_status");
+        const body = bodies[0];
+        assert.ok(!body.includes("housekeeping, not your task"), "no continue-driver for read-only queries — they don't replace the context, so the model continues naturally");
+    } finally {
+        probe.restore();
+    }
+});
+
 test("loop #10 (S3): upstream 500 mid-loop terminates cleanly (timer cleared, no hang)", async () => {
     process.env.BILI_REPLAY_RETRY_BASE_MS = "1";
     const ctx = makeCtx([


### PR DESCRIPTION
## Problem

#422: an ACP compression round ends the model turn with `finishReason=stop` and **zero toolCalls**, interrupting an in-progress task — the user must manually type "continue" to resume the tool loop. Clean stop, no fragment leak, upstream API normal (distinct from #361's torn-state fragment leak).

The compression boundary is where the model's task-continuity awareness is weakest: the context was just replaced and the model just produced a natural "deliverable" (the compress summary), so without an explicit drive it stops and treats the summary as the turn's end.

## Fix

In `runCompressLoop` (src/loop/core.ts), when the loop re-requests after a **context-mutating** proxy tool (`compress`/`decompress`, i.e. `MUTATING_PROXY_TOOLS`), push a one-shot task-continuity driver into the re-request's `coreMessages`:

> `[ACP] A context-management step (compress or decompress) just ran — that was housekeeping, not your task. Continue with your next planned action (the next tool call in your plan). If your task is in fact already complete, stop normally.`

Design notes:
- **Proactive** (user suggestion 1) rather than reactive: no wasted round, directly addresses the root cause (lack of drive at the compression boundary).
- **Outcome-neutral text**: true for compress-success, compress-failure, and decompress alike (the gate is `MUTATING_PROXY_TOOLS`, which includes decompress and failed compress — so the text must not assert "compression completed").
- **Right-to-terminate**: grants the model the option to stop normally if the task is actually complete — guards the reverse risk (over-driving a finished turn) without a fragile proxy-side "is the task in progress?" heuristic.
- **Scoped to mutating tools**: read-only queries (`acp_status`/`search_context`) don't replace the context, so the model continues naturally without a driver.
- **Transient**: the driver lives in the loop-local `coreMessages` (never persisted to session state), deduped by a fixed id (`acp_loop_continue_driver`), injected once per request, survives per-round `hideConsumedCompressCalls` (which only touches `compress` tool-call records). Sent to the model in the re-request, never emitted to the client.
- `role: "user"` + `contentType: "text"` is the safe role across all three wire protocols.

## Tests

- `loop #422a`: compress round → re-request body carries the continue-driver (asserts the outcome-neutral text + the right-to-terminate clause).
- `loop #422b`: read-only `acp_status` round → re-request body does NOT carry the driver (scoping control).

## Pre-flight

- `npm run typecheck` — clean
- `npm test` — 898 pass, 0 fail (in this environment; includes 49 loop tests + 2 new)
- `npm run build` — success
- E2E (`tests/e2e/e2e-codex.test.ts`): could not run in this environment — the `codex` binary is unavailable. Recommend running the E2E 4-phase core on a machine with `codex` + a Responses-compatible upstream before merge.

## Review iteration

Addressed @ranxianglei's review: (1) softened the driver text to be outcome-neutral (no longer asserts "compression completed", which was false for decompress + failed-compress paths); (2) replaced the forceful "do not stop" with a right-to-terminate clause (reverse-risk guard); (3) rebased onto current master (`5fe15a2`, includes #431/#433).