### PR TITLE
fix(#468): engage tag-echo filter on tag-head tails so micro-fragmented tags are stripped

### DIFF
--- a/src/loop/tag-echo-filter.ts
+++ b/src/loop/tag-echo-filter.ts
@@ -56,6 +56,17 @@ export function containsRenderTagText(s: string): boolean {
     return RENDER_TAG_DETECT.test(s);
 }
 
+// #468: some upstreams stream a model-imitated render tag in tokenizer-sized
+// fragments ("\x3cac", "p tokens", ...) so no single chunk ever trips
+// RENDER_TAG_DETECT. Per-chunk gates must also engage when the chunk contains
+// or ends with the head of a render tag, so the streaming state machine can
+// stitch it back together. Pure-prose chunks still skip the machine
+// (byte-identical passthrough); only chunks with a `<`-head tail ("<", "</",
+// "<a", "<ac", "<acp ...attrs", "\x3c/acp ...") engage it.
+export function mayStartRenderTag(s: string): boolean {
+    return RENDER_TAG_DETECT.test(s) || PARTIAL_TAIL.test(s);
+}
+
 // #361: tool-call XML template fragments a model may echo from the context
 // (same source as acp tag echo — the model "writes the tool call as text").
 // Detected + warned for attribution, NOT stripped: a closing tool-XML tag

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -7,7 +7,7 @@ import { acquireInFlight, listSessions, markDirty, peekSession, releaseInFlight,
 import { ACP_TOOLS_ANTHROPIC, ACP_TOOLS_OPENAI, ACP_TOOLS_RESPONSES, PROXY_TOOL_NAMES } from "./compress-tool.js";
 import { executeProxyTool } from "./loop/core.js";
 import { normalizeSseLineEndings } from "./sse-util.js";
-import { containsRenderTagText, createTagEchoFilter, stripAnthropicText, stripOpenaiChatText, stripResponsesText, type TagEchoFilter } from "./loop/tag-echo-filter.js";
+import { containsRenderTagText, createTagEchoFilter, mayStartRenderTag, stripAnthropicText, stripOpenaiChatText, stripResponsesText, type TagEchoFilter } from "./loop/tag-echo-filter.js";
 import { log as loggerLog } from "./logger.js";
 import type { WireProtocol } from "./util.js";
 import { stateDir } from "./paths.js";
@@ -614,7 +614,7 @@ export async function pipePluginChatWithStrip(
                 const v = dd[field];
                 if (typeof v !== "string") continue;
                 hadText = true;
-                if (!containsRenderTagText(v) && !anyPending()) continue;
+                if (!mayStartRenderTag(v) && !anyPending()) continue;
                 const index = typeof ch?.["index"] === "number" ? ch["index"] : ci;
                 const [clean, changed] = pushField(field, index, v);
                 if (clean.length === 0) droppedText = true;
@@ -648,7 +648,7 @@ export async function pipePluginChatWithStrip(
             return rawEvent + "\n\n";
         }
         const raw = d[field] as string;
-        if (!containsRenderTagText(raw) && !anyPending()) {
+        if (!mayStartRenderTag(raw) && !anyPending()) {
             return rawEvent + "\n\n";
         }
         const [clean, changed] = pushField(field, index, raw);
@@ -802,7 +802,7 @@ export async function pipePluginResponsesWithStrip(
                             await write(rawEvent + "\n\n");
                             continue;
                         }
-                        if (!containsRenderTagText(delta) && !tagFilter.pending()) {
+                        if (!mayStartRenderTag(delta) && !tagFilter.pending()) {
                             await write(rawEvent + "\n\n");
                             continue;
                         }

--- a/tests/plugin-passthrough-tag-strip-chat.test.ts
+++ b/tests/plugin-passthrough-tag-strip-chat.test.ts
@@ -143,6 +143,55 @@ test("plugin chat passthrough keeps tool_calls deltas byte-identical", async () 
     assert.ok(text.includes(plain.trim()), "clean delta untouched");
 });
 
+test("plugin chat passthrough strips a tag streamed in tokenizer-sized fragments (#468)", async () => {
+    const out: string[] = [];
+    const res = makeRes(out);
+    const session = makeSession();
+    const whole = `ok ${TAG_OPEN}m00042${TAG_CLOSE} tail`;
+    const micro = whole.match(/.{1,4}/g) ?? [];
+    const events = [...micro.map((piece) => chatChunk({ content: piece })), DONE];
+    await pipePluginChatWithStrip(streamOf(events), res, session, "openai");
+    const text = out.join("");
+    assert.ok(!text.includes("m00042"), "micro-fragmented tag never reassembles downstream");
+    assert.ok(!text.includes("\x3cacp") && !text.includes("\x3c/acp"), "no tag fragment survives");
+    const joined = text
+        .split("\n")
+        .filter((l) => l.startsWith("data:"))
+        .filter((l) => !l.includes("[DONE]"))
+        .map((l) => JSON.parse(l.slice(5).trim()) as { choices?: Array<{ delta?: { content?: string } }> })
+        .map((c) => c.choices?.[0]?.delta?.content ?? "")
+        .join("");
+    assert.equal(joined, "ok  tail", "surrounding prose reassembles to the tag-free text");
+    const dataLines = text.split("\n").filter((l) => l.startsWith("data:")).filter((l) => !l.includes("[DONE]"));
+    for (const l of dataLines) {
+        assert.doesNotThrow(() => JSON.parse(l.slice(5).trim()), "every forwarded data line stays valid JSON");
+    }
+});
+
+test("plugin anthropic passthrough strips a tag streamed in tokenizer-sized fragments (#468)", async () => {
+    const out: string[] = [];
+    const res = makeRes(out);
+    const session = makeSession();
+    const whole = `ok ${TAG_OPEN}m00042${TAG_CLOSE} tail`;
+    const micro = whole.match(/.{1,4}/g) ?? [];
+    const events = [
+        ...micro.map((piece) => `event: content_block_delta\ndata: ${JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: piece } })}\n\n`),
+        `event: message_delta\ndata: ${JSON.stringify({ type: "message_delta", delta: { stop_reason: "end_turn" } })}\n\n`,
+    ];
+    await pipePluginChatWithStrip(streamOf(events), res, session, "anthropic");
+    const text = out.join("");
+    assert.ok(!text.includes("m00042"), "micro-fragmented tag never reassembles downstream");
+    assert.ok(!text.includes("\x3cacp") && !text.includes("\x3c/acp"), "no tag fragment survives");
+    const joined = text
+        .split("\n")
+        .filter((l) => l.startsWith("data:"))
+        .map((l) => JSON.parse(l.slice(5).trim()) as { delta?: { type?: string; text?: string } })
+        .filter((ev) => ev.delta?.type === "text_delta")
+        .map((ev) => ev.delta?.text ?? "")
+        .join("");
+    assert.equal(joined, "ok  tail", "surrounding prose reassembles to the tag-free text");
+});
+
 test("plugin chat passthrough resolves held tail at stream end without [DONE]", async () => {
     const out: string[] = [];
     const res = makeRes(out);

--- a/tests/plugin-passthrough-tag-strip.test.ts
+++ b/tests/plugin-passthrough-tag-strip.test.ts
@@ -94,6 +94,30 @@ test("plugin passthrough strips tags split across deltas and flushes tail before
     assert.ok((blocks[flushIdx] ?? "").includes("msg_1"), "flushed tail delta carries item_id");
 });
 
+test("plugin passthrough strips a tag streamed in tokenizer-sized fragments (#468)", async () => {
+    const out: string[] = [];
+    const res = makeRes(out);
+    const session = makeSession();
+    const whole = `ok ${TAG_OPEN}m00042${TAG_CLOSE} tail`;
+    const micro = whole.match(/.{1,4}/g) ?? [];
+    const events = [
+        ...micro.map((piece) => sse({ type: "response.output_text.delta", item_id: "msg_1", output_index: 0, delta: piece })),
+        sse({ type: "response.completed", response: { usage: { input_tokens: 7, output_tokens: 3 } } }),
+    ];
+    await pipePluginResponsesWithStrip(streamOf(events), res, session);
+    const text = out.join("");
+    assert.ok(!text.includes("m00042"), "micro-fragmented tag never reassembles downstream");
+    assert.ok(!text.includes("\x3cacp") && !text.includes("\x3c/acp"), "no tag fragment survives");
+    const joined = text
+        .split("\n")
+        .filter((l) => l.startsWith("data:"))
+        .map((l) => JSON.parse(l.slice(5).trim()) as { type?: string; delta?: string })
+        .filter((ev) => ev.type === "response.output_text.delta" && typeof ev.delta === "string")
+        .map((ev) => ev.delta as string)
+        .join("");
+    assert.equal(joined, "ok  tail", "surrounding prose reassembles to the tag-free text");
+});
+
 test("plugin passthrough keeps function_call and non-tag events byte-identical", async () => {
     const out: string[] = [];
     const res = makeRes(out);
@@ -167,7 +191,8 @@ test("plugin passthrough resolves held tail at stream end without a done-family 
     ];
     await pipePluginResponsesWithStrip(streamOf(events2), res2, session);
     const text2 = out2.join("");
-    assert.ok(text2.includes(`"delta":"prose \x3cac"`), "ambiguous prefix passes through untouched at stream end");
+    assert.ok(text2.includes(`"delta":"prose "`), "clean prefix passes once the ambiguous head is held");
+    assert.ok(text2.includes(`"delta":"\x3cac"`), "ambiguous prefix flushed as its own delta at stream end, never lost");
 });
 
 test("plugin passthrough rebuildEvent collapses multi-line data payloads into one line", async () => {

--- a/tests/tag-echo.test.ts
+++ b/tests/tag-echo.test.ts
@@ -4,7 +4,7 @@ import type { Config, CoreMessage } from "acp-kernel";
 import { createCore, createInitialState } from "acp-kernel";
 import type { Session } from "../src/session.ts";
 import { runCompressLoop, createOpenaiAdapter, createAnthropicAdapter, createResponsesAdapter } from "../src/loop/index.ts";
-import { stripAcpTags, createTagEchoFilter, containsRenderTagText, containsToolCallXmlFragment } from "../src/loop/tag-echo-filter.ts";
+import { stripAcpTags, createTagEchoFilter, containsRenderTagText, containsToolCallXmlFragment, mayStartRenderTag } from "../src/loop/tag-echo-filter.ts";
 import { rewriteJsonResponse } from "../src/stream.ts";
 import { rewriteOpenaiJsonResponse } from "../src/stream-openai.ts";
 import { buildCompressSystemPrompt } from "../src/compress-tool.ts";
@@ -398,4 +398,19 @@ test("tag-echo filter does not strip tool-call XML fragments (warn-only, #361)",
     const f = createTagEchoFilter();
     const out = f.push(`done ${LT}/invoke> ${LT}/tool_calls>`) + f.flush();
     assert.equal(out, `done ${LT}/invoke> ${LT}/tool_calls>`);
+});
+
+test("mayStartRenderTag engages on complete tags and tag-head tails, not prose", () => {
+    assert.equal(mayStartRenderTag(TAG("m0042")), true);
+    assert.equal(mayStartRenderTag(`prose ${OPEN}tokens="1"`), true);
+    assert.equal(mayStartRenderTag("ok \x3c"), true);
+    assert.equal(mayStartRenderTag("ok \x3c/"), true);
+    assert.equal(mayStartRenderTag("ok \x3ca"), true);
+    assert.equal(mayStartRenderTag("ok \x3cac"), true);
+    assert.equal(mayStartRenderTag(`x ${LT}/ac`), true);
+    assert.equal(mayStartRenderTag(""), false);
+    assert.equal(mayStartRenderTag("plain text"), false);
+    assert.equal(mayStartRenderTag("a < b"), false);
+    assert.equal(mayStartRenderTag("x\x3caction y"), false);
+    assert.equal(mayStartRenderTag("\x3cdiv>"), false);
 });


### PR DESCRIPTION
Fixes #468 (bypass in the #452/v0.1.71 plugin-passthrough strip).

## What

Upstreams that stream a model-imitated render tag in tokenizer-sized fragments (`delta.content: '<ac','p tokens','...'`) never trip `containsRenderTagText` in any single chunk, so the three per-chunk fast-path gates skipped the filter and the tag leaked verbatim to the client. Captured live on Zhipu glm-5.3 through bili 0.1.71 plugin mode: raw SSE shows per-character tag deltas while bili.log logged zero strip drops for that session (probe big-chunk echoes dropped fine — the strip logic itself works, the gate never engaged).

## Change

- `src/loop/tag-echo-filter.ts`: add `mayStartRenderTag(s)` = `RENDER_TAG_DETECT.test(s) || PARTIAL_TAIL.test(s)` (PARTIAL_TAIL is the existing end-anchored partial-head regex).
- `src/plugin.ts`: the three per-delta gates (openai content/reasoning_content/reasoning at :617, anthropic text/thinking at :651, responses output_text.delta at :805) now use `mayStartRenderTag`. Pure-prose chunks keep byte-identical passthrough; only chunks carrying a complete tag or ENDING with a tag head (`<`, `</`, `<a`, `<ac`, `<acp attrs`, `</acp`) engage the state machine.
- done-family gates (`:795`) and wire-mode adapters (which already push every delta unconditionally) unchanged.

## Behavior notes

- A stream ending mid-ambiguous-prefix (e.g. final delta `prose <ac`) now resolves via the flush tail (clean prefix event + synthetic `<ac` delta) instead of verbatim passthrough — content is preserved, chunk regrouping differs. Existing tests updated to the new semantics.
- Interacts cleanly with #463/#464 (mixed-field chunk drop): this PR only changes the gate line; #464 changes the droppedText latch.

## Tests

- New: micro-fragment (1-4 char) whole-tag streams stripped + prose reassembles exactly (`ok  tail`) on all three wires; `mayStartRenderTag` unit tests (prose `<` mid-string, `<action`, `<div>` do NOT engage).
- Updated: end-of-stream ambiguous-prefix assertions to flush-tail semantics.

## Pre-flight

- `npm run typecheck` pass
- `npm test` 917/919 (2 fails = known permanent env failures in plugin-agent.test.ts, reproduce on clean master)
- `npm run build` pass
