### PR TITLE
fix: acp-loop zero-side-effect truncation retry + well-formed anthropic error stream (#413)

### DIFF
--- a/devlog/2026-09-02_acp-loop-truncation-retry/DESIGN.md
+++ b/devlog/2026-09-02_acp-loop-truncation-retry/DESIGN.md
@@ -1,0 +1,109 @@
+# DESIGN: acp-loop truncation retry + well-formed Anthropic error stream
+
+## Problem shape
+
+`runCompressLoop` is an `AsyncGenerator<Buffer>`: it reads the upstream SSE
+stream, forwards client-facing chunks as it parses them, and only knows the
+stream was truncated *after* the parse loop ends without a done event
+(`!sawDone`). `fetchWithRetry` cannot see this failure — it inspects
+`response.ok` after headers and never reads the body. So recovery has to live
+at loop level, where the "did I already commit to the client?" state is known.
+
+## Retry predicate — the zero-side-effect invariant
+
+A truncated round can be transparently replayed **iff** nothing observable
+happened. All of these must hold at the end of the parse loop:
+
+- `!sawDone` — the stream actually truncated;
+- `!forwardedAny` — no chunk was yielded to the client this attempt. A
+  per-attempt flag set by `fwd()` wrapping the five yield sites in the parse
+  loop (raw text, synthetic text, raw reasoning, synthetic reasoning, meta).
+  Ping-only streams count as forwarded (conservative: the client saw
+  something, so a retry would duplicate it);
+- `calls.length === 0` — no tool call was collected. The `tool_call` /
+  marker / `emitText` yields happen *after* the parse loop, so they are not
+  yet covered by `forwardedAny` and need explicit checks:
+  - `calls.length === 0` rules out tool_call and marker yields (both are
+    derived from `calls`);
+  - `!(ctx.textProtocol && assistantText.length > 0)` rules out the
+    text-protocol `emitText` yield (only emitted when textProtocol and the
+    round produced text);
+- `!signal?.aborted` — the client is still connected;
+- `!truncationRetried` — function-level flag: at most ONE retry per request
+  (the issue says "走一次"). The flag is never reset, so a second truncated
+  round (round 2+) also fails fast.
+
+Placement: the check runs **after** the parse loop and **before**
+`recordUsage`. This matters: a round-2+ `message_start` sets `usage` without
+forwarding anything, so recording before the retry check would double-count
+the retried attempt's tokens.
+
+Mechanics: the parse loop is wrapped in an inner `for (;;)` attempt loop.
+On a qualifying truncation the loop calls `fetchUpstream(roundBody)` (the
+hoisted `fetchWithRetry` wrapper — same backoff, same `BILI_REPLAY_RETRY_*`
+env knobs, same #189 rejection logging) and `continue`s; the outer round
+number is unchanged, so a round-1 retry re-parses as round 1 and its
+`message_start` is forwarded exactly once (attempt 1 forwarded nothing).
+Per-attempt state (text/reasoning/calls/usage/finishReason/sawDone/
+suppressCompletion/forwardedAny) is reset at the top of the attempt loop.
+
+`roundBody` (new): the re-request path replaces the body each round
+(`compressMessages`); the old code re-fetched with `requestOptions` + a local
+`newBody`. The retry must re-send **the body that produced the truncated
+stream** — on round 1 that is the original `requestBody`, on round N it is
+the compressed body. `roundBody` is updated right before the
+`currentUpstream` swap, so it always holds the last body actually sent.
+
+Failure of the retry itself falls through to the existing truncation error
+path (empty body on the retry response is converted to
+`UpstreamHttpError` so it is caught by the same handler).
+
+## Adapter: tracking what was forwarded
+
+The Anthropic adapter closure gains two pieces of state:
+
+- `messageStartForwarded: boolean` — set where the round-1 `message_start`
+  is forwarded (always forwarded in round 1, so the flag is set there);
+- `openBlocks: number[]` — client indices of blocks whose
+  `content_block_start` was forwarded but whose `content_block_stop` was not.
+  Pushed in the non-tool `content_block_start` branch (forwarded in all
+  rounds); removed in the `content_block_stop` branches via an `indexOf`
+  guard (tool_use blocks are never pushed — they are buffered in `pending`
+  and emitted as a whole later).
+
+`emitError(message)` now emits, in order:
+
+1. synthetic `message_start` (if `!messageStartForwarded`) —
+   `buildSyntheticMessageStart()`: the captured `messageId` if any, else a
+   generated `msg_acp_error_<ts>` id; empty `content`, null stop reason,
+   zero usage, the request model if known. Zero usage is honest: nothing
+   completed.
+2. `content_block_stop` for every index in `openBlocks` (drained);
+3. the existing error text block (`[acp-proxy: <message>]`);
+4. the existing terminal (`message_delta` + `message_stop`).
+
+Result: the stream is always well-formed — starting frame first, every block
+closed, terminal last — regardless of where the truncation hit (before
+`message_start`, mid-thinking-block, mid-text-block, or after everything).
+
+On the retry path the adapter state is all-initial at re-parse time
+(`messageId` undefined, `clientIndex` 0, flag false, no open blocks), so the
+re-parsed stream is shaped exactly like a fresh first parse — consistent.
+
+## Logging
+
+The truncation path keeps `ctx.log` (session-prefixed `info` line, which is
+what session-level dashboards key on) and drops the global
+`loggerLog("error", ...)` duplicate. One event, one line. (The upstream-HTTP
+failure path on re-request still double-logs — same pattern, out of scope,
+reported in the PR.)
+
+## What is NOT retried (and why)
+
+- Anything that forwarded a single byte to the client (retry would emit a
+  duplicate/partial stream the client cannot reconcile);
+- Any round that collected a tool call or ran a proxy tool (side effects);
+- Text-protocol rounds that accumulated text (the post-loop `emitText` yield
+  would double it);
+- Aborted requests;
+- Second and later truncations within one request (one retry, per the issue).

--- a/devlog/2026-09-02_acp-loop-truncation-retry/REQ.md
+++ b/devlog/2026-09-02_acp-loop-truncation-retry/REQ.md
@@ -1,0 +1,57 @@
+# REQ: acp-loop upstream truncation — zero-side-effect retry, well-formed Anthropic error stream, single-point logging
+
+Issue #413: when the upstream LLM returns 200 but the SSE stream ends early
+(no `message_delta`/`message_stop`), the compress loop (`src/loop/core.ts`)
+fails fast with `emitError` and no recovery. Three concrete defects, all
+confirmed by code read + red tests before the fix:
+
+1. **No retry for zero-side-effect truncation.** `fetchWithRetry` only wraps
+   the re-request fetches (it inspects `response.ok` after headers and never
+   reads the body — mid-stream EOF is only observable at loop level via the
+   missing done event). A round that forwarded nothing to the client
+   (`0 text + 0 reasoning + 0 executed tools`, nothing yielded) is a
+   zero-side-effect retry candidate; the loop instead surfaced the upstream
+   flake to the host session. Production evidence: 3 truncation events in
+   3 days, two of them 0+0 (2026-08-31T00:35:24Z, 2026-08-31T06:03:43Z).
+2. **Orphan Anthropic stream on first-round truncation.** The adapter's
+   `emitError` is stateless w.r.t. what was already forwarded: it emits
+   `content_block_start/delta/stop + message_delta + message_stop` directly.
+   If the stream truncated before `message_start` reached the client, the
+   client sees a `content_block_*` sequence with no starting frame —
+   malformed per the Anthropic stream protocol. Open `thinking` blocks left
+   by the truncation are never closed either. The responses branch already
+   fixed the same class (see `src/stream-error.ts` comment); the Anthropic
+   adapter was missed.
+3. **Double logging.** Every truncation event was logged twice: `ctx.log`
+   (→ `log("info", "[sid] ...")`) plus a global `loggerLog("error", ...)` —
+   both tee to the same file + stderr.
+
+## Acceptance criteria (from the issue)
+
+- Stub upstream: headers then 0-event EOF → exactly 1 retry observed; after
+  the failed retry the client stream passes "SSE start frame before
+  content_block" schema validation.
+- Truncation fixture with open blocks: every `content_block_start` has a
+  matching `content_block_stop` before stream end.
+- Each single truncation produces exactly 1 log line.
+
+## Constraints
+
+- The retry must be provably side-effect-free: nothing forwarded to the
+  client, no tool calls executed, no usage recorded, no state mutation.
+- At most ONE retry per request (the issue says "走一次").
+- No new dependencies; `fetchWithRetry` reuse (same backoff/env knobs).
+- The re-request path's behavior (degraded retry, #189 rejection logging)
+  is unchanged; only its `fetchUpstream` definition is hoisted.
+
+## Non-goals (reported in the PR, not fixed)
+
+- `adapter-responses.ts` `emitError`: a `response.failed` without a prior
+  `response.created` is the same orphan class if the stream truncated before
+  the created event.
+- `core.ts` upstream-error path (HTTP failure on re-request) also double-logs
+  (`ctx.log` + `loggerLog("error")`) — same pattern; the issue only reported
+  the truncation one.
+- Truncation with `reRequest = true` (truncated after a complete proxy tool
+  call, before the done event) is silently swallowed — the loop continues to
+  the next round. Arguably benign; unchanged.

--- a/devlog/2026-09-02_acp-loop-truncation-retry/WORKLOG.md
+++ b/devlog/2026-09-02_acp-loop-truncation-retry/WORKLOG.md
@@ -1,0 +1,58 @@
+# WORKLOG: acp-loop upstream truncation — zero-side-effect retry, well-formed Anthropic error stream, single-point logging
+
+- Task ID: `2026-09-02_acp-loop-truncation-retry`
+- Home Repo: `billion-context`
+- Status: Done
+- Updated: 2026-09-02
+
+## 1. Summary
+
+- **What was done**: (1) the compress loop now retries once when an upstream
+  stream truncates (200 + early EOF) after forwarding nothing to the client;
+  (2) the Anthropic adapter's `emitError` now synthesizes a `message_start`
+  if none was forwarded and closes every block still open at error time;
+  (3) the truncation event is logged once (via `ctx.log`) instead of twice.
+- **Why**: zero-side-effect truncations are the most common recoverable
+  upstream flake (3 in 3 days in production, two of them 0+0); failing fast
+  lands the flake in the host session. The orphan stream shape violates the
+  Anthropic stream protocol and can crash strict clients (the responses
+  branch already fixed its own copy of this class). Double logging makes
+  incident triage count events wrong.
+- **Behavior / compatibility changes**: Yes, three —
+  1. A first-round (or any-round) truncation that forwarded nothing and
+     executed no tool calls now triggers exactly one retry through
+     `fetchWithRetry` before the error is surfaced. Clients see either a
+     clean successful stream or the error stream — never a partial one.
+  2. The Anthropic error stream is now always well-formed: starts with
+     `message_start`, every `content_block_start` has a matching
+     `content_block_stop`, ends with `message_delta` + `message_stop`.
+  3. Truncation is logged once at `info` (session-prefixed) instead of twice
+     (`info` + `error`).
+- **Risk level**: Low. The retry is gated on a strict zero-side-effect
+  predicate (nothing forwarded, no tool calls, nothing accumulated for the
+  host, not aborted, not already retried); the adapter change only adds
+  frames that strict clients require; logging change is cosmetic.
+
+## 2. Change Log
+
+### Commits
+
+| Commit | Description |
+|--------|-------------|
+| `<sha>` | fix: acp-loop zero-side-effect truncation retry + well-formed anthropic error stream (#413) |
+
+### Key Files
+
+- `src/loop/core.ts` — retry loop around the per-round parse; hoisted
+  `fetchUpstream`; dropped the second (global error) log line on truncation;
+  `roundBody` tracks the last body actually sent so a retry re-sends the
+  compressed round body, not the original request.
+- `src/loop/adapter-anthropic.ts` — `messageStartForwarded` / `openBlocks`
+  tracking in the adapter closure; `buildSyntheticMessageStart()`;
+  `emitError` closes open blocks and backfills the starting frame.
+- `tests/loop-truncation.test.ts` — new; 6 tests covering all three
+  acceptance criteria plus retry-body tracking and the once-per-request cap.
+
+## 3. Design & Implementation Notes
+
+See `DESIGN.md` for the dataflow and the safety invariants.

--- a/src/loop/adapter-anthropic.ts
+++ b/src/loop/adapter-anthropic.ts
@@ -120,6 +120,35 @@ export function createAnthropicAdapter(requestBody: Record<string, unknown>, ori
     const model = (requestBody.model as string) ?? undefined;
     let messageId: string | undefined;
     let clientIndex = 0;
+    let messageStartForwarded = false;
+    const openBlocks: number[] = [];
+
+    const removeOpenBlock = (index: number): void => {
+        const i = openBlocks.indexOf(index);
+        if (i >= 0) openBlocks.splice(i, 1);
+    };
+
+    // #413: emitError must terminate a well-formed stream even when the
+    // upstream died before sending message_start — synthesize the start frame
+    // so content blocks are never orphaned (strict clients reject them).
+    const buildSyntheticMessageStart = (): Buffer => {
+        const extra: Record<string, unknown> = {};
+        if (model) extra.model = model;
+        const msg: Record<string, unknown> = {
+            id: messageId ?? `msg_acp_error_${Date.now()}`,
+            type: "message",
+            role: "assistant",
+            content: [],
+            stop_reason: null,
+            stop_sequence: null,
+            usage: { input_tokens: 0, output_tokens: 0 },
+            ...extra,
+        };
+        return Buffer.from(
+            `event: message_start\ndata: ${JSON.stringify({ type: "message_start", message: msg })}\n\n`,
+            "utf8",
+        );
+    };
 
     const buildTextBlock = (index: number, text: string): Buffer =>
         Buffer.from(
@@ -206,6 +235,7 @@ export function createAnthropicAdapter(requestBody: Record<string, unknown>, ori
                     if (typeof u.input_tokens === "number") roundInput = u.input_tokens;
                     if (typeof u.cache_read_input_tokens === "number") roundCached = u.cache_read_input_tokens;
                     if (round === 1) {
+                        messageStartForwarded = true;
                         yield { kind: "meta", chunk: rawBuf, firstRoundOnly: true } as ParsedStreamEvent;
                     }
                 } else if (type === "ping") {
@@ -221,6 +251,7 @@ export function createAnthropicAdapter(requestBody: Record<string, unknown>, ori
                         if (block.type === "thinking" || block.type === "redacted_thinking") thinkingIndexes.add(upstreamIndex);
                         const ci = clientIndex++;
                         indexMap.set(upstreamIndex, ci);
+                        openBlocks.push(ci);
                         yield { kind: "meta", chunk: remapIndexInEvent(eventStr, ci), firstRoundOnly: round === 1 } as ParsedStreamEvent;
                     }
                 } else if (type === "content_block_delta") {
@@ -272,10 +303,12 @@ export function createAnthropicAdapter(requestBody: Record<string, unknown>, ori
                         // Seal the current thinking segment so interleaved thinking
                         // blocks each keep their own signature on rebuild.
                         const ci = indexMap.get(upstreamIndex) ?? upstreamIndex;
+                        removeOpenBlock(ci);
                         yield { kind: "meta", chunk: remapIndexInEvent(eventStr, ci), firstRoundOnly: false } as ParsedStreamEvent;
                         yield { kind: "reasoning", delta: "", blockEnd: true } as ParsedStreamEvent;
                     } else {
                         const ci = indexMap.get(upstreamIndex) ?? upstreamIndex;
+                        removeOpenBlock(ci);
                         if (lastTextIndex !== null) {
                             const tail = tagFilter.flush();
                             if (tail.length > 0) {
@@ -385,8 +418,17 @@ export function createAnthropicAdapter(requestBody: Record<string, unknown>, ori
         },
 
         emitError(message) {
-            const errBlock = buildTextBlock(clientIndex++, `\n[acp-proxy: ${message}]\n`);
-            return Buffer.concat([errBlock, buildTerminal("end_turn", 0, 0, 0)]);
+            const parts: Buffer[] = [];
+            if (!messageStartForwarded) {
+                parts.push(buildSyntheticMessageStart());
+                messageStartForwarded = true;
+            }
+            for (const index of openBlocks.splice(0)) {
+                parts.push(Buffer.from(`event: content_block_stop\ndata: ${JSON.stringify({ type: "content_block_stop", index })}\n\n`, "utf8"));
+            }
+            parts.push(buildTextBlock(clientIndex++, `\n[acp-proxy: ${message}]\n`));
+            parts.push(buildTerminal("end_turn", 0, 0, 0));
+            return Buffer.concat(parts);
         },
     };
 }

--- a/src/loop/adapter-responses.ts
+++ b/src/loop/adapter-responses.ts
@@ -475,7 +475,7 @@ export function createResponsesAdapter(textProtocol?: boolean, projection?: Resp
                 }
             }
             if (!terminalKind) {
-                yield { kind: "done", finishReason: "failed" } as ParsedStreamEvent;
+                yield { kind: "done", finishReason: "failed", truncated: true } as ParsedStreamEvent;
             }
         },
 

--- a/src/loop/adapter-responses.ts
+++ b/src/loop/adapter-responses.ts
@@ -252,6 +252,19 @@ export function createResponsesAdapter(textProtocol?: boolean, projection?: Resp
     let responseObj: Record<string, unknown> | null = null;
     let terminalRaw: Buffer | null = null;
     let terminalKind: string | null = null;
+    // #440: response.failed with no preceding response.created is an orphan that
+    // crashes strict clients (codex) — same class as the anthropic gap (#413).
+    let createdForwarded = false;
+    let createdRespId: string | null = null;
+    const ensureCreated = (): Buffer | null => {
+        if (createdForwarded) return null;
+        createdForwarded = true;
+        if (!createdRespId) createdRespId = `resp-proxy-${Date.now()}`;
+        return Buffer.from(
+            `event: response.created\ndata: ${JSON.stringify({ type: "response.created", response: { id: createdRespId, status: "in_progress", output: [] } })}\n\n`,
+            "utf8",
+        );
+    };
 
     return {
         buildRequest(coreMessages, systemPrompt, requestBody) {
@@ -318,6 +331,11 @@ export function createResponsesAdapter(textProtocol?: boolean, projection?: Resp
                 }
 
                 if (type === "response.created" || type === "response.in_progress") {
+                    if (type === "response.created") {
+                        const resp = obj.response as Record<string, unknown> | undefined;
+                        if (resp && typeof resp.id === "string") createdRespId = resp.id;
+                        if (round === 1) createdForwarded = true;
+                    }
                     yield { kind: "meta", chunk: rawBuf, firstRoundOnly: true } as ParsedStreamEvent;
                 } else if (type === "response.output_item.added") {
                     const item = obj.item as Record<string, unknown> | undefined;
@@ -484,15 +502,19 @@ export function createResponsesAdapter(textProtocol?: boolean, projection?: Resp
                 return terminalRaw;
             }
             if (!responseObj && opts?.finishReason === "failed") {
+                const parts: Buffer[] = [];
+                const created = ensureCreated();
+                if (created) parts.push(created);
                 const failed = {
-                    id: `resp-error-${Date.now()}`,
+                    id: createdRespId ?? `resp-error-${Date.now()}`,
                     status: "failed",
                     error: { code: "server_error", message: "upstream returned no response" },
                 };
-                return Buffer.from(
+                parts.push(Buffer.from(
                     `event: response.failed\ndata: ${JSON.stringify({ type: "response.failed", response: failed })}\n\n`,
                     "utf8",
-                );
+                ));
+                return Buffer.concat(parts);
             }
             let resp = responseObj
                 ? ({ ...responseObj } as Record<string, unknown>)
@@ -517,15 +539,19 @@ export function createResponsesAdapter(textProtocol?: boolean, projection?: Resp
         },
 
         emitError(message) {
+            const parts: Buffer[] = [];
+            const created = ensureCreated();
+            if (created) parts.push(created);
             const resp = {
-                id: `resp-error-${Date.now()}`,
+                id: createdRespId ?? `resp-error-${Date.now()}`,
                 status: "failed",
                 error: { code: "server_error", message },
             };
-            return Buffer.from(
+            parts.push(Buffer.from(
                 `event: response.failed\ndata: ${JSON.stringify({ type: "response.failed", response: resp })}\n\n`,
                 "utf8",
-            );
+            ));
+            return Buffer.concat(parts);
         },
 
         extractTextTriggers(text) {

--- a/src/loop/core.ts
+++ b/src/loop/core.ts
@@ -67,7 +67,7 @@ export type ParsedStreamEvent =
     | { kind: "reasoning"; delta: string; raw?: Buffer; signature?: string; blockEnd?: boolean }
     | { kind: "tool_call"; name: string; callId: string; arguments: string; passthrough?: boolean }
     | { kind: "usage"; inputTokens?: number; outputTokens?: number; cachedTokens?: number }
-    | { kind: "done"; finishReason?: string; suppressCompletion?: boolean }
+    | { kind: "done"; finishReason?: string; suppressCompletion?: boolean; truncated?: boolean }
     | { kind: "meta"; chunk: Buffer; firstRoundOnly?: boolean };
 
 export interface EmitCompletionOpts {
@@ -243,6 +243,7 @@ export async function* runCompressLoop(
             let finishReason: string | undefined;
             let sawDone = false;
             let suppressCompletion = false;
+            let truncatedDone = false;
             let forwardedAny = false;
             const fwd = (chunk: Buffer): Buffer => {
                 forwardedAny = true;
@@ -259,6 +260,7 @@ export async function* runCompressLoop(
                 finishReason = undefined;
                 sawDone = false;
                 suppressCompletion = false;
+                truncatedDone = false;
                 forwardedAny = false;
 
                 for await (const ev of adapter.parseStream(currentUpstream, round)) {
@@ -283,9 +285,9 @@ export async function* runCompressLoop(
                         if (ev.blockEnd) reasoningSealed = true;
                         if (!ctx.textProtocol) {
                             if (ev.raw) {
-                                yield ev.raw;
+                                yield fwd(ev.raw);
                             } else if (round > 1 && ev.delta.length > 0 && adapter.emitReasoning) {
-                                yield adapter.emitReasoning(ev.delta);
+                                yield fwd(adapter.emitReasoning(ev.delta));
                             }
                         }
                     } else if (ev.kind === "tool_call") {
@@ -300,6 +302,7 @@ export async function* runCompressLoop(
                         sawDone = true;
                         finishReason = ev.finishReason;
                         suppressCompletion = ev.suppressCompletion === true;
+                        truncatedDone = ev.truncated === true;
                     } else if (ev.kind === "meta") {
                         if (round === 1 || !ev.firstRoundOnly) {
                             yield fwd(ev.chunk);
@@ -312,8 +315,11 @@ export async function* runCompressLoop(
                 // bytes), so re-fetching the same round is invisible to it.
                 // One retry per request; 200+early-EOF flakiness (common on
                 // relays) no longer lands in the agent session.
+                // `truncatedDone` covers adapters that surface truncation as a
+                // synthetic failed done (responses) instead of ending with
+                // !sawDone (anthropic) — same retry, both shapes.
                 if (
-                    !sawDone &&
+                    (!sawDone || truncatedDone) &&
                     !forwardedAny &&
                     calls.length === 0 &&
                     !(ctx.textProtocol && assistantText.length > 0) &&

--- a/src/loop/core.ts
+++ b/src/loop/core.ts
@@ -199,8 +199,30 @@ export async function* runCompressLoop(
 ): AsyncGenerator<Buffer> {
     let activeClearTimer: (() => void) | null = null;
     let currentUpstream = upstream;
+    let roundBody: Record<string, unknown> = requestBody;
     const coreMessages: CoreMessage[] = [...ctx.messages];
     let degradedRetried = false;
+    let truncationRetried = false;
+
+    const fetchUpstream = (body: Record<string, unknown>) =>
+        fetchWithRetry(
+            requestOptions.url,
+            {
+                method: "POST",
+                headers: requestOptions.headers,
+                body: JSON.stringify(body),
+                ...(ctx.proxyUrl ? { dispatcher: proxyDispatcher(ctx.proxyUrl) } : {}),
+            },
+            undefined,
+            signal,
+            (info) => {
+                // #189: correlate the rejection with the rewrite that
+                // preceded it (shrink ratio + fold point), if any.
+                const lc = lastCompressSuffix(ctx.session.lastCompress);
+                ctx.log(`[acp-proxy: upstream rejected replay (HTTP ${info.status}: ${info.detail.slice(0, 120)}); likely provider risk-control — retrying in ${info.delayMs}ms (attempt ${info.attempt}/${info.maxAttempts})${lc}]`);
+                loggerLog("warn", `[acp-loop] upstream rejected replay (HTTP ${info.status}); retrying in ${info.delayMs}ms (attempt ${info.attempt}/${info.maxAttempts})${lc}`);
+            },
+        );
 
     try {
         for (let round = 1; round <= MAX_LOOP_ROUNDS; round++) {
@@ -214,15 +236,32 @@ export async function* runCompressLoop(
             let finishReason: string | undefined;
             let sawDone = false;
             let suppressCompletion = false;
+            let forwardedAny = false;
+            const fwd = (chunk: Buffer): Buffer => {
+                forwardedAny = true;
+                return chunk;
+            };
 
-            for await (const ev of adapter.parseStream(currentUpstream, round)) {
-                if (signal?.aborted) break;
+            for (;;) {
+                assistantText = "";
+                assistantReasoning = "";
+                reasoningSegments.length = 0;
+                reasoningSealed = true;
+                calls.length = 0;
+                usage = {};
+                finishReason = undefined;
+                sawDone = false;
+                suppressCompletion = false;
+                forwardedAny = false;
+
+                for await (const ev of adapter.parseStream(currentUpstream, round)) {
+                    if (signal?.aborted) break;
                     if (ev.kind === "text") {
                         assistantText += ev.delta;
                         if (!ctx.textProtocol && ev.raw) {
-                            yield ev.raw;
+                            yield fwd(ev.raw);
                         } else if (!ctx.textProtocol && round > 1 && ev.delta.length > 0) {
-                            yield adapter.emitText(ev.delta);
+                            yield fwd(adapter.emitText(ev.delta));
                         }
                     } else if (ev.kind === "reasoning") {
                         assistantReasoning += ev.delta;
@@ -243,22 +282,59 @@ export async function* runCompressLoop(
                             }
                         }
                     } else if (ev.kind === "tool_call") {
-                    calls.push({ name: ev.name, callId: ev.callId, arguments: ev.arguments, passthrough: ev.passthrough });
-                } else if (ev.kind === "usage") {
-                    usage = {
-                        inputTokens: ev.inputTokens,
-                        outputTokens: ev.outputTokens,
-                        cachedTokens: ev.cachedTokens,
-                    };
-                } else if (ev.kind === "done") {
-                    sawDone = true;
-                    finishReason = ev.finishReason;
-                    suppressCompletion = ev.suppressCompletion === true;
-                } else if (ev.kind === "meta") {
-                    if (round === 1 || !ev.firstRoundOnly) {
-                        yield ev.chunk;
+                        calls.push({ name: ev.name, callId: ev.callId, arguments: ev.arguments, passthrough: ev.passthrough });
+                    } else if (ev.kind === "usage") {
+                        usage = {
+                            inputTokens: ev.inputTokens,
+                            outputTokens: ev.outputTokens,
+                            cachedTokens: ev.cachedTokens,
+                        };
+                    } else if (ev.kind === "done") {
+                        sawDone = true;
+                        finishReason = ev.finishReason;
+                        suppressCompletion = ev.suppressCompletion === true;
+                    } else if (ev.kind === "meta") {
+                        if (round === 1 || !ev.firstRoundOnly) {
+                            yield fwd(ev.chunk);
+                        }
                     }
                 }
+
+                // #413: zero-side-effect truncation — the client received
+                // nothing from this attempt (no text/reasoning/meta/tool
+                // bytes), so re-fetching the same round is invisible to it.
+                // One retry per request; 200+early-EOF flakiness (common on
+                // relays) no longer lands in the agent session.
+                if (
+                    !sawDone &&
+                    !forwardedAny &&
+                    calls.length === 0 &&
+                    !(ctx.textProtocol && assistantText.length > 0) &&
+                    !signal?.aborted &&
+                    !truncationRetried
+                ) {
+                    truncationRetried = true;
+                    ctx.log(`[acp-loop] round ${round}: upstream truncated before any content reached the client; retrying fetch once`);
+                    try {
+                        const respResult = await fetchUpstream(roundBody);
+                        if (!respResult.response.body) {
+                            respResult.clearTimer();
+                            throw new UpstreamHttpError(respResult.response.status, "(empty response body)", 1);
+                        }
+                        currentUpstream = respResult.response.body as ReadableStream<Uint8Array>;
+                        if (activeClearTimer) activeClearTimer();
+                        activeClearTimer = respResult.clearTimer;
+                        continue;
+                    } catch (e) {
+                        if (e instanceof UpstreamHttpError) {
+                            const suffix = e.attempts > 1 ? ` after ${e.attempts} attempt(s)` : "";
+                            ctx.log(`[acp-loop] round ${round}: truncation retry failed (upstream error ${e.status}${suffix}: ${e.body.slice(0, 200)})`);
+                        } else {
+                            ctx.log(`[acp-loop] round ${round}: truncation retry failed (${e instanceof Error ? e.message : String(e)})`);
+                        }
+                    }
+                }
+                break;
             }
 
             if (
@@ -403,7 +479,6 @@ export async function* runCompressLoop(
                     const partialReasoning = assistantReasoning.length;
                     const msg = `upstream stream truncated (no completion event; round ${round}, ${partialText} text chars + ${partialReasoning} reasoning chars received)`;
                     ctx.log(`[acp-loop] round ${round}: ${msg}`);
-                    loggerLog("error", `[acp-loop] ${msg}`);
                     yield adapter.emitError(msg);
                     return;
                 }
@@ -428,26 +503,6 @@ export async function* runCompressLoop(
             ctx.log(`[acp-loop] round ${round}: proxy tool executed; re-requesting so the model sees the result`);
 
             if (signal?.aborted) break;
-
-            const fetchUpstream = (body: Record<string, unknown>) =>
-                fetchWithRetry(
-                    requestOptions.url,
-                    {
-                        method: "POST",
-                        headers: requestOptions.headers,
-                        body: JSON.stringify(body),
-                        ...(ctx.proxyUrl ? { dispatcher: proxyDispatcher(ctx.proxyUrl) } : {}),
-                    },
-                    undefined,
-                    signal,
-                    (info) => {
-                        // #189: correlate the rejection with the rewrite that
-                        // preceded it (shrink ratio + fold point), if any.
-                        const lc = lastCompressSuffix(ctx.session.lastCompress);
-                        ctx.log(`[acp-proxy: upstream rejected replay (HTTP ${info.status}: ${info.detail.slice(0, 120)}); likely provider risk-control — retrying in ${info.delayMs}ms (attempt ${info.attempt}/${info.maxAttempts})${lc}]`);
-                        loggerLog("warn", `[acp-loop] upstream rejected replay (HTTP ${info.status}); retrying in ${info.delayMs}ms (attempt ${info.attempt}/${info.maxAttempts})${lc}`);
-                    },
-                );
 
             let newBody = adapter.buildRequest(coreMessages, systemPrompt, requestBody);
             if (process.env.ACP_DUMP_BODY === "1") {
@@ -498,6 +553,7 @@ export async function* runCompressLoop(
             }
 
             currentUpstream = respResult.response.body as ReadableStream<Uint8Array>;
+            roundBody = newBody;
             if (activeClearTimer) activeClearTimer();
             activeClearTimer = respResult.clearTimer;
         }

--- a/tests/loop-responses-orphan.test.ts
+++ b/tests/loop-responses-orphan.test.ts
@@ -1,0 +1,113 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { Config, CoreMessage } from "acp-kernel";
+import { createCore, createInitialState } from "acp-kernel";
+import type { Session } from "../src/session.ts";
+import { runCompressLoop, createResponsesAdapter } from "../src/loop/index.ts";
+import { buildCompressSystemPrompt } from "../src/compress-tool.ts";
+
+// #440: responses adapter must not emit response.failed with no preceding
+// response.created (orphan stream crashes codex; same class as #413).
+
+const BODY = { model: "gpt-5", input: [], stream: true };
+
+function sse(event: string, obj: Record<string, unknown>): string {
+    return `event: ${event}\ndata: ${JSON.stringify({ type: event, ...obj })}\n\n`;
+}
+
+function makeCtx(id: string) {
+    return {
+        core: createCore(),
+        config: { modelContextLimit: 200000 } as Config,
+        messages: [] as CoreMessage[],
+        session: {
+            id,
+            meta: {},
+            stats: { requests: 0, tokensSaved: 0, inputTokens: 0, cachedTokens: 0, outputTokens: 0, cacheSamples: 0, lastInputTokens: 0, contextTokens: 0 },
+            metadata: {},
+            state: createInitialState(),
+            createdAt: Date.now(),
+            lastSeen: Date.now(),
+            blockContents: new Map(),
+            inFlight: 0,
+            persisted: false,
+        } as unknown as Session,
+        log: () => {},
+        protocol: "responses" as const,
+    };
+}
+
+async function drain(stream: ReadableStream<Uint8Array>, ctx: ReturnType<typeof makeCtx>): Promise<string> {
+    const chunks: Buffer[] = [];
+    for await (const chunk of runCompressLoop(
+        stream,
+        ctx,
+        BODY,
+        { url: "http://mock", headers: {} },
+        createResponsesAdapter(),
+        buildCompressSystemPrompt(),
+    )) {
+        chunks.push(chunk);
+    }
+    return Buffer.concat(chunks).toString("utf8");
+}
+
+interface OutEvent { event: string; data: Record<string, unknown> }
+
+function parseOut(out: string): OutEvent[] {
+    const events: OutEvent[] = [];
+    for (const block of out.split("\n\n")) {
+        let event = "";
+        const dataLines: string[] = [];
+        for (const line of block.split("\n")) {
+            if (line.startsWith("event:")) event = line.slice(6).trim();
+            else if (line.startsWith("data:")) dataLines.push(line.slice(5).replace(/^ /, ""));
+        }
+        if (!event || dataLines.length === 0) continue;
+        try {
+            events.push({ event, data: JSON.parse(dataLines.join("\n")) as Record<string, unknown> });
+        } catch { }
+    }
+    return events;
+}
+
+function assertCreatedBeforeFailed(events: OutEvent[]): void {
+    const failedIdx = events.findIndex((e) => e.event === "response.failed");
+    assert.ok(failedIdx >= 0, "stream has a response.failed");
+    const createdIdx = events.findIndex((e) => e.event === "response.created");
+    assert.ok(createdIdx >= 0, "stream has a response.created");
+    assert.ok(createdIdx < failedIdx, `response.created (idx ${createdIdx}) precedes response.failed (idx ${failedIdx})`);
+}
+
+test("#440 T1: 0-event EOF → first event is response.created, failed preceded by created", async () => {
+    const ctx = makeCtx("resp-orphan-t1");
+    const out = await drain(new Response("", { status: 200 }).body!, ctx);
+    const events = parseOut(out);
+    assert.ok(events.length > 0, "stream non-empty");
+    assert.equal(events[0].event, "response.created", `first event must be response.created (got ${events[0].event})`);
+    assertCreatedBeforeFailed(events);
+});
+
+test("#440 T2: truncation after created forwarded → single created, failed references same id", async () => {
+    const round1 = sse("response.created", { response: { id: "resp_1", status: "in_progress", output: [] } });
+    const ctx = makeCtx("resp-orphan-t2");
+    const out = await drain(new Response(round1, { status: 200 }).body!, ctx);
+    const events = parseOut(out);
+    const created = events.filter((e) => e.event === "response.created");
+    assert.equal(created.length, 1, `exactly one response.created (no synthetic duplicate); got ${created.length}`);
+    assertCreatedBeforeFailed(events);
+    const failed = events.find((e) => e.event === "response.failed")!;
+    const failedId = (failed.data.response as Record<string, unknown>)?.id;
+    assert.equal(failedId, "resp_1", "failed references the forwarded created's id");
+});
+
+test("#440 T3: emitError with no created forwarded → synthesizes created before failed", () => {
+    const adapter = createResponsesAdapter();
+    const out = adapter.emitError("upstream stream truncated").toString("utf8");
+    const events = parseOut(out);
+    assert.equal(events[0].event, "response.created", "emitError leads with a synthesized response.created");
+    assertCreatedBeforeFailed(events);
+    const createdId = (events[0].data.response as Record<string, unknown>)?.id;
+    const failedId = (events.find((e) => e.event === "response.failed")!.data.response as Record<string, unknown>)?.id;
+    assert.equal(createdId, failedId, "synthesized created and failed share an id");
+});

--- a/tests/loop-responses-orphan.test.ts
+++ b/tests/loop-responses-orphan.test.ts
@@ -79,26 +79,69 @@ function assertCreatedBeforeFailed(events: OutEvent[]): void {
     assert.ok(createdIdx < failedIdx, `response.created (idx ${createdIdx}) precedes response.failed (idx ${failedIdx})`);
 }
 
+function mockFetch(handler: () => Response): { calls: () => number; restore: () => void } {
+    let n = 0;
+    const orig = globalThis.fetch;
+    globalThis.fetch = (async () => {
+        n++;
+        return handler();
+    }) as typeof fetch;
+    return { calls: () => n, restore: () => { globalThis.fetch = orig; } };
+}
+
 test("#440 T1: 0-event EOF → first event is response.created, failed preceded by created", async () => {
+    process.env.BILI_REPLAY_RETRY_MAX = "1";
     const ctx = makeCtx("resp-orphan-t1");
-    const out = await drain(new Response("", { status: 200 }).body!, ctx);
-    const events = parseOut(out);
-    assert.ok(events.length > 0, "stream non-empty");
-    assert.equal(events[0].event, "response.created", `first event must be response.created (got ${events[0].event})`);
-    assertCreatedBeforeFailed(events);
+    const mock = mockFetch(() => new Response('{"error":"boom"}', { status: 500, headers: { "content-type": "application/json" } }));
+    try {
+        const out = await drain(new Response("", { status: 200 }).body!, ctx);
+        assert.equal(mock.calls(), 1, "zero-side-effect truncation retried exactly once (responses adapter too)");
+        const events = parseOut(out);
+        assert.ok(events.length > 0, "stream non-empty");
+        assert.equal(events[0].event, "response.created", `first event must be response.created (got ${events[0].event})`);
+        assertCreatedBeforeFailed(events);
+    } finally {
+        mock.restore();
+        delete process.env.BILI_REPLAY_RETRY_MAX;
+    }
 });
 
-test("#440 T2: truncation after created forwarded → single created, failed references same id", async () => {
+test("#440 T2: truncation after created forwarded → single created, failed references same id, no retry", async () => {
     const round1 = sse("response.created", { response: { id: "resp_1", status: "in_progress", output: [] } });
     const ctx = makeCtx("resp-orphan-t2");
-    const out = await drain(new Response(round1, { status: 200 }).body!, ctx);
-    const events = parseOut(out);
+    const mock = mockFetch(() => new Response("{}", { status: 200 }));
+    try {
+        const out = await drain(new Response(round1, { status: 200 }).body!, ctx);
+        assert.equal(mock.calls(), 0, "no retry: created already reached the client");
+        const events = parseOut(out);
     const created = events.filter((e) => e.event === "response.created");
     assert.equal(created.length, 1, `exactly one response.created (no synthetic duplicate); got ${created.length}`);
     assertCreatedBeforeFailed(events);
     const failed = events.find((e) => e.event === "response.failed")!;
     const failedId = (failed.data.response as Record<string, unknown>)?.id;
     assert.equal(failedId, "resp_1", "failed references the forwarded created's id");
+    } finally {
+        mock.restore();
+    }
+});
+
+test("#440 T4: 0-event EOF → retry succeeds → clean completion, no failed event", async () => {
+    const created = sse("response.created", { response: { id: "resp_retry", status: "in_progress", output: [] } });
+    const item = sse("response.output_item.added", { output_index: 0, item: { type: "message", id: "msg_1", role: "assistant", status: "in_progress", content: [] } });
+    const textDelta = sse("response.output_text.delta", { item_id: "msg_1", output_index: 0, content_index: 0, delta: "RETRY OK" });
+    const textDone = sse("response.output_text.done", { item_id: "msg_1", output_index: 0, content_index: 0, text: "RETRY OK" });
+    const itemDone = sse("response.output_item.done", { output_index: 0, item: { type: "message", id: "msg_1", role: "assistant", status: "completed", content: [{ type: "output_text", text: "RETRY OK", annotations: [] }] } });
+    const completed = sse("response.completed", { response: { id: "resp_retry", status: "completed", output: [] } });
+    const mock = mockFetch(() => new Response(created + item + textDelta + textDone + itemDone + completed, { status: 200 }));
+    const ctx = makeCtx("resp-orphan-t4");
+    try {
+        const out = await drain(new Response("", { status: 200 }).body!, ctx);
+        assert.equal(mock.calls(), 1, "retried once");
+        assert.ok(out.includes("RETRY OK"), "retried round's content delivered");
+        assert.ok(!out.includes("response.failed"), "no failed event on successful retry");
+    } finally {
+        mock.restore();
+    }
 });
 
 test("#440 T3: emitError with no created forwarded → synthesizes created before failed", () => {

--- a/tests/loop-truncation-reasoning.test.ts
+++ b/tests/loop-truncation-reasoning.test.ts
@@ -1,0 +1,85 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { Config, CoreMessage } from "acp-kernel";
+import { createCore, createInitialState } from "acp-kernel";
+import type { Session } from "../src/session.ts";
+import { runCompressLoop, createOpenaiAdapter } from "../src/loop/index.ts";
+import { buildCompressSystemPrompt } from "../src/compress-tool.ts";
+
+// #413 review: the truncation-retry predicate must treat live-forwarded
+// reasoning chunks as client-visible side effects. The openai adapter yields
+// reasoning events with `raw` (adapter-openai.ts:328) and no meta precedes a
+// pure reasoning_content chunk — if those yields don't set forwardedAny, a
+// round-1 truncation after reasoning-only output retries and the client sees
+// the partial reasoning TWICE.
+
+const OPENAI_BODY = { model: "glm", messages: [], stream: true, max_tokens: 10 };
+
+function makeCtx(id: string): {
+    core: ReturnType<typeof createCore>;
+    config: Config;
+    messages: CoreMessage[];
+    session: Session;
+    log: (m: string) => void;
+} {
+    return {
+        core: createCore(),
+        config: { modelContextLimit: 200000 } as Config,
+        messages: [],
+        session: {
+            id,
+            meta: {},
+            stats: { requests: 0, tokensSaved: 0, inputTokens: 0, cachedTokens: 0, outputTokens: 0, cacheSamples: 0, lastInputTokens: 0, contextTokens: 0 },
+            metadata: {},
+            state: createInitialState(),
+            createdAt: Date.now(),
+            lastSeen: Date.now(),
+            blockContents: new Map(),
+            inFlight: 0,
+            persisted: false,
+        },
+        log: () => {},
+    };
+}
+
+async function drain(stream: ReadableStream<Uint8Array>, ctx: ReturnType<typeof makeCtx>): Promise<string> {
+    const adapter = createOpenaiAdapter(OPENAI_BODY);
+    const chunks: Buffer[] = [];
+    for await (const chunk of runCompressLoop(stream, ctx, OPENAI_BODY, { url: "http://mock", headers: {} }, adapter, buildCompressSystemPrompt())) {
+        chunks.push(chunk);
+    }
+    return Buffer.concat(chunks).toString("utf8");
+}
+
+function mockFetch(handler: () => Response): { calls: () => number; restore: () => void } {
+    let n = 0;
+    const orig = globalThis.fetch;
+    globalThis.fetch = (async () => {
+        n++;
+        return handler();
+    }) as typeof fetch;
+    return { calls: () => n, restore: () => { globalThis.fetch = orig; } };
+}
+
+const sse = (obj: unknown): string => `data: ${JSON.stringify(obj)}\n\n`;
+
+test("truncation after live reasoning chunks must not retry (reasoning already reached the client)", async () => {
+    const partial = sse({ id: "c1", choices: [{ index: 0, delta: { reasoning_content: "partial thought before EOF" } }] });
+    const full = sse({ id: "c2", choices: [{ index: 0, delta: { reasoning_content: "second attempt reasoning" } }] })
+        + sse({ id: "c2", choices: [{ index: 0, delta: { content: "FINAL ANSWER" } }] })
+        + sse({ id: "c2", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] })
+        + "data: [DONE]\n\n";
+    const mock = mockFetch(() => new Response(full, { status: 200 }));
+    const ctx = makeCtx("trunc-reasoning");
+    try {
+        const out = await drain(new Response(partial, { status: 200 }).body!, ctx);
+        assert.equal(mock.calls(), 0, "no retry: reasoning bytes were already forwarded to the client");
+        const firstIdx = out.indexOf("partial thought before EOF");
+        assert.ok(firstIdx >= 0, "partial reasoning was forwarded to the client");
+        assert.equal(out.indexOf("partial thought before EOF", firstIdx + 1), -1, "partial reasoning appears exactly once (no duplicated attempt)");
+        assert.ok(!out.includes("second attempt reasoning"), "retry stream content never fetched");
+        assert.ok(out.includes("upstream stream truncated"), "truncation surfaced to client");
+    } finally {
+        mock.restore();
+    }
+});

--- a/tests/loop-truncation.test.ts
+++ b/tests/loop-truncation.test.ts
@@ -1,0 +1,230 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { Config, CoreMessage } from "acp-kernel";
+import { createCore, createInitialState } from "acp-kernel";
+import type { Session } from "../src/session.ts";
+import { runCompressLoop, createAnthropicAdapter } from "../src/loop/index.ts";
+import { buildCompressSystemPrompt } from "../src/compress-tool.ts";
+import { log as loggerLog, setLogCapture } from "../src/logger.ts";
+
+// #413: upstream truncation (200 + early SSE EOF) — zero-side-effect retry,
+// well-formed Anthropic error stream (message_start before content blocks,
+// all blocks closed), single-point logging.
+
+const ANTHROPIC_BODY = { model: "claude", messages: [], stream: true, max_tokens: 10 };
+
+function makeCtx(id: string, logSink?: string[], wireThroughLogger = false): {
+    core: ReturnType<typeof createCore>;
+    config: Config;
+    messages: CoreMessage[];
+    session: Session;
+    log: (m: string) => void;
+} {
+    return {
+        core: createCore(),
+        config: { modelContextLimit: 200000 } as Config,
+        messages: [],
+        session: {
+            id,
+            meta: {},
+            stats: { requests: 0, tokensSaved: 0, inputTokens: 0, cachedTokens: 0, outputTokens: 0, cacheSamples: 0, lastInputTokens: 0, contextTokens: 0 },
+            metadata: {},
+            state: createInitialState(),
+            createdAt: Date.now(),
+            lastSeen: Date.now(),
+            blockContents: new Map(),
+            inFlight: 0,
+            persisted: false,
+        },
+        log: (m: string) => {
+            logSink?.push(m);
+            if (wireThroughLogger) loggerLog("info", `[${id}] ${m}`);
+        },
+    };
+}
+
+async function drain(stream: ReadableStream<Uint8Array>, ctx: ReturnType<typeof makeCtx>): Promise<string> {
+    const adapter = createAnthropicAdapter(ANTHROPIC_BODY);
+    const chunks: Buffer[] = [];
+    for await (const chunk of runCompressLoop(stream, ctx, ANTHROPIC_BODY, { url: "http://mock", headers: {} }, adapter, buildCompressSystemPrompt())) {
+        chunks.push(chunk);
+    }
+    return Buffer.concat(chunks).toString("utf8");
+}
+
+function mockFetch(handler: (call: number) => Response): { calls: () => number; restore: () => void } {
+    let n = 0;
+    const orig = globalThis.fetch;
+    globalThis.fetch = (async () => {
+        n++;
+        return handler(n);
+    }) as typeof fetch;
+    return { calls: () => n, restore: () => { globalThis.fetch = orig; } };
+}
+
+const ev = (type: string, data: unknown): string => `event: ${type}\ndata: ${JSON.stringify(data)}\n\n`;
+
+const MESSAGE_START = ev("message_start", {
+    type: "message_start",
+    message: {
+        id: "msg_1", type: "message", role: "assistant", model: "claude",
+        content: [], stop_reason: null, stop_sequence: null,
+        usage: { input_tokens: 5, output_tokens: 0 },
+    },
+});
+const textStart = (index: number) => ev("content_block_start", { type: "content_block_start", index, content_block: { type: "text", text: "" } });
+const textDelta = (index: number, text: string) => ev("content_block_delta", { type: "content_block_delta", index, delta: { type: "text_delta", text } });
+const textBlock = (index: number, text: string) => textStart(index) + textDelta(index, text) + blockStop(index);
+const thinkingStart = (index: number) => ev("content_block_start", { type: "content_block_start", index, content_block: { type: "thinking", thinking: "" } });
+const thinkingDelta = (index: number, thinking: string) => ev("content_block_delta", { type: "content_block_delta", index, delta: { type: "thinking_delta", thinking } });
+const blockStop = (index: number) => ev("content_block_stop", { type: "content_block_stop", index });
+const toolUseBlock = (index: number, id: string, name: string, input: string) =>
+    ev("content_block_start", { type: "content_block_start", index, content_block: { type: "tool_use", id, name, input: {} } }) +
+    ev("content_block_delta", { type: "content_block_delta", index, delta: { type: "input_json_delta", partial_json: input } }) +
+    blockStop(index);
+const MESSAGE_DELTA = (stopReason = "end_turn") => ev("message_delta", { type: "message_delta", delta: { stop_reason: stopReason, stop_sequence: null }, usage: { input_tokens: 5, output_tokens: 3 } });
+const MESSAGE_STOP = ev("message_stop", { type: "message_stop" });
+
+interface SseEvent { type: string; data: Record<string, unknown>; }
+
+function parseSse(s: string): SseEvent[] {
+    const out: SseEvent[] = [];
+    for (const block of s.split("\n\n")) {
+        if (!block.trim()) continue;
+        let type = "";
+        const dataLines: string[] = [];
+        for (const line of block.split("\n")) {
+            if (line.startsWith("event:")) type = line.slice(6).trim();
+            else if (line.startsWith("data:")) dataLines.push(line.slice(5).replace(/^ /, ""));
+        }
+        if (!type) continue;
+        const jsonStr = dataLines.join("\n").trim();
+        out.push({ type, data: jsonStr ? (JSON.parse(jsonStr) as Record<string, unknown>) : {} });
+    }
+    return out;
+}
+
+// Anthropic stream protocol invariants: message_start first, every
+// content_block_start matched by a stop before the terminal, message_stop last.
+function assertAnthropicStreamSchema(s: string): void {
+    const events = parseSse(s);
+    assert.ok(events.length > 0, "stream non-empty");
+    assert.equal(events[0].type, "message_start", `first event must be message_start (got ${events[0].type})`);
+    const open = new Map<number, string>();
+    let sawTerminal = false;
+    for (const e of events) {
+        if (e.type === "content_block_start") {
+            const idx = e.data.index as number;
+            const cb = (e.data.content_block ?? {}) as Record<string, unknown>;
+            assert.ok(!open.has(idx), `block ${idx} started twice`);
+            open.set(idx, String(cb.type));
+        } else if (e.type === "content_block_stop") {
+            const idx = e.data.index as number;
+            assert.ok(open.has(idx), `content_block_stop for never-started block ${idx}`);
+            open.delete(idx);
+        } else if (e.type === "message_delta" || e.type === "message_stop") {
+            assert.equal(open.size, 0, `all blocks closed before ${e.type} (still open: ${[...open.entries()].map(([i, t]) => `${i}:${t}`).join(", ")})`);
+            sawTerminal = true;
+        }
+    }
+    assert.ok(sawTerminal, "stream has message_delta/message_stop terminal");
+    assert.equal(events[events.length - 1].type, "message_stop", "last event is message_stop");
+}
+
+test("#413 T1: 0-event EOF → retried once; failed retry → well-formed error stream, single log line", async () => {
+    process.env.BILI_REPLAY_RETRY_MAX = "1";
+    const captured: { level: string; msg: string }[] = [];
+    setLogCapture((level, msg) => captured.push({ level, msg }));
+    const logSink: string[] = [];
+    const ctx = makeCtx("trunc-t1", logSink, true);
+    const mock = mockFetch(() => new Response('{"error":"boom"}', { status: 500, headers: { "content-type": "application/json" } }));
+    try {
+        const out = await drain(new Response("", { status: 200 }).body!, ctx);
+        assert.equal(mock.calls(), 1, "zero-side-effect truncation retried exactly once");
+        assertAnthropicStreamSchema(out);
+        assert.ok(out.includes("upstream stream truncated"), "truncation surfaced to client");
+        const truncCaptured = captured.filter((l) => l.msg.includes("upstream stream truncated"));
+        assert.equal(truncCaptured.length, 1, `truncation logged exactly once (got ${truncCaptured.length}): ${JSON.stringify(truncCaptured)}`);
+        assert.equal(truncCaptured[0].level, "info", "the single line is the ctx.log info line — no global error duplicate");
+        assert.equal(logSink.filter((l) => l.includes("upstream stream truncated")).length, 1, "ctx.log called once for the truncation event");
+    } finally {
+        mock.restore();
+        setLogCapture(null);
+        delete process.env.BILI_REPLAY_RETRY_MAX;
+    }
+});
+
+test("#413 T2: 0-event EOF → retry succeeds → one clean stream, no error surfaced", async () => {
+    const round2 = [MESSAGE_START, textBlock(0, "Hello retry"), MESSAGE_DELTA(), MESSAGE_STOP].join("");
+    const mock = mockFetch(() => new Response(round2, { status: 200 }));
+    const ctx = makeCtx("trunc-t2");
+    try {
+        const out = await drain(new Response("", { status: 200 }).body!, ctx);
+        assert.equal(mock.calls(), 1, "retried once");
+        assertAnthropicStreamSchema(out);
+        assert.ok(out.includes("Hello retry"), "retried round's content delivered");
+        assert.ok(!out.includes("upstream stream truncated"), "no error surfaced on successful retry");
+    } finally {
+        mock.restore();
+    }
+});
+
+test("#413 T3: truncation with open thinking block → block closed, no retry (content already forwarded)", async () => {
+    const round1 = [MESSAGE_START, thinkingStart(0), thinkingDelta(0, "let me think")].join("");
+    const mock = mockFetch(() => new Response("{}", { status: 200 }));
+    const ctx = makeCtx("trunc-t3");
+    try {
+        const out = await drain(new Response(round1, { status: 200 }).body!, ctx);
+        assert.equal(mock.calls(), 0, "no retry when content already reached the client");
+        assertAnthropicStreamSchema(out);
+        assert.ok(out.includes("upstream stream truncated"), "truncation surfaced to client");
+    } finally {
+        mock.restore();
+    }
+});
+
+test("#413 T4: truncation with open text block → block closed before error block", async () => {
+    const round1 = [MESSAGE_START, textStart(0), textDelta(0, "partial")].join("");
+    const mock = mockFetch(() => new Response("{}", { status: 200 }));
+    const ctx = makeCtx("trunc-t4");
+    try {
+        const out = await drain(new Response(round1, { status: 200 }).body!, ctx);
+        assert.equal(mock.calls(), 0, "no retry when content already reached the client");
+        assertAnthropicStreamSchema(out);
+        assert.ok(out.includes("partial"), "already-forwarded text preserved");
+        assert.ok(out.includes("upstream stream truncated"), "truncation surfaced to client");
+    } finally {
+        mock.restore();
+    }
+});
+
+test("#413 T5: retry itself truncated → no second retry (one per request)", async () => {
+    const mock = mockFetch(() => new Response("", { status: 200 }));
+    const ctx = makeCtx("trunc-t5");
+    try {
+        const out = await drain(new Response("", { status: 200 }).body!, ctx);
+        assert.equal(mock.calls(), 1, "exactly one retry per request");
+        assertAnthropicStreamSchema(out);
+        assert.ok(out.includes("upstream stream truncated"), "truncation surfaced after exhausted retry");
+    } finally {
+        mock.restore();
+    }
+});
+
+test("#413 T6: round-2 truncation (after proxy tool) retries with the round-2 body", async () => {
+    const round1 = [MESSAGE_START, toolUseBlock(0, "toolu_1", "acp_status", "{}"), MESSAGE_DELTA("tool_use"), MESSAGE_STOP].join("");
+    const round2 = [MESSAGE_START, textBlock(0, "after retry"), MESSAGE_DELTA(), MESSAGE_STOP].join("");
+    const mock = mockFetch((call) =>
+        call === 1 ? new Response("", { status: 200 }) : new Response(round2, { status: 200 }),
+    );
+    const ctx = makeCtx("trunc-t6");
+    try {
+        const out = await drain(new Response(round1, { status: 200 }).body!, ctx);
+        assert.equal(mock.calls(), 2, "re-request + one truncation retry");
+        assert.ok(out.includes("[ACP]"), "proxy tool marker surfaced to client");
+        assert.ok(out.includes("after retry"), "retried round-2 content delivered");
+        assertAnthropicStreamSchema(out);
+    } finally {
+        mock.restore();
+    }
+});


### PR DESCRIPTION
fix: acp-loop zero-side-effect truncation retry + well-formed anthropic error stream (#413)

## Root cause (confirmed, all three)

When the upstream returns 200 and the SSE stream ends early (no `message_delta`/`message_stop`), the compress loop only discovers the truncation *after* the parse loop ends with `!sawDone` — `fetchWithRetry` inspects `response.ok` after headers and never reads the body, so mid-stream EOF is invisible to it. Consequences, each confirmed by code read and by red tests written against the unmodified code:

1. **No retry.** The `!sawDone` branch fails fast. A round that forwarded nothing (`0 text + 0 reasoning + 0 executed tools`) is a zero-side-effect retry candidate; instead the upstream flake landed in the host session (3 production events in 3 days, two of them 0+0).
2. **Orphan Anthropic stream.** The adapter's `emitError` is stateless w.r.t. what was already forwarded — it emits `content_block_start/delta/stop + message_delta + message_stop` directly. If the truncation hit before `message_start` reached the client, the client sees a block sequence with no starting frame (protocol-malformed); open `thinking` blocks are never closed. The responses branch already fixed its own copy of this class (`src/stream-error.ts`); the Anthropic adapter was missed.
3. **Double logging.** `ctx.log` (→ `log("info", "[sid] ...")`) plus a global `loggerLog("error", ...)` — both tee to the same sink, so every truncation produced two lines.

## Changes

**`src/loop/core.ts`**
- The per-round parse loop is wrapped in an inner attempt loop. On a qualifying truncation it retries **once** through the (hoisted) `fetchWithRetry` wrapper and re-parses the same round.
- Retry predicate — the zero-side-effect invariant: `!sawDone && !forwardedAny && calls.length === 0 && !(textProtocol && text accumulated) && !signal.aborted && !truncationRetried`. `forwardedAny` is a per-attempt flag set by the five parse-loop yield sites; the post-loop `tool_call`/marker/`emitText` yields are covered by the explicit `calls`/text checks. The check runs before `recordUsage` so a retried round's tokens are not double-counted.
- `roundBody` tracks the last body actually sent (updated on the re-request path before the `currentUpstream` swap), so a round-2+ retry re-sends the compressed body, not the original request.
- Truncation is logged once (via `ctx.log`); the duplicate global `loggerLog("error", ...)` line is removed.

**`src/loop/adapter-anthropic.ts`**
- The adapter closure now tracks `messageStartForwarded` and `openBlocks` (client indices of forwarded-but-unclosed blocks).
- `emitError` emits, in order: a synthetic `message_start` if none was forwarded (captured id or generated, zero usage), `content_block_stop` for every still-open block, the existing error text block, and the existing terminal. The stream is now always well-formed — starting frame first, every block closed, terminal last — regardless of where the truncation hit.

**`tests/loop-truncation.test.ts`** (new, 6 tests — all failed against the pre-fix code)
- T1: 0-event EOF + failed retry → exactly 1 fetch, schema-valid error stream, exactly 1 log line (acceptance criteria 1 + 3)
- T2: 0-event EOF + successful retry → one clean stream, no error surfaced
- T3/T4: truncation with an open thinking / text block → block closed before the error block, no retry (content already forwarded) (acceptance criterion 2)
- T5: the retry itself truncates → no second retry (one per request)
- T6: round-2 truncation after a proxy tool call → retry re-sends the round-2 body

## Pre-flight

- `npm run typecheck` — clean
- `npm test` — 874 pass / 0 fail (868 + 6 new)
- `npm run build` — success

## Out of scope (reported, not fixed)

- `adapter-responses.ts` `emitError`: a `response.failed` without a prior `response.created` is the same orphan class if the stream truncated before the created event.
- The re-request HTTP-failure path in `core.ts` also double-logs (`ctx.log` + `loggerLog("error")`) — same pattern; the issue only reported the truncation one.
- Truncation with `reRequest = true` (truncated after a complete proxy tool call, before the done event) is silently swallowed — the loop continues to the next round. Arguably benign; unchanged.

## Devlog

`devlog/2026-09-02_acp-loop-truncation-retry/` — REQ.md, WORKLOG.md, DESIGN.md.
