### PR TITLE
release v0.1.72

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.71",
+  "version": "0.1.72",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Version bump only. Changes since v0.1.71:

## Tag-echo strip hardening (plugin-mode passthrough)

- #469 / fixes #468 — micro-fragment bypass: upstreams streaming an imitated render tag in tokenizer-sized fragments (1-4 char deltas) never tripped the per-chunk fast-path gates, so the tag leaked verbatim to the client (captured live on Zhipu glm-5.3). New `mayStartRenderTag()` (full detect OR end-anchored tag-head tail) engages the filter on all three wires; pure-prose chunks keep byte-identical passthrough.
- #464 / fixes #463 — mixed-field over-drop: a chunk whose delta carried multiple managed text fields (`content`/`reasoning_content`/`reasoning`) was wholly dropped when ANY one field stripped to empty — losing real sibling content. New `keptText` latch drops a chunk only when every managed field is a pure tag echo.
- Includes the conflict resolution merging both onto the same gate line.

## Pre-flight

- `npm run typecheck` pass
- `npm test` 919/921 (2 fails = known permanent env failures in plugin-agent.test.ts, reproduce on clean master)
- `npm run build` pass
- acp-kernel stays pinned at 0.0.47 (no kernel change)
