### PR TITLE
fix(#457): strip model-emitted render tags from plugin-mode openai/anthropic wires

### DIFF
--- a/src/loop/tag-echo-filter.ts
+++ b/src/loop/tag-echo-filter.ts
@@ -231,3 +231,50 @@ export function stripResponsesText<T>(obj: T): T {
     }
     return obj;
 }
+
+// Strip render tags from OpenAI chat-completion text fields:
+// .choices[].message.content (a string, or an array of {type:"text",text}
+// parts on some providers). Structural fields (tool_calls and their argument
+// strings) are never touched — the model's tool calls must pass through.
+export function stripOpenAIText<T>(obj: T): T {
+    if (!obj || typeof obj !== "object") return obj;
+    const o = obj as Record<string, unknown>;
+    const choices = o["choices"];
+    if (!Array.isArray(choices)) return obj;
+    o["choices"] = choices.map((c) => {
+        if (!c || typeof c !== "object") return c;
+        const choice = { ...(c as Record<string, unknown>) };
+        const msg = choice["message"];
+        if (!msg || typeof msg !== "object") return choice;
+        const message = { ...(msg as Record<string, unknown>) };
+        const content = message["content"];
+        if (typeof content === "string" && containsRenderTagText(content)) {
+            message["content"] = stripAcpTags(content);
+        } else if (Array.isArray(content)) {
+            message["content"] = stripParts(content);
+        }
+        choice["message"] = message;
+        return choice;
+    });
+    return obj;
+}
+
+// Strip render tags from Anthropic message text blocks (.content[] entries
+// with type === "text"). tool_use / thinking / other blocks pass through
+// untouched — tool input JSON is structural, not prose.
+export function stripAnthropicText<T>(obj: T): T {
+    if (!obj || typeof obj !== "object") return obj;
+    const o = obj as Record<string, unknown>;
+    const content = o["content"];
+    if (!Array.isArray(content)) return obj;
+    o["content"] = content.map((blk) => {
+        if (blk && typeof blk === "object" && (blk as Record<string, unknown>).type === "text" && typeof (blk as Record<string, unknown>).text === "string") {
+            const b = blk as Record<string, unknown>;
+            if (containsRenderTagText(b.text as string)) {
+                return { ...b, text: stripAcpTags(b.text as string) };
+            }
+        }
+        return blk;
+    });
+    return obj;
+}

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -7,7 +7,7 @@ import { acquireInFlight, listSessions, markDirty, peekSession, releaseInFlight,
 import { ACP_TOOLS_ANTHROPIC, ACP_TOOLS_OPENAI, ACP_TOOLS_RESPONSES, PROXY_TOOL_NAMES } from "./compress-tool.js";
 import { executeProxyTool } from "./loop/core.js";
 import { normalizeSseLineEndings } from "./sse-util.js";
-import { containsRenderTagText, createTagEchoFilter, stripResponsesText } from "./loop/tag-echo-filter.js";
+import { containsRenderTagText, createTagEchoFilter, stripAnthropicText, stripOpenAIText, stripResponsesText } from "./loop/tag-echo-filter.js";
 import { log as loggerLog } from "./logger.js";
 import type { WireProtocol } from "./util.js";
 import { stateDir } from "./paths.js";
@@ -529,10 +529,15 @@ function mergeUsageSample(acc: UsageSample, sample: UsageSample): void {
     if (sample.outputTokens !== undefined) acc.outputTokens = sample.outputTokens;
 }
 
-/** Plugin-mode streaming passthrough: forward upstream bytes verbatim (the
- *  agent's native tool loop must see the model's tool calls untouched) while
- *  sniffing usage out of the SSE events — without this, lastInputTokens
- *  would never update and compression nudges would never fire. */
+/** Plugin-mode streaming passthrough for the OpenAI / Anthropic wires:
+ *  structural events (tool_calls / tool_use / usage frames) reach the agent
+ *  byte-identical — the native tool loop must see the model's calls
+ *  untouched — while prose text deltas (openai choices[].delta.content,
+ *  anthropic text_delta) stream through the same tag-echo state machine as
+ *  pipePluginResponsesWithStrip (#206 parity, #457): models can echo ACP
+ *  render tags in visible text, which the client stores in its history and
+ *  replays next turn, amplifying. Usage is sniffed from the same parsed
+ *  events so lastInputTokens keeps tracking reality. */
 export async function pipeThroughWithUsage(
     stream: ReadableStream<Uint8Array>,
     res: import("node:http").ServerResponse,
@@ -543,31 +548,111 @@ export async function pipeThroughWithUsage(
     const decoder = new TextDecoder("utf-8");
     let buf = "";
     const acc: UsageSample = {};
+    const stripText = protocol === "openai" || protocol === "anthropic";
+    const tagFilter = createTagEchoFilter((snippet) => {
+        loggerLog("warn", `[tag-echo] stripped model-emitted render tag (plugin passthrough): ${snippet.slice(0, 80).replace(/\n/g, " ")}`);
+    });
+    let lastChunkBase: Record<string, unknown> | null = null;
+    let lastChoiceIndex = 0;
+    let lastBlockIndex = 0;
+    const write = async (s: string): Promise<void> => {
+        if (!res.write(Buffer.from(s, "utf8"))) {
+            await new Promise<void>((r) => res.once("drain", () => r()));
+        }
+    };
+    // Emit the filter's held tail as one synthetic text delta so prose is
+    // never lost when the stream ends mid-hold. Must only be called at
+    // terminal events / stream end: flushing mid-stream would drop a
+    // partially-swallowed tag before its close can arrive.
+    const flushTail = (): string => {
+        const tail = tagFilter.flush();
+        if (tail.length === 0) return "";
+        if (protocol === "openai") {
+            const base = lastChunkBase ? { ...lastChunkBase } : {};
+            delete base["usage"];
+            return `data: ${JSON.stringify({ ...base, choices: [{ index: lastChoiceIndex, delta: { content: tail }, finish_reason: null }] })}\n\n`;
+        }
+        return `event: content_block_delta\ndata: ${JSON.stringify({ type: "content_block_delta", index: lastBlockIndex, delta: { type: "text_delta", text: tail } })}\n\n`;
+    };
     try {
         for (;;) {
             const { done, value } = await reader.read();
             if (done) break;
             if (value && value.length > 0) {
-                if (!res.write(Buffer.from(value))) {
-                    await new Promise<void>((r) => res.once("drain", () => r()));
-                }
                 buf = normalizeSseLineEndings(buf + decoder.decode(value, { stream: true }));
                 let idx: number;
                 while ((idx = buf.indexOf("\n\n")) !== -1) {
                     const rawEvent = buf.slice(0, idx);
                     buf = buf.slice(idx + 2);
                     const dataLines = rawEvent.split("\n").filter((l) => l.startsWith("data:"));
-                    if (dataLines.length === 0) continue;
+                    if (dataLines.length === 0) {
+                        await write(rawEvent + "\n\n");
+                        continue;
+                    }
                     const jsonStr = dataLines.map((l) => l.slice(5).replace(/^ /, "")).join("\n").trim();
-                    if (!jsonStr || jsonStr === "[DONE]") continue;
+                    if (!jsonStr || jsonStr === "[DONE]") {
+                        await write(flushTail() + rawEvent + "\n\n");
+                        continue;
+                    }
+                    let ev: Record<string, unknown>;
                     try {
-                        const ev = JSON.parse(jsonStr) as Record<string, unknown>;
-                        const sample = usageFromSseEvent(ev);
-                        if (sample) mergeUsageSample(acc, sample);
-                    } catch { /* non-JSON data line */ }
+                        ev = JSON.parse(jsonStr) as Record<string, unknown>;
+                    } catch {
+                        await write(rawEvent + "\n\n");
+                        continue;
+                    }
+                    const sample = usageFromSseEvent(ev);
+                    if (sample) mergeUsageSample(acc, sample);
+                    if (!stripText) {
+                        await write(rawEvent + "\n\n");
+                        continue;
+                    }
+                    let dirty = false;
+                    let terminal = false;
+                    if (protocol === "openai") {
+                        const choices = ev["choices"];
+                        if (Array.isArray(choices)) {
+                            for (let i = 0; i < choices.length; i++) {
+                                const choice = (choices[i] ?? {}) as Record<string, unknown>;
+                                const fr = choice["finish_reason"];
+                                if (typeof fr === "string" && fr !== "null") terminal = true;
+                                const delta = choice["delta"] as Record<string, unknown> | undefined;
+                                const content = delta?.["content"];
+                                if (delta && typeof content === "string" && content.length > 0) {
+                                    lastChunkBase = ev;
+                                    lastChoiceIndex = i;
+                                    if (!containsRenderTagText(content) && !tagFilter.pending()) continue;
+                                    delta["content"] = tagFilter.push(content);
+                                    dirty = true;
+                                }
+                            }
+                        }
+                    } else {
+                        const t = ev["type"];
+                        if (t === "message_delta" || t === "message_stop") terminal = true;
+                        if (t === "content_block_delta") {
+                            const delta = ev["delta"] as Record<string, unknown> | undefined;
+                            const text = delta?.["text"];
+                            if (delta?.["type"] === "text_delta" && typeof text === "string" && text.length > 0) {
+                                lastBlockIndex = typeof ev["index"] === "number" ? ev["index"] : 0;
+                                if (containsRenderTagText(text) || tagFilter.pending()) {
+                                    delta["text"] = tagFilter.push(text);
+                                    dirty = true;
+                                }
+                            }
+                        }
+                    }
+                    if (terminal) await write(flushTail());
+                    await write(dirty ? rebuildEvent(rawEvent, ev) : rawEvent + "\n\n");
                 }
             }
             if (res.destroyed || res.writableEnded) break;
+        }
+        // Stream cut without a terminal event: flush whatever the tag filter
+        // still holds so prose is never silently lost.
+        if (!res.destroyed && !res.writableEnded) {
+            const rest = flushTail();
+            if (rest.length > 0) await write(rest);
         }
         // Apply BEFORE res.end() in the finally below: the client can issue
         // its next request (e.g. /__bili/plugin/status, or the follow-up turn
@@ -758,14 +843,18 @@ export async function pipePluginJson(
             }
         }
     } catch { /* non-JSON body — forward verbatim */ }
-    if (protocol === "responses") {
-        // #206 parity for the non-streaming plugin path: the compress loop's
-        // JSON branch strips render tags from every round (compressLoopResponsesJson);
-        // a verbatim plugin JSON response would re-feed the model's tag echoes.
+    if (protocol !== undefined) {
+        // #206/#457 parity for the non-streaming plugin path: the compress loop's
+        // JSON branch strips render tags from every round; a verbatim plugin JSON
+        // response would re-feed the model's tag echoes into its own history.
         try {
             const json = JSON.parse(text) as Record<string, unknown>;
             if (containsRenderTagText(text)) {
-                res.end(Buffer.from(JSON.stringify(stripResponsesText(json)), "utf8"));
+                const stripped =
+                    protocol === "responses" ? stripResponsesText(json)
+                        : protocol === "openai" ? stripOpenAIText(json)
+                            : stripAnthropicText(json);
+                res.end(Buffer.from(JSON.stringify(stripped), "utf8"));
                 return;
             }
         } catch { /* fall through to verbatim */ }

--- a/src/server.ts
+++ b/src/server.ts
@@ -2538,10 +2538,12 @@ async function forward(
         }
         return;
     }
-    // Plugin mode: the agent's native loop owns the tool surface — pass the
-    // response through VERBATIM (a model-emitted compress call must reach the
-    // plugin untouched) while sniffing usage so lastInputTokens (the input to
-    // the next nudge decision) keeps tracking reality.
+    // Plugin mode: the agent's native loop owns the tool surface — structural
+    // events (tool calls, usage frames) pass through VERBATIM (a model-emitted
+    // compress call must reach the plugin untouched) while prose text streams
+    // through render-tag stripping on every wire (#206/#457). Usage is sniffed
+    // so lastInputTokens (the input to the next nudge decision) keeps tracking
+    // reality.
     if (prepared?.pluginMode) {
         if (prepared.stream) {
             if (prepared.protocol === "responses") {

--- a/tests/plugin-passthrough-tag-strip.test.ts
+++ b/tests/plugin-passthrough-tag-strip.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { pipePluginResponsesWithStrip } from "../src/plugin.ts";
+import { pipePluginResponsesWithStrip, pipeThroughWithUsage } from "../src/plugin.ts";
 import type { Session } from "../src/session.ts";
 
 function makeSession(): Session {
@@ -205,16 +205,49 @@ test("plugin JSON passthrough strips render tags for responses protocol", async 
     assert.equal((session.stats as Record<string, unknown>)["lastInputTokens"], 4, "usage still sampled");
 });
 
-test("plugin JSON passthrough stays verbatim for openai protocol and tag-free bodies", async () => {
+test("plugin JSON passthrough strips render tags for openai protocol (#457)", async () => {
     const { pipePluginJson } = await import("../src/plugin.ts");
     {
         const out: string[] = [];
         const res = makeRes(out);
         const session = makeSession();
-        const body = JSON.stringify({ choices: [{ message: { content: `x ${TAG_OPEN}m00005${TAG_CLOSE}` } }], usage: { prompt_tokens: 2 } });
+        const body = JSON.stringify({ choices: [{ index: 0, message: { role: "assistant", content: `x ${TAG_OPEN}m00005${TAG_CLOSE}` }, finish_reason: "stop" }], usage: { prompt_tokens: 2, completion_tokens: 1 } });
         await pipePluginJson(streamOf([body]), res as unknown as import("node:http").ServerResponse, session, "openai");
-        assert.equal(out.join(""), body, "openai protocol body byte-identical");
+        const text = out.join("");
+        assert.ok(!text.includes("m00005"), "tag stripped from non-streaming openai body");
+        const parsed = JSON.parse(text) as { choices: Array<{ message: { role: string; content: string }; finish_reason: string }> };
+        assert.equal(parsed.choices[0]?.message.content, "x ", "prose survives");
+        assert.equal(parsed.choices[0]?.message.role, "assistant", "structural fields untouched");
+        assert.equal((session.stats as Record<string, unknown>)["lastInputTokens"], 2, "usage still sampled");
     }
+    {
+        const out: string[] = [];
+        const res = makeRes(out);
+        const session = makeSession();
+        const tcBody = JSON.stringify({ choices: [{ index: 0, message: { role: "assistant", content: null, tool_calls: [{ id: "call_1", type: "function", function: { name: "compress", arguments: "{\"content\":[]}" } }] }, finish_reason: "tool_calls" }], usage: { prompt_tokens: 3 } });
+        await pipePluginJson(streamOf([tcBody]), res as unknown as import("node:http").ServerResponse, session, "openai");
+        assert.equal(out.join(""), tcBody, "tag-free tool_calls body byte-identical");
+    }
+});
+
+test("plugin JSON passthrough strips render tags for anthropic protocol (#457)", async () => {
+    const { pipePluginJson } = await import("../src/plugin.ts");
+    const out: string[] = [];
+    const res = makeRes(out);
+    const session = makeSession();
+    const toolUse = { type: "tool_use", id: "tu_1", name: "compress", input: { content: [] } };
+    const body = JSON.stringify({ id: "msg_1", type: "message", role: "assistant", model: "test", stop_reason: "end_turn", content: [{ type: "text", text: `hey ${TAG_OPEN}m00007${TAG_CLOSE}` }, toolUse], usage: { input_tokens: 8, output_tokens: 2 } });
+    await pipePluginJson(streamOf([body]), res as unknown as import("node:http").ServerResponse, session, "anthropic");
+    const text = out.join("");
+    assert.ok(!text.includes("m00007"), "tag stripped from non-streaming anthropic body");
+    const parsed = JSON.parse(text) as { content: Array<{ type: string; text?: string }> };
+    assert.equal(parsed.content[0]?.text, "hey ", "prose survives");
+    assert.ok(text.includes(JSON.stringify(toolUse)), "tool_use block untouched");
+    assert.equal((session.stats as Record<string, unknown>)["lastInputTokens"], 8, "usage still sampled");
+});
+
+test("plugin JSON passthrough stays verbatim for tag-free bodies", async () => {
+    const { pipePluginJson } = await import("../src/plugin.ts");
     {
         const out: string[] = [];
         const res = makeRes(out);
@@ -223,4 +256,148 @@ test("plugin JSON passthrough stays verbatim for openai protocol and tag-free bo
         await pipePluginJson(streamOf([body]), res as unknown as import("node:http").ServerResponse, session, "responses");
         assert.equal(out.join(""), body, "tag-free responses body byte-identical");
     }
+});
+
+test("plugin SSE passthrough strips tags from openai delta.content (#457)", async () => {
+    const oai = (o: Record<string, unknown>): string => `data: ${JSON.stringify(o)}\n\n`;
+    const roleChunk = oai({ id: "chatcmpl-1", object: "chat.completion.chunk", choices: [{ index: 0, delta: { role: "assistant" } }] });
+    const finishChunk = oai({ id: "chatcmpl-1", choices: [{ index: 0, delta: {}, finish_reason: "stop" }], usage: { prompt_tokens: 30, completion_tokens: 4 } });
+    const out: string[] = [];
+    const res = makeRes(out);
+    const session = makeSession();
+    const events = [
+        roleChunk,
+        oai({ id: "chatcmpl-1", choices: [{ index: 0, delta: { content: `hi ${TAG_OPEN}m00042${TAG_CLOSE} there` } }] }),
+        finishChunk,
+        "data: [DONE]\n\n",
+    ];
+    await pipeThroughWithUsage(streamOf(events), res, session, "openai");
+    const text = out.join("");
+    assert.ok(!text.includes("m00042"), "render tag swallowed");
+    assert.ok(text.includes(`"content":"hi  there"`), "non-tag prose survives in rebuilt delta");
+    assert.ok(text.includes(roleChunk.trim()), "role chunk byte-identical");
+    assert.ok(text.includes(finishChunk.trim()), "finish chunk byte-identical");
+    assert.ok(text.endsWith("data: [DONE]\n\n"), "[DONE] framing preserved");
+    assert.equal((session.stats as Record<string, unknown>)["lastInputTokens"], 30, "usage still sampled");
+});
+
+test("plugin SSE passthrough keeps openai tool_calls events byte-identical while stripping prose (#457)", async () => {
+    const oai = (o: Record<string, unknown>): string => `data: ${JSON.stringify(o)}\n\n`;
+    const tcChunk = oai({ id: "chatcmpl-1", choices: [{ index: 0, delta: { tool_calls: [{ index: 0, id: "call_9", type: "function", function: { name: "compress", arguments: "" } }] } }] });
+    const argChunk = oai({ id: "chatcmpl-1", choices: [{ index: 0, delta: { tool_calls: [{ index: 0, function: { arguments: "{\"content\":[]}" } }] } }] });
+    const out: string[] = [];
+    const res = makeRes(out);
+    const session = makeSession();
+    const events = [
+        oai({ id: "chatcmpl-1", choices: [{ index: 0, delta: { content: `note ${TAG_OPEN}m00011${TAG_CLOSE} ok` } }] }),
+        tcChunk,
+        argChunk,
+        oai({ id: "chatcmpl-1", choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }] }),
+        "data: [DONE]\n\n",
+    ];
+    await pipeThroughWithUsage(streamOf(events), res, session, "openai");
+    const text = out.join("");
+    assert.ok(!text.includes("m00011"), "prose tag stripped");
+    assert.ok(text.includes(tcChunk.trim()), "tool_call declaration untouched");
+    assert.ok(text.includes(argChunk.trim()), "tool_call argument bytes untouched");
+});
+
+test("plugin SSE passthrough flushes held openai tail before finish_reason ([DONE] mid-hold)", async () => {
+    const oai = (o: Record<string, unknown>): string => `data: ${JSON.stringify(o)}\n\n`;
+    const out: string[] = [];
+    const res = makeRes(out);
+    const session = makeSession();
+    const events = [
+        oai({ id: "chatcmpl-1", choices: [{ index: 0, delta: { content: `ok ${TAG_OPEN}m0` } }] }),
+        oai({ id: "chatcmpl-1", choices: [{ index: 0, delta: { content: `0042${TAG_CLOSE} tail` } }] }),
+        oai({ id: "chatcmpl-1", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] }),
+        "data: [DONE]\n\n",
+    ];
+    await pipeThroughWithUsage(streamOf(events), res, session, "openai");
+    const text = out.join("");
+    assert.ok(!text.includes("m00042"), "split tag fully swallowed");
+    assert.ok(text.includes(`"content":" tail"`), "post-tag tail flushed as synthetic delta");
+    const blocks = text.split("\n\n").filter((b) => b.trim().length > 0);
+    const flushIdx = blocks.findIndex((b) => b.includes('"content":" tail"'));
+    const finishIdx = blocks.findIndex((b) => b.includes("finish_reason"));
+    assert.ok(flushIdx !== -1 && finishIdx !== -1 && flushIdx < finishIdx, "flushed tail must precede the terminal event");
+    assert.ok(blocks[flushIdx].includes('"id":"chatcmpl-1"'), "synthetic flush chunk carries upstream chunk fields");
+});
+
+test("plugin SSE passthrough is byte-identical for tag-free openai streams", async () => {
+    const oai = (o: Record<string, unknown>): string => `data: ${JSON.stringify(o)}\n\n`;
+    const e1 = oai({ id: "c", choices: [{ index: 0, delta: { content: "hello" } }] });
+    const e2 = oai({ id: "c", choices: [{ index: 0, delta: { content: " world" } }] });
+    const e3 = oai({ id: "c", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] });
+    const out: string[] = [];
+    const res = makeRes(out);
+    const session = makeSession();
+    await pipeThroughWithUsage(streamOf([e1 + e2 + e3 + "data: [DONE]\n\n"]), res, session, "openai");
+    assert.equal(out.join(""), e1 + e2 + e3 + "data: [DONE]\n\n", "tag-free stream byte-identical across event boundaries");
+});
+
+test("plugin SSE passthrough strips tags from anthropic text_delta (#457)", async () => {
+    const ant = (ev: Record<string, unknown>): string => sse(ev);
+    const start = ant({ type: "message_start", message: { id: "msg_1", role: "assistant", usage: { input_tokens: 12 } } });
+    const mDelta = ant({ type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 6 } });
+    const out: string[] = [];
+    const res = makeRes(out);
+    const session = makeSession();
+    const events = [
+        start,
+        ant({ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } }),
+        ant({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: `yo ${TAG_OPEN}m00009${TAG_CLOSE} end` } }),
+        ant({ type: "content_block_stop", index: 0 }),
+        mDelta,
+        ant({ type: "message_stop" }),
+    ];
+    await pipeThroughWithUsage(streamOf(events), res, session, "anthropic");
+    const text = out.join("");
+    assert.ok(!text.includes("m00009"), "render tag swallowed");
+    assert.ok(text.includes(`"text":"yo  end"`), "non-tag prose survives in rebuilt delta");
+    assert.ok(text.includes(start.trim()), "message_start untouched");
+    assert.ok(text.includes(mDelta.trim()), "message_delta untouched");
+    assert.equal((session.stats as Record<string, unknown>)["lastInputTokens"], 12, "nested message_start usage sampled");
+});
+
+test("plugin SSE passthrough keeps anthropic tool_use input_json_delta byte-identical (#457)", async () => {
+    const ant = (ev: Record<string, unknown>): string => sse(ev);
+    const jsonDelta = ant({ type: "content_block_delta", index: 1, delta: { type: "input_json_delta", partial_json: "{\"content\":[\"a\"]}" } });
+    const out: string[] = [];
+    const res = makeRes(out);
+    const session = makeSession();
+    const events = [
+        ant({ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } }),
+        ant({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: `go ${TAG_OPEN}m00013${TAG_CLOSE}` } }),
+        ant({ type: "content_block_start", index: 1, content_block: { type: "tool_use", id: "tu_1", name: "compress" } }),
+        jsonDelta,
+        ant({ type: "message_delta", delta: { stop_reason: "tool_use" }, usage: { output_tokens: 3 } }),
+        ant({ type: "message_stop" }),
+    ];
+    await pipeThroughWithUsage(streamOf(events), res, session, "anthropic");
+    const text = out.join("");
+    assert.ok(!text.includes("m00013"), "prose tag stripped");
+    assert.ok(text.includes(jsonDelta.trim()), "input_json_delta bytes untouched");
+});
+
+test("plugin SSE passthrough flushes held anthropic tail before message_stop", async () => {
+    const ant = (ev: Record<string, unknown>): string => sse(ev);
+    const out: string[] = [];
+    const res = makeRes(out);
+    const session = makeSession();
+    const events = [
+        ant({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: `pre ${TAG_OPEN}m0` } }),
+        ant({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: `0050${TAG_CLOSE} post` } }),
+        ant({ type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 1 } }),
+        ant({ type: "message_stop" }),
+    ];
+    await pipeThroughWithUsage(streamOf(events), res, session, "anthropic");
+    const text = out.join("");
+    assert.ok(!text.includes("m00050"), "split tag fully swallowed");
+    assert.ok(text.includes(`"text":" post"`), "post-tag tail flushed as synthetic text_delta");
+    const blocks = text.split("\n\n").filter((b) => b.trim().length > 0);
+    const flushIdx = blocks.findIndex((b) => b.includes('"text":" post"'));
+    const stopIdx = blocks.findIndex((b) => b.includes("message_stop"));
+    assert.ok(flushIdx !== -1 && stopIdx !== -1 && flushIdx < stopIdx, "flushed tail must precede message_stop");
+    assert.ok(blocks[flushIdx].includes('"index":0'), "synthetic flush carries block index");
 });


