### PR TITLE
fix: land #454 (omp native compaction disable) on master — it was merged into its already-merged base branch

### DIFF
--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -1167,60 +1167,157 @@ export function unpackDeadProxyUrlsInFile(filePath: string, livePorts: Set<numbe
     return changed;
 }
 
+function mergeOmpCompactionDisabledYaml(text: string): string {
+    const lines = text.split(/\r?\n/);
+    let compactionLine = -1;
+    for (let i = 0; i < lines.length; i++) {
+        const rawLine = lines[i];
+        const trimmed = rawLine.trim();
+        if (!trimmed || trimmed.startsWith("#")) continue;
+        const indent = rawLine.length - rawLine.trimStart().length;
+        if (indent === 0 && /^compaction:\s*(#.*)?$/.test(trimmed)) {
+            compactionLine = i;
+            break;
+        }
+    }
+    if (compactionLine === -1) {
+        const base = text === "" || text.endsWith("\n") ? text : `${text}\n`;
+        return `${base}compaction:\n  enabled: false\n`;
+    }
+    for (let i = compactionLine + 1; i < lines.length; i++) {
+        const rawLine = lines[i];
+        const trimmed = rawLine.trim();
+        if (!trimmed || trimmed.startsWith("#")) continue;
+        const indent = rawLine.length - rawLine.trimStart().length;
+        if (indent === 0) break;
+        if (/^enabled:/.test(trimmed)) {
+            const leading = rawLine.slice(0, rawLine.length - rawLine.trimStart().length);
+            const commentMatch = /\s+#.*$/.exec(rawLine);
+            const comment = commentMatch ? commentMatch[0] : "";
+            lines[i] = `${leading}enabled: false${comment}`;
+            return lines.join("\n");
+        }
+    }
+    let childIndent = 2;
+    for (let i = compactionLine + 1; i < lines.length; i++) {
+        const rawLine = lines[i];
+        const trimmed = rawLine.trim();
+        if (!trimmed || trimmed.startsWith("#")) continue;
+        const indent = rawLine.length - rawLine.trimStart().length;
+        if (indent === 0) break;
+        childIndent = indent;
+        break;
+    }
+    lines.splice(compactionLine + 1, 0, `${" ".repeat(childIndent)}enabled: false`);
+    return lines.join("\n");
+}
+
+function writeOmpCompactionDisabledConfig(ompHome: string, overlay: string): void {
+    // omp reads config.yml at runtime (settings.json is only a one-time migration
+    // source, renamed to .bak). Merge compaction.enabled=false over the real
+    // config.yml / config.yaml / settings.json so the native auto-compaction
+    // never fires alongside bili's ACP compression. JSON is a valid YAML subset,
+    // so the settings.json fallback is written as JSON and parsed by omp fine.
+    let base: string | undefined;
+    let baseIsJson = false;
+    for (const name of ["config.yml", "config.yaml"]) {
+        try {
+            base = fs.readFileSync(path.join(ompHome, name), "utf8");
+            break;
+        } catch {}
+    }
+    if (base === undefined) {
+        try {
+            base = fs.readFileSync(path.join(ompHome, "settings.json"), "utf8");
+            baseIsJson = true;
+        } catch {}
+    }
+    let merged: string;
+    if (base === undefined) {
+        merged = "compaction:\n  enabled: false\n";
+    } else if (baseIsJson) {
+        let settings: Record<string, unknown> = {};
+        try {
+            const parsed: unknown = JSON.parse(base);
+            if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+                settings = parsed as Record<string, unknown>;
+            }
+        } catch {}
+        const compactionRaw = settings.compaction;
+        const compaction =
+            compactionRaw && typeof compactionRaw === "object" && !Array.isArray(compactionRaw)
+                ? { ...(compactionRaw as Record<string, unknown>) }
+                : {};
+        compaction.enabled = false;
+        settings.compaction = compaction;
+        merged = JSON.stringify(settings, null, 2);
+    } else {
+        merged = mergeOmpCompactionDisabledYaml(base);
+    }
+    writeOverlayFileAtomic(overlay, "config.yml", merged);
+}
+
 export function prepareOmpHttpRewrite(
     ompHome: string,
     origin: string,
     httpRewrites: HttpRewrite[],
     httpsRewrites: HttpRewrite[],
 ): string | undefined {
+    if (!fs.existsSync(ompHome)) return undefined;
+    const overlay = `${ompHome}-bili`;
+    // #449: the overlay always carries a config.yml disabling omp's native
+    // auto-compaction (its summarizer must never fire alongside bili's ACP
+    // compression); models.yml is generated only when present, so both stay
+    // out of the real-home symlink set.
+    const generated: string[] = ["config.yml"];
     const modelsPath = path.join(ompHome, "models.yml");
     const unpacked = unpackDeadProxyUrlsInFile(modelsPath, liveProxyPorts());
     if (unpacked > 0) {
         console.error(`bili: unpacked ${unpacked} dead proxy URL(s) from the real ${modelsPath}`);
     }
-    if (httpRewrites.length === 0 && httpsRewrites.length === 0) return undefined;
-    let txt: string;
+    let modelsText: string | undefined;
     try {
-        txt = fs.readFileSync(modelsPath, "utf8");
-    } catch {
-        return undefined;
-    }
-    const httpMap = new Map(httpRewrites.map((r) => [r.key, wrapUpstream(origin, r.realUpstream)]));
-    const httpsMap = new Map(httpsRewrites.map((r) => [r.key, r.realUpstream]));
-    const lines = txt.split(/\r?\n/);
-    let providersIndent = -1;
-    let providerIndent = -1;
-    let currentProvider: string | null = null;
-    for (let i = 0; i < lines.length; i++) {
-        const rawLine = lines[i];
-        const trimmed = rawLine.trim();
-        if (!trimmed || trimmed.startsWith("#")) continue;
-        const indent = rawLine.length - rawLine.trimStart().length;
-        if (providersIndent === -1) {
-            if (/^providers:\s*(#.*)?$/.test(trimmed)) providersIndent = indent;
-            continue;
-        }
-        if (indent <= providersIndent) break;
-        if (providerIndent === -1) providerIndent = indent;
-        if (indent === providerIndent) {
-            const m = /^([A-Za-z0-9_.-]+):/.exec(trimmed);
-            currentProvider = m ? m[1] : null;
-        } else if (indent > providerIndent && currentProvider) {
-            const baseMatch = /^(baseUrl:\s*)(\S+)/.exec(trimmed);
-            if (baseMatch) {
-                const target = httpMap.get(currentProvider) ?? httpsMap.get(currentProvider);
-                if (target) {
-                    const leading = rawLine.slice(0, rawLine.length - rawLine.trimStart().length);
-                    const commentMatch = /\s+#.*$/.exec(rawLine);
-                    const comment = commentMatch ? commentMatch[0] : "";
-                    lines[i] = `${leading}baseUrl: ${target}${comment}`;
+        modelsText = fs.readFileSync(modelsPath, "utf8");
+        generated.push("models.yml");
+    } catch {}
+    if (!refreshOverlayHome(ompHome, overlay, generated)) return undefined;
+    if (modelsText !== undefined) {
+        const httpMap = new Map(httpRewrites.map((r) => [r.key, wrapUpstream(origin, r.realUpstream)]));
+        const httpsMap = new Map(httpsRewrites.map((r) => [r.key, r.realUpstream]));
+        const lines = modelsText.split(/\r?\n/);
+        let providersIndent = -1;
+        let providerIndent = -1;
+        let currentProvider: string | null = null;
+        for (let i = 0; i < lines.length; i++) {
+            const rawLine = lines[i];
+            const trimmed = rawLine.trim();
+            if (!trimmed || trimmed.startsWith("#")) continue;
+            const indent = rawLine.length - rawLine.trimStart().length;
+            if (providersIndent === -1) {
+                if (/^providers:\s*(#.*)?$/.test(trimmed)) providersIndent = indent;
+                continue;
+            }
+            if (indent <= providersIndent) break;
+            if (providerIndent === -1) providerIndent = indent;
+            if (indent === providerIndent) {
+                const m = /^([A-Za-z0-9_.-]+):/.exec(trimmed);
+                currentProvider = m ? m[1] : null;
+            } else if (indent > providerIndent && currentProvider) {
+                const baseMatch = /^(baseUrl:\s*)(\S+)/.exec(trimmed);
+                if (baseMatch) {
+                    const target = httpMap.get(currentProvider) ?? httpsMap.get(currentProvider);
+                    if (target) {
+                        const leading = rawLine.slice(0, rawLine.length - rawLine.trimStart().length);
+                        const commentMatch = /\s+#.*$/.exec(rawLine);
+                        const comment = commentMatch ? commentMatch[0] : "";
+                        lines[i] = `${leading}baseUrl: ${target}${comment}`;
+                    }
                 }
             }
         }
+        writeOverlayFileAtomic(overlay, "models.yml", lines.join("\n"));
     }
-    const overlay = `${ompHome}-bili`;
-    if (!refreshOverlayHome(ompHome, overlay, "models.yml")) return undefined;
-    writeOverlayFileAtomic(overlay, "models.yml", lines.join("\n"));
+    writeOmpCompactionDisabledConfig(ompHome, overlay);
     return overlay;
 }
 
@@ -1881,8 +1978,8 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
         // ship the bili plugin — when the config carries no loadable entry,
         // ride omp's `-e <file>` (loads for this run only, writes nothing)
         // instead of dropping to wire-mode fallback. A loadable entry (the
-        // overlay symlinks config.yml from the real home) already provides
-        // the plugin; adding `-e` too would double-register tools/commands.
+        // overlay's generated config.yml preserves the real home's entries)
+        // already provides the plugin; adding `-e` too would double-register.
         const ompExt = selfDistFile("agent/omp.js");
         if (ompExt && fs.existsSync(ompExt) && !ompPluginLoadedFrom(resolveOmpHome(process.env))) {
             clientArgs = ["-e", ompExt, ...clientArgs];

--- a/tests/launcher.test.ts
+++ b/tests/launcher.test.ts
@@ -1092,6 +1092,7 @@ test("prepareOmpHttpRewrite: rewrites matching provider, leaves others, symlinks
         ].join("\n"),
     );
     fs.writeFileSync(path.join(home, "config.yml"), "extensions:\n  - /x/omp.js\n");
+    fs.writeFileSync(path.join(home, "auth.json"), '{"key":"x"}');
     const tmp = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", [
         { key: "a", realUpstream: "http://example.com/v1" },
     ], []);
@@ -1100,11 +1101,88 @@ test("prepareOmpHttpRewrite: rewrites matching provider, leaves others, symlinks
         const out = fs.readFileSync(path.join(tmp!, "models.yml"), "utf8");
         assert.ok(out.includes("baseUrl: http://127.0.0.1:8787/bili/http://example.com/v1"), "a rewritten");
         assert.ok(out.includes("baseUrl: https://secure.example.com"), "b unchanged");
-        assert.equal(fs.lstatSync(path.join(tmp!, "config.yml")).isSymbolicLink(), true);
-        assert.equal(fs.realpathSync(path.join(tmp!, "config.yml")), path.join(home, "config.yml"));
+        assert.equal(fs.lstatSync(path.join(tmp!, "auth.json")).isSymbolicLink(), true, "sibling symlinked");
+        assert.equal(fs.realpathSync(path.join(tmp!, "auth.json")), path.join(home, "auth.json"));
+        assert.equal(fs.lstatSync(path.join(tmp!, "config.yml")).isSymbolicLink(), false, "config.yml generated, not symlinked");
+        const cfg = fs.readFileSync(path.join(tmp!, "config.yml"), "utf8");
+        assert.ok(cfg.includes("extensions:"), "config.yml preserves other keys");
+        assert.ok(cfg.includes("compaction:"), "config.yml has compaction block");
+        assert.ok(cfg.includes("enabled: false"), "omp native compaction disabled");
     } finally {
         if (tmp) fs.rmSync(tmp, { recursive: true, force: true });
         fs.rmSync(home, { recursive: true, force: true });
+    }
+});
+
+test("prepareOmpHttpRewrite: non-existent home → undefined", () => {
+    assert.equal(prepareOmpHttpRewrite("/nonexistent-bili-omp-home-xyz", "http://127.0.0.1:8787", [], []), undefined);
+});
+
+test("prepareOmpHttpRewrite: no rewrites → overlay built, omp native compaction disabled, models.yml copied verbatim", () => {
+    const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "bili-omphome-")));
+    fs.writeFileSync(path.join(home, "models.yml"), "providers:\n  a:\n    baseUrl: https://keep.example.com\n");
+    try {
+        const overlay = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", [], []);
+        assert.ok(typeof overlay === "string" && overlay.length > 0);
+        const cfg = fs.readFileSync(path.join(overlay!, "config.yml"), "utf8");
+        assert.ok(cfg.includes("enabled: false"), "omp native compaction disabled");
+        const out = fs.readFileSync(path.join(overlay!, "models.yml"), "utf8");
+        assert.ok(out.includes("baseUrl: https://keep.example.com"), "no rewrite → baseUrl untouched");
+    } finally {
+        fs.rmSync(home, { recursive: true, force: true });
+        fs.rmSync(`${home}-bili`, { recursive: true, force: true });
+    }
+});
+
+test("prepareOmpHttpRewrite: preserves other config.yml keys, disables only compaction", () => {
+    const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "bili-omphome-")));
+    fs.writeFileSync(path.join(home, "config.yml"), "theme: dark\nmodel: omp/large\nextensions:\n  - /x/omp.js\n");
+    try {
+        const overlay = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", [], []);
+        assert.ok(typeof overlay === "string");
+        const cfg = fs.readFileSync(path.join(overlay!, "config.yml"), "utf8");
+        assert.ok(cfg.includes("theme: dark"), "theme preserved");
+        assert.ok(cfg.includes("model: omp/large"), "model preserved");
+        assert.ok(cfg.includes("extensions:"), "extensions preserved");
+        assert.ok(cfg.includes("compaction:"), "compaction block added");
+        assert.ok(cfg.includes("enabled: false"), "compaction disabled");
+    } finally {
+        fs.rmSync(home, { recursive: true, force: true });
+        fs.rmSync(`${home}-bili`, { recursive: true, force: true });
+    }
+});
+
+test("prepareOmpHttpRewrite: existing compaction block → enabled overridden to false, other compaction keys preserved", () => {
+    const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "bili-omphome-")));
+    fs.writeFileSync(path.join(home, "config.yml"), "theme: dark\ncompaction:\n  enabled: true\n  reserveTokens: 8000\n");
+    try {
+        const overlay = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", [], []);
+        assert.ok(typeof overlay === "string");
+        const cfg = fs.readFileSync(path.join(overlay!, "config.yml"), "utf8");
+        assert.ok(cfg.includes("theme: dark"), "theme preserved");
+        assert.ok(cfg.includes("enabled: false"), "enabled overridden to false");
+        assert.ok(!cfg.includes("enabled: true"), "old enabled: true gone");
+        assert.ok(cfg.includes("reserveTokens: 8000"), "other compaction keys preserved");
+    } finally {
+        fs.rmSync(home, { recursive: true, force: true });
+        fs.rmSync(`${home}-bili`, { recursive: true, force: true });
+    }
+});
+
+test("prepareOmpHttpRewrite: legacy settings.json (no config.yml) → config.yml generated from it, compaction disabled", () => {
+    const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "bili-omphome-")));
+    fs.writeFileSync(path.join(home, "settings.json"), JSON.stringify({ theme: "dark", compaction: { reserveTokens: 1234 } }));
+    try {
+        const overlay = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", [], []);
+        assert.ok(typeof overlay === "string");
+        const cfg = fs.readFileSync(path.join(overlay!, "config.yml"), "utf8");
+        const parsed = JSON.parse(cfg);
+        assert.equal(parsed.compaction.enabled, false, "compaction disabled");
+        assert.equal(parsed.compaction.reserveTokens, 1234, "other compaction keys preserved");
+        assert.equal(parsed.theme, "dark", "theme preserved");
+    } finally {
+        fs.rmSync(home, { recursive: true, force: true });
+        fs.rmSync(`${home}-bili`, { recursive: true, force: true });
     }
 });
 
