### PR TITLE
release v0.1.69

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.68",
+  "version": "0.1.69",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Version bump only. Changes since v0.1.68:

- **#428 (#377)**: re-voice mid-stream `acp_summary` as user messages (user-carrier) so multi-block summaries no longer render as multiple system messages (SGLang/vLLM 400 fix); gate nudge injection by `!pluginMode` (clean plugin mode); docs for nudge gating.
- **#431 (#429)**: openai chat — write the merged terminal chunk (tool_calls + finish_reason) exactly once, and stop leaking `finish_reason` across ACP loop rounds.
- **#439 (#437)**: make the upstream timeout idle-based so long healthy streams aren't truncated.

Local install verified from this branch: `npm install -g .` → `bili --version` = 0.1.69, server boots, banner clean.

Pre-flight: typecheck ✓ / 899/899 tests ✓ / build ✓.