### PR DESCRIPTION
## What

Closes #457. Plugin mode stripped model-emitted ACP render tags on the responses wire only (`pipePluginResponsesWithStrip`, #206); the openai/anthropic plugin paths passed model output through verbatim, so tags echoed in prose leaked into the client TUI and were replayed from client history next turn (amplification loop).

## Changes

- `src/plugin.ts` — `pipeThroughWithUsage` (openai/anthropic SSE): event-level processing now routes prose text deltas — openai `choices[].delta.content`, anthropic `text_delta` — through the same `createTagEchoFilter` state machine as the responses path, with the held tail flushed as one synthetic text delta before terminal events (openai `finish_reason`/`[DONE]`, anthropic `message_delta`/`message_stop`) and at stream end. Structural events (tool_calls, tool_use `input_json_delta`, usage frames) and tag-free streams stay byte-identical (fast path + verbatim fallback). Usage sniffing unchanged.
- `src/plugin.ts` — `pipePluginJson`: the #206 strip branch generalized to all three protocols; openai/anthropic bodies go through the new strippers.
- `src/loop/tag-echo-filter.ts` — new `stripOpenAIText` / `stripAnthropicText` (mutate-in-place, same convention as `stripResponsesText`); structural fields never touched.
- `src/server.ts` — updated the stale "VERBATIM" contract comment for the plugin passthrough branch.
- `tests/plugin-passthrough-tag-strip.test.ts` — the old test asserting a tagged openai JSON body stays byte-identical codified the bug; inverted. Added 8 tests: openai/anthropic SSE strip (single event, split across deltas with terminal flush ordering, tool_calls/input_json_delta untouched, tag-free byte-identity), openai/anthropic JSON strip (prose stripped, tool_calls/tool_use untouched, usage still sampled).

