### PR TITLE
fix: bound sessions storage growth (#407)

### DIFF
--- a/src/persist.ts
+++ b/src/persist.ts
@@ -60,6 +60,13 @@ import type { Session, BlockContent } from "./session.js";
 
 const PERSIST_VERSION = 3;
 
+/** On-disk block content view. `one` is optional: when it is byte-identical
+ *  to `full` (all leaf blocks) only `full` is written (#407). */
+interface PersistedBlockContent {
+    one?: { text: string; count: number };
+    full: { text: string; count: number };
+}
+
 interface PersistedSession {
     version: number;
     savedAt: number;
@@ -101,8 +108,10 @@ interface PersistedSession {
     lastInputTokens?: number;
     contextTokens?: number;
     state: CompressionState;
-    /** blockContents serialized as a plain record (Maps do not survive JSON). */
-    blockContents: Record<string, BlockContent>;
+    /** blockContents serialized as a plain record (Maps do not survive JSON).
+     *  `one` is omitted when byte-identical to `full` (always true for leaf
+     *  blocks — #407); buildSession restores it on load. */
+    blockContents: Record<string, PersistedBlockContent>;
     /** Latest full-conversation snapshot (v3+): the client's raw messages
      *  from its most recent request, overwritten every turn. Absent on v2
      *  files — export falls back to block-only rendering. */
@@ -164,15 +173,18 @@ function relPathFor(id: string, protocol?: string, upstreamOrigin?: string): str
  *  server.ts / export.ts. */
 export class SessionStore {
     readonly enabled: boolean;
-    private readonly dir: string;
+    get dir(): string {
+        return this.root;
+    }
+    private readonly root: string;
     private readonly store: StateStore<PersistedSession>;
 
     constructor(opts?: { dir?: string; debounceMs?: number; enabled?: boolean; log?: Logger }) {
         const debounceMs = opts?.debounceMs ?? defaultDebounce();
         this.enabled = (opts?.enabled ?? true) && debounceMs >= 0;
-        this.dir = opts?.dir ?? defaultDir();
+        this.root = opts?.dir ?? defaultDir();
         this.store = new StateStore<PersistedSession>({
-            dir: this.dir,
+            dir: this.root,
             version: PERSIST_VERSION,
             debounceMs: Math.max(0, debounceMs),
             enabled: this.enabled,
@@ -199,55 +211,67 @@ export class SessionStore {
         return out;
     }
 
-    /** One-time migration for the #286 identity change: sessions persisted
-     *  under the old derived hash id are re-keyed to the client-provided
-     *  conversation value stored in meta.label (which is now the session id
-     *  itself). Collisions on the same label keep the most recently saved
-     *  record; the losers, and any label already claimed by a new-format
-     *  session, are deleted. Records without a label cannot be mapped and are
-     *  left in place (they load under their old id but are never requested
-     *  again — the new proxy 400s anonymous requests). Self-terminating:
-     *  after one pass no loaded id differs from its label. */
-    async migrateLegacyIds(): Promise<void> {
-        if (!this.enabled) return;
+    /** Startup load: ONE directory walk + parse (previously #286's
+     *  migrateLegacyIds ran its own loadAll before initSessions' second
+     *  loadAll — two full walks per boot, #407), with the legacy-id rekey
+     *  applied in-memory on the same data. The #286 migration: sessions
+     *  persisted under the old derived hash id are re-keyed to the
+     *  client-provided conversation value stored in meta.label (which is now
+     *  the session id itself). Collisions on the same label keep the most
+     *  recently saved record; the losers, and any label already claimed by a
+     *  new-format session, are deleted. Records without a label cannot be
+     *  mapped and are left in place (they load under their old id but are
+     *  never requested again — the new proxy 400s anonymous requests).
+     *  Self-terminating: after one pass no loaded id differs from its label,
+     *  so the log fires exactly once ever instead of on every boot. */
+    async loadAllMigrated(): Promise<Map<string, Session>> {
+        const out = new Map<string, Session>();
+        if (!this.enabled) return out;
         const loaded = await this.store.loadAll();
         const claimed = new Set<string>();
         const byLabel = new Map<string, { id: string; savedAt: number; session: Session }>();
-        let unlabeled = 0;
+        const dropped = new Set<string>();
         for (const [id, envelope] of loaded) {
             const session = buildSession(envelope.payload);
+            out.set(id, session);
             const label = session.meta.label;
-            if (!label) {
-                unlabeled++;
-                continue;
-            }
+            if (!label) continue;
             if (label === id) {
                 claimed.add(id);
                 continue;
             }
             const prev = byLabel.get(label);
             if (!prev || envelope.savedAt >= prev.savedAt) {
-                if (prev) await this.removeLegacyFile(prev.id, prev.session);
+                if (prev) {
+                    await this.removeLegacyFile(prev.id, prev.session);
+                    dropped.add(prev.id);
+                }
                 byLabel.set(label, { id, savedAt: envelope.savedAt, session });
             } else {
                 await this.removeLegacyFile(id, session);
+                dropped.add(id);
             }
         }
         let rekeyed = 0;
         for (const [label, { id, session }] of byLabel) {
             if (claimed.has(label)) {
                 await this.removeLegacyFile(id, session);
+                dropped.add(id);
                 continue;
             }
             session.id = label;
             await this.store.writeNow(label, () => buildRecord(session));
             await this.removeLegacyFile(id, session);
+            out.delete(id);
+            out.set(label, session);
             claimed.add(label);
             rekeyed++;
         }
-        if (rekeyed || unlabeled) {
-            loggerLog("info", `[persist] one-time migration (#286): rekeyed ${rekeyed} legacy session(s), left ${unlabeled} unlabeled legacy file(s) in place`);
+        for (const id of dropped) out.delete(id);
+        if (rekeyed > 0) {
+            loggerLog("info", `[persist] migration (#286): rekeyed ${rekeyed} legacy session(s)`);
         }
+        return out;
     }
 
     /** Remove a legacy session file. The kernel store never deletes (cleanup
@@ -337,15 +361,31 @@ function buildRecord(session: Session): PersistedSession {
         messages: session.lastMessages,
         metadata: { ...session.metadata },
         state: session.state,
-        blockContents: Object.fromEntries(session.blockContents),
+        blockContents: serializeBlockContents(session.blockContents),
         createdAt: session.createdAt,
     };
+}
+
+/** Leaf blocks always have byte-identical one/full views (kernel
+ *  collectBlockContent: no nested children ⇒ same message set), so the body
+ *  would be stored twice per file (#407). Store one copy when identical. */
+function serializeBlockContents(map: Map<string, BlockContent>): Record<string, PersistedBlockContent> {
+    const out: Record<string, PersistedBlockContent> = {};
+    for (const [bid, c] of map) {
+        out[bid] = c.one.text === c.full.text && c.one.count === c.full.count ? { full: c.full } : c;
+    }
+    return out;
 }
 
 function buildSession(parsed: PersistedSession): Session {
     const blockContents = new Map<string, BlockContent>();
     for (const [bid, content] of Object.entries(parsed.blockContents ?? {})) {
-        if (content && typeof content === "object") blockContents.set(bid, content);
+        if (!content || typeof content !== "object" || typeof content.full?.text !== "string") continue;
+        const full = { text: content.full.text, count: content.full.count ?? 0 };
+        const one = content.one && typeof content.one.text === "string"
+            ? { text: content.one.text, count: content.one.count ?? 0 }
+            : { ...full };
+        blockContents.set(bid, { one, full });
     }
     // Read grouped shape (v2+); fall back to flat fields for v1 files.
     const meta = parsed.meta ?? {};

--- a/src/session-gc.ts
+++ b/src/session-gc.ts
@@ -1,0 +1,154 @@
+import { readdirSync, rmSync, statSync } from "node:fs";
+import * as path from "node:path";
+import { log as loggerLog } from "./logger.js";
+
+/**
+ * Startup garbage collection for the on-disk session registry (#407).
+ *
+ * WHY: the kernel StateStore deliberately never deletes records (cleanup is a
+ * downstream policy decision), so the sessions dir grew without bound —
+ * ~55 files / ~60MB per day on a single host — and every boot synchronously
+ * read + JSON.parsed every file. The saved state is derived data (the
+ * conversation itself lives on the client), so an age cap plus a total-size
+ * budget keeps both the directory and the startup parse bounded.
+ *
+ * MECHANISM: stat-only pre-pass (readdir + stat + rm; never reads or parses a
+ * file body). A session's last save time ≈ its file mtime because writes are
+ * atomic temp+rename. A canonical <base>.json and its spill sibling
+ * <base>.fb.json form one unit (age = newest mtime, size = sum) so a record
+ * and its spill are never separated. .tmp-* in-flight files are left alone.
+ *
+ * PASS 1 (retention): delete units not written within retentionMs.
+ * PASS 2 (budget): while the surviving total exceeds maxBytes, delete the
+ * oldest unit first. Each pass is independently disabled with 0.
+ */
+
+export interface GcOptions {
+    /** Delete units whose newest mtime is older than this many ms. 0 disables. */
+    retentionMs: number;
+    /** Keep surviving units under this many bytes by dropping oldest first. 0 disables. */
+    maxBytes: number;
+    nowMs?: number;
+}
+
+export interface GcResult {
+    scannedFiles: number;
+    scannedBytes: number;
+    deletedUnits: number;
+    deletedFiles: number;
+    bytesFreed: number;
+    remainingBytes: number;
+}
+
+interface Unit {
+    files: string[];
+    size: number;
+    mtimeMs: number;
+}
+
+const DAY_MS = 86_400_000;
+const DEFAULT_RETENTION_DAYS = 90;
+const DEFAULT_MAX_BYTES = 1024 * 1024 * 1024; // 1 GiB
+
+export function gcOptionsFromEnv(): GcOptions {
+    const days = intEnv("BILI_SESSION_RETENTION_DAYS", DEFAULT_RETENTION_DAYS);
+    const maxBytes = intEnv("BILI_SESSION_MAX_BYTES", DEFAULT_MAX_BYTES);
+    return { retentionMs: Math.max(0, days) * DAY_MS, maxBytes: Math.max(0, maxBytes) };
+}
+
+function intEnv(name: string, fallback: number): number {
+    const v = process.env[name];
+    if (!v) return fallback;
+    const n = Number.parseInt(v, 10);
+    return Number.isFinite(n) ? n : fallback;
+}
+
+function collectUnits(dir: string): Unit[] {
+    const units = new Map<string, Unit>();
+    const walk = (d: string): void => {
+        let entries;
+        try {
+            entries = readdirSync(d, { withFileTypes: true });
+        } catch {
+            return;
+        }
+        for (const e of entries) {
+            if (!e.isFile()) {
+                if (e.isDirectory()) walk(path.join(d, e.name));
+                continue;
+            }
+            if (!e.name.endsWith(".json") || e.name.startsWith(".tmp-")) continue;
+            const abs = path.join(d, e.name);
+            let st;
+            try {
+                st = statSync(abs);
+            } catch {
+                continue;
+            }
+            const rel = path.relative(dir, abs);
+            const key = e.name.endsWith(".fb.json") ? `${rel.slice(0, -".fb.json".length)}.json` : rel;
+            const u = units.get(key);
+            if (u) {
+                u.files.push(abs);
+                u.size += st.size;
+                u.mtimeMs = Math.max(u.mtimeMs, st.mtimeMs);
+            } else {
+                units.set(key, { files: [abs], size: st.size, mtimeMs: st.mtimeMs });
+            }
+        }
+    };
+    walk(dir);
+    return [...units.values()];
+}
+
+/** Run the GC pre-pass over the sessions dir. Returns null when there is
+ *  nothing to scan (missing/empty dir) or stats could not be gathered. */
+export function gcSessionFiles(dir: string, opts: GcOptions): GcResult | null {
+    let units: Unit[];
+    try {
+        units = collectUnits(dir);
+    } catch {
+        return null;
+    }
+    if (units.length === 0) return null;
+    const result: GcResult = { scannedFiles: 0, scannedBytes: 0, deletedUnits: 0, deletedFiles: 0, bytesFreed: 0, remainingBytes: 0 };
+    for (const u of units) {
+        result.scannedFiles += u.files.length;
+        result.scannedBytes += u.size;
+    }
+    const deleted = new Set<Unit>();
+    const deleteUnit = (u: Unit): void => {
+        for (const f of u.files) rmSync(f, { force: true });
+        deleted.add(u);
+        result.deletedUnits++;
+        result.deletedFiles += u.files.length;
+        result.bytesFreed += u.size;
+    };
+    if (opts.retentionMs > 0) {
+        const cutoff = (opts.nowMs ?? Date.now()) - opts.retentionMs;
+        for (const u of units) if (u.mtimeMs < cutoff) deleteUnit(u);
+    }
+    if (opts.maxBytes > 0) {
+        let total = 0;
+        for (const u of units) if (!deleted.has(u)) total += u.size;
+        if (total > opts.maxBytes) {
+            const sorted = units.filter((u) => !deleted.has(u)).sort((a, b) => a.mtimeMs - b.mtimeMs);
+            for (const u of sorted) {
+                if (total <= opts.maxBytes) break;
+                deleteUnit(u);
+                total -= u.size;
+            }
+        }
+    }
+    result.remainingBytes = result.scannedBytes - result.bytesFreed;
+    if (result.deletedFiles > 0) {
+        loggerLog("info", `[gc] sessions dir: removed ${result.deletedUnits} old session record(s), freed ${fmtBytes(result.bytesFreed)}, ${fmtBytes(result.remainingBytes)} remaining`);
+    }
+    return result;
+}
+
+function fmtBytes(n: number): string {
+    if (n >= 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(1)}MB`;
+    if (n >= 1024) return `${(n / 1024).toFixed(1)}KB`;
+    return `${n}B`;
+}

--- a/src/session.ts
+++ b/src/session.ts
@@ -1,5 +1,6 @@
 import { createInitialState, type CompressionState, type CoreMessage } from "acp-kernel";
 import { getStore } from "./persist.js";
+import { gcSessionFiles, gcOptionsFromEnv } from "./session-gc.js";
 
 export type BlockContent = {
     one: { text: string; count: number };
@@ -131,16 +132,19 @@ let MAX_SESSIONS = Math.max(1, Number.parseInt(process.env.BILI_MAX_SESSIONS ?? 
 
 let initialized = false;
 
-/** Bulk-load persisted sessions from disk into the in-memory map. Called once
- *  at server startup before listening. Caps at MAX_SESSIONS by createdAt
- *  (keeps the most recent) so a huge backlog cannot OOM on boot. Idempotent. */
+/** Startup: GC the on-disk registry (stat-only; expired/over-budget files
+ *  are removed BEFORE anything is read, so they cost no parse time), then
+ *  bulk-load the survivors into the in-memory map with a single directory
+ *  walk (loadAllMigrated folds the #286 legacy-id migration into that same
+ *  pass). Caps at MAX_SESSIONS by createdAt (keeps the most recent) so a
+ *  huge backlog cannot OOM on boot. Idempotent. */
 export async function initSessions(): Promise<void> {
     if (initialized) return;
     initialized = true;
     const store = getStore();
     if (!store.enabled) return;
-    await store.migrateLegacyIds();
-    const loaded = await store.loadAll();
+    gcSessionFiles(store.dir, gcOptionsFromEnv());
+    const loaded = await store.loadAllMigrated();
     if (loaded.size > MAX_SESSIONS) {
         const entries = [...loaded.entries()].sort((a, b) => (b[1].createdAt ?? 0) - (a[1].createdAt ?? 0));
         for (const [id, s] of entries) {
@@ -250,9 +254,16 @@ export function markDirty(session: Session): void {
     getStore().scheduleSave(session);
 }
 
-/** Record original block content at compress time. */
+/** Record original block content at compress time. Identical one/full views
+ *  (all leaf blocks — #407) share one object so the body is held once in
+ *  memory and serialized once on disk; consumers are read-only. */
 export function cacheBlockContent(session: Session, blockId: string, content: BlockContent): void {
-    session.blockContents.set(blockId, content);
+    if (content.one.text === content.full.text && content.one.count === content.full.count) {
+        const view = { text: content.full.text, count: content.full.count };
+        session.blockContents.set(blockId, { one: view, full: view });
+    } else {
+        session.blockContents.set(blockId, content);
+    }
 }
 
 export function resetSessionCompression(session: Session): void {
@@ -322,6 +333,7 @@ export async function flushAllSessions(): Promise<void> {
 
 export function _resetSessionsForTest(max?: number): void {
     if (max !== undefined) MAX_SESSIONS = Math.max(1, Math.floor(max));
+    initialized = false;
     for (const s of sessions.values()) {
         if (s.inFlight > 0) s.inFlight = 0;
     }

--- a/tests/proxy-persist.test.ts
+++ b/tests/proxy-persist.test.ts
@@ -6,6 +6,8 @@ import { mkdirSync, mkdtempSync, rmSync, readdirSync, readFileSync, statSync, wr
 import { SessionStore } from "../src/persist.ts";
 import { dirname, join, relative, sep } from "node:path";
 import type { Session, BlockContent } from "../src/session.ts";
+import { cacheBlockContent } from "../src/session.ts";
+import { setLogCapture } from "../src/logger.ts";
 import { createInitialState } from "acp-kernel";
 /** Recursively collect *.json files under dir (sessions are namespaced into
  *  protocol/ subdirs). */
@@ -369,17 +371,66 @@ await withTempStore("one-time migration re-keys legacy hash-id sessions to their
     // A fresh store mirrors a new process: no discovered-file cache.
     const cold = new SessionStore({ dir, debounceMs: 5, enabled: true });
     try {
-        await cold.migrateLegacyIds();
-
-        const all = await cold.loadAll();
+        const all = await cold.loadAllMigrated();
         assert.ok(all.has(label), "re-keyed under the client-provided label");
         assert.ok(!all.has(legacyA) && !all.has(legacyB), "legacy ids no longer resolve");
         assert.equal(all.get(label)!.stats.requests, 7, "newest savedAt wins the collision");
         assert.equal(jsonFilesUnder(dir).length, 1, "loser and old files removed");
 
-        await cold.migrateLegacyIds();
-        assert.equal((await cold.loadAll()).size, 1, "second migration is a no-op");
+        assert.equal((await cold.loadAllMigrated()).size, 1, "second pass is a no-op");
     } finally {
         cold.cancelAll();
+    }
+});
+
+await withTempStore("identical one/full views persist once (leaf-block dedup, #407)", async (store, dir) => {
+    const s = makeSession("dedup-1");
+    const body = "x".repeat(100_000);
+    cacheBlockContent(s, "b1", { one: { text: body, count: 5 }, full: { text: body, count: 5 } });
+    cacheBlockContent(s, "b2", { one: { text: "one-view", count: 1 }, full: { text: "full-view", count: 2 } });
+    s.state.nextBlockId = 3;
+    await store.writeNow(s);
+
+    const file = jsonFilesUnder(dir)[0];
+    const raw = JSON.parse(readFileSync(file, "utf8")).payload.blockContents;
+    assert.equal(raw.b1.one, undefined, "identical view stored once on disk");
+    assert.equal(raw.b1.full.text, body);
+    assert.ok(raw.b2.one && raw.b2.full, "distinct views keep both");
+    const forced = JSON.stringify({ one: { text: body, count: 5 }, full: { text: body, count: 5 } }).length;
+    const actual = JSON.stringify(raw.b1).length;
+    assert.ok(actual <= forced / 2 + 32, `deduped record ≈half size (actual=${actual}, forced=${forced})`);
+
+    const loaded = store.loadSync("dedup-1")!;
+    const c1 = loaded.blockContents.get("b1")!;
+    assert.equal(c1.one.text, body, "one restored from full when omitted");
+    assert.equal(c1.one.count, 5);
+    assert.equal(c1.full.text, body);
+    assert.notEqual(c1.one, c1.full, "restored views are independent objects");
+});
+
+await withTempStore("migration log fires only when a rekey actually happens (#407)", async (store, dir) => {
+    const lines: string[] = [];
+    setLogCapture((level, msg) => lines.push(`${level}: ${msg}`));
+    const legacy = "legacy-" + "c".repeat(24);
+    const s = makeSession(legacy);
+    s.meta.label = "conv-407";
+    s.meta.protocol = "responses";
+    s.meta.upstreamOrigin = "https://chatgpt.com";
+    try {
+        await store.writeNow(s);
+        const cold = new SessionStore({ dir, debounceMs: 5, enabled: true });
+        try {
+            const first = await cold.loadAllMigrated();
+            assert.ok(first.has("conv-407"), "rekeyed under the label");
+            assert.ok(lines.some((l) => l.includes("rekeyed 1 legacy")), "first boot logs the migration");
+            const before = lines.length;
+            const second = await cold.loadAllMigrated();
+            assert.equal(second.size, 1, "second boot still sees the session");
+            assert.ok(!lines.slice(before).some((l) => l.includes("migration (#286)")), "second boot logs nothing");
+        } finally {
+            cold.cancelAll();
+        }
+    } finally {
+        setLogCapture(null);
     }
 });

--- a/tests/session-gc.test.ts
+++ b/tests/session-gc.test.ts
@@ -1,0 +1,200 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, rmSync, readdirSync, readFileSync, statSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createInitialState } from "acp-kernel";
+import { gcSessionFiles, gcOptionsFromEnv } from "../src/session-gc.ts";
+import { SessionStore, _setStoreForTest } from "../src/persist.ts";
+import { initSessions, _resetSessionsForTest, _sessionsSizeForTest } from "../src/session.ts";
+import type { Session } from "../src/session.ts";
+import { setLogCapture } from "../src/logger.ts";
+
+const DAY = 86_400_000;
+
+function makeSession(id: string): Session {
+    return {
+        id,
+        meta: {},
+        stats: { requests: 0, tokensSaved: 0, inputTokens: 0, cachedTokens: 0, outputTokens: 0, cacheSamples: 0, lastInputTokens: 0, contextTokens: 0 },
+        metadata: {},
+        state: createInitialState(),
+        createdAt: Date.now(),
+        lastSeen: Date.now(),
+        blockContents: new Map(),
+        inFlight: 0,
+        persisted: false,
+    };
+}
+
+function jsonFilesUnder(dir: string): string[] {
+    const out: string[] = [];
+    for (const name of readdirSync(dir)) {
+        if (name.startsWith(".tmp-")) continue;
+        const full = join(dir, name);
+        if (statSync(full).isDirectory()) out.push(...jsonFilesUnder(full));
+        else if (name.endsWith(".json")) out.push(full);
+    }
+    return out;
+}
+
+function withTempDir<T>(name: string, fn: (dir: string) => Promise<T> | T): Promise<void> {
+    return test(name, async () => {
+        const dir = mkdtempSync(join(tmpdir(), "bili-session-gc-"));
+        try {
+            await fn(dir);
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+}
+
+function touchAt(file: string, msAgo: number, size = 1000): void {
+    writeFileSync(file, "x".repeat(size));
+    const t = new Date(Date.now() - msAgo);
+    utimesSync(file, t, t);
+}
+
+await withTempDir("retention pass deletes expired units, keeps fresh", (dir) => {
+    const now = Date.now();
+    const oldA = join(dir, "old-a.json");
+    const oldB = join(dir, "old-b.json");
+    const fresh = join(dir, "fresh.json");
+    touchAt(oldA, 100 * DAY);
+    touchAt(oldB, 91 * DAY);
+    touchAt(fresh, 1 * DAY);
+    const res = gcSessionFiles(dir, { retentionMs: 90 * DAY, maxBytes: 0, nowMs: now })!;
+    assert.ok(!existsSync(oldA), "100d-old file removed");
+    assert.ok(!existsSync(oldB), "91d-old file removed");
+    assert.ok(existsSync(fresh), "fresh file kept");
+    assert.equal(res.deletedUnits, 2);
+    assert.equal(res.deletedFiles, 2);
+    assert.equal(res.bytesFreed, 2000);
+    assert.equal(res.remainingBytes, 1000);
+});
+
+await withTempDir("budget pass drops oldest units until under maxBytes", (dir) => {
+    const now = Date.now();
+    // 4 fresh-ish files of 10KB each (total 40KB > 25KB budget), distinct ages.
+    const f1 = join(dir, "a.json");
+    const f2 = join(dir, "b.json");
+    const f3 = join(dir, "c.json");
+    const f4 = join(dir, "d.json");
+    touchAt(f1, 4 * DAY, 10_000);
+    touchAt(f2, 3 * DAY, 10_000);
+    touchAt(f3, 2 * DAY, 10_000);
+    touchAt(f4, 1 * DAY, 10_000);
+    const res = gcSessionFiles(dir, { retentionMs: 0, maxBytes: 25_000, nowMs: now })!;
+    assert.ok(!existsSync(f1) && !existsSync(f2), "two oldest dropped");
+    assert.ok(existsSync(f3) && existsSync(f4), "newest two kept");
+    assert.equal(res.deletedUnits, 2);
+    assert.equal(res.remainingBytes, 20_000);
+});
+
+await withTempDir("both passes disabled (0/0) deletes nothing", (dir) => {
+    const now = Date.now();
+    const old = join(dir, "ancient.json");
+    touchAt(old, 999 * DAY, 10_000);
+    const res = gcSessionFiles(dir, { retentionMs: 0, maxBytes: 0, nowMs: now })!;
+    assert.ok(existsSync(old));
+    assert.equal(res.deletedUnits, 0);
+});
+
+await withTempDir("canonical + spill sibling form one unit (age = newest mtime)", (dir) => {
+    const now = Date.now();
+    const main = join(dir, "sess.json");
+    const spill = join(dir, "sess.fb.json");
+    touchAt(main, 100 * DAY, 4000);
+    touchAt(spill, 1 * DAY, 6000);
+    let res = gcSessionFiles(dir, { retentionMs: 90 * DAY, maxBytes: 0, nowMs: now })!;
+    assert.ok(existsSync(main) && existsSync(spill), "recent spill keeps the whole unit alive");
+    assert.equal(res.deletedUnits, 0);
+    // Now age both past retention → both files removed together.
+    const t = new Date(now - 100 * DAY);
+    utimesSync(main, t, t);
+    utimesSync(spill, t, t);
+    res = gcSessionFiles(dir, { retentionMs: 90 * DAY, maxBytes: 0, nowMs: now })!;
+    assert.ok(!existsSync(main) && !existsSync(spill), "unit deleted as a pair");
+    assert.equal(res.deletedUnits, 1);
+    assert.equal(res.deletedFiles, 2);
+});
+
+await withTempDir(".tmp-* in-flight files are never touched", (dir) => {
+    const now = Date.now();
+    const tmp = join(dir, ".tmp-pending.json");
+    touchAt(tmp, 999 * DAY);
+    const res = gcSessionFiles(dir, { retentionMs: 90 * DAY, maxBytes: 100, nowMs: now });
+    assert.ok(existsSync(tmp), ".tmp- file untouched even under budget pressure");
+    assert.equal(res?.deletedFiles ?? 0, 0);
+});
+
+await withTempDir("missing or empty dir returns null without throwing", () => {
+    assert.equal(gcSessionFiles(join(tmpdir(), "does-not-exist-bili-gc"), { retentionMs: 90 * DAY, maxBytes: 100 }), null);
+    const empty = mkdtempSync(join(tmpdir(), "bili-session-gc-empty-"));
+    try {
+        assert.equal(gcSessionFiles(empty, { retentionMs: 90 * DAY, maxBytes: 100 }), null);
+    } finally {
+        rmSync(empty, { recursive: true, force: true });
+    }
+});
+
+await withTempDir("gcOptionsFromEnv: defaults 90d / 1GiB, overrides incl. 0=off", () => {
+    const d = gcOptionsFromEnv();
+    assert.equal(d.retentionMs, 90 * DAY);
+    assert.equal(d.maxBytes, 1024 * 1024 * 1024);
+    process.env.BILI_SESSION_RETENTION_DAYS = "0";
+    process.env.BILI_SESSION_MAX_BYTES = "1048576";
+    try {
+        const o = gcOptionsFromEnv();
+        assert.equal(o.retentionMs, 0);
+        assert.equal(o.maxBytes, 1_048_576);
+    } finally {
+        delete process.env.BILI_SESSION_RETENTION_DAYS;
+        delete process.env.BILI_SESSION_MAX_BYTES;
+    }
+});
+
+// Acceptance (#407): a directory holding 300 expired session files plus 5
+// live ones. One startup must (a) remove the expired files BEFORE any read,
+// (b) parse/load only the 5 survivors, and (c) leave the total stable across
+// boots. If the expired files were ever parsed they would land in the pool
+// (MAX_SESSIONS raised above 305), so pool size is the read probe.
+await withTempDir("startup: 300 expired files GC'd before the single load pass, total stays stable", async (dir) => {
+    const store = new SessionStore({ dir, debounceMs: 5, enabled: true });
+    _setStoreForTest(store);
+    _resetSessionsForTest(1000);
+    const lines: string[] = [];
+    setLogCapture((level, msg) => lines.push(`${level}: ${msg}`));
+    try {
+        const past = new Date(Date.now() - 120 * DAY);
+        for (let i = 0; i < 300; i++) {
+            const s = makeSession(`expired-${i}`);
+            s.stats.requests = 1000 + i;
+            await store.writeNow(s);
+        }
+        for (const f of jsonFilesUnder(dir)) utimesSync(f, past, past);
+        for (let i = 0; i < 5; i++) {
+            const s = makeSession(`fresh-${i}`);
+            s.stats.requests = 500 + i;
+            await store.writeNow(s);
+        }
+        assert.equal(jsonFilesUnder(dir).length, 305, "fixture: 300 expired + 5 fresh");
+
+        await initSessions();
+        assert.equal(_sessionsSizeForTest(), 5, "only the 5 fresh sessions were loaded (expired never parsed)");
+        assert.equal(jsonFilesUnder(dir).length, 5, "expired files removed before load");
+        assert.ok(lines.some((l) => l.includes("[gc]") && l.includes("removed 300")), "GC logged the sweep");
+
+        _resetSessionsForTest(1000);
+        const before = jsonFilesUnder(dir).length;
+        await initSessions();
+        assert.equal(_sessionsSizeForTest(), 5, "second boot loads the same 5");
+        assert.equal(jsonFilesUnder(dir).length, before, "second boot changes nothing on disk");
+        const sample = readFileSync(jsonFilesUnder(dir)[0], "utf8");
+        assert.ok(sample.length > 0, "surviving files intact");
+    } finally {
+        setLogCapture(null);
+        store.cancelAll();
+        _resetSessionsForTest();
+    }
+});


### PR DESCRIPTION
## What changed

Fixes the three stacked root causes of unbounded sessions-dir growth:

**1. Leaf-block `blockContents` stored byte-identical `one`+`full` twice (~50% of file bytes)**
- `cacheBlockContent` (src/session.ts): identical views now share one object in memory (consumers are read-only).
- `buildRecord`/`serializeBlockContents` (src/persist.ts): when `one.text === full.text && one.count === full.count` (all leaf blocks — kernel `collectBlockContent` with no nested children yields the same message set), only `full` is written; `one` is omitted from the record.
- `buildSession`: restores `one` from `full` on load (independent copy). Old files with both keys load unchanged — backward compatible.

**2. Zero GC → new startup GC pre-pass (src/session-gc.ts)**
- Stat-only (readdir + stat + rm; never reads/parses a body), runs BEFORE the load pass in `initSessions`, so expired files cost zero parse time.
- Retention: delete records not written within `BILI_SESSION_RETENTION_DAYS` (default 90, `0` = off). Age ≈ mtime because writes are atomic temp+rename.
- Budget: while surviving total exceeds `BILI_SESSION_MAX_BYTES` (default 1 GiB, `0` = off), drop oldest first.
- A canonical `<base>.json` and its spill sibling `<base>.fb.json` form one unit (age = newest mtime, size = sum) so a record and its spill are never separated; `.tmp-*` in-flight files are untouched.
- Rationale for deleting: bili session state is derived data — the conversation itself lives on the client (same posture as the existing in-memory LRU eviction).

**3. Two full synchronous walks per boot + migration log repeating every boot**
- `migrateLegacyIds()` (own `loadAll`) + `initSessions()` (`loadAll`) → single `loadAllMigrated()`: one walk + parse, #286 rekey applied in-memory on the same data. Collision/unlabeled semantics unchanged.
- Migration log now fires only when a rekey actually happens — exactly once ever instead of every boot (the old log was gated on `rekeyed || unlabeled`, and unlabeled>0 forever).

**MAX_SESSIONS (#407 suggestion 4):** kept as the post-load newest-N cap; true stop-parsing-early would need an early-stop hook in the kernel's recursive walk (cross-repo change, acp-kernel must ship first). With GC bounding total bytes at the default 1 GiB, parse cost no longer grows without bound — corpus is bounded by construction.

## Tests

- `tests/proxy-persist.test.ts`: leaf-block dedup round-trip (identical view stored once, distinct views keep both, ~half serialized size, `one` restored on load), migration rekey test migrated to `loadAllMigrated`, migration-log-fires-once test (log capture).
- `tests/session-gc.test.ts` (new): retention/budget/disabled/spill-unit/`.tmp-*`/missing-dir unit tests + env defaults; acceptance integration test — 300 expired + 5 fresh files: one startup removes the expired BEFORE any read (pool size is the read probe: MAX_SESSIONS raised above 305, only the 5 survivors land in memory), disk total stable across boots.

## Pre-flight

- `npm run typecheck` ✅
- `npm test`: 877/878 pass; the 1 failure (`launcher.test.ts: resolveClientCommand codex/claude`) fails identically on pristine master — environment-dependent (`/usr/bin/codex` present on this host), unrelated to this change.
- `npm run build` ✅
- E2E (codex) not run: local upstream unreachable here; change does not touch the request pipeline (server.ts / src/loop / adapters / preflight paths).
