### PR TITLE
fix: stateless decompress — pure retrieval, no deactivate, cache retained (#400)

### DIFF
--- a/src/decompress-shared.ts
+++ b/src/decompress-shared.ts
@@ -1,6 +1,5 @@
 import {
     collectBlockContent,
-    deactivateBlock,
     type CompressionCore,
     type Config,
     type CoreMessage,
@@ -48,6 +47,9 @@ export type ProxyToolCtx = {
     core: CompressionCore;
     config: Config;
     messages: CoreMessage[];
+    /** Unfolded original history. Loop paths hand the folded view as
+     *  `messages`; decompress's cache-miss fallback must scan this instead. */
+    compressMessages?: CoreMessage[];
     session: Session;
     log: (msg: string) => void;
 };
@@ -55,13 +57,16 @@ export type ProxyToolCtx = {
 /** Resolve a decompress request to a result string, honoring the `full` flag
  *  and the cross-round original-content cache on the session.
  *
+ *  STATELESS RETRIEVAL: decompress is copy-paste — it changes no state. The
+ *  block stays active, the forwarded view keeps folding, the cache is kept
+ *  (repeat decompresses are free), and there is no expand/re-fold cycle.
+ *
  *  - If the block has cached originals (captured at compress time), use the
  *    cached `one` or `full` view per the flag. This is the cross-round-safe
  *    path: ctx.messages only holds the folded view by the time decompress runs.
- *  - Otherwise fall back to collectBlockContent against ctx.messages; if that
- *    yields nothing (originals already folded out), return the block summary.
- *  - deactivateBlock + delete the cache ONLY when content was actually
- *    recovered. A 0-count, no-cache result leaves the block active for retries. */
+ *  - Otherwise fall back to collectBlockContent against the unfolded view
+ *    (ctx.compressMessages ?? ctx.messages); if that yields nothing, return
+ *    the block summary. */
 export function resolveDecompress(
     args: Record<string, unknown>,
     ctx: ProxyToolCtx,
@@ -86,20 +91,12 @@ export function resolveDecompress(
         body = view.text;
         count = view.count;
     } else {
-        const collected = collectBlockContent(ctx.session.state, block, ctx.messages, { full });
+        const collected = collectBlockContent(ctx.session.state, block, ctx.compressMessages ?? ctx.messages, { full });
         body = collected.text || block.summary;
         count = collected.count;
     }
 
-    if (count > 0 || cached) {
-        ctx.session.state = deactivateBlock(ctx.session.state, [blockId]);
-        // Drop the cached originals now that the block is deactivated — it
-        // cannot be decompressed again, and keeping large original messages
-        // around grows memory unbounded over a long session.
-        ctx.session.blockContents.delete(blockId);
-    }
-
-    const header = `[Restored block ${blockId} — ${count} item(s)${full ? ", full" : ""}]`;
+    const header = `[Block ${blockId} content — ${count} item(s)${full ? ", full" : ""}]`;
     const safeBlockId = blockId.replace(/[^a-zA-Z0-9_-]/g, "-");
     const outPath = body.length > 10000 ? join(tmpdir(), `acp-decompress-${safeBlockId}-${Date.now()}.txt`) : null;
     if (outPath) {

--- a/tests/proxy-decompress-cache.test.ts
+++ b/tests/proxy-decompress-cache.test.ts
@@ -31,7 +31,7 @@ function compressARange() {
     session.state = turn.state;
     const ctx = { core, config, messages: turn.messages, session, log: () => {} };
     applyRanges(parseCompressInput({ content: [{ startId: "m00001", endId: "m00007", summary: "Early history: messages 1-7 covered initial setup, configuration, and baseline testing of the compression pipeline. This is the cached summary used by the one-level view." }] }), ctx as never);
-    return { ctx, core, config, session };
+    return { ctx, core, config, session, msgs };
 }
 
 test("resolveDecompress: default (full:false) returns one-level view, not nested full text", () => {
@@ -39,7 +39,7 @@ test("resolveDecompress: default (full:false) returns one-level view, not nested
     const blockId = [...session.state.blocks].slice(-1)[0]?.blockId;
     assert.ok(blockId, "a block was created");
     const out = resolveDecompress({ blockId }, ctx);
-    assert.match(out, /Restored block b\d+/);
+    assert.match(out, /Block b\d+ content/);
     // one-level view: count reflects direct messages + nested child summaries
     // (for a fresh leaf block there are no nested children, so count == direct msgs)
     assert.doesNotMatch(out, /written to:/, "small body not spilled to a temp file");
@@ -63,12 +63,29 @@ test("resolveDecompress: full:true returns all original messages", () => {
     assert.match(fullOut, /full/);
 });
 
-test("resolveDecompress: successful decompress deletes the cache", () => {
+test("resolveDecompress: stateless — cache kept, block stays active, repeat is idempotent", () => {
     const { ctx, session } = compressARange();
     const blockId = [...session.state.blocks].slice(-1)[0]?.blockId!;
     assert.ok(session.blockContents.has(blockId), "cache populated at compress time");
-    resolveDecompress({ blockId }, ctx);
-    assert.ok(!session.blockContents.has(blockId), "cache deleted after decompress");
+    const out1 = resolveDecompress({ blockId }, ctx);
+    assert.ok(session.blockContents.has(blockId), "cache retained after decompress (stateless retrieval)");
+    const block = session.state.blocks.find((b) => b.blockId === blockId);
+    assert.equal(block?.active, true, "block NOT deactivated — decompress changes no state");
+    const out2 = resolveDecompress({ blockId }, ctx);
+    assert.equal(out1, out2, "repeat decompress returns identical content");
+});
+
+test("resolveDecompress: cache miss falls back to originals via compressMessages (unfolded view)", () => {
+    const { core, config, session, msgs } = compressARange();
+    const blockId = [...session.state.blocks].slice(-1)[0]?.blockId!;
+    session.blockContents.delete(blockId);
+    // Loop paths hand the folded view as `messages` and the original history
+    // as `compressMessages`; the fallback must scan the latter, not the former.
+    const foldedCtx = { core, config, messages: [] as CoreMessage[], compressMessages: msgs, session, log: () => {} };
+    const out = resolveDecompress({ blockId }, foldedCtx as never);
+    assert.match(out, /Historical detail 0\./, "originals recovered from the unfolded view");
+    const block = session.state.blocks.find((b) => b.blockId === blockId);
+    assert.equal(block?.active, true, "block stays active after fallback retrieval");
 });
 
 test("resolveDecompress: missing cache + folded messages returns summary, keeps block active", () => {
@@ -81,7 +98,7 @@ test("resolveDecompress: missing cache + folded messages returns summary, keeps 
     assert.ok(blockBefore?.active, "block active before decompress");
     const out = resolveDecompress({ blockId }, emptyCtx);
     // Falls back to summary (count 0 → summary used); block stays active.
-    assert.match(out, /Restored block/);
+    assert.match(out, /Block b\d+ content/);
     const blockAfter = session.state.blocks.find((b) => b.blockId === blockId);
     assert.equal(blockAfter?.active, true, "block NOT deactivated when no content recovered and no cache");
 });


### PR DESCRIPTION
Fixes #400.

**[Design decision by maintainer — supersedes this issue's original acceptance criteria]** decompress is **stateless copy-paste**: it changes no state. The old "state transition" semantics (deactivate the block → originals re-enter the view → re-compress cycle) is rejected as a design error.

## What changed

`src/decompress-shared.ts` `resolveDecompress`:
- **Removed** `deactivateBlock(...)` — the block stays `active`, the forwarded view keeps folding, the summary stays in place
- **Removed** `session.blockContents.delete(...)` — the cache is retained forever, so decompress is **infinitely repeatable** and always returns originals (the old one-shot semantics deleted the cache, degrading the second decompress to the summary)
- Cache-miss fallback now scans the **unfolded view** (`ctx.compressMessages ?? ctx.messages`) — fixes the loop path handing the folded `processedMessages` view to `collectBlockContent`, which found zero originals (third root cause in #400)
- Tool-result header reworded to neutral retrieval semantics: `[Block b5 content — N item(s)]`

## Why this kills the whole #400 bug family

All three root causes were state writes: syncBlocks re-activation clobbering the deactivation, cache deletion breaking repeat decompress, folded-view fallback divergence. With zero state writes there is nothing to clobber — no `expanded` flag needed, no kernel change needed (kernel `core.decompress` is a pure lookup; `collectBlockContent` is already documented as the stateless primitive). Matches the semantics acp-kernel documents for the pi host ("The compressed block stays folded").

## Related

- acp-kernel PR #181 (`expanded` field) is superseded by this approach — recommend closing it (commented there)
- Supersedes the acceptance criteria in #400 (which demanded `active === false` + summary removed from view)

## Tests

- `resolveDecompress: stateless — cache kept, block stays active, repeat is idempotent` (flipped from the old "deletes the cache" assertion)
- `resolveDecompress: cache miss falls back to originals via compressMessages` (new — covers the loop-path folded-view bug)
- typecheck ✓ / 892 tests 892 pass ✓ / build ✓