### PR TITLE
test: fix pipePluginChatWithStrip call order after #466 signature swap

### DIFF
--- a/tests/plugin-passthrough-tag-strip-chat.test.ts
+++ b/tests/plugin-passthrough-tag-strip-chat.test.ts
@@ -138,7 +138,7 @@ test("plugin chat passthrough keeps sibling text when one field is a pure tag ec
         chatChunk({ content: "real answer", reasoning_content: `${TAG_OPEN}m00044${TAG_CLOSE}` }),
         DONE,
     ];
-    await pipePluginChatWithStrip(streamOf(events), res, session, "openai");
+    await pipePluginChatWithStrip(streamOf(events), res, "openai", session);
     const text = out.join("");
     assert.ok(!text.includes("m00044"), "echo-only sibling field stripped");
     assert.ok(text.includes("real answer"), "sibling field with real content must survive");
@@ -152,7 +152,7 @@ test("plugin chat passthrough still drops a chunk where every managed field is a
         chatChunk({ content: `${TAG_OPEN}m1${TAG_CLOSE}`, reasoning_content: `${TAG_OPEN}m2${TAG_CLOSE}` }),
         DONE,
     ];
-    await pipePluginChatWithStrip(streamOf(events), res, session, "openai");
+    await pipePluginChatWithStrip(streamOf(events), res, "openai", session);
     const text = out.join("");
     assert.ok(!text.includes("m1") && !text.includes("m2"), "echoes stripped");
     const dataLines = text.split("\n").filter((l) => l.startsWith("data:")).filter((l) => !l.includes("[DONE]"));
@@ -179,7 +179,7 @@ test("plugin chat passthrough strips a tag streamed in tokenizer-sized fragments
     const whole = `ok ${TAG_OPEN}m00042${TAG_CLOSE} tail`;
     const micro = whole.match(/.{1,4}/g) ?? [];
     const events = [...micro.map((piece) => chatChunk({ content: piece })), DONE];
-    await pipePluginChatWithStrip(streamOf(events), res, session, "openai");
+    await pipePluginChatWithStrip(streamOf(events), res, "openai", session);
     const text = out.join("");
     assert.ok(!text.includes("m00042"), "micro-fragmented tag never reassembles downstream");
     assert.ok(!text.includes("\x3cacp") && !text.includes("\x3c/acp"), "no tag fragment survives");
@@ -207,7 +207,7 @@ test("plugin anthropic passthrough strips a tag streamed in tokenizer-sized frag
         ...micro.map((piece) => `event: content_block_delta\ndata: ${JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: piece } })}\n\n`),
         `event: message_delta\ndata: ${JSON.stringify({ type: "message_delta", delta: { stop_reason: "end_turn" } })}\n\n`,
     ];
-    await pipePluginChatWithStrip(streamOf(events), res, session, "anthropic");
+    await pipePluginChatWithStrip(streamOf(events), res, "anthropic", session);
     const text = out.join("");
     assert.ok(!text.includes("m00042"), "micro-fragmented tag never reassembles downstream");
     assert.ok(!text.includes("\x3cacp") && !text.includes("\x3c/acp"), "no tag fragment survives");


### PR DESCRIPTION
## What

#466 merged cleanly (textual) but left 4 test call sites in `tests/plugin-passthrough-tag-strip-chat.test.ts` using the OLD parameter order `(stream, res, session, protocol)` against the NEW signature `(stream, res, protocol, session?)`:

- lines 141/155 (#462 tests) and 182 (#468 openai micro-fragment test): passed `session` into the `protocol` slot
- line 210 (#468 anthropic micro-fragment test): same

These call sites were added by #469/#464 **after** #466's branch point, so the three-way merge kept them untouched while #466 swapped every pre-existing call.

## Why it slipped through

`npm run typecheck` uses `tsconfig.build.json` which only includes `src/**` — tests are never type-checked, so the wrong argument order produced no compile error. At runtime the wrong binding misroutes the anthropic wire processing and the `#468` micro-fragment regression test fails with the tag fully leaked:

```
✖ plugin anthropic passthrough strips a tag streamed in tokenizer-sized fragments (#468)
  + actual   - expected
  + 'ok <acp tokens="247" type="text">m00042</acp> tail'
  - 'ok  tail'
```

i.e. `npm test` on master HEAD (b612263) is red.

## Fix

Swap the 4 call sites to the new order. No production code changes.

## Pre-flight

- `npm run typecheck` ✓
- `npm test`: 922/924 pass (2 known pre-existing env failures in `plugin-agent.test.ts`, reproduce on clean master)
- targeted file: 15/15 ✓
