### PR TITLE
fix(launcher): isolate launches on a random free port; drop proxy attach (#446)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -103,7 +103,7 @@ Launcher (bili pi / bili codex / bili claude / bili omp / bili opencode / bili h
 Options (override config file / env):
   -F <url>                         upstream proxy to forward through (gost-style;
                                    http://host:port; must precede the client name)
-  --port <N>                       listen port (default 8787)
+   --port <N>                       listen port (bili start: 8787; launcher: random free port)
   --host <ADDR>                    listen host (default 127.0.0.1)
   --mitm-domain <domain>           extra MITM domain (repeatable; launcher only)
   --config <FILE>                  path to config JSON (default: XDG location)

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -70,6 +70,14 @@ export function instanceFilePath(): string {
     return path.join(stateDir(), "proxy-origin");
 }
 
+/** Per-launch handshake report (#446): keyed by launchToken so concurrent
+ *  launcher-spawned proxies don't clobber each other's single proxy-origin
+ *  record. The launcher reads only its own child's report (matched by
+ *  construction — it generated the token), so N isolated launchers coexist. */
+export function launchTokenFilePath(token: string): string {
+    return path.join(stateDir(), `proxy-origin-${token}`);
+}
+
 /** tmp+fsync+rename (same shape as web/api.ts atomicWriteConfig) — a torn
  *  write must never leave a half-origin behind (#406 family). */
 export function atomicWriteInstanceFile(info: ProxyInstanceFile, file?: string): void {

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -33,7 +33,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { spawn, type StdioOptions } from "node:child_process";
 import { DEFAULT_MITM_DOMAINS } from "./mitm.js";
-import { isProxyInstanceFile, isPidAlive, readProxyInstanceFile, type ProxyInstanceFile } from "./instance.js";
+import { isProxyInstanceFile, isPidAlive, launchTokenFilePath, readProxyInstanceFile, type ProxyInstanceFile } from "./instance.js";
 import { selfPackageRoot, isBiliPiEntry, ompPluginLoadedFrom } from "./plugin-install.js";
 
 /** Absolute path of a file inside our dist/, resolved via the package root
@@ -82,7 +82,6 @@ export {
 } from "./client-config.js";
 
 export const LAUNCHER_DEFAULT_HOST = "127.0.0.1";
-export const LAUNCHER_DEFAULT_PORT = 8787;
 export const LAUNCH_CLIENTS = ["pi", "codex", "claude", "omp", "opencode", "hermes", "dsh", "pi-test"] as const;
 export type ClientName = (typeof LAUNCH_CLIENTS)[number];
 export type BaseClientName = "claude" | "codex" | "pi" | "omp" | "opencode" | "hermes" | "dsh";
@@ -125,12 +124,10 @@ export interface ProxyHandle {
     port: number;
     child?: SpawnChild;
     logPath?: string;
-    attached?: boolean;
 }
 
 export interface LauncherDeps {
     fetchImpl?: (url: string) => Promise<{ ok: boolean }>;
-    fetchHealthInfo?: (origin: string) => Promise<{ ok: boolean; instanceId?: string } | undefined>;
     readInstanceFile?: () => ProxyInstanceFile | { origin: string } | undefined;
     spawnImpl?: SpawnFn;
     now?: () => number;
@@ -1517,43 +1514,21 @@ async function probeHealth(
     }
 }
 
-interface HealthInfo {
-    ok: boolean;
-    instanceId?: string;
-}
-
-async function fetchHealthInfoDefault(origin: string): Promise<HealthInfo | undefined> {
-    try {
-        const res = await fetch(healthUrl(origin), { signal: AbortSignal.timeout(PROBE_TIMEOUT_MS) });
-        if (!res.ok) return undefined;
-        const data = (await res.json()) as { ok?: boolean; instanceId?: string };
-        return { ok: Boolean(data.ok), instanceId: typeof data.instanceId === "string" ? data.instanceId : undefined };
-    } catch {
-        return undefined;
-    }
-}
-
-function instanceCompatible(inst: ProxyInstanceFile, opts: LaunchOptions): boolean {
-    if (inst.host !== opts.host || inst.passthrough !== opts.passthrough) return false;
-    const wantDomains = opts.mitmDomains ?? [];
-    if (inst.mitmDomains.length !== wantDomains.length || inst.mitmDomains.some((d, i) => d !== wantDomains[i])) return false;
-    const wantWindows = opts.modelWindows ?? {};
-    const keys = Object.keys(wantWindows);
-    if (Object.keys(inst.modelWindows).length !== keys.length) return false;
-    return keys.every((k) => inst.modelWindows[k] === wantWindows[k]);
-}
-
-async function probeExistingInstance(
-    readInstance: () => ProxyInstanceFile | { origin: string } | undefined,
-    fetchHealthInfo: (origin: string) => Promise<HealthInfo | undefined>,
-): Promise<ProxyInstanceFile | undefined> {
-    const inst = readInstance();
-    if (!isProxyInstanceFile(inst)) return undefined;
-    if (!isPidAlive(inst.pid)) return undefined;
-    const health = await fetchHealthInfo(inst.origin);
-    if (!health || !health.ok) return undefined;
-    if (health.instanceId !== undefined && health.instanceId !== inst.instanceId) return undefined;
-    return inst;
+/** Bind a throwaway server on an OS-assigned port and return that port. The
+ *  launcher default: every launch gets its own free port so isolated launches
+ *  never collide (#446). */
+export function pickEphemeralPort(host = LAUNCHER_DEFAULT_HOST): Promise<number> {
+    return new Promise<number>((resolve, reject) => {
+        const srv = net.createServer();
+        srv.once("error", reject);
+        srv.listen(0, host, () => {
+            const addr = srv.address();
+            srv.close(() => {
+                if (addr && typeof addr === "object") resolve(addr.port);
+                else reject(new Error("could not allocate a free port"));
+            });
+        });
+    });
 }
 
 export function findFreePort(preferred: number, host = LAUNCHER_DEFAULT_HOST): Promise<number> {
@@ -1564,20 +1539,7 @@ export function findFreePort(preferred: number, host = LAUNCHER_DEFAULT_HOST): P
             srv.once("listening", () => srv.close(() => resolve(true)));
             srv.listen(port, host);
         });
-    return tryBind(preferred).then((free) => {
-        if (free) return preferred;
-        return new Promise<number>((resolve, reject) => {
-            const srv = net.createServer();
-            srv.once("error", reject);
-            srv.listen(0, host, () => {
-                const addr = srv.address();
-                srv.close(() => {
-                    if (addr && typeof addr === "object") resolve(addr.port);
-                    else reject(new Error("could not allocate a free port"));
-                });
-            });
-        });
-    });
+    return tryBind(preferred).then((free) => (free ? Promise.resolve(preferred) : pickEphemeralPort(host)));
 }
 
 const INHERITED_PROXY_VARS = ["http_proxy", "https_proxy", "all_proxy", "HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY"];
@@ -1600,25 +1562,17 @@ export async function ensureProxyRunning(
     deps: LauncherDeps = {},
 ): Promise<ProxyHandle> {
     const fetchImpl = deps.fetchImpl ?? defaultFetch;
-    const fetchHealthInfo = deps.fetchHealthInfo ?? fetchHealthInfoDefault;
-    const readInstance = deps.readInstanceFile ?? readProxyInstanceFile;
     const spawnImpl = deps.spawnImpl ?? (spawn as SpawnFn);
     const now = deps.now ?? Date.now;
     const sleepImpl = deps.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
 
-    // #394/#417: a healthy proxy with a compatible config is SHARED, not
-    // doubled — two concurrent launches of the same client would otherwise
-    // spawn two writers over one sessions dir.
-    const existing = await probeExistingInstance(readInstance, fetchHealthInfo);
-    if (existing && instanceCompatible(existing, opts)) {
-        console.error(`bili: attaching to running proxy at ${existing.origin} (pid ${existing.pid})`);
-        return { origin: existing.origin, port: existing.port, attached: true };
-    }
-
-    // #407: no probe-release-rebind. The child binds the preferred port
-    // itself and retries on EADDRINUSE, reporting the real origin through
-    // the instance file via this launchToken.
+    // #407/#446: no probe-release-rebind and no attach/share. Every launch
+    // spawns its own proxy on the requested (random free) port; the child
+    // self-binds, retries on EADDRINUSE, and reports the real origin through a
+    // per-launchToken file so concurrent isolated launches don't clobber one
+    // record.
     const launchToken = randomUUID();
+    const readInstance = deps.readInstanceFile ?? (() => readProxyInstanceFile(launchTokenFilePath(launchToken)));
     const port = opts.port;
     const script = process.argv[1];
     if (!script) throw new Error("bili: cannot resolve launcher script path");
@@ -1678,7 +1632,6 @@ export async function ensureProxyRunning(
 }
 
 export function stopProxy(handle: ProxyHandle): void {
-    if (handle.attached) return;
     const child = handle.child;
     if (!child || child.pid === undefined) return;
     if (process.platform === "win32") {
@@ -1769,8 +1722,11 @@ export interface RunLaunchParams {
     overrides: Record<string, string | undefined>;
 }
 
-function parsePort(raw: string | undefined): number {
-    const port = raw && raw.trim() ? parseInt(raw, 10) : LAUNCHER_DEFAULT_PORT;
+// No explicit --port -> undefined: the launcher allocates a random free port
+// so isolated launches never collide on a fixed default (#446).
+function parsePort(raw: string | undefined): number | undefined {
+    if (!raw || !raw.trim()) return undefined;
+    const port = parseInt(raw, 10);
     if (!Number.isFinite(port) || port <= 0 || port > 65535) {
         console.error(`bili: invalid --port "${raw}"`);
         process.exit(2);
@@ -1780,7 +1736,8 @@ function parsePort(raw: string | undefined): number {
 
 export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}): Promise<void> {
     const host = params.overrides.ACP_HOST?.trim() || LAUNCHER_DEFAULT_HOST;
-    const port = parsePort(params.overrides.ACP_PORT ?? process.env.ACP_PORT);
+    const requestedPort = parsePort(params.overrides.ACP_PORT ?? process.env.ACP_PORT);
+    const port = requestedPort ?? (await pickEphemeralPort(host));
     const passthrough = params.overrides.ACP_PASSTHROUGH === "1";
     const debug = params.overrides.ACP_DEBUG === "1";
 
@@ -2023,7 +1980,8 @@ export interface RunTestPiParams {
 
 export async function runTestPi(params: RunTestPiParams, deps: LauncherDeps = {}): Promise<number> {
     const host = params.overrides.ACP_HOST?.trim() || LAUNCHER_DEFAULT_HOST;
-    const port = parsePort(params.overrides.ACP_PORT ?? process.env.ACP_PORT);
+    const requestedPort = parsePort(params.overrides.ACP_PORT ?? process.env.ACP_PORT);
+    const port = requestedPort ?? (await pickEphemeralPort(host));
     const passthrough = params.overrides.ACP_PASSTHROUGH === "1";
     const debug = params.overrides.ACP_DEBUG === "1";
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -51,7 +51,7 @@ import { reapOrphanBlocks } from "./orphan-gc.js";
 import { getStore } from "./persist.js";
 import { log as loggerLog, configureLogger, getLogPath, closeLogger } from "./logger.js";
 import { defaultLogFile, stateDir } from "./paths.js";
-import { atomicWriteInstanceFile, clearProxyInstanceFile, isPidAlive, registerInstanceAndWarn, unregisterInstance } from "./instance.js";
+import { atomicWriteInstanceFile, clearProxyInstanceFile, isPidAlive, launchTokenFilePath, registerInstanceAndWarn, unregisterInstance } from "./instance.js";
 import { compressLoopResponsesJson } from "./compress-loop-responses.js";
 import { runCompressLoop, pickAdapter } from "./loop/index.js";
 import { containsToolCallXmlFragment } from "./loop/tag-echo-filter.js";
@@ -375,20 +375,25 @@ export async function startServer(opts: ProxyOptions): Promise<http.Server> {
         // so the file always holds a valid URL.
         const originHost = opts.host === "0.0.0.0" || opts.host === "::" || opts.host === "localhost" ? "127.0.0.1" : opts.host.includes(":") && !opts.host.startsWith("[") ? `[${opts.host}]` : opts.host;
         const origin = `http://${originHost}:${actualPort}`;
+        const instanceInfo = {
+            origin,
+            instanceId,
+            pid: process.pid,
+            startedAt: instanceStartedAt,
+            host: opts.host,
+            port: actualPort,
+            passthrough: opts.passthrough,
+            mitmDomains: opts.mitm.enabled ? opts.mitm.domains : [],
+            modelWindows: { ...LAUNCHER_MODEL_WINDOWS },
+            launchToken: launchToken || undefined,
+        };
         try {
             fs.mkdirSync(stateDir(), { recursive: true });
-            atomicWriteInstanceFile({
-                origin,
-                instanceId,
-                pid: process.pid,
-                startedAt: instanceStartedAt,
-                host: opts.host,
-                port: actualPort,
-                passthrough: opts.passthrough,
-                mitmDomains: opts.mitm.enabled ? opts.mitm.domains : [],
-                modelWindows: { ...LAUNCHER_MODEL_WINDOWS },
-                launchToken: launchToken || undefined,
-            });
+            atomicWriteInstanceFile(instanceInfo);
+            // #446: per-launchToken report so concurrent isolated launchers don't
+            // clobber each other's handshake record (the shared file above is a
+            // "latest proxy" discovery hint only).
+            if (launchToken) atomicWriteInstanceFile(instanceInfo, launchTokenFilePath(launchToken));
         } catch {
             // best-effort discovery hint for host-spawned MCP shells
         }
@@ -463,6 +468,11 @@ export async function startServer(opts: ProxyOptions): Promise<http.Server> {
     let shuttingDown = false;
     const finishShutdown = (): void => {
         clearProxyInstanceFile(instanceId);
+        if (launchToken) {
+            try {
+                fs.unlinkSync(launchTokenFilePath(launchToken));
+            } catch {}
+        }
         unregisterInstance(instanceId);
         closeLogger();
         process.exit(0);

--- a/tests/launcher.test.ts
+++ b/tests/launcher.test.ts
@@ -48,6 +48,7 @@ import {
     readOpencodeConfig,
     resolveOpencodeConfigFile,
     findFreePort,
+    pickEphemeralPort,
     ensureProxyRunning,
     stopProxy,
     resolveLauncherWindow,
@@ -271,6 +272,11 @@ test("findFreePort: returns another port when preferred is occupied", async () =
     } finally {
         blocker.close();
     }
+});
+
+test("pickEphemeralPort: returns a live OS-assigned port", async () => {
+    const port = await pickEphemeralPort(LAUNCHER_DEFAULT_HOST);
+    assert.ok(Number.isInteger(port) && port > 0 && port <= 65535);
 });
 
 import { selfPackageRoot, ompPluginLoadedFrom } from "../src/plugin-install.js";
@@ -592,10 +598,12 @@ function recordedInstance(over: Partial<InstanceFile> = {}): InstanceFile {
     };
 }
 
-test("ensureProxyRunning: attaches to a compatible healthy instance instead of doubling (#394)", async () => {
+test("ensureProxyRunning: always spawns its own proxy, never attaches to a recorded one (#446)", async () => {
     let spawnCalls = 0;
-    const spawnImpl: SpawnFn = () => {
+    let capturedToken = "";
+    const spawnImpl: SpawnFn = (_cmd, _args, options) => {
         spawnCalls++;
+        capturedToken = (options.env?.BILI_LAUNCH_TOKEN as string) ?? "";
         return makeFakeChild(42431);
     };
     const handle = await ensureProxyRunning(
@@ -603,56 +611,16 @@ test("ensureProxyRunning: attaches to a compatible healthy instance instead of d
         {
             spawnImpl,
             fetchImpl: async () => ({ ok: true }),
-            fetchHealthInfo: async () => ({ ok: true, instanceId: "inst-1" }),
-            readInstanceFile: () => recordedInstance(),
+            // A fully compatible, healthy instance is already recorded — under the
+            // old #394/#417 attach model this would short-circuit and reuse it. We
+            // must ignore it and trust only our own child's report (launchToken).
+            readInstanceFile: () =>
+                capturedToken ? recordedInstance({ launchToken: capturedToken }) : undefined,
         },
     );
-    assert.equal(spawnCalls, 0);
-    assert.equal(handle.attached, true);
+    assert.equal(spawnCalls, 1, "spawned our own proxy instead of attaching");
+    assert.ok(handle.child, "handle owns the spawned child");
     assert.equal(handle.origin, "http://127.0.0.1:8787");
-    let killed = false;
-    stopProxy({ ...handle, child: { pid: 77777, kill: () => { killed = true; return true; } } });
-    assert.equal(killed, false);
-});
-
-test("ensureProxyRunning: incompatible recorded instance (modelWindows) is not attached", async () => {
-    let spawnCalls = 0;
-    const spawnImpl: SpawnFn = () => {
-        spawnCalls++;
-        return makeFakeChild(42434);
-    };
-    let reads = 0;
-    const handle = await ensureProxyRunning(
-        { host: "127.0.0.1", port: 8787, passthrough: false, debug: false, modelWindows: { "m1": 100000 } },
-        {
-            spawnImpl,
-            fetchImpl: async () => ({ ok: true }),
-            fetchHealthInfo: async () => ({ ok: true, instanceId: "inst-1" }),
-            readInstanceFile: () => (reads++ === 0 ? recordedInstance() : undefined),
-            sleep: () => Promise.resolve(),
-        },
-    );
-    assert.equal(spawnCalls, 1);
-    assert.equal(handle.attached, undefined);
-});
-
-test("ensureProxyRunning: dead recorded pid is ignored (no attach)", async () => {
-    let spawnCalls = 0;
-    const spawnImpl: SpawnFn = () => {
-        spawnCalls++;
-        return makeFakeChild(42435);
-    };
-    const handle = await ensureProxyRunning(
-        { host: "127.0.0.1", port: 8787, passthrough: false, debug: false },
-        {
-            spawnImpl,
-            fetchImpl: async () => ({ ok: true }),
-            fetchHealthInfo: async () => ({ ok: true, instanceId: "inst-1" }),
-            readInstanceFile: () => recordedInstance({ pid: 99999999 }),
-            sleep: () => Promise.resolve(),
-        },
-    );
-    assert.equal(spawnCalls, 1);
 });
 
 test("ensureProxyRunning: launchToken handshake returns the child's real port (#407)", async () => {


### PR DESCRIPTION
Closing as superseded by #526 (plan 1: port isolation only).

This PR over-interpreted 「启动器模式都是隔离」 as process isolation — dropping the #417 attach-or-spawn share path and adding per-token handshake files. Per the issue thread, the intent was **port isolation only**: launcher proxies shouldn't squat on 8787, but a healthy compatible instance (including an explicitly-started `bili start`) should still be attached, keeping the single-writer property #417 was built for.

The crash-root-cause narrative here also predates part of #417's guards; the residual owner-exit cascade was accepted in the issue thread. Thanks for the groundwork — the ephemeral-port portion lives on in #526.