@@ -1249,13 +1327,18 @@ test("prepareOmpHttpRewrite: returns undefined when no rewrites", () => {
     assert.equal(prepareOmpHttpRewrite("/whatever", "http://127.0.0.1:8787", [], []), undefined);
 });
 
-test("prepareOmpHttpRewrite: returns undefined when models.yml missing", () => {
-    const home = fs.mkdtempSync(path.join(os.tmpdir(), "bili-omphome-"));
+test("prepareOmpHttpRewrite: models.yml missing → overlay still built (config.yml generated), no models.yml", () => {
+    const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "bili-omphome-")));
     try {
         const rw = [{ key: "a", realUpstream: "http://example.com/v1" }];
-        assert.equal(prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", rw, []), undefined);
+        const overlay = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", rw, []);
+        assert.equal(overlay, `${home}-bili`);
+        assert.equal(fs.existsSync(path.join(overlay!, "config.yml")), true, "config.yml generated");
+        assert.ok(fs.readFileSync(path.join(overlay!, "config.yml"), "utf8").includes("enabled: false"), "omp native compaction disabled");
+        assert.equal(fs.existsSync(path.join(overlay!, "models.yml")), false, "no models.yml copied");
     } finally {
         fs.rmSync(home, { recursive: true, force: true });
+        fs.rmSync(`${home}-bili`, { recursive: true, force: true });
     }
 });
 


