### PR TITLE
fix: bili pi launcher disables pi's native auto-compaction (#447)

### DIFF
--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -782,7 +782,10 @@ function mergeSqliteSet(overlay: string, realHome: string, base: string): boolea
     }
 }
 
-function refreshOverlayHome(realHome: string, overlay: string, generatedFile: string): boolean {
+function refreshOverlayHome(realHome: string, overlay: string, generatedFile: string | string[]): boolean {
+    const generatedFiles = new Set(Array.isArray(generatedFile) ? generatedFile : [generatedFile]);
+    const isGeneratedDraft = (name: string): boolean =>
+        [...generatedFiles].some((g) => name.startsWith(`.${g}.`) && name.endsWith(".tmp"));
     try {
         fs.mkdirSync(overlay, { recursive: true });
     } catch {
@@ -814,7 +817,7 @@ function refreshOverlayHome(realHome: string, overlay: string, generatedFile: st
         // re-points the db; any other set moves wholesale.
         const dbSets: { base: string; keepSidecars: boolean }[] = [];
         for (const entry of overlayEntries) {
-            if (!entry.endsWith(".db") || entry === generatedFile) continue;
+            if (!entry.endsWith(".db") || generatedFiles.has(entry)) continue;
             const members = sqliteSetMembers(entry);
             if (!members.some((m) => m !== entry && overlayEntries.includes(m))) continue;
             let mainSt: fs.Stats | undefined;
@@ -832,9 +835,9 @@ function refreshOverlayHome(realHome: string, overlay: string, generatedFile: st
             }
         }
         for (const entry of overlayEntries) {
-            if (entry === generatedFile) continue;
+            if (generatedFiles.has(entry)) continue;
             const overlayPath = path.join(overlay, entry);
-            if (entry.startsWith(`.${generatedFile}.`) && entry.endsWith(".tmp")) {
+            if (isGeneratedDraft(entry)) {
                 try {
                     fs.unlinkSync(overlayPath);
                 } catch {}
@@ -864,7 +867,7 @@ function refreshOverlayHome(realHome: string, overlay: string, generatedFile: st
                     try {
                         fs.unlinkSync(overlayPath);
                     } catch {}
-                } else if (mergeOverlayEntry(overlayPath, realPath, generatedFile)) {
+                } else if (mergeOverlayEntry(overlayPath, realPath, generatedFiles)) {
                     try {
                         fs.rmSync(overlayPath, { recursive: true, force: true });
                     } catch {}
@@ -886,7 +889,7 @@ function refreshOverlayHome(realHome: string, overlay: string, generatedFile: st
         let total = 0;
         const linkFailures: string[] = [];
         for (const entry of realEntries) {
-            if (entry === generatedFile) continue;
+            if (generatedFiles.has(entry)) continue;
             total += 1;
             const overlayPath = path.join(overlay, entry);
             let present = false;
@@ -925,7 +928,7 @@ function refreshOverlayHome(realHome: string, overlay: string, generatedFile: st
     return true;
 }
 
-function mergeOverlayEntry(src: string, dst: string, excludedName?: string): boolean {
+function mergeOverlayEntry(src: string, dst: string, excludedNames?: ReadonlySet<string>): boolean {
     let st: fs.Stats;
     try {
         st = fs.lstatSync(src);
@@ -961,8 +964,8 @@ function mergeOverlayEntry(src: string, dst: string, excludedName?: string): boo
             // #410: generated configs must never merge back into the real
             // home, at ANY depth — a nested promote bakes proxy URLs into
             // the user's real config.
-            if (excludedName !== undefined && entry === excludedName) continue;
-            if (!mergeOverlayEntry(path.join(src, entry), path.join(dst, entry), excludedName)) ok = false;
+            if (excludedNames?.has(entry)) continue;
+            if (!mergeOverlayEntry(path.join(src, entry), path.join(dst, entry), excludedNames)) ok = false;
         }
         return ok;
     }
@@ -1038,50 +1041,69 @@ function writeOverlayFileAtomic(overlay: string, fileName: string, contents: str
     }
 }
 
+function writePiCompactionDisabledSettings(piHome: string, overlay: string): void {
+    let settings: Record<string, unknown> = {};
+    try {
+        const parsed: unknown = JSON.parse(fs.readFileSync(path.join(piHome, "settings.json"), "utf8"));
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+            settings = parsed as Record<string, unknown>;
+        }
+    } catch {}
+    const compactionRaw = settings.compaction;
+    const compaction =
+        compactionRaw && typeof compactionRaw === "object" && !Array.isArray(compactionRaw)
+            ? { ...(compactionRaw as Record<string, unknown>) }
+            : {};
+    compaction.enabled = false;
+    settings.compaction = compaction;
+    writeOverlayFileAtomic(overlay, "settings.json", JSON.stringify(settings, null, 2));
+}
+
 export function preparePiHttpRewrite(
     piHome: string,
     origin: string,
     httpRewrites: HttpRewrite[],
     httpsRewrites: HttpRewrite[],
 ): string | undefined {
-    if (httpRewrites.length === 0 && httpsRewrites.length === 0) return undefined;
-    const modelsPath = path.join(piHome, "models.json");
-    let txt: string;
-    try {
-        txt = fs.readFileSync(modelsPath, "utf8");
-    } catch {
-        return undefined;
-    }
-    let parsed: unknown;
-    try {
-        parsed = JSON.parse(txt);
-    } catch {
-        return undefined;
-    }
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return undefined;
-    const root = parsed as Record<string, unknown>;
-    const providersVal = root.providers;
-    if (providersVal && typeof providersVal === "object" && !Array.isArray(providersVal)) {
-        const providers = providersVal as Record<string, unknown>;
-        for (const r of httpRewrites) {
-            const prov = providers[r.key];
-            if (prov && typeof prov === "object" && !Array.isArray(prov)) {
-                const p = prov as { baseUrl?: unknown };
-                const existing = typeof p.baseUrl === "string" ? p.baseUrl : r.realUpstream;
-                p.baseUrl = wrapUpstream(origin, unwrapUpstream(existing));
-            }
-        }
-        for (const r of httpsRewrites) {
-            const prov = providers[r.key];
-            if (prov && typeof prov === "object" && !Array.isArray(prov)) {
-                const p = prov as { baseUrl?: unknown };
-                p.baseUrl = r.realUpstream;
-            }
-        }
-    }
+    if (!fs.existsSync(piHome)) return undefined;
     const overlay = `${piHome}-bili`;
-    if (!refreshOverlayHome(piHome, overlay, "models.json")) return undefined;
-    writeOverlayFileAtomic(overlay, "models.json", JSON.stringify(root));
+    // #447: the overlay always carries a settings.json disabling pi's native
+    // auto-compaction (its summarizer must never fire alongside bili's ACP
+    // compression); models.json is generated only when present, so both stay
+    // out of the real-home symlink set.
+    const generated: string[] = ["settings.json"];
+    let modelsRoot: Record<string, unknown> | undefined;
+    try {
+        const parsed: unknown = JSON.parse(fs.readFileSync(path.join(piHome, "models.json"), "utf8"));
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+            modelsRoot = parsed as Record<string, unknown>;
+            generated.push("models.json");
+        }
+    } catch {}
+    if (!refreshOverlayHome(piHome, overlay, generated)) return undefined;
+    if (modelsRoot) {
+        const providersVal = modelsRoot.providers;
+        if (providersVal && typeof providersVal === "object" && !Array.isArray(providersVal)) {
+            const providers = providersVal as Record<string, unknown>;
+            for (const r of httpRewrites) {
+                const prov = providers[r.key];
+                if (prov && typeof prov === "object" && !Array.isArray(prov)) {
+                    const p = prov as { baseUrl?: unknown };
+                    const existing = typeof p.baseUrl === "string" ? p.baseUrl : r.realUpstream;
+                    p.baseUrl = wrapUpstream(origin, unwrapUpstream(existing));
+                }
+            }
+            for (const r of httpsRewrites) {
+                const prov = providers[r.key];
+                if (prov && typeof prov === "object" && !Array.isArray(prov)) {
+                    const p = prov as { baseUrl?: unknown };
+                    p.baseUrl = r.realUpstream;
+                }
+            }
+        }
+        writeOverlayFileAtomic(overlay, "models.json", JSON.stringify(modelsRoot));
+    }
+    writePiCompactionDisabledSettings(piHome, overlay);
     return overlay;
 }
 
@@ -1842,7 +1864,7 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
         // Native tooling out of the box: when the user has NOT installed the
         // plugin, ride pi's `-e <file>` (loads for this run only, writes
         // nothing) instead of leaving them on wire-mode fallback. When they
-        // HAVE installed it, settings.json (symlinked into the overlay home)
+        // HAVE installed it, settings.json (merged into the overlay home)
         // already loads it — adding `-e` too would double-register.
         const piExt = selfDistFile("agent/pi.js");
         if (piExt && fs.existsSync(piExt) && !piPluginInstalled(resolvePiHome(process.env))) {

--- a/tests/launcher.test.ts
+++ b/tests/launcher.test.ts
@@ -938,36 +938,51 @@ test("preparePiHttpRewrite: rewrites matching provider, leaves others, symlinks 
         assert.equal(out.providers.b.baseUrl, "https://secure.example.com");
         assert.equal(fs.lstatSync(path.join(tmp!, "auth.json")).isSymbolicLink(), true);
         assert.equal(fs.realpathSync(path.join(tmp!, "auth.json")), path.join(home, "auth.json"));
+        const settings = JSON.parse(fs.readFileSync(path.join(tmp!, "settings.json"), "utf8"));
+        assert.equal(settings.compaction.enabled, false, "pi native compaction disabled");
     } finally {
         if (tmp) fs.rmSync(tmp, { recursive: true, force: true });
         fs.rmSync(home, { recursive: true, force: true });
     }
 });
 
-test("preparePiHttpRewrite: returns undefined when no rewrites", () => {
-    assert.equal(preparePiHttpRewrite("/whatever", "http://127.0.0.1:8787", [], []), undefined);
+test("preparePiHttpRewrite: non-existent home → undefined", () => {
+    assert.equal(preparePiHttpRewrite("/nonexistent-bili-pi-home-xyz", "http://127.0.0.1:8787", [], []), undefined);
 });
 
-test("preparePiHttpRewrite: returns undefined when models.json missing or unparseable", () => {
-    const home = fs.mkdtempSync(path.join(os.tmpdir(), "bili-pihome-"));
-    const rw: HttpRewrite[] = [{ key: "a", realUpstream: "http://x/v1" }];
+test("preparePiHttpRewrite: no rewrites → overlay built, pi native compaction disabled, models.json copied verbatim", () => {
+    const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "bili-pihome-")));
+    fs.writeFileSync(path.join(home, "models.json"), JSON.stringify({ providers: { a: { baseUrl: "https://keep.example.com" } } }));
     try {
-        assert.equal(preparePiHttpRewrite(home, "http://127.0.0.1:8787", rw, []), undefined);
-        fs.writeFileSync(path.join(home, "models.json"), "not-json{");
-        assert.equal(preparePiHttpRewrite(home, "http://127.0.0.1:8787", rw, []), undefined);
+        const overlay = preparePiHttpRewrite(home, "http://127.0.0.1:8787", [], []);
+        assert.ok(typeof overlay === "string" && overlay.length > 0);
+        const settings = JSON.parse(fs.readFileSync(path.join(overlay!, "settings.json"), "utf8"));
+        assert.equal(settings.compaction.enabled, false, "pi native compaction disabled");
+        const out = JSON.parse(fs.readFileSync(path.join(overlay!, "models.json"), "utf8"));
+        assert.equal(out.providers.a.baseUrl, "https://keep.example.com", "no rewrite → baseUrl untouched");
     } finally {
         fs.rmSync(home, { recursive: true, force: true });
+        fs.rmSync(`${home}-bili`, { recursive: true, force: true });
     }
 });
 
-test("preparePiHttpRewrite: returns undefined when models.json is not an object", () => {
-    const home = fs.mkdtempSync(path.join(os.tmpdir(), "bili-pihome-"));
-    const rw: HttpRewrite[] = [{ key: "a", realUpstream: "http://x/v1" }];
+test("preparePiHttpRewrite: preserves other settings.json keys, disables only compaction", () => {
+    const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "bili-pihome-")));
+    fs.writeFileSync(
+        path.join(home, "settings.json"),
+        JSON.stringify({ packages: ["/opt/pi-plugin"], theme: "dark", compaction: { reserveTokens: 9999 } }),
+    );
     try {
-        fs.writeFileSync(path.join(home, "models.json"), JSON.stringify([1, 2, 3]));
-        assert.equal(preparePiHttpRewrite(home, "http://127.0.0.1:8787", rw, []), undefined);
+        const overlay = preparePiHttpRewrite(home, "http://127.0.0.1:8787", [], []);
+        assert.ok(typeof overlay === "string");
+        const settings = JSON.parse(fs.readFileSync(path.join(overlay!, "settings.json"), "utf8"));
+        assert.equal(settings.compaction.enabled, false, "compaction disabled");
+        assert.equal(settings.compaction.reserveTokens, 9999, "other compaction keys preserved");
+        assert.deepEqual(settings.packages, ["/opt/pi-plugin"], "packages preserved");
+        assert.equal(settings.theme, "dark", "theme preserved");
     } finally {
         fs.rmSync(home, { recursive: true, force: true });
+        fs.rmSync(`${home}-bili`, { recursive: true, force: true });
     }
 });
 


### PR DESCRIPTION
## Problem (#447)

`bili pi` never disabled pi's own context compaction, so pi's native summarizer (`shouldCompact`, `enabled: true` by default) could fire ahead of / alongside bili's ACP compression and lossily rewrite the context bili is managing — losing the detailed history.

## Fix

The pi overlay (`<piHome>-bili`) is now **always** built when the real pi home exists, and always carries a `settings.json` with `compaction.enabled=false` (merged over the user's real `settings.json`, which is never mutated). This makes bili's ACP compression the sole compression path under `bili pi`, mirroring how codex/claude already get their native auto-compact aligned (codex `model_auto_compact_token_limit`, claude `CLAUDE_CODE_AUTO_COMPACT_WINDOW`).

Changes:
- `refreshOverlayHome` / `mergeOverlayEntry` now accept a **set** of generated files (`models.json` + `settings.json`) so both stay out of the real-home symlink and merge-back sets (the #410 guarantee now holds for both).
- `preparePiHttpRewrite` returns `undefined` only for a missing real home; `models.json` is still rewritten for HTTP/wrapped-HTTPS upstreams when present, and copied verbatim otherwise.
- New `writePiCompactionDisabledSettings` merges the real `settings.json` with `compaction.enabled=false` (other keys — `packages`, `theme`, `reserveTokens`, … — preserved).

## Verification

- `npm run typecheck` ✅
- `npm test` — 899 pass, 0 fail ✅
- `npm run build` ✅
- Integration check: realistic pi home (HTTP vllm provider + user `settings.json`) → overlay `settings.json` = `{packages, theme, compaction:{reserveTokens:16384, enabled:false}}`, `models.json` baseUrl rewritten to `/bili/`, real `settings.json` untouched ✅

Launcher-only change (no request-pipeline change), so the codex E2E suite is not exercised by this diff.