### PR TITLE
fix(launcher): fail fast when the spawned proxy child exits pre-bind

### DIFF
--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -1689,8 +1689,15 @@ export async function ensureProxyRunning(
         child.unref?.();
     } catch {}
 
+    // #481: fail fast on pre-bind child death (bad config, missing upstream,
+    // startup crash) instead of burning SPAWN_WAIT_MS and reporting a timeout.
+    let childExit: [unknown, unknown] | undefined;
+    child.on?.("exit", (...rest: unknown[]) => {
+        childExit = [rest[0], rest[1]];
+    });
+
     const deadline = now() + SPAWN_WAIT_MS;
-    while (now() < deadline) {
+    while (!childExit && now() < deadline) {
         await sleepImpl(HEALTH_POLL_INTERVAL_MS);
         const inst = readInstance();
         if (isProxyInstanceFile(inst) && inst.launchToken === launchToken) {
@@ -1708,6 +1715,13 @@ export async function ensureProxyRunning(
         if (stale && (await probeHealth(proxyOrigin(opts.host, port), fetchImpl))) {
             return { origin: proxyOrigin(opts.host, port), port, child, logPath };
         }
+    }
+    if (childExit) {
+        const parts: string[] = [];
+        if (typeof childExit[0] === "number") parts.push(`code ${childExit[0]}`);
+        if (typeof childExit[1] === "string") parts.push(`signal ${childExit[1]}`);
+        const detail = parts.length > 0 ? parts.join(", ") : "unknown";
+        throw new Error(`bili: proxy child exited before becoming healthy (${detail}) (log: ${logPath})`);
     }
     throw new Error(`bili: proxy did not become healthy within ${SPAWN_WAIT_MS}ms (log: ${logPath})`);
 }

--- a/tests/launcher.test.ts
+++ b/tests/launcher.test.ts
@@ -578,6 +578,41 @@ test("ensureProxyRunning: throws when never healthy within deadline", async () =
     );
 });
 
+test("ensureProxyRunning: fails fast when the child exits before becoming healthy (#481)", async () => {
+    const listeners = new Map<string, ((...args: unknown[]) => void)[]>();
+    const spawnImpl: SpawnFn = () => {
+        setImmediate(() => {
+            for (const l of listeners.get("exit") ?? []) l(1, null);
+        });
+        return {
+            pid: 42440,
+            unref() {},
+            kill() {
+                return true;
+            },
+            on(event, listener) {
+                const list = listeners.get(event) ?? [];
+                list.push(listener);
+                listeners.set(event, list);
+            },
+        };
+    };
+    const started = Date.now();
+    await assert.rejects(
+        ensureProxyRunning(
+            { host: "127.0.0.1", port: 8787, passthrough: false, debug: false },
+            { fetchImpl: async () => ({ ok: false }), spawnImpl, readInstanceFile: () => undefined },
+        ),
+        (err: unknown) => {
+            assert.ok(err instanceof Error);
+            assert.match(err.message, /exited before becoming healthy \(code 1\)/);
+            assert.match(err.message, /bili-proxy-8787\.log/);
+            assert.ok(Date.now() - started < 5000, `rejected in ${Date.now() - started}ms (< 5s)`);
+            return true;
+        },
+    );
+});
+
 function recordedInstance(over: Partial<InstanceFile> = {}): InstanceFile {
     return {
         origin: "http://127.0.0.1:8787",


### PR DESCRIPTION
Salvages the one non-duplicated improvement from #480 (see that thread for the full duplicate analysis; its other two goals already landed via c2567cc/#417).

## Problem

If the spawned proxy child dies before becoming healthy (bad config, missing upstream, startup crash), `ensureProxyRunning` waits the full `SPAWN_WAIT_MS = 20000` before erroring — there is no `child.on("exit")` watch inside it (the only exit handler lives in `runClient`). The user gets a misleading "did not become healthy within 20000ms" timeout message instead of the real cause.

## Change

- `src/launcher.ts` `ensureProxyRunning`: register an `exit` listener on the spawned child; break the health-poll loop as soon as it fires; throw a specific error carrying the exit code/signal (`exited before becoming healthy (code N)` / `(signal SIGTERM)`) and pointing at the per-launch log instead of the generic timeout message.
- `tests/launcher.test.ts`: new test — the child fires `exit(1)` right after spawn → `ensureProxyRunning` rejects in well under 5s with `exited before becoming healthy (code 1)` plus the log path.

The success path is untouched: a live child never emits `exit` during polling, so normal startup behavior is unchanged.

## Verification

- `npm run typecheck` — clean
- `npm test` — 947/948 pass; the single failure (`resolveClientCommand: codex/claude resolve to themselves`) is the pre-existing env-dependent one (this sandbox has `/usr/bin/codex`), reproduces identically on pristine master, unrelated to this change
- `npm run build` — clean

Partially supersedes #480.