### PR DESCRIPTION
## What happened

#454 was a **stacked PR**: its base was `2026-09-02_pi-disable-native-compaction` (#448's branch), not `master`. The merge sequence was:

1. #421 → master (1000c12, 04:26:32Z) ✅
2. #448 → master (cdbf2bc, 04:27:14Z) ✅
3. #454 → **merged 04:27:49Z into the pi branch** (b36d418), which had already been merged 35s earlier — so the omp fix never reached master

Evidence:
- `git merge-base --is-ancestor b36d4183 master` → **NO**; b36d4183 lives only on `origin/2026-09-02_pi-disable-native-compaction`
- master's `prepareOmpHttpRewrite` is still the old version (models.yml-only, no generated config.yml, no `compaction.enabled=false` for omp)
- The stranded content is exactly one commit: 01212cc `fix: bili omp launcher disables omp's native auto-compaction (#449)`
- #449 was closed as completed, but the fix is absent from master

## This PR

Merges the pi-branch tip into master, bringing in exactly the missing #454 content (`cdbf2bc..b36d4183` = 01212cc only). Clean merge, no conflicts.

## Pre-flight

- `npm run typecheck` ✅
- Full suite: **956/958** — the 2 failures are the known permanent `plugin-agent.test.ts` ones (reproduce on clean master)
- `tests/launcher.test.ts` + `tests/launcher-plugin-mode.test.ts`: **130/130** ✅

## After merge

- Re-close comment on #449 pointing here
- omp launcher compaction disable finally effective; pairs with #421 (archive path) already on master

Human merges, as always.