### PR TITLE
fix: responses adapter synthesizes response.created before orphan response.failed (#440)

### DIFF
--- a/src/loop/adapter-responses.ts
+++ b/src/loop/adapter-responses.ts
@@ -252,6 +252,19 @@ export function createResponsesAdapter(textProtocol?: boolean, projection?: Resp
     let responseObj: Record<string, unknown> | null = null;
     let terminalRaw: Buffer | null = null;
     let terminalKind: string | null = null;
+    // #440: response.failed with no preceding response.created is an orphan that
+    // crashes strict clients (codex) — same class as the anthropic gap (#413).
+    let createdForwarded = false;
+    let createdRespId: string | null = null;
+    const ensureCreated = (): Buffer | null => {
+        if (createdForwarded) return null;
+        createdForwarded = true;
+        if (!createdRespId) createdRespId = `resp-proxy-${Date.now()}`;
+        return Buffer.from(
+            `event: response.created\ndata: ${JSON.stringify({ type: "response.created", response: { id: createdRespId, status: "in_progress", output: [] } })}\n\n`,
+            "utf8",
+        );
+    };
 
     return {
         buildRequest(coreMessages, systemPrompt, requestBody) {
@@ -318,6 +331,11 @@ export function createResponsesAdapter(textProtocol?: boolean, projection?: Resp
                 }
 
                 if (type === "response.created" || type === "response.in_progress") {
+                    if (type === "response.created") {
+                        const resp = obj.response as Record<string, unknown> | undefined;
+                        if (resp && typeof resp.id === "string") createdRespId = resp.id;
+                        if (round === 1) createdForwarded = true;
+                    }
                     yield { kind: "meta", chunk: rawBuf, firstRoundOnly: true } as ParsedStreamEvent;
                 } else if (type === "response.output_item.added") {
                     const item = obj.item as Record<string, unknown> | undefined;
@@ -484,15 +502,19 @@ export function createResponsesAdapter(textProtocol?: boolean, projection?: Resp
                 return terminalRaw;
             }
             if (!responseObj && opts?.finishReason === "failed") {
+                const parts: Buffer[] = [];
+                const created = ensureCreated();
+                if (created) parts.push(created);
                 const failed = {
-                    id: `resp-error-${Date.now()}`,
+                    id: createdRespId ?? `resp-error-${Date.now()}`,
                     status: "failed",
                     error: { code: "server_error", message: "upstream returned no response" },
                 };
-                return Buffer.from(
+                parts.push(Buffer.from(
                     `event: response.failed\ndata: ${JSON.stringify({ type: "response.failed", response: failed })}\n\n`,
                     "utf8",
-                );
+                ));
+                return Buffer.concat(parts);
             }
             let resp = responseObj
                 ? ({ ...responseObj } as Record<string, unknown>)
@@ -517,15 +539,19 @@ export function createResponsesAdapter(textProtocol?: boolean, projection?: Resp
         },
 
         emitError(message) {
+            const parts: Buffer[] = [];
+            const created = ensureCreated();
+            if (created) parts.push(created);
             const resp = {
-                id: `resp-error-${Date.now()}`,
+                id: createdRespId ?? `resp-error-${Date.now()}`,
                 status: "failed",
                 error: { code: "server_error", message },
             };
-            return Buffer.from(
+            parts.push(Buffer.from(
                 `event: response.failed\ndata: ${JSON.stringify({ type: "response.failed", response: resp })}\n\n`,
                 "utf8",
-            );
+            ));
+            return Buffer.concat(parts);
         },
 
         extractTextTriggers(text) {

--- a/tests/loop-responses-orphan.test.ts
+++ b/tests/loop-responses-orphan.test.ts
@@ -1,0 +1,113 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { Config, CoreMessage } from "acp-kernel";
+import { createCore, createInitialState } from "acp-kernel";
+import type { Session } from "../src/session.ts";
+import { runCompressLoop, createResponsesAdapter } from "../src/loop/index.ts";
+import { buildCompressSystemPrompt } from "../src/compress-tool.ts";
+
+// #440: responses adapter must not emit response.failed with no preceding
+// response.created (orphan stream crashes codex; same class as #413).
+
+const BODY = { model: "gpt-5", input: [], stream: true };
+
+function sse(event: string, obj: Record<string, unknown>): string {
+    return `event: ${event}\ndata: ${JSON.stringify({ type: event, ...obj })}\n\n`;
+}
+
+function makeCtx(id: string) {
+    return {
+        core: createCore(),
+        config: { modelContextLimit: 200000 } as Config,
+        messages: [] as CoreMessage[],
+        session: {
+            id,
+            meta: {},
+            stats: { requests: 0, tokensSaved: 0, inputTokens: 0, cachedTokens: 0, outputTokens: 0, cacheSamples: 0, lastInputTokens: 0, contextTokens: 0 },
+            metadata: {},
+            state: createInitialState(),
+            createdAt: Date.now(),
+            lastSeen: Date.now(),
+            blockContents: new Map(),
+            inFlight: 0,
+            persisted: false,
+        } as unknown as Session,
+        log: () => {},
+        protocol: "responses" as const,
+    };
+}
+
+async function drain(stream: ReadableStream<Uint8Array>, ctx: ReturnType<typeof makeCtx>): Promise<string> {
+    const chunks: Buffer[] = [];
+    for await (const chunk of runCompressLoop(
+        stream,
+        ctx,
+        BODY,
+        { url: "http://mock", headers: {} },
+        createResponsesAdapter(),
+        buildCompressSystemPrompt(),
+    )) {
+        chunks.push(chunk);
+    }
+    return Buffer.concat(chunks).toString("utf8");
+}
+
+interface OutEvent { event: string; data: Record<string, unknown> }
+
+function parseOut(out: string): OutEvent[] {
+    const events: OutEvent[] = [];
+    for (const block of out.split("\n\n")) {
+        let event = "";
+        const dataLines: string[] = [];
+        for (const line of block.split("\n")) {
+            if (line.startsWith("event:")) event = line.slice(6).trim();
+            else if (line.startsWith("data:")) dataLines.push(line.slice(5).replace(/^ /, ""));
+        }
+        if (!event || dataLines.length === 0) continue;
+        try {
+            events.push({ event, data: JSON.parse(dataLines.join("\n")) as Record<string, unknown> });
+        } catch { }
+    }
+    return events;
+}
+
+function assertCreatedBeforeFailed(events: OutEvent[]): void {
+    const failedIdx = events.findIndex((e) => e.event === "response.failed");
+    assert.ok(failedIdx >= 0, "stream has a response.failed");
+    const createdIdx = events.findIndex((e) => e.event === "response.created");
+    assert.ok(createdIdx >= 0, "stream has a response.created");
+    assert.ok(createdIdx < failedIdx, `response.created (idx ${createdIdx}) precedes response.failed (idx ${failedIdx})`);
+}
+
+test("#440 T1: 0-event EOF → first event is response.created, failed preceded by created", async () => {
+    const ctx = makeCtx("resp-orphan-t1");
+    const out = await drain(new Response("", { status: 200 }).body!, ctx);
+    const events = parseOut(out);
+    assert.ok(events.length > 0, "stream non-empty");
+    assert.equal(events[0].event, "response.created", `first event must be response.created (got ${events[0].event})`);
+    assertCreatedBeforeFailed(events);
+});
+
+test("#440 T2: truncation after created forwarded → single created, failed references same id", async () => {
+    const round1 = sse("response.created", { response: { id: "resp_1", status: "in_progress", output: [] } });
+    const ctx = makeCtx("resp-orphan-t2");
+    const out = await drain(new Response(round1, { status: 200 }).body!, ctx);
+    const events = parseOut(out);
+    const created = events.filter((e) => e.event === "response.created");
+    assert.equal(created.length, 1, `exactly one response.created (no synthetic duplicate); got ${created.length}`);
+    assertCreatedBeforeFailed(events);
+    const failed = events.find((e) => e.event === "response.failed")!;
+    const failedId = (failed.data.response as Record<string, unknown>)?.id;
+    assert.equal(failedId, "resp_1", "failed references the forwarded created's id");
+});
+
+test("#440 T3: emitError with no created forwarded → synthesizes created before failed", () => {
+    const adapter = createResponsesAdapter();
+    const out = adapter.emitError("upstream stream truncated").toString("utf8");
+    const events = parseOut(out);
+    assert.equal(events[0].event, "response.created", "emitError leads with a synthesized response.created");
+    assertCreatedBeforeFailed(events);
+    const createdId = (events[0].data.response as Record<string, unknown>)?.id;
+    const failedId = (events.find((e) => e.event === "response.failed")!.data.response as Record<string, unknown>)?.id;
+    assert.equal(createdId, failedId, "synthesized created and failed share an id");
+});


### PR DESCRIPTION
## What

Fixes #440. The loop-level responses adapter (`src/loop/adapter-responses.ts`) emitted a `response.failed` with **no preceding `response.created`** when the upstream stream truncated (200 + early EOF) before `response.created` reached the client. An orphan `response.failed` crashes strict clients (codex) — the same class as the anthropic `message_start` gap fixed in #413.

## Why two emit paths, not just `emitError`

The issue title scopes the fix to `emitError`, but the common case actually routes elsewhere:

- **0-event / partial EOF → `emitCompletion` failed branch.** The responses `parseStream` yields a fallback `done: failed` on truncation (the anthropic adapter has no such fallback), so `sawDone` is true and the loop goes through `emitCompletion({ finishReason: "failed" })`, never `emitError`. Fixing only `emitError` would leave the most common failure (200 + early EOF) still broken.
- **`emitError`** covers the HTTP-error / empty-body paths.

Both now:
1. Track `createdForwarded` (set in `parseStream` when `response.created` is forwarded in round 1) and capture the upstream created `id` (`createdRespId`).
2. Call `ensureCreated()` before emitting `response.failed` — synthesizing a minimal `response.created` (`{id, status: "in_progress", output: []}`) only when none was forwarded.
3. Reuse `createdRespId` for the failed response so `created`/`failed` stay id-consistent (matching the forwarded created's id when present).

This is the same shape as #413's anthropic fix (`messageStartForwarded` + synthetic start frame). Note #413 is still on an unmerged branch; this PR is based on `master` and touches only `adapter-responses.ts` + a new test file, so it does not conflict with #413.

## Tests

`tests/loop-responses-orphan.test.ts` (3 cases, all fail on the pre-fix adapter, pass after):
- **T1** 0-event EOF → first event is `response.created`; `response.failed` preceded by created.
- **T2** truncation after created forwarded → exactly one `response.created` (no synthetic dup); failed references the forwarded created's id.
- **T3** `emitError` with no created forwarded → synthesizes created before failed, ids match.

## Pre-flight

- `npm run typecheck` ✅
- `npm test` — 902 pass, 0 fail ✅
- `npm run build` ✅

No `version` change (content branch).