### PR TITLE
fix: keep sibling text when a mixed chunk's other field is a pure tag echo (#462)

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -604,6 +604,7 @@ export async function pipePluginChatWithStrip(
         }
         let rebuilt: Record<string, unknown> | null = null;
         let droppedText = false;
+        let keptText = false;
         let hadText = false;
         for (let ci = 0; ci < choices.length; ci++) {
             const ch = choices[ci] as Record<string, unknown> | null;
@@ -614,10 +615,14 @@ export async function pipePluginChatWithStrip(
                 const v = dd[field];
                 if (typeof v !== "string") continue;
                 hadText = true;
-                if (!containsRenderTagText(v) && !anyPending()) continue;
+                if (!containsRenderTagText(v) && !anyPending()) {
+                    if (v.length > 0) keptText = true;
+                    continue;
+                }
                 const index = typeof ch?.["index"] === "number" ? ch["index"] : ci;
                 const [clean, changed] = pushField(field, index, v);
                 if (clean.length === 0) droppedText = true;
+                else keptText = true;
                 if (changed) {
                     if (!rebuilt) {
                         rebuilt = { ...ev, choices: choices.map((c) => ({ ...(c as Record<string, unknown>), delta: { ...((c as Record<string, unknown>)["delta"] as Record<string, unknown>) } })) };
@@ -627,9 +632,11 @@ export async function pipePluginChatWithStrip(
             }
         }
         if (rebuilt) {
-            // Delta carried nothing but the (now-stripped) text: drop the whole
-            // chunk instead of forwarding an empty content delta.
-            if (droppedText && !hadTextOtherThanTextFields(rebuilt["choices"])) {
+            // Delta carried no visible text after stripping: drop the whole
+            // chunk instead of forwarding an empty content delta. Only when
+            // EVERY managed text field emptied out — a sibling field with real
+            // content must survive (#462).
+            if (droppedText && !keptText && !hadTextOtherThanTextFields(rebuilt["choices"])) {
                 return "";
             }
             return rebuildEvent(rawEvent, rebuilt);

--- a/tests/plugin-passthrough-tag-strip-chat.test.ts
+++ b/tests/plugin-passthrough-tag-strip-chat.test.ts
@@ -130,6 +130,35 @@ test("plugin chat passthrough drops a chunk whose delta stripped to empty", asyn
     }
 });
 
+test("plugin chat passthrough keeps sibling text when one field is a pure tag echo (#462)", async () => {
+    const out: string[] = [];
+    const res = makeRes(out);
+    const session = makeSession();
+    const events = [
+        chatChunk({ content: "real answer", reasoning_content: `${TAG_OPEN}m00044${TAG_CLOSE}` }),
+        DONE,
+    ];
+    await pipePluginChatWithStrip(streamOf(events), res, session, "openai");
+    const text = out.join("");
+    assert.ok(!text.includes("m00044"), "echo-only sibling field stripped");
+    assert.ok(text.includes("real answer"), "sibling field with real content must survive");
+});
+
+test("plugin chat passthrough still drops a chunk where every managed field is a pure tag echo (#462)", async () => {
+    const out: string[] = [];
+    const res = makeRes(out);
+    const session = makeSession();
+    const events = [
+        chatChunk({ content: `${TAG_OPEN}m1${TAG_CLOSE}`, reasoning_content: `${TAG_OPEN}m2${TAG_CLOSE}` }),
+        DONE,
+    ];
+    await pipePluginChatWithStrip(streamOf(events), res, session, "openai");
+    const text = out.join("");
+    assert.ok(!text.includes("m1") && !text.includes("m2"), "echoes stripped");
+    const dataLines = text.split("\n").filter((l) => l.startsWith("data:")).filter((l) => !l.includes("[DONE]"));
+    assert.equal(dataLines.length, 0, "all-echo chunk dropped");
+});
+
 test("plugin chat passthrough keeps tool_calls deltas byte-identical", async () => {
     const out: string[] = [];
     const res = makeRes(out);


### PR DESCRIPTION
## What

plugin-mode openai-chat SSE strip (`pipePluginChatWithStrip` → `processOpenai`, `src/plugin.ts`) latched `droppedText` per-field: when a chunk's delta carried multiple managed text fields (`content` / `reasoning_content` / `reasoning`) and ANY one of them stripped to empty (pure render-tag echo), the WHOLE chunk was dropped — including real content in the sibling fields.

Repro (verified failing before the fix): `delta = { content: "real answer", reasoning_content: "<acp …>m00044</acp>" }` → chunk returned `""`, `real answer` lost. This is the #14/#206 heavy-echo scenario at the reasoning→content transition on reasoning providers (deepseek/qwen), shipped in v0.1.71.

## Fix (~3 lines, `src/plugin.ts`)

- Track `keptText`: set when any managed field retains non-empty visible text after stripping — either passed through unfiltered (skip branch) or returned non-empty by the tag-echo filter.
- Drop condition is now `droppedText && !keptText && !hadTextOtherThanTextFields(...)` — a chunk is dropped only when EVERY managed text field emptied out. The existing non-text payload check (finish_reason / tool_calls / etc.) is unchanged, as suggested in the issue.

## Tests (`tests/plugin-passthrough-tag-strip-chat.test.ts`)

- New regression: mixed chunk `content="real answer"` + pure-echo `reasoning_content` → echo stripped, `real answer` survives (failed before the fix).
- New control: chunk where BOTH managed fields are pure echoes → still dropped (guards against over-correction; matches the existing single-field drop test).

## Pre-flight

- `npm run typecheck` clean
- `npm test`: 916/917 pass; the one failure (`launcher.test.ts` resolveClientCommand codex) fails identically on clean master in this sandbox (codex installed at an absolute path here) — pre-existing, unrelated.
- `npm run build` OK.
- E2E codex suite not run: change is in the plugin passthrough pipe (`src/plugin.ts`), outside the listed pipeline scope (server.ts / src/loop/ / adapters / preflight).

Fixes #462.