### PR TITLE
release v0.1.70

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.65",
+  "version": "0.1.70",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.65",
+      "version": "0.1.70",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.69",
+  "version": "0.1.70",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Changes since v0.1.69

- **#422** (PR #455): proxy 模式压缩后的代理内部重请求携带压缩前旧视图(模型被告知「省了 51341 tokens」却看着一字未变的 ~212K 上下文 → 把「写完摘要」当回合终点、stop、零 toolCalls,任务停摆直到用户手动继续)。修复:compress 成功后用当前 state 重跑 processTurn 刷新重请求视图(fold-on-re-request),本轮 compress 调用+结果保留在尾部;失败压缩不刷新,hook 异常优雅回退;`compressCreditTokens` 在 fold 落到模型可见请求后清零避免重复净扣。新增 3 个 loop 回归测试(#422a/b/c)。
- **#451** (PR #456): 0.1.69 回归 —— `225ceb4`(#377 跟进)给三处 nudge 注入加了 `!pluginMode` 门,前提「plugin 模式 agent 自有压缩通道」不成立(pi/omp extension 是纯协议客户端,无 nudge 投递),导致 plugin 模式主动压缩只剩 preflight 硬顶应急(实测 37s–310s 卡顿)。修复:恢复 0.1.68 注入行为(仅删 `!pluginMode`,`shouldInject`/`!isCompactionTrigger` 保留);`diagNudge` 诚实化(真投递才打 INJECT,否则 ARMED-SUPPRESSED)。新增 plugin/proxy 双模式注入回归测试(负向验证过能抓回归)。README two-modes 表同步。

## Pre-flight

- `npm run typecheck` ✅
- `npm test` 904 tests: 902 pass / 2 fail —— 两个失败(`plugin-agent.test.ts`: `before_provider_headers stays silent…`、`pi extension is inert without a proxy`)在 clean master 上同样失败,既有环境问题,与本 release 无关
- `npm run build` ✅
- 未触碰 `src/update.ts` —— 无需 no-op 验证 release(§5)
- `acp-kernel` pin 未变(0.0.47),无跨仓库发布顺序问题

合并后 CI 自动 publish + tag + GitHub Release,`npm view billion-context version` 验证。