### PR TITLE
release v0.1.75

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.71",
+  "version": "0.1.75",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.71",
+      "version": "0.1.75",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.74",
+  "version": "0.1.75",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Version bump only (`0.1.74` → `0.1.75`) + `package-lock.json` version fields synced (they had drifted to `0.1.71` across the last few releases; `npm install --package-lock-only` touched nothing else).

## Changes since v0.1.74

| Change | Fixes | Notes |
|---|---|---|
| omp native-compaction archive: `markCompactionBoundary` + `POST /__bili/plugin/compact` + `applyCompactionArchive` | #395 | PR #421 |
| pi launcher disables native auto-compaction (settings.json overlay merge) | #447 | PR #448 |
| omp launcher disables native auto-compaction (generated config.yml overlay) | #449 | PR #454 (stranded on a merged base, recovered via #483) |
| Hard backstop for plugin-mode context overflow: `max_tokens` clamp (`clampOutputBudget`/`estimateInputTokens`) + emergency nudge at 0.7 | #453 | PR #467, E2E verified |
| Overlay merge hardening (SQLite set adjudication, -journal, conflict rename) | #381 family | ework, shipped via #396 |

Full diff: 7 non-merge commits since `v0.1.74`.

## Pre-flight (local, on this branch)

- `npm run typecheck` ✓
- `npm test` — 966/968 (2 = known permanent `plugin-agent.test.ts` env failures, reproduce on clean master)
- `npm run build` ✓

Merge is human-only as always; CI publishes on merge.