### PR TITLE
release v0.1.73

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.72",
+  "version": "0.1.73",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
### Changes since v0.1.72

- **#466**: proxy-mode non-inject SSE now runs through the same tag-strip pipeline (title-gen / classifier / `ACP_NO_INJECT_TOOL` bypasses no longer leak render tags)
- **#472**: fix 4 stale call-site argument orders in `tests/plugin-passthrough-tag-strip-chat.test.ts` left by the #466 merge (runtime session-slot corruption)
- **#378**: fake-completion detection & retry (opt-in via `BILI_FAKE_COMPLETION_RETRIES`, default off) for #371 — model echoing tool calls as text instead of emitting tool_use blocks

Version bump only, no code changes on this branch.

Pre-flight: typecheck ✅ / test 943/945 (2 known permanent env failures) ✅ / build ✅