### PR TITLE
fix: bound session storage growth — single-copy leaf blocks, boot GC, one-pass startup (#478)

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -363,6 +363,8 @@ Environment variables take precedence over the config file. They are useful for 
 | `BILI_TUNNEL_ALLOWED_HOSTS` | `/bili/<absolute-url>` tunnel admission for **remote clients** (#409): comma-separated `host` or `host:port` entries that unlock loopback/private destinations (e.g. a LAN relay or the machine's own sglang) for non-loopback clients. The proxy itself and link-local/metadata addresses are always denied; local (loopback) clients always pass. |
 | `BILI_MAX_SESSIONS` | Max sessions held in memory (default `256`; LRU eviction — disk is the source of truth). |
 | `BILI_SESSIONS_DIR` | Directory for persisted session state (default XDG data dir). |
+| `BILI_SESSIONS_RETENTION_DAYS` | Session-file retention window in days (default `90`). Session state is derived (the conversation itself lives client-side), so at boot, files not saved within the window are deleted. `0` or negative disables age-based pruning. See #478. |
+| `BILI_SESSIONS_MAX_BYTES` | Total on-disk budget for session storage in bytes (default `1073741824` = 1 GiB). If the store exceeds it at boot, oldest files are pruned until under budget. `0` or negative disables size-based pruning. See #478. |
 | `BILLION_CONTEXT_PROXY` | Exported by the launcher; client-side bili plugins/extensions detect it and self-disable their own compression (no double compression). |
 | `BILLION_CONTEXT_PLUGIN` | Set `0` to disable plugin mode entirely (wire-level tool injection resumes). |
 | `BILI_LAUNCHER_MODEL_WINDOWS` | Internal: the launcher hands the client's own per-model context windows (pi `models.json`, omp `models.yml`, opencode `models.<id>.limit`, codex `model_context_window`) to the spawned proxy as JSON, so the nudge denominator matches the real window for self-hosted models. Only the launcher sets it — no user configuration. |
@@ -633,6 +635,15 @@ Compression state (blocks, summaries, original message cache) lives **in the pro
 
 - If you point the client back at the real upstream (or stop the proxy), the client replays its **full local history** every turn. After a long compressed session this can exceed the model's context window (`context_window_exceeded`).
 - There is no way to "unpack" a compression block into the client's local history — the client never saw the compressed form.
+
+### Storage lifecycle at boot (#478)
+
+Session files are derived state, so the proxy bounds them at boot with a **single** directory walk+parse (load, the one-time #286 identity migration, and GC all run over the same parsed map):
+
+- **Retention** — files not saved within `BILI_SESSIONS_RETENTION_DAYS` (default `90`) are deleted.
+- **Size budget** — if total on-disk bytes exceed `BILI_SESSIONS_MAX_BYTES` (default 1 GiB), oldest files are pruned until under budget.
+- A pruned session simply starts fresh if its client returns.
+- The #286 migration writes a `.bili-migration-286.done` marker after its first pass, so it never re-scans or re-logs on later boots.
 
 ### Migrating off the proxy
 

--- a/src/decompress-shared.ts
+++ b/src/decompress-shared.ts
@@ -91,7 +91,9 @@ export function resolveDecompress(
         // Honor the full flag: `one` = direct msgs + nested child summaries,
         // `full` = all original messages. Returning the cached full text
         // unconditionally would break the default one-level semantics.
-        const view = full ? cached.full : cached.one;
+        // `one === null` means the two views were byte-identical at cache
+        // time and deduped to one copy (#478).
+        const view = full ? cached.full : (cached.one ?? cached.full);
         body = view.text;
         count = view.count;
     } else {

--- a/src/persist.ts
+++ b/src/persist.ts
@@ -1,11 +1,12 @@
 import { createHash } from "node:crypto";
-import { rm } from "node:fs/promises";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { rm, stat } from "node:fs/promises";
 import * as path from "node:path";
 import { StateStore, flatFileNameFor, type PersistedEnvelope } from "acp-kernel/persist";
 import { sessionsDir } from "./paths.js";
 import { log as loggerLog } from "./logger.js";
 import { createInitialState, type CompressionState, type CoreMessage } from "acp-kernel";
-import type { Session, BlockContent } from "./session.js";
+import type { Session, BlockContent, BlockView } from "./session.js";
 
 /**
  * On-disk persistence for proxy sessions.
@@ -30,6 +31,11 @@ import type { Session, BlockContent } from "./session.js";
  *    debounced writes keep the on-disk state within ~debounce of in-memory.
  *  - Forward-compat: `mergeState` fills any fields missing on a file written
  *    by an older version, so a schema change never breaks old files.
+ *  - Boot-time GC (retention window + size budget, #478): session files are
+ *    derived state — the conversation itself lives client-side — so stale or
+ *    over-budget records are pruned on boot, over the already-parsed map
+ *    (no extra directory walk). A pruned session simply starts fresh if the
+ *    client returns.
  *  - Disable with BILI_PERSIST=0 for ephemeral/test runs.
  *
  * MECHANISM lives in `acp-kernel/persist` (StateStore: atomic write, rename
@@ -59,6 +65,10 @@ import type { Session, BlockContent } from "./session.js";
  */
 
 const PERSIST_VERSION = 3;
+const DAY_MS = 86400_000;
+/** Dotfile (invisible to the kernel's .json walk): written after the first
+ *  successful #286 migration pass so later boots skip the scan entirely. */
+const MIGRATION_MARKER = ".bili-migration-286.done";
 
 interface PersistedSession {
     version: number;
@@ -166,11 +176,15 @@ export class SessionStore {
     readonly enabled: boolean;
     private readonly dir: string;
     private readonly store: StateStore<PersistedSession>;
+    private readonly retentionMs: number;
+    private readonly maxBytes: number;
 
-    constructor(opts?: { dir?: string; debounceMs?: number; enabled?: boolean; log?: Logger }) {
+    constructor(opts?: { dir?: string; debounceMs?: number; enabled?: boolean; log?: Logger; retentionDays?: number; maxBytes?: number }) {
         const debounceMs = opts?.debounceMs ?? defaultDebounce();
         this.enabled = (opts?.enabled ?? true) && debounceMs >= 0;
         this.dir = opts?.dir ?? defaultDir();
+        this.retentionMs = Math.max(0, Math.trunc((opts?.retentionDays ?? defaultRetentionDays()) * DAY_MS));
+        this.maxBytes = opts?.maxBytes ?? defaultMaxBytes();
         this.store = new StateStore<PersistedSession>({
             dir: this.dir,
             version: PERSIST_VERSION,
@@ -199,6 +213,23 @@ export class SessionStore {
         return out;
     }
 
+    /** Single-pass boot (#478): ONE loadAll walk+parse, then the #286
+     *  identity migration and the retention/size GC over the SAME parsed map
+     *  (no extra directory walks), then hydration into Sessions. initSessions
+     *  calls this instead of migrateLegacyIds()+loadAll(), which walked and
+     *  parsed the whole tree twice per start. */
+    async boot(): Promise<Map<string, Session>> {
+        if (!this.enabled) return new Map();
+        const loaded = await this.store.loadAll();
+        await this.applyLegacyMigration(loaded);
+        await this.gcLoaded(loaded);
+        const out = new Map<string, Session>();
+        for (const [id, envelope] of loaded) {
+            out.set(id, buildSession(envelope.payload));
+        }
+        return out;
+    }
+
     /** One-time migration for the #286 identity change: sessions persisted
      *  under the old derived hash id are re-keyed to the client-provided
      *  conversation value stored in meta.label (which is now the session id
@@ -207,10 +238,27 @@ export class SessionStore {
      *  session, are deleted. Records without a label cannot be mapped and are
      *  left in place (they load under their old id but are never requested
      *  again — the new proxy 400s anonymous requests). Self-terminating:
-     *  after one pass no loaded id differs from its label. */
+     *  after one pass no loaded id differs from its label. A completion
+     *  marker makes it run ONCE EVER (#478): the old code re-scanned the tree
+     *  on every boot because unlabeled files are intentionally kept, so the
+     *  "one-time" log line repeated forever. */
     async migrateLegacyIds(): Promise<void> {
         if (!this.enabled) return;
+        if (existsSync(this.markerPath())) return;
         const loaded = await this.store.loadAll();
+        await this.applyLegacyMigration(loaded);
+    }
+
+    private markerPath(): string {
+        return path.join(this.dir, MIGRATION_MARKER);
+    }
+
+    private async applyLegacyMigration(loaded: Map<string, PersistedEnvelope<PersistedSession>>): Promise<void> {
+        // Marker gate lives HERE (not just in migrateLegacyIds) because boot()
+        // invokes this directly — unlabeled files are intentionally kept
+        // forever, so without the gate the "one-time" pass would re-run and
+        // re-log on every single start (#478 root cause 3).
+        if (existsSync(this.markerPath())) return;
         const claimed = new Set<string>();
         const byLabel = new Map<string, { id: string; savedAt: number; session: Session }>();
         let unlabeled = 0;
@@ -234,23 +282,39 @@ export class SessionStore {
             }
             const prev = byLabel.get(label);
             if (!prev || envelope.savedAt >= prev.savedAt) {
-                if (prev) await this.removeLegacyFile(prev.id, prev.session);
+                if (prev) {
+                    await this.removeLegacyFile(prev.id, prev.session);
+                    loaded.delete(prev.id);
+                }
                 byLabel.set(label, { id, savedAt: envelope.savedAt, session });
             } else {
                 await this.removeLegacyFile(id, session);
+                loaded.delete(id);
             }
         }
         let rekeyed = 0;
         for (const [label, { id, session }] of byLabel) {
             if (claimed.has(label)) {
                 await this.removeLegacyFile(id, session);
+                loaded.delete(id);
                 continue;
             }
             session.id = label;
             await this.store.writeNow(label, () => buildRecord(session));
             await this.removeLegacyFile(id, session);
+            const envelope = loaded.get(id);
+            if (envelope) {
+                loaded.set(label, { ...envelope, id: label, payload: { ...envelope.payload, id: label } });
+            }
+            loaded.delete(id);
             claimed.add(label);
             rekeyed++;
+        }
+        try {
+            mkdirSync(this.dir, { recursive: true });
+            writeFileSync(this.markerPath(), String(Date.now()), "utf8");
+        } catch {
+            // Read-only dir — migration re-runs next boot (it is idempotent).
         }
         if (rekeyed || unlabeled) {
             loggerLog("info", `[persist] one-time migration (#286): rekeyed ${rekeyed} legacy session(s), left ${unlabeled} unlabeled legacy file(s) in place`);
@@ -270,6 +334,91 @@ export class SessionStore {
         for (const rel of candidates) {
             await rm(path.join(this.dir, rel), { force: true }).catch(() => {});
         }
+    }
+
+    /** Boot-time storage GC (#478): session files are derived state — the
+     *  conversation lives client-side — so prune records whose savedAt is past
+     *  the retention window, then drop oldest-first while total on-disk bytes
+     *  exceed the size budget. Runs over the already-parsed boot map: zero
+     *  extra directory walks. A pruned session simply starts fresh if its
+     *  client returns. */
+    private async gcLoaded(loaded: Map<string, PersistedEnvelope<PersistedSession>>): Promise<void> {
+        if (loaded.size === 0) return;
+        const now = Date.now();
+        let prunedExpired = 0;
+        let prunedOverBudget = 0;
+        let freedBytes = 0;
+        if (this.retentionMs > 0) {
+            for (const [id, envelope] of [...loaded]) {
+                if (now - envelope.savedAt <= this.retentionMs) continue;
+                const p = envelope.payload;
+                freedBytes += await this.pruneRecord(p.id, p.meta?.protocol ?? p.protocol, p.meta?.upstreamOrigin ?? p.upstreamOrigin);
+                loaded.delete(id);
+                prunedExpired++;
+            }
+        }
+        if (this.maxBytes > 0 && loaded.size > 0) {
+            const survivors: { id: string; savedAt: number; protocol?: string; origin?: string; bytes: number }[] = [];
+            for (const [id, envelope] of loaded) {
+                const p = envelope.payload;
+                survivors.push({
+                    id,
+                    savedAt: envelope.savedAt,
+                    protocol: p.meta?.protocol ?? p.protocol,
+                    origin: p.meta?.upstreamOrigin ?? p.upstreamOrigin,
+                    bytes: await this.recordSize(p.id, p.meta?.protocol ?? p.protocol, p.meta?.upstreamOrigin ?? p.upstreamOrigin),
+                });
+            }
+            let total = survivors.reduce((n, s) => n + s.bytes, 0);
+            if (total > this.maxBytes) {
+                survivors.sort((a, b) => a.savedAt - b.savedAt);
+                for (const s of survivors) {
+                    if (total <= this.maxBytes) break;
+                    freedBytes += await this.pruneRecord(s.id, s.protocol, s.origin);
+                    loaded.delete(s.id);
+                    total -= s.bytes;
+                    prunedOverBudget++;
+                }
+            }
+        }
+        if (prunedExpired || prunedOverBudget) {
+            loggerLog("info", `[persist] gc: pruned ${prunedExpired} expired (>${Math.round(this.retentionMs / DAY_MS)}d) + ${prunedOverBudget} over-budget session file(s), freed ${(freedBytes / 1048576).toFixed(1)} MB`);
+        }
+    }
+
+    private candidateRelPaths(id: string, protocol?: string, upstreamOrigin?: string): string[] {
+        const base = [
+            relPathFor(id, protocol, upstreamOrigin),
+            relPathFor(id),
+            flatFileNameFor(id),
+        ];
+        const rels = new Set<string>(base);
+        // The kernel spills to `<name>.fb.json` when canonical renames keep
+        // failing (Windows AV locks) — prune both or a stale spill survives.
+        for (const r of base) rels.add(r.replace(/\.json$/, ".fb.json"));
+        return [...rels];
+    }
+
+    private async recordSize(id: string, protocol?: string, upstreamOrigin?: string): Promise<number> {
+        let bytes = 0;
+        for (const rel of this.candidateRelPaths(id, protocol, upstreamOrigin)) {
+            try {
+                bytes += (await stat(path.join(this.dir, rel))).size;
+            } catch { /* file absent */ }
+        }
+        return bytes;
+    }
+
+    /** Delete every file belonging to a record. Returns bytes actually removed. */
+    private async pruneRecord(id: string, protocol?: string, upstreamOrigin?: string): Promise<number> {
+        let freed = 0;
+        for (const rel of this.candidateRelPaths(id, protocol, upstreamOrigin)) {
+            try {
+                freed += (await stat(path.join(this.dir, rel))).size;
+                await rm(path.join(this.dir, rel), { force: true });
+            } catch { /* file absent */ }
+        }
+        return freed;
     }
 
     /** Synchronous reload of a single session. Used on a memory miss (after
@@ -349,10 +498,24 @@ function buildRecord(session: Session): PersistedSession {
     };
 }
 
+function isBlockView(v: unknown): v is BlockView {
+    return !!v && typeof v === "object" && typeof (v as BlockView).text === "string" && typeof (v as BlockView).count === "number";
+}
+
 function buildSession(parsed: PersistedSession): Session {
     const blockContents = new Map<string, BlockContent>();
     for (const [bid, content] of Object.entries(parsed.blockContents ?? {})) {
-        if (content && typeof content === "object") blockContents.set(bid, content);
+        if (!content || typeof content !== "object") continue;
+        const full = (content as Record<string, unknown>).full;
+        if (!isBlockView(full)) continue;
+        // Legacy files stored byte-identical one/full pairs (#478); normalize
+        // to the single-copy form on load so the next write persists it once.
+        const one = (content as Record<string, unknown>).one;
+        const oneView = isBlockView(one) ? one : null;
+        blockContents.set(bid, {
+            one: oneView && !(oneView.text === full.text && oneView.count === full.count) ? oneView : null,
+            full,
+        });
     }
     // Read grouped shape (v2+); fall back to flat fields for v1 files.
     const meta = parsed.meta ?? {};
@@ -411,6 +574,27 @@ function defaultDebounce(): number {
         if (Number.isFinite(n) && n >= 0) return n;
     }
     return 500;
+}
+
+/** Session retention window in days (#478). <= 0 disables age-based pruning. */
+function defaultRetentionDays(): number {
+    const env = process.env.BILI_SESSIONS_RETENTION_DAYS;
+    if (env !== undefined) {
+        const n = Number.parseInt(env, 10);
+        if (Number.isFinite(n)) return n;
+    }
+    return 90;
+}
+
+/** Total on-disk session storage budget in bytes (#478). <= 0 disables the
+ *  size-based pruning pass. */
+function defaultMaxBytes(): number {
+    const env = process.env.BILI_SESSIONS_MAX_BYTES;
+    if (env !== undefined) {
+        const n = Number.parseInt(env, 10);
+        if (Number.isFinite(n)) return n;
+    }
+    return 1 << 30;
 }
 
 function persistEnabled(): boolean {

--- a/src/session.ts
+++ b/src/session.ts
@@ -1,9 +1,18 @@
 import { createInitialState, type CompressionState, type CoreMessage } from "acp-kernel";
 import { getStore } from "./persist.js";
 
+export type BlockView = { text: string; count: number };
+
+/** Original content of a compressed block, captured at compress time. `full`
+ *  (all original messages) is always stored. `one` (one-level: direct messages
+ *  + nested child summaries) is `null` when it is byte-identical to `full` —
+ *  always the case for leaf blocks, since nested children are deactivated at
+ *  creation and the one-level view skips inactive children — and is persisted
+ *  as a single copy in that case (#478: the duplicated copy was 50% of
+ *  blockContents bytes on disk). */
 export type BlockContent = {
-    one: { text: string; count: number };
-    full: { text: string; count: number };
+    one: BlockView | null;
+    full: BlockView;
 };
 
 /** One successful compress, recorded for #189 observability: correlating a
@@ -89,9 +98,11 @@ export type Session = {
      *  the source messages are still present in the request. decompress reads
      *  from here instead of scanning ctx.messages (which only holds the
      *  post-compression / folded view and loses originals across rounds).
-     *  Two views are cached: `one` (one-level: direct messages + nested
+     *  Two views are cached — `one` (one-level: direct messages + nested
      *  child summaries) and `full` (all original messages), matching the
-     *  collectBlockContent full flag semantics.
+     *  collectBlockContent full flag semantics — but when the views are
+     *  byte-identical (leaf blocks) only one copy is kept (`one: null`,
+     *  #478).
      *  Unbounded in memory by design — block summaries are small relative to
      *  the history they replace, and disk persistence keeps the source of
      *  truth; the MAX_SESSIONS cap bounds the number of concurrent sessions
@@ -139,18 +150,19 @@ let MAX_SESSIONS = Math.max(1, Number.parseInt(process.env.BILI_MAX_SESSIONS ?? 
 let initialized = false;
 
 /** Bulk-load persisted sessions from disk into the in-memory map. Called once
- *  at server startup before listening. Caps at MAX_SESSIONS by the most
- *  recently active of createdAt/lastSeen-from-disk (keeps the freshest; a
- *  session that is old but was active until recently must not lose its slot
- *  to a newer-created-but-idle one, #404) so a huge backlog cannot OOM on
- *  boot. Idempotent. */
+ *  at server startup before listening. boot() does ONE loadAll pass plus the
+ *  #286 migration and retention/size GC over the same parsed map (#478: the
+ *  old migrateLegacyIds()+loadAll() pair walked and parsed the tree twice).
+ *  Caps at MAX_SESSIONS by the most recently active of createdAt/lastSeen-
+ *  from-disk (keeps the freshest; a session that is old but was active until
+ *  recently must not lose its slot to a newer-created-but-idle one, #404) so
+ *  a huge backlog cannot OOM on boot. Idempotent. */
 export async function initSessions(): Promise<void> {
     if (initialized) return;
     initialized = true;
     const store = getStore();
     if (!store.enabled) return;
-    await store.migrateLegacyIds();
-    const loaded = await store.loadAll();
+    const loaded = await store.boot();
     if (loaded.size > MAX_SESSIONS) {
         const freshness = (s: Session) => Math.max(s.createdAt ?? 0, s.lastSeen ?? 0);
         const entries = [...loaded.entries()].sort((a, b) => freshness(b[1]) - freshness(a[1]));

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -83,13 +83,17 @@ export function applyRanges(parsed: ReturnType<typeof parseCompressInput>, ctx: 
         // work in later rounds where ctx.messages no longer carries the originals.
         // Two views are cached so decompress can honor the `full` flag: `one`
         // (direct messages + nested child summaries) and `full` (all originals).
+        // Leaf blocks have no active nested children, so both kernel paths
+        // emit byte-identical text — persist a single copy in that case
+        // (#478: the duplicate was 50% of blockContents bytes on disk).
         for (const b of res.state.blocks) {
             if (beforeIds.has(b.blockId)) continue;
             const full = collectBlockContent(res.state, b, ctx.messages, { full: true });
             const one = collectBlockContent(res.state, b, ctx.messages, { full: false });
             if (full.count > 0 || one.count > 0) {
+                const sameView = one.text === full.text && one.count === full.count;
                 cacheBlockContent(ctx.session, b.blockId, {
-                    one: { text: one.text, count: one.count },
+                    one: sameView ? null : { text: one.text, count: one.count },
                     full: { text: full.text, count: full.count },
                 });
             }

--- a/tests/fix-478-storage.test.ts
+++ b/tests/fix-478-storage.test.ts
@@ -1,0 +1,206 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { tmpdir } from "node:os";
+import fsShared from "node:fs";
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { createInitialState } from "acp-kernel";
+import { SessionStore } from "../src/persist.ts";
+import type { Session } from "../src/session.ts";
+import { setLogCapture } from "../src/logger.ts";
+
+const DAY_MS = 86400_000;
+
+function jsonFilesUnder(dir: string): string[] {
+    const out: string[] = [];
+    for (const name of readdirSync(dir)) {
+        if (name.startsWith(".tmp-")) continue;
+        const full = join(dir, name);
+        if (statSync(full).isDirectory()) out.push(...jsonFilesUnder(full));
+        else if (name.endsWith(".json")) out.push(full);
+    }
+    return out;
+}
+
+function makeSession(id: string, meta: Session["meta"] = {}): Session {
+    return {
+        id,
+        meta,
+        stats: { requests: 0, tokensSaved: 0, inputTokens: 0, cachedTokens: 0, outputTokens: 0, cacheSamples: 0, lastInputTokens: 0, contextTokens: 0 },
+        metadata: {},
+        state: createInitialState(),
+        createdAt: Date.now(),
+        lastSeen: Date.now(),
+        blockContents: new Map(),
+        inFlight: 0,
+        persisted: false,
+    };
+}
+
+function paddedSession(id: string, textLen: number): Session {
+    const s = makeSession(id);
+    s.blockContents.set("b1", { one: null, full: { text: "x".repeat(textLen), count: 1 } });
+    return s;
+}
+
+function backdate(files: string[], savedAt: number): void {
+    for (const f of files) {
+        const env = JSON.parse(readFileSync(f, "utf8"));
+        env.savedAt = savedAt;
+        writeFileSync(f, JSON.stringify(env));
+    }
+}
+
+function withDir<T>(name: string, fn: (dir: string) => Promise<T> | T): Promise<unknown> {
+    return test(name, async () => {
+        const dir = mkdtempSync(join(tmpdir(), "bili-478-"));
+        try {
+            await fn(dir);
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+}
+
+await withDir("leaf block persists a single copy (one:null) and round-trips", async (dir) => {
+    const store = new SessionStore({ dir, debounceMs: 5, enabled: true });
+    const s = makeSession("leaf-1");
+    s.blockContents.set("b1", { one: null, full: { text: "body-text", count: 2 } });
+    await store.writeNow(s);
+
+    const [file] = jsonFilesUnder(dir);
+    const raw = JSON.parse(readFileSync(file, "utf8")).payload;
+    assert.equal(raw.blockContents.b1.one, null, "byte-identical leaf view is stored once");
+    assert.deepEqual(raw.blockContents.b1.full, { text: "body-text", count: 2 });
+
+    const loaded = store.loadSync("leaf-1");
+    assert.ok(loaded, "loaded from disk");
+    const bc = loaded!.blockContents.get("b1");
+    assert.equal(bc!.one, null, "null one-view survives the round-trip");
+    assert.deepEqual(bc!.full, { text: "body-text", count: 2 });
+});
+
+await withDir("legacy byte-identical one/full pair normalizes to single copy on load", async (dir) => {
+    const store = new SessionStore({ dir, debounceMs: 5, enabled: true });
+    const s = makeSession("dup-1");
+    s.blockContents.set("b1", { one: { text: "same", count: 1 }, full: { text: "same", count: 1 } });
+    await store.writeNow(s);
+    // Simulate a pre-fix file: both views persisted, byte-identical.
+    const [file] = jsonFilesUnder(dir);
+    const env = JSON.parse(readFileSync(file, "utf8"));
+    env.payload.blockContents.b1 = { one: { text: "same", count: 1 }, full: { text: "same", count: 1 } };
+    writeFileSync(file, JSON.stringify(env));
+
+    const loaded = store.loadSync("dup-1");
+    assert.ok(loaded);
+    assert.equal(loaded!.blockContents.get("b1")!.one, null, "identical pair collapses to full-only");
+    assert.deepEqual(loaded!.blockContents.get("b1")!.full, { text: "same", count: 1 });
+
+    await store.writeNow(loaded!);
+    const raw2 = JSON.parse(readFileSync(jsonFilesUnder(dir)[0], "utf8")).payload;
+    assert.equal(raw2.blockContents.b1.one, null, "next persist stores the collapsed form");
+});
+
+// The kernel walks with `fs.readFileSync` on the shared node:fs object
+// (dist/persist/index.js: `import fs from "fs"`), so patching the default
+// export counts every file read during boot — a second loadAll pass would
+// double the count.
+await withDir("boot() prunes expired sessions in a single directory walk", async (dir) => {
+    const store = new SessionStore({ dir, debounceMs: 5, enabled: true });
+    for (let i = 0; i < 300; i++) await store.writeNow(makeSession(`exp-${i}`));
+    const expiredFiles = jsonFilesUnder(dir);
+    assert.equal(expiredFiles.length, 300);
+    backdate(expiredFiles, Date.now() - 100 * DAY_MS);
+    await store.writeNow(makeSession("fresh-1"));
+    await store.writeNow(makeSession("fresh-2"));
+    writeFileSync(join(dir, ".bili-migration-286.done"), String(Date.now()), "utf8");
+
+    const cold = new SessionStore({ dir, debounceMs: 5, enabled: true, retentionDays: 90, maxBytes: 0 });
+    const origReadFileSync = fsShared.readFileSync;
+    let reads = 0;
+    Object.assign(fsShared, {
+        readFileSync: (...args: Parameters<typeof fsShared.readFileSync>): unknown => {
+            reads++;
+            return origReadFileSync(...args);
+        },
+    });
+    let map: Map<string, Session>;
+    try {
+        map = await cold.boot();
+    } finally {
+        Object.assign(fsShared, { readFileSync: origReadFileSync });
+    }
+
+    assert.equal(reads, 302, "exactly one read per session file — a single walk+parse pass");
+    assert.equal(map.size, 2, "expired records dropped from the loaded map");
+    assert.ok(map.has("fresh-1") && map.has("fresh-2"));
+    assert.equal(jsonFilesUnder(dir).length, 2, "expired files deleted, volume stable");
+});
+
+await withDir("#286 migration runs exactly once ever (completion marker)", async (dir) => {
+    const store = new SessionStore({ dir, debounceMs: 5, enabled: true });
+    await store.writeNow(makeSession("old-hash-id", { label: "conv-123" }));
+
+    const lines: string[] = [];
+    setLogCapture((_level, msg) => lines.push(msg));
+    try {
+        const cold1 = new SessionStore({ dir, debounceMs: 5, enabled: true, retentionDays: 90, maxBytes: 0 });
+        const map1 = await cold1.boot();
+        assert.ok(map1.has("conv-123"), "rekeyed under the client conversation id");
+        assert.ok(!map1.has("old-hash-id"));
+        assert.equal(lines.filter((m) => m.includes("one-time migration")).length, 1);
+        assert.ok(existsSync(join(dir, ".bili-migration-286.done")), "completion marker written");
+        assert.equal(jsonFilesUnder(dir).length, 1, "loser file deleted");
+
+        lines.length = 0;
+        const cold2 = new SessionStore({ dir, debounceMs: 5, enabled: true, retentionDays: 90, maxBytes: 0 });
+        const map2 = await cold2.boot();
+        assert.ok(map2.has("conv-123"));
+        assert.equal(lines.filter((m) => m.includes("one-time migration")).length, 0, "marker suppresses the rescan");
+        assert.equal(jsonFilesUnder(dir).length, 1, "second boot changes nothing");
+    } finally {
+        setLogCapture(null);
+    }
+});
+
+await withDir("size budget prunes oldest-first until under maxBytes", async (dir) => {
+    const store = new SessionStore({ dir, debounceMs: 5, enabled: true, retentionDays: 0, maxBytes: 12_000 });
+    for (let i = 0; i < 6; i++) await store.writeNow(paddedSession(`sz-${i}`, 4000));
+    const byId = new Map<string, string>();
+    for (const f of jsonFilesUnder(dir)) byId.set(JSON.parse(readFileSync(f, "utf8")).id, f);
+    const base = Date.now() - 10 * DAY_MS;
+    for (let i = 0; i < 6; i++) {
+        const env = JSON.parse(readFileSync(byId.get(`sz-${i}`)!, "utf8"));
+        env.savedAt = base + i * 60_000;
+        writeFileSync(byId.get(`sz-${i}`)!, JSON.stringify(env));
+    }
+    writeFileSync(join(dir, ".bili-migration-286.done"), "1", "utf8");
+
+    const lines: string[] = [];
+    setLogCapture((_level, msg) => lines.push(msg));
+    let map: Map<string, Session>;
+    try {
+        const cold = new SessionStore({ dir, debounceMs: 5, enabled: true, retentionDays: 0, maxBytes: 12_000 });
+        map = await cold.boot();
+    } finally {
+        setLogCapture(null);
+    }
+
+    assert.ok(map.size < 6, "over-budget corpus was pruned");
+    assert.ok(map.has("sz-5"), "newest record survives");
+    assert.ok(!map.has("sz-0"), "oldest record pruned first");
+    const remainingBytes = jsonFilesUnder(dir).reduce((n, f) => n + statSync(f).size, 0);
+    assert.ok(remainingBytes <= 12_000, `survivors fit the budget (${remainingBytes} <= 12000)`);
+    assert.ok(lines.some((m) => m.includes("[persist] gc:") && m.includes("over-budget")), "gc logged the pruning");
+});
+
+await withDir("retentionDays:0 + maxBytes:0 disable both GC passes", async (dir) => {
+    const store = new SessionStore({ dir, debounceMs: 5, enabled: true });
+    for (let i = 0; i < 3; i++) await store.writeNow(paddedSession(`keep-${i}`, 4000));
+    backdate(jsonFilesUnder(dir), Date.now() - 100 * DAY_MS);
+
+    const cold = new SessionStore({ dir, debounceMs: 5, enabled: true, retentionDays: 0, maxBytes: 0 });
+    const map = await cold.boot();
+    assert.equal(map.size, 3, "GC fully disabled — expired + oversized corpus untouched");
+    assert.equal(jsonFilesUnder(dir).length, 3);
+});

--- a/tests/issue404-restore-timestamps.test.ts
+++ b/tests/issue404-restore-timestamps.test.ts
@@ -75,12 +75,16 @@ await test("boot restore: lastSeen=savedAt, restored flag, freshness-keyed trunc
     const store = new SessionStore({ dir, debounceMs: 5, enabled: true });
     _setStoreForTest(store);
     try {
-        // Freshness by max(createdAt, savedAt): A=9000, C=8000, B=5000.
+        // Freshness by max(createdAt, savedAt): A=freshest, C=second, B=stalest
+        // (savedAt must be RECENT absolute epochs — the #478 boot GC prunes any
+        // record older than the retention window, and hand-written 1970-era
+        // timestamps would be pruned before truncation ever runs).
         // The OLD truncation key (createdAt only: B=5000 > A=1000 > C=2000)
         // would keep B and drop C — the active-but-old A / idle-but-new B mix.
-        writeEnvelope(dir, "sess-A", 1000, 9000);
-        writeEnvelope(dir, "sess-B", 5000, 5000);
-        writeEnvelope(dir, "sess-C", 2000, 8000);
+        const recent = Date.now() - 60_000;
+        writeEnvelope(dir, "sess-A", 1000, recent + 3000);
+        writeEnvelope(dir, "sess-B", 5000, recent + 1000);
+        writeEnvelope(dir, "sess-C", 2000, recent + 2000);
 
         _resetSessionsForTest(2);
         await initSessions();
@@ -90,7 +94,7 @@ await test("boot restore: lastSeen=savedAt, restored flag, freshness-keyed trunc
         const c = peekSession("sess-C");
         assert.ok(a && c, "the two freshest sessions by max(createdAt, savedAt) survive boot truncation");
         assert.equal(b, undefined, "newer-created but idle-since-boot session loses its slot to the active-but-old one");
-        assert.equal(a!.lastSeen, 9000, "restored lastSeen is the on-disk savedAt, not the restore moment");
+        assert.equal(a!.lastSeen, recent + 3000, "restored lastSeen is the on-disk savedAt, not the restore moment");
         assert.equal(a!.restored, true, "restored sessions are flagged until their first request in this process");
         assert.equal(c!.restored, true);
 


### PR DESCRIPTION
Closing as superseded by #530. Scope change decided in #401: the retention/size GC half is dropped (sessions are permanent — a year-long session must never be lost); #530 keeps the single-copy leaf-block dedup, the one-pass boot, and the once-ever migration marker, and carries this PR's rebase fixes. The ework-agent work here (and in #478) was the correct diagnosis and the base for #530 — thank you.