### PR TITLE
release v0.1.68

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.67",
+  "version": "0.1.68",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Version bump only. Changes since v0.1.67:

- **#419 instance governance**: proxy instance file + registry (`src/instance.ts`), announce actual listening port, `BILI_LAUNCH_TOKEN` handshake, `BILI_PARENT_PID` watchdog, probe-attach-or-spawn in launchers, atomic conversations writes, overlay merge excluded-name handling. Fixes #391 family's instance lifecycle root causes.
- **#420 tunnel admission control** (`src/tunnel-guard.ts`): self/link-local always denied, private-range remote endpoints require `BILI_TUNNEL_ALLOWED_HOSTS` allowlist, `x-bili-tunnel` marker prevents forgery. Fixes #409.
- **#426 stateless decompress**: pure retrieval — no deactivation, block cache retained, loop fallback scans `compressMessages`. Fixes #400.
- **#416 omp install/uninstall idempotency**: top-level `extensions:` block-item matching, unified `OMP_ENTRY_RE` existence check + `broken` status, `ompConfigFile()` redirects when `PI_CODING_AGENT_DIR` points at the bili overlay. Fixes #393.

Pre-flight: typecheck ✓ / 893/893 tests ✓ / build ✓.