### PR TITLE
fix(#436): force repeat nudge when the model ignores the prior one

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1379,6 +1379,39 @@ function diagNudge(turn: { nudge?: { shouldInject: boolean; reason: string; cont
     return `[${sessionId}] nudge ${inject}: usage=${pct} (${tokenCount}/${limit}), growth=${growth}/${floor} (ref=${ref}, interval=${interval}), pendingT1=${pendingT1}/${interval}${modelTag}, reason="${n.reason.slice(0, 120)}"`;
 }
 
+// #436: the kernel re-arms its nudge cadence from lastShownByTier (stamped on
+// injection, NOT on a successful compress). When the model ignores a nudge that
+// reference stays high, so the full growth floor must re-accumulate before the
+// next nudge even with a large ready range un-compressed ("blocked: T1
+// (cadence)"). Force a repeat tier-1 nudge at a shorter cadence. Mutates the
+// decision post-processTurn (kernel lastShownByTier untouched); tracks its own
+// interval in session.metadata so it doesn't nudge every turn.
+function maybeForceRepeatNudge(
+    turn: { nudge?: NudgeDecision | null },
+    session: Session,
+    pluginMode: boolean,
+    log: (level: string, msg: string) => void,
+): void {
+    if (pluginMode) return;
+    const nudge = turn.nudge;
+    if (!nudge || nudge.shouldInject) return;
+    const bd = nudge.breakdown;
+    const pendingT1 = bd.pendingT1;
+    const interval = bd.nudgeGrowthTokens;
+    if (interval <= 0 || pendingT1 < interval) return;
+    const lastShown = session.state.nudge?.lastNudgeShownTokens ?? 0;
+    if (lastShown <= 0) return;
+    const shortCadence = Math.max(5000, Math.floor(bd.growthFloor / 2));
+    const tokenCount = bd.growthReference + bd.growth;
+    const lastForced = (session.metadata.lastForcedNudgeTokens as number | undefined) ?? 0;
+    if (tokenCount - lastForced < shortCadence) return;
+    nudge.shouldInject = true;
+    nudge.tier = 1;
+    nudge.reason = `forced repeat nudge: model ignored prior nudge (ready T1 ${pendingT1}, growth ${bd.growth} since injection at ${lastShown})`;
+    session.metadata.lastForcedNudgeTokens = tokenCount;
+    log("info", `[${session.id}] nudge FORCED repeat T1: model ignored prior nudge (ready T1 ${pendingT1}, growth ${bd.growth} since injection at ${lastShown}, now ${tokenCount})`);
+}
+
 function prepareAnthropic(
     parsed: AnthropicRequestBody,
     req: http.IncomingMessage,
@@ -1430,6 +1463,7 @@ function prepareAnthropic(
         // (kernel validates the whole batch). Mirrors billion-context-pi.
         if (turn.nudge) turn.nudge.compressibleRanges = viableRanges(turn.nudge.compressibleRanges);
         nudge = turn.nudge;
+        maybeForceRepeatNudge(turn, session, pluginMode, log);
         session.stats.contextTokens = tokenCount;
         if (!session.meta.title) {
             const t = deriveTitle(msgs);
@@ -1526,6 +1560,7 @@ function prepareOpenai(
         // (kernel validates the whole batch). Mirrors billion-context-pi.
         if (turn.nudge) turn.nudge.compressibleRanges = viableRanges(turn.nudge.compressibleRanges);
         nudge = turn.nudge;
+        maybeForceRepeatNudge(turn, session, pluginMode, log);
         session.stats.contextTokens = tokenCount;
         if (!session.meta.title) {
             const t = deriveTitle(msgs);
@@ -1681,6 +1716,7 @@ function prepareResponses(
         // (kernel validates the whole batch). Mirrors billion-context-pi.
         if (turn.nudge) turn.nudge.compressibleRanges = viableRanges(turn.nudge.compressibleRanges);
         nudge = turn.nudge;
+        maybeForceRepeatNudge(turn, session, pluginMode, log);
         session.stats.contextTokens = tokenCount;
         if (!session.meta.title) {
             const t = deriveTitle(msgs);

--- a/tests/nudge-repeat-cadence.test.ts
+++ b/tests/nudge-repeat-cadence.test.ts
@@ -1,0 +1,126 @@
+process.env.NODE_ENV = "test";
+import test from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import { once } from "node:events";
+import { AddressInfo } from "node:net";
+import { defaultConfig } from "acp-kernel";
+import { startServer, type ProxyOptions } from "../src/server.ts";
+import { SessionStore, _setStoreForTest } from "../src/persist.ts";
+import { _setForTest as setRegistryForTest } from "../src/registry.ts";
+
+// #436: a nudge that the model ignores leaves the kernel's growth reference
+// (lastNudgeShownTokens) pinned at the injection point, so the full growth
+// floor must re-accumulate before the kernel nudges again — even when a large
+// compressible range is sitting ready. maybeForceRepeatNudge (src/server.ts)
+// shortens that cadence on the billion-context side: once a prior nudge is
+// pending (model never compressed) and a ready range >= the interval exists,
+// re-nudge at ~half the growth floor instead of waiting the full floor.
+//
+// This drives the real proxy (startServer) against a local upstream that
+// reports a growing prompt_tokens each turn, so bili's tokenCount (the previous
+// turn's usage) climbs 10k → 20k → 30k → 40k → 42k:
+//   turn 1: tokenCount 0      → no nudge (baseline not set)
+//   turn 2: tokenCount 10k    → no nudge (growth 0; baseline set to 10k here)
+//   turn 3: tokenCount 20k    → no nudge (growth 10k < floor 20k)
+//   turn 4: tokenCount 30k    → KERNEL nudge (growth 20k >= floor, pendingT1 ready)
+//   turn 5: tokenCount 40k    → kernel silent (growth 10k < floor since turn 4)
+//                                but the model ignored the turn-4 nudge, so the
+//                                FORCED repeat nudge fires.
+// A nudge surfaces as one extra trailing user message in the forwarded payload.
+
+const PROMPT_TOKENS = [10_000, 20_000, 30_000, 40_000, 42_000];
+
+function okJson(promptTokens: number) {
+    return JSON.stringify({
+        id: "chatcmpl-test",
+        object: "chat.completion",
+        created: 1,
+        model: "test-model",
+        choices: [{ index: 0, message: { role: "assistant", content: "ok" }, finish_reason: "stop" }],
+        usage: { prompt_tokens: promptTokens, completion_tokens: 3, total_tokens: promptTokens + 3 },
+    });
+}
+
+// A system prompt + many long user/assistant pairs + a small recent tail. The
+// long pairs sit well outside the protected recent zone, so the kernel reports
+// a large tier-1 pending range (>= the 5k nudge interval) on every turn.
+function historyMessages(): Array<{ role: string; content: string }> {
+    const msgs: Array<{ role: string; content: string }> = [
+        { role: "system", content: "You are a helpful assistant." },
+    ];
+    for (let i = 0; i < 16; i++) {
+        msgs.push({ role: i % 2 === 0 ? "user" : "assistant", content: `Turn ${i} detail. ${"x".repeat(5000)}` });
+    }
+    msgs.push({ role: "user", content: "Please continue." });
+    return msgs;
+}
+
+test("nudge repeat cadence: forced nudge fires when the model ignored the prior one", async () => {
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    setRegistryForTest({});
+
+    const received: Array<Array<{ role: string; content?: unknown }>> = [];
+    let turn = 0;
+    const upstream = http.createServer((req, res) => {
+        let body = "";
+        req.on("data", (c) => (body += c));
+        req.on("end", () => {
+            const parsed = JSON.parse(body);
+            received.push(parsed.messages ?? []);
+            const promptTokens = PROMPT_TOKENS[turn] ?? PROMPT_TOKENS[PROMPT_TOKENS.length - 1];
+            turn++;
+            res.writeHead(200, { "content-type": "application/json" });
+            res.end(okJson(promptTokens));
+        });
+    });
+    upstream.listen(0, "127.0.0.1");
+    await once(upstream, "listening");
+    const upstreamPort = (upstream.address() as AddressInfo).port;
+
+    const proxy = await startServer({
+        port: 0,
+        host: "127.0.0.1",
+        upstream: `http://127.0.0.1:${upstreamPort}`,
+        routes: {},
+        modelContextLimit: 200_000,
+        kernelConfig: defaultConfig(200_000),
+        compress: { injectTool: true, injectNudge: true, nudgeGrowthTokens: 5_000 },
+        promptCache: { routing: "auto" },
+        sessionHeader: "x-acp-session",
+        log: false,
+        debug: false,
+        passthrough: false,
+        autoUpdate: false,
+        mitm: { enabled: false, domains: [] },
+    } as ProxyOptions);
+    await once(proxy, "listening");
+    const proxyPort = (proxy.address() as AddressInfo).port;
+    const url = `http://127.0.0.1:${proxyPort}/bili/http://127.0.0.1:${upstreamPort}/v1/chat/completions`;
+    const sess = "nudge-repeat-test";
+
+    try {
+        for (let i = 0; i < 5; i++) {
+            const resp = await fetch(url, {
+                method: "POST",
+                headers: { "content-type": "application/json", "x-acp-session": sess },
+                body: JSON.stringify({ model: "test-model", messages: historyMessages() }),
+            });
+            assert.equal(resp.status, 200, `turn ${i + 1} should be proxied`);
+            await resp.text();
+        }
+
+        const base = received[0].length;
+        assert.equal(received[1].length, base, "turn 2: no nudge (growth 0, baseline just set)");
+        assert.equal(received[2].length, base, "turn 3: no nudge (growth 10k < floor 20k)");
+        assert.equal(received[3].length, base + 1, "turn 4: kernel nudge appended (growth 20k >= floor)");
+        assert.equal(received[4].length, base + 1, "turn 5: forced repeat nudge appended (model ignored turn 4)");
+
+        const last = received[4][received[4].length - 1] as { role: string; content?: unknown };
+        assert.equal(last.role, "user", "the nudge is a trailing user message");
+        assert.ok(typeof last.content === "string" && last.content.length > 0, "nudge carries rendered text");
+    } finally {
+        proxy.close();
+        upstream.close();
+    }
+});


### PR DESCRIPTION
## Problem (#436)

`上下文满了不压缩 bili omp` — with `bili omp` the context fills up but bili never compresses. From the attached `bili.log` (session `01a05d8f`, proxy mode, local Qwen model, 229k window):

- At 15:26:45 the kernel fires `nudge INJECT T1` (pendingT1 50772 ≥ 50000, growth 83676 ≥ floor 22500).
- The model **never calls the `compress` tool** (`Blocks: none`).
- Every subsequent turn logs `nudge idle: growth {g} < floor 22500, ready: T1 {p}, blocked: T1 (cadence)` — pendingT1 climbs to 64088 while growth only reaches 13177, so the next nudge is blocked until ~128k tokens.

## Root cause

The kernel re-arms its nudge cadence from `lastShownByTier` / `lastNudgeShownTokens`, which are stamped on nudge **injection**, not on a successful **compress** (`acp-kernel` `nudgeNode.run`). When the model ignores a nudge, that reference stays high, so the full growth floor must re-accumulate before re-nudging — even with a large ready range sitting un-compressed. The user sees the context fill up while bili stays idle.

## Fix

`maybeForceRepeatNudge` in `src/server.ts` (called in all three `prepare*` paths, proxy mode only): when the kernel declines a nudge **but** a tier-1 range is already at/above the nudge interval and a prior nudge went un-compressed (`lastNudgeShownTokens > 0`), force a repeat tier-1 nudge at a shorter cadence (half the growth floor, min 5k). It mutates the decision post-`processTurn`, so the kernel's own cadence keeps running independently; its own interval is tracked in `session.metadata.lastForcedNudgeTokens` so it doesn't nudge every turn. Once the model actually compresses, `lastNudgeShownTokens` resets to 0 and the forcing stops.

No kernel change — `acp-kernel` is a separate pinned package. Plugin mode is suppressed (the agent owns compression there), matching the existing `!pluginMode` nudge gate.

## Verification

- New `tests/nudge-repeat-cadence.test.ts` drives the real proxy: turn 4 gets the kernel's growth-path nudge, the model ignores it, and turn 5 — which the kernel leaves idle (`growth < floor`) — gets the forced repeat nudge. Disabling the helper makes turn 5 lose its nudge (isolates the fix).
- `npm run typecheck` clean, `npm test` 897/897 pass, `npm run build` succeeds.

Closes #436.