### PR TITLE
fix(launcher): fail fast when the spawned proxy child exits pre-bind

### DIFF
--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -1689,8 +1689,20 @@ export async function ensureProxyRunning(
         child.unref?.();
     } catch {}
 
+    // #401/#480: fail fast when OUR spawned child dies before becoming
+    // healthy — otherwise a startup crash (bad config, missing upstream, …)
+    // burns the whole SPAWN_WAIT_MS poll window before erroring.
+    let childExit: { code: number | null; signal: string | null } | undefined;
+    child.on?.("exit", (...rest: unknown[]) => {
+        childExit = {
+            code: typeof rest[0] === "number" ? rest[0] : null,
+            signal: typeof rest[1] === "string" ? rest[1] : null,
+        };
+    });
+
     const deadline = now() + SPAWN_WAIT_MS;
     while (now() < deadline) {
+        if (childExit) break;
         await sleepImpl(HEALTH_POLL_INTERVAL_MS);
         const inst = readInstance();
         if (isProxyInstanceFile(inst) && inst.launchToken === launchToken) {
@@ -1708,6 +1720,12 @@ export async function ensureProxyRunning(
         if (stale && (await probeHealth(proxyOrigin(opts.host, port), fetchImpl))) {
             return { origin: proxyOrigin(opts.host, port), port, child, logPath };
         }
+    }
+    if (childExit) {
+        const detail = childExit.code !== null
+            ? `code ${childExit.code}`
+            : childExit.signal ? `signal ${childExit.signal}` : "unknown reason";
+        throw new Error(`bili: proxy child exited before becoming healthy (${detail}) (log: ${logPath})`);
     }
     throw new Error(`bili: proxy did not become healthy within ${SPAWN_WAIT_MS}ms (log: ${logPath})`);
 }

--- a/tests/launcher.test.ts
+++ b/tests/launcher.test.ts
@@ -681,6 +681,41 @@ test("ensureProxyRunning: launchToken handshake returns the child's real port (#
     assert.equal(handle.origin, "http://127.0.0.1:8799");
 });
 
+test("ensureProxyRunning: spawned child exits pre-bind → fails fast (<5s) with log path (#401/#480)", async () => {
+    const child: SpawnChild = {
+        pid: 42441,
+        unref() {},
+        kill() {
+            return true;
+        },
+        on(event, listener) {
+            if (event === "exit") setImmediate(() => listener(1, null));
+            return undefined;
+        },
+    };
+    const spawnImpl: SpawnFn = () => child;
+    const t0 = Date.now();
+    await assert.rejects(
+        ensureProxyRunning(
+            { host: "127.0.0.1", port: 8787, passthrough: false, debug: false },
+            {
+                spawnImpl,
+                fetchImpl: async () => ({ ok: false }),
+                fetchHealthInfo: async () => undefined,
+                readInstanceFile: () => undefined,
+                sleep: () => new Promise((r) => setTimeout(r, 1)),
+            },
+        ),
+        (err: Error) => {
+            assert.match(err.message, /exited before becoming healthy/);
+            assert.match(err.message, /code 1/);
+            assert.match(err.message, /log:/);
+            return true;
+        },
+    );
+    assert.ok(Date.now() - t0 < 5000, `fast-fail took ${Date.now() - t0}ms; must not burn the full poll window`);
+});
+
 test("stopProxy: no-op when child missing pid", () => {
     assert.doesNotThrow(() =>
         stopProxy({ origin: "http://127.0.0.1:8787", port: 8787, child: { pid: 0 } }),


### PR DESCRIPTION
Closes #596 — tracking issue for this PR.

## Context

Salvages the one non-duplicated improvement from **PR #480** ("child-reported handshake bind; stop forcing --debug").

While reviewing #480 I found that two of its three goals are **already merged into master** via an independent, more complete implementation — commit `c2567cc` "instance governance … (#417)":

- The port TOCTOU is already fixed: the child self-binds and retries on `EADDRINUSE` (≤17 attempts), reporting its real origin through the instance file matched by `BILI_LAUNCH_TOKEN` (`src/server.ts`, and `ensureProxyRunning` in `src/launcher.ts`).
- The forced `debug: true` is already removed (`proxyStartArgs` uses `opts.debug`).

Merging #480 as-is would add a second, competing handshake mechanism (a per-launch `--handshake-file`) and conflicts with master in `src/launcher.ts`, `src/server.ts`, and `tests/launcher.test.ts` (all changed-in-both since #480's base). So #480 should be closed as superseded by #417.

The single piece of #480 that master still lacks is **fast-fail on child exit**: if the spawned proxy dies before becoming healthy (bad config, missing upstream, startup crash), master's spawn path waits the full `SPAWN_WAIT_MS = 20000` before erroring — there is no `child.on("exit")` watch inside `ensureProxyRunning` (the only exit handler lives in `runClient`).

## Change

- `src/launcher.ts` `ensureProxyRunning`: register an `exit` listener on the spawned child; break the health-poll loop as soon as it fires; throw a specific error carrying the exit code/signal and pointing at the per-launch log instead of the generic 20s timeout message.
- `tests/launcher.test.ts`: new test — the child fires `exit(1)` right after spawn → `ensureProxyRunning` rejects in well under 5s with `exited before becoming healthy (code 1)` plus the log path.

The success path is untouched: a live child never emits `exit` during polling, so normal startup behavior is unchanged.

## Verification

- `npm run typecheck` — clean
- `npm test` — 947/948 pass; the single failure (`resolveClientCommand: codex/claude resolve to themselves`) is the pre-existing env-dependent one (this sandbox has `/usr/bin/codex`), reproduces identically on pristine master, unrelated to this change
- `npm run build` — clean

Partially supersedes #480; see that thread for the full duplicate analysis.
