### PR TITLE
release v0.1.71

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.70",
+  "version": "0.1.71",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.70",
+      "version": "0.1.71",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.70",
+  "version": "0.1.71",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Changes since v0.1.70

- **#457 / dog#14** (PR #452): plugin 模式 openai-chat / anthropic wire 的透传此前不 strip 模型 emit 的 `<acp>` 渲染标签(仅 responses wire 有 #206 的 strip)→ 标签漏进 agent 重放历史并放大(pi+qwen 实测一条 assistant 消息 77 个 tag + ~3300 空行,表现为「输出循环」)。修复:新增 `pipePluginChatWithStrip`(SSE 逐事件 strip 文本字段,tool_calls/usage byte-identical)+ 非流式 JSON 三 wire 统一 strip + 删除 verbatim 的 `pipeThroughWithUsage`。11 个新测试(含 split-tag、reasoning_content、echo-only 块丢弃、tool_calls 字节恒等)。
- 其余(0.1.70 已含):#422 压缩后重请求旧视图修复、#451 plugin 模式 nudge 恢复。

## 未包含(进行中,不阻塞)

- #460:经实测主路径论断不成立(活路径 loop adapter 三协议均已 strip,issue 引用的是死代码),真实残留仅 `useRewriter=false` 窄路径(title-gen / ACP_NO_INJECT_TOOL / #353 旁路),范围已在 issue 里更正
- PR #459:与已合并的 #452 重复(修改已被替换删除的 `pipeThroughWithUsage`),建议关闭

## Pre-flight

- `npm run typecheck` ✅
- `npm test` 915 tests: 913 pass / 2 fail —— `plugin-agent.test.ts` 两个失败隔离单跑也复现,为既有环境问题(clean master 同样失败);另观察到 `logger-rotation` 在全量下偶发时序 flake(隔离 3/3 过),与本 release 无关
- `npm run build` ✅
- 未触碰 `src/update.ts`;`acp-kernel` pin 未变(0.0.47)

合并后 CI 自动 publish + tag + GitHub Release,`npm view billion-context version` 验证。