### PR TITLE
chore(#436): log context-window source per model (diagnostic)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -150,6 +150,8 @@ function launcherContextWindow(model: string): number | undefined {
     return LAUNCHER_MODEL_WINDOWS[model];
 }
 
+const windowSourceLogged = new Set<string>();
+
 /** Parse an `anthropic-beta` header for a larger-context beta (e.g.
  *  `context-1m-2025-08-07` → 1,000,000). The beta lets the CLIENT negotiate a
  *  window beyond the model's standard size, so it is the most direct per-request
@@ -936,6 +938,13 @@ async function handle(
                 if (native) nativeFromFallback = false;
             }
             reqConfig = resolveRequestConfig(config, opts.routes, embeddedUrl, model, native, opts.compress);
+            {
+                if (!windowSourceLogged.has(model)) {
+                    windowSourceLogged.add(model);
+                    const wsSource = betaWindow ? "anthropic-beta" : pluginWindow ? "plugin" : launcherWindow ? "launcher" : configuredWindow ? "configured" : peekWindow ? "registry-peek" : native ? "table-or-registry" : "default";
+                    log("info", `[window] model=${model} source=${wsSource} native=${native ?? "none"} effective=${reqConfig.modelContextLimit} launcher=${launcherWindow ?? "none"} configured=${configuredWindow ?? "none"} peek=${peekWindow ?? "none"} fallback=${nativeFromFallback}`);
+                }
+            }
             // #321 PR-E1: a codex client carries its OWN window perception
             // (bundled model table + 272K unknown-model fallback) and
             // auto-compacts at 90% of it. If bili's budget exceeds what codex


### PR DESCRIPTION
Closes #597 — tracking issue for this PR.

## What
Added a one-line diagnostic log at the context-window resolution site (src/server.ts) that records, once per model, the chosen window source (anthropic-beta / plugin / launcher / configured / registry-peek / table-or-registry / default) plus the native + effective values.

## Why
The window-resolution path was invisible in logs. In #436 the user's omp model (contextWindow: 131072 in models.yml) showed 229376/261120 in the proxy — the variation implied a dynamic source (learned overflow), but without the source log it was impossible to confirm whether BILI_LAUNCHER_MODEL_WINDOWS was reaching the proxy. This log makes the source explicit so the next repro is one grep away.

## Pre-flight
- `npm run typecheck` — clean
- `npm test` — 897/897 pass
- `npm run build` — success

Related: #436