### PR TITLE
fix(#437): make upstream timeout idle-based so long healthy streams aren't truncated

### DIFF
--- a/src/fetch-util.ts
+++ b/src/fetch-util.ts
@@ -19,11 +19,15 @@ export const UPSTREAM_TIMEOUT_MS = 10 * 60 * 1000;
  *  is accepted, without `as any`. */
 export type FetchOptions = Omit<RequestInit, "dispatcher"> & { dispatcher?: object };
 
-/** Abort a fetch after `timeoutMs`. Unlike the naive version, the timer is
- *  NOT cleared when headers arrive — it must cover the response BODY too
- *  (LLM SSE streams can stall mid-stream). Callers receive a `clearTimer`
- *  callback and invoke it once the response stream has been fully consumed;
- *  otherwise the timer correctly fires and aborts a stuck stream.
+/** Abort a fetch after `timeoutMs` of IDLE time. The timer starts when the
+ *  fetch begins (bounding time-to-first-byte / headers) and is RE-ARMED on
+ *  every response-body chunk, so it becomes an idle timeout once the body is
+ *  streaming: a healthy stream that keeps producing chunks is never aborted
+ *  mid-flight (LLM generations can legitimately run for minutes — a total
+ *  timer would kill a healthy 12-minute stream at the 10-minute mark), while a
+ *  genuinely stuck stream (no chunk for `timeoutMs`) still trips the abort.
+ *  Callers receive a `clearTimer` callback and invoke it once the response
+ *  stream has been fully consumed (or on the error path) to stop the timer.
  *
  *  `opts.dispatcher` (optional) routes the fetch through an upstream proxy
  *  (an `undici.ProxyAgent`). When omitted, fetch uses its default agent.
@@ -39,7 +43,11 @@ export async function fetchWithTimeout(
     externalSignal?: AbortSignal,
 ): Promise<{ response: Response; clearTimer: () => void }> {
     const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    let timer = setTimeout(() => controller.abort(), timeoutMs);
+    const rearm = () => {
+        clearTimeout(timer);
+        timer = setTimeout(() => controller.abort(), timeoutMs);
+    };
     let onExternalAbort: (() => void) | null = null;
     if (externalSignal) {
         if (externalSignal.aborted) controller.abort();
@@ -48,6 +56,10 @@ export async function fetchWithTimeout(
             externalSignal.addEventListener("abort", onExternalAbort, { once: true });
         }
     }
+    const cleanup = () => {
+        clearTimeout(timer);
+        if (onExternalAbort && externalSignal) externalSignal.removeEventListener("abort", onExternalAbort);
+    };
     try {
         const finalOpts: Omit<RequestInit, "dispatcher"> & { dispatcher?: object } = { ...opts, signal: controller.signal };
         // `fetch` is undici's global; it accepts `dispatcher` at runtime. @types/node
@@ -55,19 +67,51 @@ export async function fetchWithTimeout(
         // which structurally conflicts with the `undici` package's exported
         // Dispatcher — but at runtime they're the same thing. Assert to the
         // concrete RequestInit type (no `as any`) to satisfy the call site.
-        const response = await fetch(url, finalOpts as RequestInit);
-        return {
-            response: response as Response,
-            clearTimer: () => {
-                clearTimeout(timer);
-                if (onExternalAbort && externalSignal) externalSignal.removeEventListener("abort", onExternalAbort);
-            },
-        };
+        const raw = await fetch(url, finalOpts as RequestInit) as Response;
+        if (raw.body) {
+            // Wrap the body so each chunk re-arms the timer (idle timeout); carry
+            // status/headers onto a fresh Response so callers see an identical shape.
+            const wrapped = armIdleBody(raw.body, rearm);
+            return {
+                response: new Response(wrapped, {
+                    status: raw.status,
+                    statusText: raw.statusText,
+                    headers: raw.headers,
+                }),
+                clearTimer: cleanup,
+            };
+        }
+        return { response: raw, clearTimer: cleanup };
     } catch (e) {
-        clearTimeout(timer);
-        if (onExternalAbort && externalSignal) externalSignal.removeEventListener("abort", onExternalAbort);
+        cleanup();
         throw e;
     }
+}
+
+function armIdleBody(body: ReadableStream<Uint8Array>, rearm: () => void): ReadableStream<Uint8Array> {
+    const reader = body.getReader();
+    return new ReadableStream<Uint8Array>({
+        async pull(controller) {
+            try {
+                const result = await reader.read();
+                if (result.done) {
+                    controller.close();
+                    return;
+                }
+                rearm();
+                controller.enqueue(result.value);
+            } catch (e) {
+                controller.error(e);
+            }
+        },
+        async cancel(reason) {
+            try {
+                await reader.cancel(reason);
+            } catch {
+                /* already closed */
+            }
+        },
+    });
 }
 
 /** Upstream HTTP failure after all retry attempts are exhausted (or a

--- a/tests/fix-437-idle-timeout.test.ts
+++ b/tests/fix-437-idle-timeout.test.ts
@@ -1,0 +1,126 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import { once } from "node:events";
+import { fetchWithTimeout } from "../src/fetch-util.ts";
+
+function listen(server: http.Server, port: number = 0): Promise<void> {
+    server.listen(port, "127.0.0.1");
+    return once(server, "listening").then(() => undefined);
+}
+
+function close(server: http.Server): Promise<void> {
+    return new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+}
+
+async function readAll(body: ReadableStream<Uint8Array>): Promise<Uint8Array[]> {
+    const reader = body.getReader();
+    const chunks: Uint8Array[] = [];
+    for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (value) chunks.push(value);
+    }
+    return chunks;
+}
+
+test("idle timeout: a healthy stream longer than the timeout is NOT aborted (#437)", async () => {
+    // 8 chunks at 100ms intervals = ~800ms total, which EXCEEDS the 500ms
+    // timeout. A total timer would abort at 500ms (mid-stream); the idle timer
+    // re-arms on each chunk (100ms << 500ms) so the full stream completes.
+    const timeoutMs = 500;
+    const intervalMs = 100;
+    const totalChunks = 8;
+    const upstream = http.createServer((req, res) => {
+        res.writeHead(200, { "content-type": "text/event-stream" });
+        res.flushHeaders();
+        let sent = 0;
+        const t = setInterval(() => {
+            sent += 1;
+            res.write(`chunk-${sent}\n`);
+            if (sent >= totalChunks) {
+                clearInterval(t);
+                res.end();
+            }
+        }, intervalMs);
+        req.on("close", () => clearInterval(t));
+    });
+    await listen(upstream);
+    const port = (upstream.address() as { port: number }).port;
+    try {
+        const started = Date.now();
+        const result = await fetchWithTimeout(`http://127.0.0.1:${port}/stream`, {}, timeoutMs);
+        const chunks = await readAll(result.response.body as ReadableStream<Uint8Array>);
+        result.clearTimer();
+        const elapsed = Date.now() - started;
+        assert.equal(chunks.length, totalChunks);
+        assert.equal(
+            Buffer.concat(chunks).toString("utf8"),
+            "chunk-1\nchunk-2\nchunk-3\nchunk-4\nchunk-5\nchunk-6\nchunk-7\nchunk-8\n",
+        );
+        assert.ok(elapsed >= timeoutMs, `expected the stream to outlive the timeout (>= ${timeoutMs}ms), got ${elapsed}ms`);
+    } finally {
+        upstream.closeAllConnections();
+        await close(upstream);
+    }
+});
+
+test("idle timeout: a stuck stream (no further chunks) IS still aborted (#437)", async () => {
+    // Sends headers + 1 chunk, then goes silent and never ends. The idle timer
+    // re-arms on that single chunk and, with no further chunks, fires at the
+    // timeout → abort. Because the server never ends, the only way the read
+    // loop terminates is via that abort, so we read-until-error and assert it
+    // threw (and that a chunk actually arrived before the stall).
+    const timeoutMs = 300;
+    const upstream = http.createServer((_req, res) => {
+        res.writeHead(200, { "content-type": "text/event-stream" });
+        res.flushHeaders();
+        res.write("chunk-1\n");
+        // never ends — simulates a stalled upstream
+    });
+    await listen(upstream);
+    const port = (upstream.address() as { port: number }).port;
+    try {
+        const result = await fetchWithTimeout(`http://127.0.0.1:${port}/stuck`, {}, timeoutMs);
+        const reader = (result.response.body as ReadableStream<Uint8Array>).getReader();
+        let threw = false;
+        let gotData = false;
+        try {
+            for (;;) {
+                const { done, value } = await reader.read();
+                if (done) break;
+                if (value && value.length > 0) gotData = true;
+            }
+        } catch {
+            threw = true;
+        } finally {
+            result.clearTimer();
+        }
+        assert.ok(gotData, "expected at least one chunk to arrive before the stall");
+        assert.ok(threw, "expected the stuck stream to be aborted by the idle timeout");
+    } finally {
+        upstream.closeAllConnections();
+        await close(upstream);
+    }
+});
+
+test("wrapped body preserves status + headers (identical shape for callers)", async () => {
+    const upstream = http.createServer((_req, res) => {
+        res.writeHead(201, { "content-type": "application/json", "x-bili-test": "abc123" });
+        res.end('{"ok":true}');
+    });
+    await listen(upstream);
+    const port = (upstream.address() as { port: number }).port;
+    try {
+        const result = await fetchWithTimeout(`http://127.0.0.1:${port}/json`, {});
+        assert.equal(result.response.status, 201);
+        assert.equal(result.response.ok, true);
+        assert.equal(result.response.headers.get("content-type"), "application/json");
+        assert.equal(result.response.headers.get("x-bili-test"), "abc123");
+        assert.equal(await result.response.text(), '{"ok":true}');
+        result.clearTimer();
+    } finally {
+        upstream.closeAllConnections();
+        await close(upstream);
+    }
+});


### PR DESCRIPTION
## What & why

Issue #437: with `bili dsh` (DeepSeek), a long streaming generation got cut off ~10 minutes in ("流式输出十分钟后对话被截断").

Root cause: `fetchWithTimeout` (`src/fetch-util.ts`) armed a single **total** `setTimeout(abort, UPSTREAM_TIMEOUT_MS)` (10 min) that was only cleared once the response body was fully consumed. A healthy stream that legitimately runs longer than 10 minutes was aborted at the 10-minute mark **mid-stream** — the `for await` loop threw, `emitStreamError` wrote `❌ [ACP] stream error: …` + a finish event, and the client saw the conversation truncated.

## Fix

Make the timeout **idle-based** during the body phase: the timer is re-armed on every response-body chunk (via a backpressure-preserving `armIdleBody` body wrapper). So:

- a healthy stream that keeps producing chunks is never aborted mid-flight (LLM generations can run for minutes);
- a genuinely stuck stream (no chunk for `timeoutMs`) still trips the abort;
- time-to-first-byte bounding is unchanged;
- `clearTimer` / `externalSignal` semantics are preserved, and callers see an identical `Response` shape (status/headers/body).

Centralized in `fetchWithTimeout`, so it covers every upstream path (main `forward()`, preflight, compress-loop re-requests, registry).

## Tests

- New `tests/fix-437-idle-timeout.test.ts`:
  - a healthy stream of ~800ms with a 500ms timeout completes in full (verified it **fails** under the old total timer by reverting `src/fetch-util.ts`);
  - a stuck stream (one chunk then silence) is still aborted by the idle timeout;
  - the wrapped body preserves status + headers.
- `npm run typecheck` — clean
- `npm test` — 899/899 pass
- `npm run build` — clean

## E2E note

`tests/e2e/e2e-codex.test.ts` requires a live `codex` binary + a local Responses upstream, which aren't available in this environment (`spawn codex ENOENT`). The change is an isolated timeout-semantics change in `fetchWithTimeout` (no message-rebuild/rewrite logic touched) and is covered by the full unit suite above. Please run the E2E core before merging if you have the upstream available.
