### PR TITLE
fix(#460): strip render-tag echoes from non-injected proxy-mode chat SSE

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -536,12 +536,18 @@ function mergeUsageSample(acc: UsageSample, sample: UsageSample): void {
  *  model prose through the tag-echo state machine — #206 parity with
  *  pipePluginResponsesWithStrip. The verbatim variant let a model-emitted
  *  render tag echo land in the agent's replayed history and amplify into the
- *  "endless blank output" loop observed with pi + qwen (issue #14). */
+ *  "endless blank output" loop observed with pi + qwen (issue #14).
+ *
+ *  Also serves proxy-mode chat SSE that skipped compress injection (#460:
+ *  title-gen exclusion / ACP_NO_INJECT_TOOL / classifier bypass). Pass no
+ *  session there — usage accounting must be skipped or a title-gen call's
+ *  tiny input_tokens would clobber lastInputTokens and break compression
+ *  triggering for the main conversation. */
 export async function pipePluginChatWithStrip(
     stream: ReadableStream<Uint8Array>,
     res: import("node:http").ServerResponse,
-    session: Session,
     protocol: WireProtocol,
+    session?: Session,
     log?: (msg: string) => void,
 ): Promise<void> {
     const reader = stream.getReader();
@@ -691,7 +697,7 @@ export async function pipePluginChatWithStrip(
         }
         const rest = flushTails();
         if (rest.length > 0 && !res.destroyed && !res.writableEnded) await write(rest);
-        if (acc.inputTokens !== undefined || acc.outputTokens !== undefined || acc.cachedTokens !== undefined) {
+        if (session && (acc.inputTokens !== undefined || acc.outputTokens !== undefined || acc.cachedTokens !== undefined)) {
             applyUsageSample(session, acc, protocol);
             markDirty(session);
         }
@@ -727,11 +733,14 @@ function hadTextOtherThanTextFields(choices: unknown): boolean {
  * tag-echo state machine the compress loop uses. A held tail is flushed as a
  * final delta before the first done/completed event so the client's assembled
  * text never loses content.
- */
+ *
+ *  Also serves proxy-mode Responses SSE that skipped compress injection
+ *  (#460, e.g. ACP_NO_INJECT_TOOL). Pass no session there — see
+ *  pipePluginChatWithStrip for why usage accounting must be skipped. */
 export async function pipePluginResponsesWithStrip(
     stream: ReadableStream<Uint8Array>,
     res: import("node:http").ServerResponse,
-    session: Session,
+    session?: Session,
     log?: (msg: string) => void,
 ): Promise<void> {
     const reader = stream.getReader();
@@ -827,7 +836,7 @@ export async function pipePluginResponsesWithStrip(
             const rest = flushTail("");
             if (rest.length > 0) await write(rest);
         }
-        if (acc.inputTokens !== undefined || acc.outputTokens !== undefined || acc.cachedTokens !== undefined) {
+        if (session && (acc.inputTokens !== undefined || acc.outputTokens !== undefined || acc.cachedTokens !== undefined)) {
             applyUsageSample(session, acc, "responses");
             markDirty(session);
         }

--- a/src/server.ts
+++ b/src/server.ts
@@ -2561,7 +2561,7 @@ async function forward(
             if (prepared.protocol === "responses") {
                 await pipePluginResponsesWithStrip(upstream.body as ReadableStream<Uint8Array>, res, prepared.session, (msg) => log("info", `[${prepared.session.id}] ${msg}`));
             } else {
-                await pipePluginChatWithStrip(upstream.body as ReadableStream<Uint8Array>, res, prepared.session, prepared.protocol, (msg) => log("info", `[${prepared.session.id}] ${msg}`));
+                await pipePluginChatWithStrip(upstream.body as ReadableStream<Uint8Array>, res, prepared.protocol, prepared.session, (msg) => log("info", `[${prepared.session.id}] ${msg}`));
             }
         } else {
             await pipePluginJson(upstream.body as ReadableStream<Uint8Array>, res, prepared.session, prepared.protocol);
@@ -2570,11 +2570,11 @@ async function forward(
         return;
     }
     // We only rewrite when THIS request actually had the compress tool
-    // injected (per-request). For the OpenAI title-gen path
-    // (`compressInjected === false`) we must NOT route the stream into a
-    // rewriter — `rewriteSseStream` below is the *Anthropic* SSE rewriter
-    // and would mishandle OpenAI `choices[].delta` events. Plain passthrough
-    // is correct there.
+    // injected (per-request). Non-injected requests (OpenAI title-gen
+    // exclusion, ACP_NO_INJECT_TOOL, auto-mode classifier bypass) must NOT
+    // enter the compress loop — but their chat SSE still gets render-tag
+    // echo stripping (#460) below, so history-borne tags echoed in model
+    // prose cannot leak to the client and amplify via its replay.
     const useRewriter =
         prepared !== null &&
         prepared.compressInjected &&
@@ -2592,6 +2592,24 @@ async function forward(
             } else {
                 log("warn", `[${prepared.session.id}] native compact response terminal=${terminal}; rebase NOT scheduled`);
             }
+        } else if (
+            prepared &&
+            prepared.stream &&
+            (upstream.headers.get("content-type") ?? "").includes("text/event-stream")
+        ) {
+            // #460: same strip pipes as plugin mode; byte-identical for
+            // tag-free streams. No session is passed: usage accounting must
+            // stay off here, or a title-gen call's tiny input_tokens would
+            // clobber lastInputTokens and break compression triggering for
+            // the main conversation (see pipePluginChatWithStrip docs).
+            const p = prepared;
+            const tagLog = (msg: string) => log("info", `[${p.session.id}] ${msg}`);
+            if (p.protocol === "responses") {
+                await pipePluginResponsesWithStrip(upstream.body as ReadableStream<Uint8Array>, res, undefined, tagLog);
+            } else {
+                await pipePluginChatWithStrip(upstream.body as ReadableStream<Uint8Array>, res, p.protocol, undefined, tagLog);
+            }
+            clearUpstreamTimer();
         } else {
             await pipeThrough(upstream.body, res);
             clearUpstreamTimer();

--- a/tests/plugin-passthrough-tag-strip-chat.test.ts
+++ b/tests/plugin-passthrough-tag-strip-chat.test.ts
@@ -68,7 +68,7 @@ test("plugin chat passthrough strips render tags from delta.content", async () =
         chatChunk({}, { choices: [{ index: 0, delta: {}, finish_reason: "stop" }], usage: { prompt_tokens: 100, completion_tokens: 5 } }),
         DONE,
     ];
-    await pipePluginChatWithStrip(streamOf(events), res, session, "openai");
+    await pipePluginChatWithStrip(streamOf(events), res, "openai", session);
     const text = out.join("");
     assert.ok(!text.includes("m00042"), "render tag content must not pass through");
     assert.ok(text.includes("leading  trailing"), "non-tag prose survives");
@@ -85,7 +85,7 @@ test("plugin chat passthrough strips tags split across deltas and flushes tail b
         chatChunk({ content: `0042${TAG_CLOSE} tail` }),
         DONE,
     ];
-    await pipePluginChatWithStrip(streamOf(events), res, session, "openai");
+    await pipePluginChatWithStrip(streamOf(events), res, "openai", session);
     const text = out.join("");
     assert.ok(!text.includes("m00042"), "split tag fully swallowed");
     assert.ok(text.includes("ok "), "first delta prose passes");
@@ -104,7 +104,7 @@ test("plugin chat passthrough strips echo from reasoning_content too", async () 
         chatChunk({ reasoning_content: `think ${TAG_OPEN}m00007${TAG_CLOSE} done` }),
         DONE,
     ];
-    await pipePluginChatWithStrip(streamOf(events), res, session, "openai");
+    await pipePluginChatWithStrip(streamOf(events), res, "openai", session);
     const text = out.join("");
     assert.ok(!text.includes("m00007"), "reasoning echo stripped");
     assert.ok(text.includes("think  done"), "reasoning prose survives");
@@ -120,7 +120,7 @@ test("plugin chat passthrough drops a chunk whose delta stripped to empty", asyn
         chatChunk({ content: "more" }),
         DONE,
     ];
-    await pipePluginChatWithStrip(streamOf(events), res, session, "openai");
+    await pipePluginChatWithStrip(streamOf(events), res, "openai", session);
     const text = out.join("");
     assert.ok(!text.includes("m1") && !text.includes("m2"), "echo-only chunk stripped");
     const dataLines = text.split("\n").filter((l) => l.startsWith("data:")).filter((l) => !l.includes("[DONE]"));
@@ -137,7 +137,7 @@ test("plugin chat passthrough keeps tool_calls deltas byte-identical", async () 
     const toolChunk = chatChunk({ tool_calls: [{ index: 0, id: "call_1", type: "function", function: { name: "compress", arguments: "{\"content\":[]}" } }] });
     const plain = chatChunk({ content: "plain text no tags" });
     const events = [plain, toolChunk, chatChunk({}, { choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }] }), DONE];
-    await pipePluginChatWithStrip(streamOf(events), res, session, "openai");
+    await pipePluginChatWithStrip(streamOf(events), res, "openai", session);
     const text = out.join("");
     assert.ok(text.includes(toolChunk.trim()), "tool_calls delta untouched");
     assert.ok(text.includes(plain.trim()), "clean delta untouched");
@@ -148,7 +148,7 @@ test("plugin chat passthrough resolves held tail at stream end without [DONE]", 
     const res = makeRes(out);
     const session = makeSession();
     const events = [chatChunk({ content: `prose ${TAG_OPEN}m0` })];
-    await pipePluginChatWithStrip(streamOf(events), res, session, "openai");
+    await pipePluginChatWithStrip(streamOf(events), res, "openai", session);
     const text = out.join("");
     assert.ok(text.includes("prose "), "clean prefix passes");
     assert.ok(!text.includes("m0"), "unclosed tag content dropped at stream end");
@@ -165,7 +165,7 @@ test("plugin anthropic passthrough strips render tags from text_delta and thinki
         `event: message_delta\ndata: ${JSON.stringify({ type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 3 } })}\n\n`,
         `event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`,
     ];
-    await pipePluginChatWithStrip(streamOf(events), res, session, "anthropic");
+    await pipePluginChatWithStrip(streamOf(events), res, "anthropic", session);
     const text = out.join("");
     assert.ok(!text.includes("m00009") && !text.includes("m00010"), "render tags stripped from both delta types");
     assert.ok(text.includes("hi  bye"), "text prose survives");
@@ -182,7 +182,7 @@ test("plugin anthropic passthrough strips tags split across deltas and flushes b
         `event: content_block_delta\ndata: ${JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: `0042${TAG_CLOSE} tail` } })}\n\n`,
         `event: message_delta\ndata: ${JSON.stringify({ type: "message_delta", delta: { stop_reason: "end_turn" } })}\n\n`,
     ];
-    await pipePluginChatWithStrip(streamOf(events), res, session, "anthropic");
+    await pipePluginChatWithStrip(streamOf(events), res, "anthropic", session);
     const text = out.join("");
     assert.ok(!text.includes("m00042"), "split tag swallowed");
     assert.ok(text.includes("tail"), "tail flushed before message_delta");

--- a/tests/proxy-noinject-tag-strip.test.ts
+++ b/tests/proxy-noinject-tag-strip.test.ts
@@ -1,0 +1,198 @@
+import assert from "node:assert";
+import http from "node:http";
+import { once } from "node:events";
+import test from "node:test";
+
+process.env.NODE_ENV = "test";
+
+import { defaultConfig } from "acp-kernel";
+import { startServer, type ProxyOptions } from "../src/server.ts";
+import { SessionStore, _setStoreForTest } from "../src/persist.ts";
+import { _setForTest as setRegistryForTest } from "../src/registry.ts";
+
+// Render-tag pieces are assembled from hex escapes so no literal tag sequence
+// appears in this file's source.
+const LT = "\x3c";
+const GT = "\x3e";
+const TAG = (id: string, tokens = 177) => `${LT}acp tokens="${tokens}" type="text"${GT}${id}${LT}/acp${GT}`;
+const OPEN_MARK = `${LT}acp `;
+const CLOSE_MARK = `${LT}/acp${GT}`;
+
+interface Harness {
+    proxyPort: number;
+    upstreamPort: number;
+    close(): Promise<void>;
+}
+
+function anthropicSse(event: string, data: unknown): string {
+    return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+function openaiChunk(data: unknown): string {
+    return `data: ${JSON.stringify(data)}\n\n`;
+}
+
+async function startHarness(compress: { injectTool: boolean; injectNudge: boolean }, scripts: string[][]): Promise<Harness> {
+    let call = 0;
+    const upstream = http.createServer((req, res) => {
+        req.on("data", () => {});
+        req.on("end", () => {
+            res.writeHead(200, { "content-type": "text/event-stream" });
+            const script = scripts[Math.min(call, scripts.length - 1)]!;
+            call += 1;
+            for (const line of script) res.write(line);
+            res.end();
+        });
+    });
+    upstream.listen(0, "127.0.0.1");
+    return (async () => {
+        await once(upstream, "listening");
+        const upstreamPort = upstream.address().port;
+        _setStoreForTest(new SessionStore({ enabled: false }));
+        setRegistryForTest({});
+        const proxy = await startServer({
+            port: 0,
+            host: "127.0.0.1",
+            upstream: "http://127.0.0.1",
+            routes: { [`http://127.0.0.1:${upstreamPort}`]: { models: { "claude-test": { context: 400_000 }, "gpt-test": { context: 400_000 } } } },
+            modelContextLimit: 400_000,
+            kernelConfig: defaultConfig(400_000),
+            compress,
+            sessionHeader: "x-acp-session",
+            log: false,
+            debug: false,
+            passthrough: false,
+            autoUpdate: false,
+            mitm: { enabled: false, domains: [] },
+        } as ProxyOptions);
+        await once(proxy, "listening");
+        const proxyPort = proxy.address().port;
+        return {
+            proxyPort,
+            upstreamPort,
+            close: async () => {
+                proxy.close();
+                await once(proxy, "close");
+                upstream.close();
+                await once(upstream, "close");
+            },
+        };
+    })();
+}
+
+function tagEchoAnthropicScript(): string[] {
+    const full = `好的，总结如下 ${TAG("m00155")}${TAG("m00155", 44)}${TAG("m00156", 33)}另外 5 « 6 成立${TAG("m00157")}完毕`;
+    const splitAt = [7, 20, 26, 41, 48, 60];
+    const parts: string[] = [];
+    let prev = 0;
+    for (const s of splitAt) {
+        parts.push(full.slice(prev, s));
+        prev = s;
+    }
+    parts.push(full.slice(prev));
+    return [
+        anthropicSse("message_start", { type: "message_start", message: { id: "msg_ninj_1", role: "assistant", usage: { input_tokens: 20 } } }),
+        anthropicSse("content_block_start", { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } }),
+        ...parts.map((p) => anthropicSse("content_block_delta", { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: p } })),
+        anthropicSse("content_block_stop", { type: "content_block_stop", index: 0 }),
+        anthropicSse("message_delta", { type: "message_delta", delta: { stop_reason: "end_turn", stop_sequence: null }, usage: { output_tokens: 9 } }),
+        anthropicSse("message_stop", { type: "message_stop" }),
+    ];
+}
+
+function tagEchoOpenAiScript(): string[] {
+    const full = `title: ${TAG("m00009", 12)}summary ok`;
+    const parts = [full.slice(0, 6), full.slice(6, 22), full.slice(22)];
+    const base = { id: "chatcmpl_ninj", object: "chat.completion.chunk", created: 1, model: "gpt-test" };
+    return [
+        openaiChunk({ ...base, choices: [{ index: 0, delta: { role: "assistant", content: "" } }] }),
+        ...parts.map((p) => openaiChunk({ ...base, choices: [{ index: 0, delta: { content: p } }] })),
+        openaiChunk({ ...base, choices: [{ index: 0, delta: {}, finish_reason: "stop" }] }),
+        "data: [DONE]\n\n",
+    ];
+}
+
+function cleanAnthropicText(raw: string): string {
+    return [...raw.matchAll(/"type":"text_delta","text":"((?:[^"\\]|\\.)*)"/g)]
+        .map((m) => JSON.parse(`"${m[1]}"`) as string)
+        .join("");
+}
+
+function cleanOpenAiContent(raw: string): string {
+    let out = "";
+    for (const line of raw.split("\n")) {
+        if (!line.startsWith("data:") || line.slice(5).trim() === "[DONE]") continue;
+        try {
+            const obj = JSON.parse(line.slice(5).trim()) as { choices?: Array<{ delta?: { content?: string } }> };
+            out += obj.choices?.[0]?.delta?.content ?? "";
+        } catch {}
+    }
+    return out;
+}
+
+test("#460: non-injected anthropic SSE — echoed render tags stripped, prose intact", async () => {
+    const h = await startHarness({ injectTool: false, injectNudge: false }, [tagEchoAnthropicScript()]);
+    try {
+        const resp = await fetch(`http://127.0.0.1:${h.proxyPort}/bili/http://127.0.0.1:${h.upstreamPort}/v1/messages`, {
+            method: "POST",
+            headers: { "content-type": "application/json", "x-acp-session": "noinject-anth" },
+            body: JSON.stringify({ model: "claude-test", max_tokens: 1024, stream: true, system: "You are a test assistant.", messages: [{ role: "user", content: "hello" }] }),
+        });
+        assert.equal(resp.status, 200);
+        let raw = "";
+        for await (const chunk of resp.body) raw += Buffer.from(chunk).toString("utf8");
+        assert.equal(raw.includes(OPEN_MARK), false, "client stream leaked a render open tag");
+        assert.equal(raw.includes(CLOSE_MARK), false, "client stream leaked a render close tag");
+        assert.ok(cleanAnthropicText(raw).endsWith("好的，总结如下 另外 5 « 6 成立完毕"), `unexpected client text: ${JSON.stringify(cleanAnthropicText(raw))}`);
+        assert.ok(raw.includes("message_stop"), "terminal event missing");
+    } finally {
+        await h.close();
+    }
+});
+
+test("#460: non-injected anthropic SSE without tags — byte-identical passthrough", async () => {
+    const script = [
+        anthropicSse("message_start", { type: "message_start", message: { id: "msg_ninj_2", role: "assistant", usage: { input_tokens: 20 } } }),
+        anthropicSse("content_block_start", { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } }),
+        anthropicSse("content_block_delta", { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "plain " } }),
+        anthropicSse("content_block_delta", { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "prose" } }),
+        anthropicSse("content_block_stop", { type: "content_block_stop", index: 0 }),
+        anthropicSse("message_delta", { type: "message_delta", delta: { stop_reason: "end_turn", stop_sequence: null }, usage: { output_tokens: 2 } }),
+        anthropicSse("message_stop", { type: "message_stop" }),
+    ];
+    const h = await startHarness({ injectTool: false, injectNudge: false }, [script]);
+    try {
+        const resp = await fetch(`http://127.0.0.1:${h.proxyPort}/bili/http://127.0.0.1:${h.upstreamPort}/v1/messages`, {
+            method: "POST",
+            headers: { "content-type": "application/json", "x-acp-session": "noinject-anth-clean" },
+            body: JSON.stringify({ model: "claude-test", max_tokens: 1024, stream: true, system: "s", messages: [{ role: "user", content: "hello" }] }),
+        });
+        assert.equal(resp.status, 200);
+        let raw = "";
+        for await (const chunk of resp.body) raw += Buffer.from(chunk).toString("utf8");
+        assert.equal(raw, script.join(""), "tag-free stream must pass through byte-identical");
+    } finally {
+        await h.close();
+    }
+});
+
+test("#460: openai title-gen (max_tokens<=200) SSE — echoed render tags stripped, [DONE] intact", async () => {
+    const h = await startHarness({ injectTool: true, injectNudge: true }, [tagEchoOpenAiScript()]);
+    try {
+        const resp = await fetch(`http://127.0.0.1:${h.proxyPort}/bili/http://127.0.0.1:${h.upstreamPort}/v1/chat/completions`, {
+            method: "POST",
+            headers: { "content-type": "application/json", "x-acp-session": "noinject-openai-title" },
+            body: JSON.stringify({ model: "gpt-test", max_tokens: 100, stream: true, messages: [{ role: "user", content: "hello" }] }),
+        });
+        assert.equal(resp.status, 200);
+        let raw = "";
+        for await (const chunk of resp.body) raw += Buffer.from(chunk).toString("utf8");
+        assert.equal(raw.includes(OPEN_MARK), false, "client stream leaked a render open tag");
+        assert.equal(raw.includes(CLOSE_MARK), false, "client stream leaked a render close tag");
+        assert.equal(cleanOpenAiContent(raw), "title: summary ok", `unexpected content: ${JSON.stringify(cleanOpenAiContent(raw))}`);
+        assert.ok(raw.includes("[DONE]"), "[DONE] missing");
+        assert.ok(raw.includes('"finish_reason":"stop"'), "finish_reason chunk missing");
+    } finally {
+        await h.close();
+    }
+});


### PR DESCRIPTION
## What

Issue #460 (ework #459), as rescoped by @ranxianglei: requests that skip compress injection — OpenAI title-gen exclusion (`max_tokens <= 200`), `ACP_NO_INJECT_TOOL` sessions, #353 stop_sequences classifier bypass — piped upstream SSE straight through to the client with no render-tag handling. A model echoing history-borne ACP render tags into prose leaks them to the client TUI, where they re-enter the conversation via replay and amplify (same mechanism as #457/#459).

This routes those non-injected streaming responses through the same tag-strip pipes plugin mode already uses (#452): `pipePluginChatWithStrip` (openai/anthropic) and `pipePluginResponsesWithStrip` (responses). Byte-identical for tag-free streams.

## Why no session is passed

The new call sites pass `undefined` for session on purpose: `pipePluginChatWithStrip` accumulates usage samples into `session.stats.lastInputTokens` (last-wins merge). A title-gen call's tiny `input_tokens` would clobber the main conversation's value and break compression triggering. Usage accounting is now guarded by session presence in both pipes.

## Changes

- `src/plugin.ts`: `pipePluginChatWithStrip` signature reordered to `(stream, res, protocol, session?, log?)`, session optional; usage sample applied only when a session is present. Same optionality for `pipePluginResponsesWithStrip`.
- `src/server.ts` `!useRewriter` branch: streaming requests whose upstream response is `text/event-stream` go through the strip pipes; everything else (non-SSE bodies, non-streaming) stays raw `pipeThrough` exactly as before. The content-type gate also protects against the strip pipes' residual-buffer behavior on malformed/undelimited bodies.
- Also replaces a stale comment that referenced `rewriteSseStream` "below" (removed long ago) — the misleading comment that contributed to the original mis-triage of this issue.
- `tests/proxy-noinject-tag-strip.test.ts` (new): full-server tests — anthropic `injectTool:false` stream with tags split across deltas → stripped, prose intact; tag-free stream → byte-identical; openai title-gen stream → stripped, `[DONE]` + `finish_reason` intact.
- `tests/plugin-passthrough-tag-strip-chat.test.ts`: call sites updated for the reordered signature (behavior unchanged).

## Residuals (reported in issue thread, out of scope here)

- Non-streaming JSON responses on the same non-injected paths are still not stripped (owner's scope decision).
- Dead legacy rewriters `rewriteSseStream` / `rewriteOpenaiSseStream` still exported with zero call sites — removal awaiting owner sign-off.

## Pre-flight

- typecheck: clean
- npm test: 917/918 pass; the 1 failure (`launcher.test.ts` resolveClientCommand codex path) fails identically on pristine master in this environment (codex installed at /usr/bin/codex) — pre-existing, unrelated
- tsup build: OK
- E2E codex suite not run locally (requires upstream at http://127.0.0.1:8199, unavailable here); change is additive on a branch covered by the new unit tests, plugin-mode call sites unchanged behaviorally