### PR TITLE
release v0.1.74

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.73",
+  "version": "0.1.74",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Release v0.1.74 — contents since v0.1.73 (all merged to master, CI green):

- **#440 / #444 — stream-corruption family (#412, #441)**: zero-side-effect truncation retry in the compress loop (round-1 upstream truncation with no client-visible forwarding → auto retry); well-formed anthropic error stream (orphan message_start gets sealed); responses adapter synthesizes `response.created` before an orphan `response.failed`; plus follow-ups found in review — live-forwarded reasoning chunks now count as side effects (no more double reasoning on openai), and responses-shaped truncation (truncated-done) now retries too.
- **#475 — #460 residual tag-echo gaps**: strip render-tag echoes on the no-inject outbound paths — native Responses compaction interception (resetAfterSuccess), non-injected responses JSON rewrites, and non-injected `application/json` answers; drops dead SSE rewriters (`rewriteSseStream` / `rewriteOpenaiSseStream`, zero call sites, −963 lines) with their orphaned tests. Includes the merge-interaction fix: the new JSON strip branch reads `responseBody` (not the drained `upstream.body` when #378 fake-completion buffering is enabled).
- No changes to `src/update.ts`, no acp-kernel bump (stays 0.0.47) → no no-op release needed.

Pre-flight: typecheck ✓, tests 944/942 (2 known permanent env failures in plugin-agent.test.ts, reproduce on clean master), build ✓.