### PR TITLE
fix(#429): openai chat — write merged terminal chunk once, don't leak finish_reason

### DIFF
--- a/src/loop/adapter-openai.ts
+++ b/src/loop/adapter-openai.ts
@@ -97,6 +97,23 @@ function rewriteContentChunk(parsed: Record<string, unknown>, content: string): 
     return Buffer.from(`data: ${JSON.stringify(clone)}\n\n`, "utf8");
 }
 
+// A chunk forwarded verbatim must never carry finish_reason: the ACP loop may run
+// another upstream round after this one (core.ts reRequest), and the completion is
+// emitted once, at the end, by emitCompletion. Leaking an early finish makes every
+// later token "content after the finish reason" to the client.
+function stripFinishReasonChunk(buf: Buffer): Buffer {
+    const m = /^data: (.*)\n\n$/s.exec(buf.toString("utf8"));
+    if (!m) return buf;
+    try {
+        const parsed = JSON.parse(m[1]) as { choices?: Array<Record<string, unknown>> };
+        if (!Array.isArray(parsed.choices)) return buf;
+        parsed.choices = parsed.choices.map((c) => ({ ...c, finish_reason: null }));
+        return Buffer.from(`data: ${JSON.stringify(parsed)}\n\n`, "utf8");
+    } catch {
+        return buf;
+    }
+}
+
 export function createOpenaiAdapter(requestBody: Record<string, unknown>, clientSystem?: string): CompressLoopAdapter {
     const model = (requestBody.model as string) ?? "unknown";
     let responseId = `chatcmpl-proxy-${Date.now()}`;
@@ -312,8 +329,13 @@ export function createOpenaiAdapter(requestBody: Record<string, unknown>, client
                         cachedTokens: typeof pd?.cached_tokens === "number" ? pd.cached_tokens : undefined,
                     } as ParsedStreamEvent;
                     if (sawRealToolCall) {
+                        // This verbatim chunk IS the round's authoritative completion
+                        // (suppressCompletion); write it once and never fall through
+                        // to the text/reasoning branches (which would re-emit the same
+                        // bytes after the finish reason).
                         yield { kind: "meta", chunk: rawBuf } as ParsedStreamEvent;
                         yield { kind: "done", finishReason, suppressCompletion: true } as ParsedStreamEvent;
+                        continue;
                     } else {
                         yield {
                             kind: "done",
@@ -325,7 +347,7 @@ export function createOpenaiAdapter(requestBody: Record<string, unknown>, client
                 if (!delta) continue;
 
                 if (typeof delta.reasoning_content === "string" && delta.reasoning_content.length > 0) {
-                    yield { kind: "reasoning", delta: delta.reasoning_content, raw: rawBuf } as ParsedStreamEvent;
+                    yield { kind: "reasoning", delta: delta.reasoning_content, raw: finishReason ? stripFinishReasonChunk(rawBuf) : rawBuf } as ParsedStreamEvent;
                 }
 
                 if (delta.tool_calls) {
@@ -362,10 +384,10 @@ export function createOpenaiAdapter(requestBody: Record<string, unknown>, client
                         const clean = tagFilter.push(delta.content);
                         if (clean.length > 0) {
                             const raw = clean === delta.content ? rawBuf : rewriteContentChunk(parsed, clean);
-                            yield { kind: "text", delta: clean, ...(hasReasoning ? {} : { raw }) } as ParsedStreamEvent;
+                            yield { kind: "text", delta: clean, ...(hasReasoning ? {} : { raw: finishReason ? stripFinishReasonChunk(raw) : raw }) } as ParsedStreamEvent;
                         }
                 } else if (!hasReasoning && (delta.role || (Object.keys(delta).length === 0 && !finishReason))) {
-                    yield { kind: "meta", chunk: rawBuf, firstRoundOnly: true } as ParsedStreamEvent;
+                    yield { kind: "meta", chunk: finishReason ? stripFinishReasonChunk(rawBuf) : rawBuf, firstRoundOnly: true } as ParsedStreamEvent;
                 }
             }
         },

--- a/tests/openai-finish-reason-dup.test.ts
+++ b/tests/openai-finish-reason-dup.test.ts
@@ -1,0 +1,119 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createOpenaiAdapter } from "../src/loop/index.ts";
+import type { ParsedStreamEvent } from "../src/loop/core.ts";
+
+// #429 "OpenAI Chat received content after the finish reason". Invariant: a
+// verbatim passthrough chunk must NEVER carry finish_reason and must be written
+// at most once; the sole authoritative completion is the final round's
+// emitCompletion, EXCEPT a real-tool-call round (suppressCompletion) where the
+// verbatim terminal chunk IS the completion and keeps finish_reason.
+
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+
+const sseChunk = (delta: Record<string, unknown>, finishReason?: string) =>
+    enc.encode(
+        `data: ${JSON.stringify({
+            id: "c1",
+            object: "chat.completion.chunk",
+            created: 1,
+            model: "gpt",
+            choices: [{ index: 0, delta, finish_reason: finishReason ?? null }],
+        })}\n\n`,
+    );
+
+const mockStream = (...chunks: Uint8Array[]): ReadableStream<Uint8Array> =>
+    new ReadableStream<Uint8Array>({
+        start(controller) {
+            for (const c of chunks) controller.enqueue(c);
+            controller.enqueue(enc.encode(`data: [DONE]\n\n`));
+            controller.close();
+        },
+    });
+
+const collect = async (stream: ReadableStream<Uint8Array>) => {
+    const adapter = createOpenaiAdapter({ model: "gpt" });
+    const events: ParsedStreamEvent[] = [];
+    for await (const ev of adapter.parseStream(stream, 1)) events.push(ev);
+    return events;
+};
+
+const wireBytes = (events: ParsedStreamEvent[]): string[] =>
+    events
+        .filter((ev) => ev.kind === "meta" || (ev.kind === "text" && "raw" in ev) || (ev.kind === "reasoning" && "raw" in ev))
+        .map((ev) => dec.decode((ev as { chunk?: Uint8Array; raw?: Uint8Array }).chunk ?? (ev as { raw: Uint8Array }).raw));
+
+const finishCount = (wire: string[]) =>
+    wire.filter((s) => {
+        const m = /^data: (.*)\n\n$/s.exec(s);
+        if (!m) return false;
+        try {
+            return typeof JSON.parse(m[1]).choices?.[0]?.finish_reason === "string";
+        } catch {
+            return false;
+        }
+    }).length;
+
+// DEFECT 1 — merged terminal chunk (content + finish_reason in ONE chunk) with a
+// real tool call: the finish block yielded the raw chunk as meta without
+// `continue`, so the text branch re-wrote the same bytes. Client set finish on
+// copy 1, saw content on copy 2. The single write keeps finish_reason.
+test("merged content+finish chunk with real tool call is written once, keeping finish_reason", async () => {
+    const stream = mockStream(
+        sseChunk({ role: "assistant" }),
+        sseChunk({ content: "working" }),
+        sseChunk({
+            tool_calls: [{ index: 0, id: "call_1", type: "function", function: { name: "bash", arguments: '{"command":"ls"}' } }],
+        }),
+        sseChunk({ content: "done" }, "tool_calls"),
+    );
+    const wire = wireBytes(await collect(stream));
+    const merged = wire.filter((s) => s.includes('"done"'));
+    assert.equal(merged.length, 1, `terminal chunk written ${merged.length}x:\n${wire.join("")}`);
+    assert.equal(finishCount(wire), 1, `expected exactly one authoritative finish, got ${finishCount(wire)}:\n${wire.join("")}`);
+});
+
+// DEFECT 2 — a proxy-tool round is followed by another upstream round (core.ts
+// reRequest) with no completion in between. If round 1's merged chunk leaks
+// finish_reason to the wire, round 2's text lands after the finish reason.
+test("passthrough chunk from a proxy-tool round must not leak finish_reason", async () => {
+    const stream = mockStream(
+        sseChunk({ role: "assistant" }),
+        sseChunk({ content: "compressing" }),
+        sseChunk({
+            tool_calls: [
+                { index: 0, id: "call_c1", type: "function", function: { name: "compress", arguments: '{"content":[]}' } },
+            ],
+        }),
+        sseChunk({ content: "please hold" }, "tool_calls"),
+    );
+    const wire = wireBytes(await collect(stream));
+    assert.equal(finishCount(wire), 0, `finish_reason leaked to wire on a proxy-tool round:\n${wire.join("")}`);
+});
+
+// REGRESSION — text-only terminal round, merged chunk, no tool call: passthrough
+// finish stripped (emitCompletion is the single finish), done event intact.
+test("text-only merged terminal round strips passthrough finish but keeps the done event", async () => {
+    const stream = mockStream(
+        sseChunk({ role: "assistant" }),
+        sseChunk({ content: "hello" }, "stop"),
+    );
+    const events = await collect(stream);
+    const wire = wireBytes(events);
+    assert.equal(finishCount(wire), 0, `passthrough chunk leaked finish_reason:\n${wire.join("")}`);
+    const done = events.find((e) => e.kind === "done");
+    assert.ok(done && done.kind === "done", "done event present");
+    assert.equal(done!.finishReason, "stop", "done carries the upstream finish_reason");
+    assert.notEqual(done!.suppressCompletion, true, "non-suppressed: the loop emits the completion");
+});
+
+// REGRESSION — reasoning chunk merged with finish_reason must not leak either.
+test("reasoning chunk merged with finish_reason must not leak finish_reason", async () => {
+    const stream = mockStream(
+        sseChunk({ role: "assistant" }),
+        sseChunk({ reasoning_content: "thinking" }, "stop"),
+    );
+    const wire = wireBytes(await collect(stream));
+    assert.equal(finishCount(wire), 0, `reasoning chunk leaked finish_reason:\n${wire.join("")}`);
+});


### PR DESCRIPTION
Fixes #429 — `OpenAI Chat received content after the finish reason`.

## What was wrong

Two independent defects in the openai adapter's `parseStream` (`src/loop/adapter-openai.ts`), both reachable **only** when the upstream merges `delta.content` and `finish_reason` into the **same** terminal chunk (MiniMax-M3, kimi-k3, and other providers that do this). The client's check is unconditional: any chunk carrying `content`/`refusal`/`reasoning_details`/`tool_calls` after `finish_reason` is set throws.

**Defect 1 — single round, real tool call.** The `if (finishReason)` block yielded the raw chunk as `meta` (verbatim) but did **not** `continue`, so control fell through to the text branch and the *same bytes* were written a second time. The client set `finishReason` on copy 1 and saw content on copy 2.

**Defect 2 — multi round, proxy tool.** A round that only called proxy tools (`compress`, …) is not terminal (`core.ts` `reRequest`) and emits no completion. But its merged chunk still reached the wire carrying `finish_reason`, so round 2's text landed *after* the finish reason. This is the high-frequency path (every compress on a long session with a merging provider).

## The fix

Invariant enforced: **a verbatim passthrough chunk must never carry `finish_reason`, and must be written at most once.** The sole authoritative completion is the final round's `emitCompletion` — *except* a real-tool-call round (`suppressCompletion`), where the verbatim terminal chunk **is** the completion and keeps `finish_reason`, written exactly once (the #209/#224 passthrough-consistency guarantee).

- `stripFinishReasonChunk(buf)` — blanks `finish_reason` on a passthrough chunk (safe fallbacks: non-`data:` line, parse error, or no `choices` → returned unchanged).
- `reasoning` / `text` / `meta` branches strip when the chunk carries `finish_reason`.
- `sawRealToolCall` branch keeps the chunk verbatim and adds `continue` (no double-write).

## Tests

`tests/openai-finish-reason-dup.test.ts` — 4 cases:
1. merged content+finish chunk with a real tool call is written **once**, keeping `finish_reason` (defect 1).
2. passthrough chunk from a proxy-tool round leaks **no** `finish_reason` (defect 2).
3. regression: text-only merged terminal round strips the passthrough finish but the `done` event is intact (not suppressed).
4. regression: reasoning chunk merged with `finish_reason` leaks nothing.

All 4 fail on the pre-fix baseline and pass with the fix.

## Pre-flight

- `npm test`: **896 pass / 0 fail** (892 baseline + 4 new, zero regressions)
- `npm run typecheck`: clean
- `npm run build`: success

## e2e note

`tests/e2e/e2e-codex.test.ts` drives the **Responses** path (codex speaks Responses) and does not exercise the OpenAI *chat* adapter touched here; it also needs a `codex` binary + live upstream, unavailable in this sandbox. The change is isolated to `adapter-openai.ts` `parseStream` (no `core.ts`/`server.ts` edits), so the 4 adapter-level unit tests + the full suite are the validation surface. The reporter's e2e table (real `bili` + opencode + a merging mock upstream) covers the end-to-end path.

## Related but separate (not fixed here)

When the terminal chunk carries **both** `tool_calls` and `finish_reason`, the call is lost: `settleToolCalls()` runs first and `pending.clear()`s, but the chunk's own `tool_calls` only enter `pending` after the fall-through — no one settles them. Tracked separately (see issue thread).