### PR TITLE
fix(#422): refresh post-compress re-request view so the model sees the fold

### DIFF
--- a/src/loop/core.ts
+++ b/src/loop/core.ts
@@ -44,6 +44,13 @@ export interface LoopCtx {
     textProtocol?: boolean;
     debug?: boolean;
     nudge?: NudgeDecision;
+    /** #422: host hook that re-runs the kernel fold (processTurn) on the
+     *  original messages with the CURRENT session state, re-attaching this
+     *  loop's round records. Called after a successful compress so the
+     *  re-request reflects the compression the model just performed instead
+     *  of the pre-compress view (stale view = model sees zero effect + a
+     *  finished deliverable → wraps up and stops). */
+    refreshFolded?: (current: CoreMessage[]) => CoreMessage[];
     // Which wire protocol produced the usage the loop records. Needed to
     // compute the true context total correctly (Anthropic reports
     // input_tokens as NEW-only; OpenAI/Responses report the TOTAL).
@@ -379,6 +386,31 @@ export async function* runCompressLoop(
                         ctx.log(`[acp-loop] round ${round} hideConsumed hid ${hidden.hidden} compress record(s)`);
                         coreMessages.length = 0;
                         coreMessages.push(...hidden.messages);
+                    }
+                }
+                // #422: a successful compress changed the session state — refresh
+                // the fold so the re-request shows the post-compress view. Falls
+                // back to the pre-compress view (previous behavior) if the host
+                // hook is absent or throws.
+                if (
+                    ctx.refreshFolded &&
+                    proxyResults.some((pr) => pr.name === "compress" && !pr.result.includes("FAILED"))
+                ) {
+                    try {
+                        const refreshed = ctx.refreshFolded(coreMessages);
+                        if (refreshed.length > 0) {
+                            coreMessages.length = 0;
+                            coreMessages.push(...refreshed);
+                            // The fold has now materialized in a request the
+                            // model actually sees — the next usage report is
+                            // post-fold reality; keeping the credit would net
+                            // the savings twice (recordUsage).
+                            ctx.session.stats.compressCreditTokens = 0;
+                            ctx.log(`[acp-loop] round ${round}: re-request view refreshed to post-compress fold`);
+                        }
+                    } catch (err) {
+                        ctx.log(`[acp-loop] round ${round}: fold refresh failed (${String(err)}); keeping pre-compress view`);
+                        loggerLog("warn", `[acp-loop] fold refresh failed: ${String(err)}`);
                     }
                 }
             }