## Deliberate scope

Only `delta.content` / `text_delta` are filtered — `reasoning_content` (deepseek/qwen) and `thinking_delta` are not covered (matches issue scope; flagged in-thread as residual). When a delta becomes empty after stripping, an empty-content event is emitted rather than dropped (safer than the responses implementation's drop for role-chunk framing).

## Pre-flight

- `npm run typecheck` — clean
- `npm test` — 911/911 pass (tag-strip file: 18/18)
- `npm run build` — success
- E2E (`tests/e2e/e2e-codex.test.ts`) — NOT run: sandbox has no `codex` binary or local upstream (preflight ENOENT). Unit coverage exercises the changed paths directly; recommend running the manual-dispatch CI E2E before merge since `src/loop/` is touched.

## Observations (minor, no separate issues)

- The committed `package-lock.json` top-level `version` field was stale (0.1.65 vs package.json 0.1.69) on master; local `npm install` rewrites it plus drops `libc` metadata fields under this npm version. Reverted here to keep this commit single-concern.
- Related gap found while triaging (separate follow-up issue being filed): **proxy mode** SSE also does not strip tags — `src/stream.ts:109-111` warns only then forwards verbatim, and `routeOpenaiEvent` in `src/stream-openai.ts` has no tag handling at all. Only proxy-mode *JSON* paths strip today.