### PR TITLE
refactor: delegate session-handoff rendering to acp-kernel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.65",
+  "version": "0.1.68",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.65",
+      "version": "0.1.68",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@types/node": "^22.0.0",
         "@types/node-forge": "^1.3.14",
-        "acp-kernel": "0.0.47",
+        "acp-kernel": "0.0.49",
         "fzstd": "0.1.1",
         "node-forge": "^1.4.0",
         "tar": "^7.5.22",
@@ -546,9 +546,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -650,9 +647,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -667,9 +661,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -684,9 +675,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -701,9 +689,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -718,9 +703,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -735,9 +717,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -752,9 +731,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -769,9 +745,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -786,9 +759,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -803,9 +773,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -820,9 +787,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -837,9 +801,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -854,9 +815,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -988,9 +946,9 @@
       }
     },
     "node_modules/acp-kernel": {
-      "version": "0.0.47",
-      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.47.tgz",
-      "integrity": "sha512-XxC8y/w1wPiaCA/euGb74XsWy9ndlZL+cHttKYCwAlmxHy9L9d2bY+Ed/h9cTctT4LI7EnpuKfJ3r3zSirq/yQ==",
+      "version": "0.0.49",
+      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.49.tgz",
+      "integrity": "sha512-BAWDs+SPWphAm3x6uOL+UzX0LVEPsmOdVlTEGET0ZBcXuTJfQ3TWn0mdW7xUBnsuYBOZMu3mAf8Nql3l93USOA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/node-forge": "^1.3.14",
-    "acp-kernel": "0.0.47",
+    "acp-kernel": "0.0.49",
     "fzstd": "0.1.1",
     "node-forge": "^1.4.0",
     "tar": "^7.5.22",

--- a/src/export.ts
+++ b/src/export.ts
@@ -1,6 +1,6 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
-import { prune, type CoreMessage } from "acp-kernel";
+import { renderHandoff as kernelRenderHandoff, matchSession } from "acp-kernel";
 import type { Session } from "./session.js";
 import { SessionStore } from "./persist.js";
 
@@ -48,6 +48,28 @@ function latestBlockTime(s: Session): number {
 }
 
 export function renderHandoff(s: Session, full: boolean): string {
+    const messages = s.lastMessages;
+    if (messages && messages.length > 0) {
+        return kernelRenderHandoff({
+            coreMessages: messages,
+            state: s.state,
+            full,
+            meta: {
+                title: s.meta.title,
+                label: s.meta.label,
+                sessionId: s.id,
+                contextTokens: s.stats.contextTokens,
+                extraBullets: [
+                    s.meta.protocol ? `- protocol: ${s.meta.protocol}` : null,
+                    s.meta.upstreamOrigin ? `- upstream: ${s.meta.upstreamOrigin}` : null,
+                    `- requests: ${s.stats.requests}`,
+                ].filter((x): x is string => x !== null),
+            },
+        });
+    }
+
+    // v2 fallback: no snapshot persisted. Block summaries (+ originals with
+    // --full from the blockContents cache) are all that is recoverable offline.
     const lines: string[] = [];
     lines.push(`# billion-context session handoff`);
     lines.push("");
@@ -60,30 +82,6 @@ export function renderHandoff(s: Session, full: boolean): string {
     if (s.stats.contextTokens) lines.push(`- last context tokens: ~${s.stats.contextTokens}`);
     lines.push(`- compression blocks: ${s.state.blocks.length} (active ${s.state.blocks.filter((b) => b.active).length})`);
     lines.push("");
-
-    const messages = s.lastMessages;
-    if (messages && messages.length > 0) {
-        // Full-conversation snapshot (v3 files): render exactly what the model
-        // saw. Default = folded view via the kernel's own renderer (summaries
-        // in place of compressed ranges); --full = every original message.
-        lines.push(full ? `## Full conversation (${messages.length} messages)` : `## Conversation (folded view as the model saw it, ${messages.length} client messages)`);
-        lines.push("");
-        let lastRole = "";
-        const view = full ? messages : prune(messages, s.state);
-        for (const m of view) {
-            if (m.role !== lastRole) {
-                lines.push(`### ${m.role}`);
-                lines.push("");
-                lastRole = m.role;
-            }
-            lines.push(renderMessage(m));
-        }
-        lines.push("");
-        return lines.join("\n");
-    }
-
-    // v2 fallback: no snapshot persisted. Block summaries (+ originals with
-    // --full from the blockContents cache) are all that is recoverable offline.
     const active = s.state.blocks.filter((b) => b.active);
     if (active.length === 0) {
         lines.push("No active compression blocks and no persisted conversation snapshot (v2 session file). Original messages are only persisted when they are compressed into a block, so this session's conversation content is not available for export.");
@@ -113,37 +111,6 @@ export function renderHandoff(s: Session, full: boolean): string {
     return lines.join("\n");
 }
 
-/** Render one CoreMessage as markdown. tool-call / tool-result / reasoning
- *  carry their structured fields; text carries the body. */
-function renderMessage(m: CoreMessage): string {
-    const parts: string[] = [];
-    switch (m.contentType) {
-        case "text":
-            parts.push(m.text ?? "");
-            break;
-        case "tool-call":
-            parts.push(`\`${m.toolName ?? "?"}(${m.toolCallId ?? ""})\` args: ${m.text ?? ""}`);
-            break;
-        case "tool-result":
-            parts.push(`\`${m.toolName ?? "?"}(${m.toolCallId ?? ""})\` → ${m.text ?? ""}`);
-            break;
-        case "reasoning":
-            parts.push(`_reasoning_: ${m.text ?? ""}`);
-            break;
-    }
-    const body = parts.join("\n").trim();
-    return body === "" ? "_(empty)_" : body + "\n";
-}
-
-function matchSession(sessions: Session[], selector: string): Session[] {
-    const exact = sessions.filter((s) => s.id === selector);
-    if (exact.length > 0) return exact;
-    const byLabel = sessions.filter((s) => s.meta.label === selector);
-    if (byLabel.length > 0) return byLabel;
-    const byPrefix = sessions.filter((s) => s.id.startsWith(selector) || (s.meta.label ?? "").startsWith(selector));
-    return byPrefix;
-}
-
 export async function exportSession(selector: string | undefined, opts: ExportOptions = {}): Promise<string> {
     const store = new SessionStore({ dir: opts.dir, enabled: true });
     const all = [...(await store.loadAll()).values()];
@@ -157,7 +124,7 @@ export async function exportSession(selector: string | undefined, opts: ExportOp
         );
         return ["Persisted sessions:", "", ...rows.map((r) => `  ${r}`), "", "Usage: bili export <session-id|label> [--output handoff.md] [--full]"].join("\n");
     }
-    const matches = matchSession(all, selector);
+    const matches = matchSession(all, selector, (s) => s.meta.label);
     if (matches.length === 0) {
         throw new Error(`no session matches "${selector}" (run "bili export" to list sessions)`);
     }


### PR DESCRIPTION
Closes #601 — tracking issue for this PR.

## What
Removes the duplicated session-handoff markdown logic from the proxy by delegating to the kernel's shared renderer (acp-kernel PR #183), so the proxy and `billion-context-pi` no longer each carry a copy of `renderHandoff` / `renderMessage` / `matchSession` (requested in ranxianglei/billion-context-pi#271).

## Changes (`src/export.ts`)
- The **v3-snapshot path** (`s.lastMessages`) now delegates the whole doc — metadata header + folded (`prune`) / full conversation — to kernel `renderHandoff({coreMessages, state, full, meta})`, with protocol / upstream / requests injected via `meta.extraBullets`.
- The **v2 fallback** (per-block summaries + `blockContents` originals) is unchanged and stays byte-identical.
- `matchSession` now comes from the kernel (label accessor = `s.meta.label`).
- Bumps `acp-kernel` `0.0.47` → `0.0.49` (the release that ships the handoff exports). `package-lock.json` is refreshed once `0.0.49` is on npm.

## Verification (local pre-validation against acp-kernel#183's build)
- `npm run typecheck` — clean
- `npm test` — **892 pass, 0 fail** (incl. `tests/cli-export.test.ts`, which asserts the v2-fallback output is byte-identical)
- `npm run build` — success

## Dependency / merge order
Blocked on **acp-kernel#183** merging + **acp-kernel 0.0.49** publishing. Until then CI is red at `npm ci` (cannot resolve 0.0.49). After 0.0.49 is live, run `npm install` to refresh the lockfile and the PR goes green.