--- a/src/server.ts
+++ b/src/server.ts
@@ -535,6 +535,11 @@ type Prepared = {
      *  rebuilt payload and compress-loop round must re-inject it. */
     openaiSystemText?: string;
     nudge?: NudgeDecision;
+    /** Render strategy the prepare used for processTurn ("none" for codex
+     *  compaction triggers / ACP_RENDER_NONE). The #422 fold-refresh hook in
+     *  forward() re-runs processTurn with the same strategy so the re-request
+     *  renders tags exactly like the request that produced it. */
+    renderTags?: "text-only" | "none";
      /** Effective compression prompts for this request (three-level cascade,
       *  defaults to the kernel's defaultPrompts). Carried so the compress loop
       *  in forward() rebuilds the SAME system prompt the request was prepared
@@ -1470,7 +1475,7 @@ function prepareAnthropic(
     // identity chain (#268), not part of the Anthropic Messages API — strip it
     // so the real upstream never sees a field it doesn't know.
     delete (rebuilt as Record<string, unknown>).prompt_cache_key;
-    return { body: JSON.stringify(rebuilt), session, processedMessages, originalMessages, anthropicSystem: parsed.system, protocol: "anthropic", stream, compressInjected: injectTools, pluginMode, nudge, prompts } as Prepared;
+    return { body: JSON.stringify(rebuilt), session, processedMessages, originalMessages, anthropicSystem: parsed.system, protocol: "anthropic", stream, compressInjected: injectTools, pluginMode, nudge, prompts, renderTags: "text-only" } as Prepared;
 }
 
 function prepareOpenai(
@@ -1587,7 +1592,7 @@ function prepareOpenai(
     }
     snapshotMessages(session, originalMessages);
     markDirty(session);
-    return { body: JSON.stringify(rebuilt), session, processedMessages, originalMessages, protocol: "openai", stream, compressInjected: injectTools, pluginMode, nudge, prompts, openaiSystemText } as Prepared;
+    return { body: JSON.stringify(rebuilt), session, processedMessages, originalMessages, protocol: "openai", stream, compressInjected: injectTools, pluginMode, nudge, prompts, openaiSystemText, renderTags: "text-only" } as Prepared;
 }
 
 function prepareResponses(
@@ -1661,6 +1666,7 @@ function prepareResponses(
     // first-wins and would silently ignore the new relay's route settings).
     const responsesTextProtocol = FORCE_TEXT_PROTOCOL ||
         resolveCompressProtocol(opts.routes, upstreamOrigin) === "marker";
+    const renderTags: "text-only" | "none" = process.env.ACP_RENDER_NONE || isCompactionTrigger ? "none" : "text-only";
 
     try {
         const projection = responsesToCore(parsed);
@@ -1671,7 +1677,7 @@ function prepareResponses(
             log("info", `[${sessionId}] input items: ${Array.isArray(parsed.input) ? parsed.input.map((i: ResponseInputItem) => i.type).join(",") : "(string)"}`);
         }
         const tokenCount = session.stats.lastInputTokens;
-        const turn = core.processTurn({ messages: msgs, state: session.state, config, tokenCount, renderTags: process.env.ACP_RENDER_NONE || isCompactionTrigger ? "none" : "text-only" });
+        const turn = core.processTurn({ messages: msgs, state: session.state, config, tokenCount, renderTags });
         session.state = turn.state;
         // The fold from last turn's compress has now materialized in state —
         // future usage reports are post-fold reality, drop the credit.
@@ -1822,6 +1828,7 @@ function prepareResponses(
         responsesTextProtocol,
         nudge,
         prompts,
+        renderTags,
         resetAfterSuccess: isCompactionTrigger,
         codexForge,
     };
@@ -2603,9 +2610,25 @@ async function forward(
             const textProtocol = prepared.protocol === "responses" && !!prepared.responsesTextProtocol;
             const systemPrompt = textProtocol ? buildCompressHybridSystemPrompt(prepared.prompts ?? defaultPrompts) : buildCompressSystemPrompt(prepared.prompts ?? defaultPrompts);
             const adapter = pickAdapter(prepared.protocol, parsedReq, textProtocol, prepared.responsesProjection, prepared.anthropicSystem, prepared.openaiSystemText);
+            const refreshFolded = (current: CoreMessage[]): CoreMessage[] => {
+                // #422: mirror the prepare's fold with the post-compress state so
+                // the re-request shows the compression the model just performed.
+                // Records from this loop round (acp_loop_* namespace) ride on top
+                // so the model still sees its own compress call + result.
+                const turn = core.processTurn({
+                    messages: prepared.originalMessages,
+                    state: prepared.session.state,
+                    config,
+                    tokenCount: prepared.session.stats.lastInputTokens,
+                    renderTags: prepared.renderTags ?? "text-only",
+                });
+                prepared.session.state = turn.state;
+                const records = current.filter((m) => typeof m.id === "string" && m.id.startsWith("acp_loop_"));
+                return stripKernelSummaries([...turn.messages, ...records] as BiliMessage[], turn.state) as CoreMessage[];
+            };
             const loop = runCompressLoop(
                 streamToRead,
-                { core, config, messages: prepared.processedMessages.length > 0 ? prepared.processedMessages : prepared.originalMessages, compressMessages: prepared.originalMessages, session: prepared.session, log: ctx.log, proxyUrl, protocol: prepared.protocol, textProtocol, debug: opts.debug, nudge: prepared.nudge },
+                { core, config, messages: prepared.processedMessages.length > 0 ? prepared.processedMessages : prepared.originalMessages, compressMessages: prepared.originalMessages, session: prepared.session, log: ctx.log, proxyUrl, protocol: prepared.protocol, textProtocol, debug: opts.debug, nudge: prepared.nudge, refreshFolded },
                 parsedReq,
                 { url: upstreamUrl, headers: reqHeaders },
                 adapter,

--- a/tests/loop-compress.test.ts
+++ b/tests/loop-compress.test.ts
@@ -429,3 +429,139 @@ test("loop #10 (S3): upstream 500 mid-loop terminates cleanly (timer cleared, no
         globalThis.fetch = orig;
     }
 });
+
+// #422: after a successful compress the re-request must reflect the post-
+// compress fold (host refreshFolded hook), not the stale pre-compress view.
+// The stale view is what made the model stop: it was told "~N tokens saved"
+// while staring at the identical context it had just compressed.
+test("loop #422a: successful compress → re-request carries the refreshed fold + round records", async () => {
+    // 7 messages: kernel protects the last 5, so m00001/m00002 are compressible.
+    const ctx = withRefs(
+        makeCtx([
+            textMsg("raw_1", "user", "task: audit files. " + bigText(5000)),
+            textMsg("raw_2", "user", "consumed content " + bigText(5000)),
+            textMsg("raw_3", "user", bigText(5000)),
+            textMsg("raw_4", "assistant", bigText(5000)),
+            textMsg("raw_5", "user", bigText(5000)),
+            textMsg("raw_6", "assistant", bigText(5000)),
+            textMsg("raw_7", "user", bigText(5000)),
+        ]),
+    );
+    const compressArgs = JSON.stringify({ content: [{ startId: "m00001", endId: "m00002", summary: "SUMMARY-422: task kickoff plus consumed file read distilled into one dense block." }] });
+    const round1 = [
+        sse("response.created", { response: { id: "resp_1", status: "in_progress" } }),
+        fcEvents(0, "call_c", "compress", compressArgs),
+        COMPLETED,
+    ].join("");
+    const probe = reFetchProbe();
+    let refreshCalls = 0;
+    try {
+        ctx.refreshFolded = (current) => {
+            refreshCalls++;
+            // Host mirror: fresh fold for the new state + this round's records.
+            const records = current.filter((m) => typeof m.id === "string" && m.id.startsWith("acp_loop_"));
+            assert.ok(records.length >= 2, `refreshFolded must receive the round records (call+result), got ${records.length}`);
+            assert.ok(records.some((m) => m.contentType === "tool-call" && m.toolName === "compress"), "records include the compress tool-call");
+            assert.ok(records.some((m) => m.contentType === "tool-result"), "records include the compress tool-result");
+            return [
+                textMsg("m00001", "user", "FRESH-FOLDED-VIEW-422 (old span folded away)"),
+                textMsg("m00003", "assistant", "recent tail"),
+                ...records,
+            ];
+        };
+        await drain(
+            new Response(round1, { status: 200 }).body!,
+            ctx,
+            { model: "gpt-4o", input: [], stream: true },
+            { url: "http://mock", headers: {} },
+        );
+        assert.ok(probe.calls() >= 1, "re-request fired");
+        const body = probe.bodies()[0]!;
+        assert.ok(body.includes("FRESH-FOLDED-VIEW-422"), "re-request carries the refreshed post-compress fold");
+        assert.ok(!body.includes("consumed content"), "consumed content is folded out of the re-request");
+        assert.ok(body.includes("SUMMARY-422"), "round records (compress call args) ride on top of the fresh fold");
+        assert.ok(body.includes("[Compressed m00001"), "compress tool-result present in the re-request tail");
+        assert.equal(refreshCalls, 1, "refreshFolded called exactly once for one successful compress");
+        assert.equal(ctx.session.stats.compressCreditTokens, 0, "credit cleared once the fold reached a model-visible request");
+    } finally {
+        probe.restore();
+    }
+});
+
+// Scope guard: a FAILED compress changes no state — no refresh, stale view kept.
+test("loop #422b: failed compress → no fold refresh (stale view kept)", async () => {
+    const ctx = withRefs(
+        makeCtx([
+            textMsg("m00001", "user", "hello"),
+            textMsg("m00002", "assistant", "hi"),
+        ]),
+    );
+    // invalid refs → applyRanges returns FAILED, no block created
+    const compressArgs = JSON.stringify({ content: [{ startId: "b99", endId: "b99", summary: "x".repeat(60) }] });
+    const round1 = [
+        sse("response.created", { response: { id: "resp_1", status: "in_progress" } }),
+        fcEvents(0, "call_f", "compress", compressArgs),
+        COMPLETED,
+    ].join("");
+    const probe = reFetchProbe();
+    try {
+        ctx.refreshFolded = () => {
+            throw new Error("refreshFolded must NOT be called for a failed compress");
+        };
+        await drain(
+            new Response(round1, { status: 200 }).body!,
+            ctx,
+            { model: "gpt-4o", input: [], stream: true },
+            { url: "http://mock", headers: {} },
+        );
+        assert.ok(probe.calls() >= 1, "re-request still fires so the model sees the failure");
+        assert.ok(probe.bodies()[0]!.includes("hello"), "stale view preserved on failure");
+        assert.ok(probe.bodies()[0]!.includes("Compression FAILED"), "failure surfaced to the model");
+    } finally {
+        probe.restore();
+    }
+});
+
+// Degradation guard: a throwing refreshFolded falls back to the pre-compress
+// view (previous behavior) instead of killing the loop.
+test("loop #422c: refreshFolded throws → re-request keeps the pre-compress view", async () => {
+    // 7 messages: kernel protects the last 5, so m00001/m00002 are compressible
+    // and refreshFolded IS invoked (then throws) — not a protected-zone failure.
+    const ctx = withRefs(
+        makeCtx([
+            textMsg("raw_1", "user", "task: audit files. " + bigText(5000)),
+            textMsg("raw_2", "user", "consumed content " + bigText(5000)),
+            textMsg("raw_3", "user", bigText(5000)),
+            textMsg("raw_4", "assistant", bigText(5000)),
+            textMsg("raw_5", "user", bigText(5000)),
+            textMsg("raw_6", "assistant", bigText(5000)),
+            textMsg("raw_7", "user", bigText(5000)),
+        ]),
+    );
+    const compressArgs = JSON.stringify({ content: [{ startId: "m00001", endId: "m00002", summary: "SUMMARY-422c: the consumed span distilled into one dense audit block for later." }] });
+    const round1 = [
+        sse("response.created", { response: { id: "resp_1", status: "in_progress" } }),
+        fcEvents(0, "call_c", "compress", compressArgs),
+        COMPLETED,
+    ].join("");
+    const probe = reFetchProbe();
+    try {
+        let refreshCalled = false;
+        ctx.refreshFolded = () => {
+            refreshCalled = true;
+            throw new Error("host fold blew up");
+        };
+        const out = await drain(
+            new Response(round1, { status: 200 }).body!,
+            ctx,
+            { model: "gpt-4o", input: [], stream: true },
+            { url: "http://mock", headers: {} },
+        );
+        assert.ok(refreshCalled, "compress succeeded and refreshFolded was invoked (the throw path is what we test)");
+        assert.ok(probe.calls() >= 1, "re-request fired despite the refresh failure");
+        assert.ok(probe.bodies()[0]!.includes("consumed content"), "pre-compress view kept as fallback");
+        assert.ok(/response\.completed/.test(out), "loop completed gracefully");
+    } finally {
+        probe.restore();
+    }
+});


### PR DESCRIPTION
## Root cause (verified by full-pipeline reproduction)

In **proxy mode** the compress loop's post-compress re-request is built from `coreMessages` — a snapshot of `processedMessages` taken at loop start (`src/loop/core.ts`) — so it carries the **pre-compress view**. This is the documented prefix-cache design (`src/stream.ts` applyRanges: "the fold materializes only at the NEXT request's processTurn; the post-compress re-request re-sends the unfolded history").

For the tier-2 distillation in #422 this means: the model is told `[Compressed b15–b26 → 1 block(s), ~51341 tokens saved.]` while staring at the **identical ~212K context** (all 12 tier-1 summaries still rendered, the new tier-2 summary nowhere in view). It had just produced a natural deliverable (the distillation summary), sees zero effect of its compression and no forward signal → writes the summary body, `finishReason=stop`, zero toolCalls. Task halts until the user manually continues.

Reproduction (scripted mock upstream + real `startServer`): request-body dumps confirmed the stale re-request (tier-1 summaries present, new block unrendered), and that **none** of the other suspects reproduce: no upstream error (the loop's error path emits `[acp-proxy: upstream error ...]`, absent here), no tool_use/tool_result pairing break, no user-message loss. The fold landing on the *next* request is why the task resumes cleanly after "继续".

Plugin mode (pi / MCP-injected claude+codex) is immune by construction: the agent owns compression, its continuation request goes through the full prepare → `processTurn` fold — there is no proxy-internal re-request with a stale view.

## Fix

After a **successful compress**, refresh the loop's view with the CURRENT state before building the re-request:

- `src/loop/core.ts` — new `LoopCtx.refreshFolded?: (current) => CoreMessage[]` host hook, invoked once per successful compress, after `hideConsumedCompressCalls`. On success it also clears `compressCreditTokens` (the fold has now materialized in a model-visible request, so the next usage report is post-fold reality — keeping the credit would net the savings twice in `recordUsage`). A throwing/absent hook degrades to the old pre-compress view.
- `src/server.ts` — `forward()` provides the hook: re-runs `processTurn(originalMessages, session.state, renderTags)` (exact mirror of the prepare that produced round 1), re-attaches this round's `acp_loop_*` records (compress call + result ride on top), then applies `stripKernelSummaries` — so the new block's summary is carried by the tool call in the re-request (plugin-mode carrier semantics) and by the anchor on the next request, per the two-mode carrier rules.
- `Prepared.renderTags` captures the strategy each prepare used ("none" for codex compaction triggers / `ACP_RENDER_NONE`) so the re-render matches round 1 byte-for-byte in tag strategy.

Prefix-cache note: total cache breaks are unchanged (the fold point broke the prefix on the next request anyway); the break just moves one request earlier, and the re-request + next request now share the folded prefix.

Client-visible wire behavior is untouched (markers, round-2 text, completion all identical) — only the upstream re-request body changes.

## Tests

- `loop #422a` — successful compress → re-request carries the refreshed fold + the round's compress call/result records; credit cleared.
- `loop #422b` — failed compress → no refresh (stale view kept, failure surfaced).
- `loop #422c` — throwing hook → graceful fallback to the pre-compress view.

## Pre-flight

- `npm run typecheck` ✅
- `npm test` 902 tests: 900 pass / 2 fail — both failures (`plugin-agent.test.ts`: `before_provider_headers stays silent…`, `pi extension is inert without a proxy`) reproduce on clean `origin/master` (899/897), pre-existing environment issue, unrelated to this change
- `npm run build` ✅
- E2E codex suite not run here (no `codex` binary in this environment)

Closes #422 (proxy-mode flavor; plugin mode unaffected as analyzed above).