### PR TITLE
fix: abort-path usage drop, upstream-timer leak, and bare AbortError logs (#411)

### DIFF
--- a/src/fetch-util.ts
+++ b/src/fetch-util.ts
@@ -11,6 +11,15 @@
 export const MAX_REQUEST_BYTES = 100 * 1024 * 1024;
 export const UPSTREAM_TIMEOUT_MS = 10 * 60 * 1000;
 
+const liveUpstreamTimers = new Set<ReturnType<typeof setTimeout>>();
+/** Test hook: how many fetchWithTimeout idle-timers are currently armed.
+ *  #411: an aborted passthrough used to leak its 10-minute timer because
+ *  clearTimer was only called on the success path — tests assert this stays
+ *  at zero after a client abort. */
+export function _liveUpstreamTimersForTest(): number {
+    return liveUpstreamTimers.size;
+}
+
 /** undici's fetch accepts a `dispatcher` option (its own Dispatcher type) that
  *  @types/node's RequestInit already declares — but typed as the internal
  *  `Dispatcher` interface, which conflicts with the `undici` package's
@@ -43,10 +52,19 @@ export async function fetchWithTimeout(
     externalSignal?: AbortSignal,
 ): Promise<{ response: Response; clearTimer: () => void }> {
     const controller = new AbortController();
-    let timer = setTimeout(() => controller.abort(), timeoutMs);
+    const armTimer = () => {
+        const t = setTimeout(() => {
+            liveUpstreamTimers.delete(t);
+            controller.abort();
+        }, timeoutMs);
+        liveUpstreamTimers.add(t);
+        return t;
+    };
+    let timer = armTimer();
     const rearm = () => {
         clearTimeout(timer);
-        timer = setTimeout(() => controller.abort(), timeoutMs);
+        liveUpstreamTimers.delete(timer);
+        timer = armTimer();
     };
     let onExternalAbort: (() => void) | null = null;
     if (externalSignal) {
@@ -58,6 +76,7 @@ export async function fetchWithTimeout(
     }
     const cleanup = () => {
         clearTimeout(timer);
+        liveUpstreamTimers.delete(timer);
         if (onExternalAbort && externalSignal) externalSignal.removeEventListener("abort", onExternalAbort);
     };
     try {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -622,6 +622,16 @@ export async function pipePluginChatWithStrip(
             return new Promise<void>((r) => res.once("drain", () => r()));
         }
     };
+    // #411: an aborted read (client cancel / upstream cut) must still land the
+    // usage sniffed so far — anthropic message_start reports input_tokens
+    // before any prose, and dropping it froze lastInputTokens at the previous
+    // turn's value, corrupting every later nudge decision.
+    const settleUsage = () => {
+        if (session && (acc.inputTokens !== undefined || acc.outputTokens !== undefined || acc.cachedTokens !== undefined)) {
+            applyUsageSample(session, acc, protocol);
+            markDirty(session);
+        }
+    };
     const pushField = (field: string, index: number, text: string): [string, boolean] => {
         const s = filterFor(field, index);
         const clean = s.filter.push(text);
@@ -731,10 +741,14 @@ export async function pipePluginChatWithStrip(
         }
         const rest = flushTails();
         if (rest.length > 0 && !res.destroyed && !res.writableEnded) await write(rest);
-        if (session && (acc.inputTokens !== undefined || acc.outputTokens !== undefined || acc.cachedTokens !== undefined)) {
-            applyUsageSample(session, acc, protocol);
-            markDirty(session);
+        settleUsage();
+    } catch (e) {
+        settleUsage();
+        if (res.destroyed || res.writableEnded) {
+            log?.("client aborted mid-stream");
+            return;
         }
+        throw e;
     } finally {
         reader.releaseLock();
         res.end();
@@ -788,6 +802,14 @@ export async function pipePluginResponsesWithStrip(
     const write = (s: string) => {
         if (!res.write(Buffer.from(s, "utf8"))) {
             return new Promise<void>((r) => res.once("drain", () => r()));
+        }
+    };
+    // #411: keep the usage sniffed before an abort (see
+    // pipePluginChatWithStrip).
+    const settleUsage = () => {
+        if (session && (acc.inputTokens !== undefined || acc.outputTokens !== undefined || acc.cachedTokens !== undefined)) {
+            applyUsageSample(session, acc, "responses");
+            markDirty(session);
         }
     };
     let lastDeltaMeta: { item_id?: unknown; output_index?: unknown } | null = null;
@@ -870,10 +892,14 @@ export async function pipePluginResponsesWithStrip(
             const rest = flushTail("");
             if (rest.length > 0) await write(rest);
         }
-        if (session && (acc.inputTokens !== undefined || acc.outputTokens !== undefined || acc.cachedTokens !== undefined)) {
-            applyUsageSample(session, acc, "responses");
-            markDirty(session);
+        settleUsage();
+    } catch (e) {
+        settleUsage();
+        if (res.destroyed || res.writableEnded) {
+            log?.("client aborted mid-stream");
+            return;
         }
+        throw e;
     } finally {
         reader.releaseLock();
         res.end();
@@ -909,10 +935,19 @@ export async function pipePluginJson(
     // (#460 residual) — pass no session there so usage accounting stays off.
     const reader = stream.getReader();
     const chunks: Buffer[] = [];
-    for (;;) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        if (value && value.length > 0) chunks.push(Buffer.from(value));
+    try {
+        for (;;) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            if (value && value.length > 0) chunks.push(Buffer.from(value));
+        }
+    } catch (e) {
+        // #411: a non-stream body cut mid-read has nothing parseable left, but
+        // the response must still end and a client cancel must not surface as
+        // a context-free error.
+        if (!res.writableEnded) res.end();
+        if (res.destroyed || res.writableEnded) return;
+        throw e;
     }
     reader.releaseLock();
     const text = Buffer.concat(chunks).toString("utf8");

--- a/src/server.ts
+++ b/src/server.ts
@@ -320,7 +320,14 @@ export async function startServer(opts: ProxyOptions): Promise<http.Server> {
             await handle(req, res, opts, core, config, log, instanceId, instanceStartedAt);
         } catch (err) {
             const msg = String(err);
-            log("error", msg);
+            const e = err as { name?: string; message?: string };
+            // #411: a client cancel aborts the upstream fetch via
+            // res.on("close") — normal agent behavior, not a proxy failure.
+            // With the client already gone it is logged as info instead of
+            // feeding the context-free [error] AbortError storm.
+            const clientAbort = (e?.name === "AbortError" || /abort/i.test(String(e?.message ?? ""))) && (res.destroyed || res.writableEnded);
+            if (clientAbort) log("info", `client aborted mid-stream: ${msg}`);
+            else log("error", msg);
             if (!res.headersSent) {
                 const status = msg.includes("exceeds") ? 413 : 502;
                 res.writeHead(status, { "content-type": "application/json" });
@@ -2646,35 +2653,46 @@ async function forward(
     // plugin untouched) while sniffing usage so lastInputTokens (the input to
     // the next nudge decision) keeps tracking reality.
     if (prepared?.pluginMode) {
-        if (prepared.stream) {
-            if (prepared.protocol === "responses") {
-                await pipePluginResponsesWithStrip(upstream.body as ReadableStream<Uint8Array>, res, prepared.session, (msg) => log("info", `[${prepared.session.id}] ${msg}`));
+        // #411: clear the idle timer on the abort path too — the pipes rethrow
+        // when the client is still connected, and a client cancel throws from
+        // inside them; without a finally each abort leaked a 10-minute timer.
+        try {
+            if (prepared.stream) {
+                if (prepared.protocol === "responses") {
+                    await pipePluginResponsesWithStrip(upstream.body as ReadableStream<Uint8Array>, res, prepared.session, (msg) => log("info", `[${prepared.session.id}] ${msg}`));
+                } else {
+                    await pipePluginChatWithStrip(upstream.body as ReadableStream<Uint8Array>, res, prepared.protocol, prepared.session, (msg) => log("info", `[${prepared.session.id}] ${msg}`));
+                }
             } else {
-                await pipePluginChatWithStrip(upstream.body as ReadableStream<Uint8Array>, res, prepared.protocol, prepared.session, (msg) => log("info", `[${prepared.session.id}] ${msg}`));
+                await pipePluginJson(upstream.body as ReadableStream<Uint8Array>, res, prepared.session, prepared.protocol);
             }
-        } else {
-            await pipePluginJson(upstream.body as ReadableStream<Uint8Array>, res, prepared.session, prepared.protocol);
+        } finally {
+            clearUpstreamTimer();
         }
-        clearUpstreamTimer();
         return;
     }
     // #371: detect + retry a fake completion for every non-plugin streaming
     // response (any turn, not just compress-injected). Buffering is required:
     // the retry re-requests before the client sees the fake completion.
     let responseBody: ReadableStream<Uint8Array> = upstream.body;
-    if (prepared !== null && prepared.stream && maxFakeCompletionRetries() > 0) {
-        const resolvedBuf = await resolveFakeCompletion(upstream.body, {
-            protocol: prepared.protocol,
-            body,
-            upstreamUrl,
-            reqHeaders: buildForwardHeaders(headers),
-            proxyUrl,
-            signal: clientAbort.signal,
-            session: prepared.session,
-            log,
-        });
-        responseBody = bufferToStream(resolvedBuf);
-    }
+    // #411: every body-consuming path below must clear the upstream idle timer
+    // even when it throws (client abort / upstream cut) — previously an abort
+    // skipped the trailing clearUpstreamTimer and leaked a live 10-minute
+    // timer plus its socket for the full window.
+    try {
+        if (prepared !== null && prepared.stream && maxFakeCompletionRetries() > 0) {
+            const resolvedBuf = await resolveFakeCompletion(upstream.body, {
+                protocol: prepared.protocol,
+                body,
+                upstreamUrl,
+                reqHeaders: buildForwardHeaders(headers),
+                proxyUrl,
+                signal: clientAbort.signal,
+                session: prepared.session,
+                log,
+            });
+            responseBody = bufferToStream(resolvedBuf);
+        }
     // We only rewrite when THIS request actually had the compress tool
     // injected (per-request). Non-injected requests (OpenAI title-gen
     // exclusion, ACP_NO_INJECT_TOOL, auto-mode classifier bypass) must NOT
@@ -2700,7 +2718,6 @@ async function forward(
             } else {
                 await pipeThrough(toClient, res);
             }
-            clearUpstreamTimer();
             const terminal = await observed;
             if (terminal === "completed") {
                 markNativeCompactionBoundary(prepared.session);
@@ -2725,7 +2742,6 @@ async function forward(
             } else {
                 await pipePluginChatWithStrip(responseBody, res, p.protocol, undefined, tagLog);
             }
-            clearUpstreamTimer();
         } else if (
             prepared &&
             (upstream.headers.get("content-type") ?? "").includes("application/json")
@@ -2736,10 +2752,8 @@ async function forward(
             // back untouched. Same pipe as plugin mode; no session, so usage
             // accounting stays off for the same reason as above.
             await pipePluginJson(responseBody, res, undefined, prepared.protocol);
-            clearUpstreamTimer();
         } else {
             await pipeThrough(responseBody, res);
-            clearUpstreamTimer();
         }
         return;
     }
@@ -2821,6 +2835,10 @@ async function forward(
         } finally {
             clearUpstreamTimer();
             if (dumpRaw) await dumpRaw;
+            // #411: persist the final snapshot on every exit (see the
+            // non-streaming twin below) — state may have mutated during
+            // streaming (compress created a block, decompress deactivated one).
+            markDirty(prepared.session);
         }
     } else {
         // Wrap the whole non-streaming branch in try/finally so the upstream
@@ -2885,11 +2903,20 @@ async function forward(
             }
         } finally {
             clearUpstreamTimer();
+            // #411: persist even when arrayBuffer() throws (client cancel /
+            // connection reset) — the comment above promised this, but
+            // markDirty sat outside the try and was skipped on the throw path.
+            markDirty(prepared.session);
         }
     }
-    // State may have mutated during response streaming (compress created a
-    // block, decompress deactivated one) — persist the final snapshot.
-    markDirty(prepared.session);
+    } finally {
+        // #411 safety net: clears on every exit — the early returns above, the
+        // rewriter throws, and the fall-through completion. The rewriter paths
+        // clear earlier in their own finallys (double-clear is idempotent);
+        // this one must sit at the very end so clearing never happens while a
+        // live stream still needs the external-abort listener.
+        clearUpstreamTimer();
+    }
 }
 
 /** Read a (small) fetch Response body stream fully into a Buffer. Used for the

--- a/tests/issue411-abort-usage.test.ts
+++ b/tests/issue411-abort-usage.test.ts
@@ -1,0 +1,240 @@
+import assert from "node:assert";
+import http from "node:http";
+import { once } from "node:events";
+import test from "node:test";
+
+process.env.NODE_ENV = "test";
+
+import { defaultConfig } from "acp-kernel";
+import { startServer, type ProxyOptions } from "../src/server.ts";
+import { SessionStore, _setStoreForTest } from "../src/persist.ts";
+import { _setForTest as setRegistryForTest } from "../src/registry.ts";
+import { _resetPluginStateForTest } from "../src/plugin.ts";
+import { listSessions } from "../src/session.ts";
+import { setLogCapture } from "../src/logger.ts";
+import { _liveUpstreamTimersForTest } from "../src/fetch-util.ts";
+
+// #411: a client cancel mid-stream used to (1) drop the usage already sniffed
+// (anthropic message_start input) so lastInputTokens froze at the previous
+// turn, (2) log a context-free global [error] AbortError (~260/day on a real
+// host), and (3) leak the fetchWithTimeout 10-minute idle timer because
+// clearUpstreamTimer only ran on success paths. These tests drive real client
+// aborts through the proxy against a slow-drip upstream.
+
+function listen(server: http.Server): Promise<void> {
+    if (server.listening) return Promise.resolve();
+    return once(server, "listening").then(() => void 0);
+}
+
+function close(server: http.Server): Promise<void> {
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    server.close((error) => (error ? reject(error) : resolve()));
+    return promise;
+}
+
+function anthropicSse(event: string, data: unknown): string {
+    return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+interface Rig {
+    proxyPort: number;
+    proxyUrl: (path: string) => string;
+    modelUrl: () => string;
+    closeAll(): Promise<void>;
+}
+
+type UpstreamMode = "drip" | "cut" | "delayed-json";
+
+async function startRig(mode: UpstreamMode = "drip"): Promise<Rig> {
+    const upstream = http.createServer((req, res) => {
+        if (mode === "delayed-json") {
+            setTimeout(() => {
+                res.writeHead(200, { "content-type": "application/json" });
+                res.end(JSON.stringify({ id: "x", usage: { input_tokens: 99, output_tokens: 1 } }));
+            }, 500);
+            return;
+        }
+        res.writeHead(200, { "content-type": "text/event-stream" });
+        res.write(anthropicSse("message_start", { type: "message_start", message: { id: "m1", role: "assistant", usage: { input_tokens: 1234 } } }));
+        res.write(anthropicSse("content_block_start", { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } }));
+        if (mode === "cut") {
+            setTimeout(() => res.destroy(), 50);
+            return;
+        }
+        let i = 0;
+        const t = setInterval(() => {
+            res.write(anthropicSse("content_block_delta", { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: `x${i++} ` } }));
+        }, 25);
+        req.on("close", () => {
+            clearInterval(t);
+            res.destroy();
+        });
+    });
+    upstream.listen(0, "127.0.0.1");
+    await listen(upstream);
+    const upstreamPort = (upstream.address() as { port: number }).port;
+
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    setRegistryForTest({});
+    _resetPluginStateForTest();
+
+    const opts: ProxyOptions = {
+        port: 0,
+        host: "127.0.0.1",
+        upstream: "http://127.0.0.1",
+        routes: { [`http://127.0.0.1:${upstreamPort}`]: { models: { "i411-model": { context: 100_000 } } } },
+        modelContextLimit: 100_000,
+        kernelConfig: defaultConfig(100_000),
+        compress: { injectTool: true, injectNudge: true },
+        promptCache: { routing: "auto" },
+        log: true,
+        logFile: "/dev/null",
+        sessionHeader: "x-acp-session",
+        debug: false,
+        passthrough: false,
+        autoUpdate: false,
+        mitm: { enabled: false, domains: [] },
+    };
+    const proxy = await startServer(opts);
+    await listen(proxy);
+    const proxyPort = (proxy.address() as { port: number }).port;
+    return {
+        proxyPort,
+        proxyUrl: (path) => `http://127.0.0.1:${proxyPort}${path}`,
+        modelUrl: () => `http://127.0.0.1:${proxyPort}/bili/http://127.0.0.1:${upstreamPort}/v1/messages`,
+        closeAll: async () => {
+            await close(proxy);
+            await close(upstream);
+        },
+    };
+}
+
+async function register(rig: Rig, conversationId: string): Promise<void> {
+    const res = await fetch(rig.proxyUrl("/__bili/plugin/register"), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ conversationId, agent: "mcp" }),
+    });
+    assert.equal(res.status, 200, "register accepted");
+}
+
+function modelBody(stream: boolean): string {
+    return JSON.stringify({ model: "i411-model", max_tokens: 10, stream, messages: [{ role: "user", content: "hello" }] });
+}
+
+async function waitFor(cond: () => boolean, ms = 3000): Promise<void> {
+    const t0 = Date.now();
+    while (!cond()) {
+        if (Date.now() - t0 > ms) throw new Error("condition not met within timeout");
+        await new Promise((r) => setTimeout(r, 25));
+    }
+}
+
+test("#411 plugin stream: client abort keeps sniffed usage, logs info (not error), clears the upstream timer", async () => {
+    const rig = await startRig("drip");
+    const captured: { level: string; msg: string }[] = [];
+    setLogCapture((level, msg) => captured.push({ level, msg }));
+    try {
+        await register(rig, "i411-conv-1");
+        const ac = new AbortController();
+        const res = await fetch(rig.modelUrl(), { method: "POST", headers: { "content-type": "application/json" }, body: modelBody(true), signal: ac.signal });
+        assert.equal(res.status, 200);
+        const reader = res.body!.getReader();
+        await reader.read();
+        await reader.read();
+        ac.abort();
+        await waitFor(() => listSessions().some((s) => s.stats.lastInputTokens === 1234));
+        await waitFor(() => _liveUpstreamTimersForTest() === 0);
+        assert.ok(captured.some((l) => l.level === "info" && l.msg.includes("client aborted mid-stream")), `expected info abort log, got: ${JSON.stringify(captured)}`);
+        assert.ok(!captured.some((l) => l.level === "error" && l.msg.includes("AbortError")), `no bare AbortError error log, got: ${JSON.stringify(captured.filter((l) => l.level === "error"))}`);
+    } finally {
+        setLogCapture(null);
+        await rig.closeAll();
+    }
+});
+
+test("#411 abort storm: repeated client cancels do not accumulate upstream timers", async () => {
+    const rig = await startRig("drip");
+    try {
+        await register(rig, "i411-conv-2");
+        for (let round = 0; round < 3; round++) {
+            const ac = new AbortController();
+            const res = await fetch(rig.modelUrl(), { method: "POST", headers: { "content-type": "application/json" }, body: modelBody(true), signal: ac.signal });
+            const reader = res.body!.getReader();
+            await reader.read();
+            await reader.read();
+            ac.abort();
+            await waitFor(() => _liveUpstreamTimersForTest() === 0);
+        }
+        assert.equal(_liveUpstreamTimersForTest(), 0);
+    } finally {
+        await rig.closeAll();
+    }
+});
+
+test("#411 upstream cut with client alive: usage still lands, failure is a real error", async () => {
+    const rig = await startRig("cut");
+    const captured: { level: string; msg: string }[] = [];
+    setLogCapture((level, msg) => captured.push({ level, msg }));
+    try {
+        await register(rig, "i411-conv-3");
+        const res = await fetch(rig.modelUrl(), { method: "POST", headers: { "content-type": "application/json" }, body: modelBody(true) });
+        assert.equal(res.status, 200);
+        const reader = res.body!.getReader();
+        try {
+            for (;;) {
+                const { done } = await reader.read();
+                if (done) break;
+            }
+        } catch {
+            // upstream socket destroyed mid-stream — the client sees a cut
+        }
+        await waitFor(() => listSessions().some((s) => s.stats.lastInputTokens === 1234));
+        await waitFor(() => _liveUpstreamTimersForTest() === 0);
+        assert.ok(!captured.some((l) => l.msg.includes("client aborted mid-stream")), "client-alive cut must not be classified as a client abort");
+    } finally {
+        setLogCapture(null);
+        await rig.closeAll();
+    }
+});
+
+test("#411 plugin non-stream: client abort mid-body does not crash and clears the timer", async () => {
+    const rig = await startRig("delayed-json");
+    try {
+        await register(rig, "i411-conv-4");
+        const ac = new AbortController();
+        const p = fetch(rig.modelUrl(), { method: "POST", headers: { "content-type": "application/json" }, body: modelBody(false), signal: ac.signal });
+        const res = await p;
+        assert.equal(res.status, 200);
+        setTimeout(() => ac.abort(), 60);
+        await assert.doesNotReject(async () => {
+            try {
+                await res.arrayBuffer();
+            } catch {
+                // aborted mid-body — expected
+            }
+        });
+        await waitFor(() => _liveUpstreamTimersForTest() === 0);
+    } finally {
+        await rig.closeAll();
+    }
+});
+
+test("#411 anonymous passthrough: client abort clears the timer and logs info", async () => {
+    const rig = await startRig("drip");
+    const captured: { level: string; msg: string }[] = [];
+    setLogCapture((level, msg) => captured.push({ level, msg }));
+    try {
+        const ac = new AbortController();
+        const res = await fetch(rig.modelUrl(), { method: "GET", signal: ac.signal });
+        assert.equal(res.status, 200);
+        const reader = res.body!.getReader();
+        await reader.read();
+        ac.abort();
+        await waitFor(() => _liveUpstreamTimersForTest() === 0);
+        assert.ok(!captured.some((l) => l.level === "error" && l.msg.includes("AbortError")), `no bare AbortError error log, got: ${JSON.stringify(captured.filter((l) => l.level === "error"))}`);
+    } finally {
+        setLogCapture(null);
+        await rig.closeAll();
+    }
+});


### PR DESCRIPTION
Fixes #411.

## Defects

1. **Usage drop on client abort** — `pipePluginChatWithStrip` / `pipePluginResponsesWithStrip` only ran `applyUsageSample` at the try-tail; a client disconnect mid-stream skipped it, so `lastInputTokens` froze at the pre-turn value and corrupted later nudge/budget decisions (same input-corruption family as #453).
2. **Upstream idle-timer leak** — `forward()` had `await pipe*(); clearUpstreamTimer();` with no try/finally on several paths; each client abort left one live `setTimeout` (up to 10 min) plus a detached abort listener. ~260 aborts/day per busy proxy.
3. **Bare `[error] AbortError` log spam** — the server-level catch logged `String(err)` with no classification or session context.
4. **Non-stream persistence gap** — `markDirty(prepared.session)` sat outside the try in the non-stream rewriter path; the adjacent comment promised persistence on throw but the code skipped it.

## Fix

- **src/plugin.ts**: both SSE pipes now `settleUsage()` (applyUsageSample + markDirty) at the try-tail **and** in the catch. Client-abort errors are swallowed once the response is destroyed/ended (`client aborted mid-stream`, info-level), everything else rethrows. `pipePluginJson` gets a try/catch around its read loop.
- **src/server.ts**: `forward()` wraps every upstream-body-consuming path in a single try/finally so `clearUpstreamTimer()` runs on every exit (the rewriter paths keep their own earlier clears; double-clear is idempotent). Both rewriter finallys now `markDirty(prepared.session)`. The server catch classifies `AbortError` + closed response as `info: client aborted mid-stream: <msg>` instead of `error`.
- **src/fetch-util.ts**: tracks live upstream timers in a module-level Set (self-removing), exposed via `_liveUpstreamTimersForTest()` for leak assertions.

Note: usage that only arrives in a stream's final chunk (openai chat `stream_options.include_usage`, Responses `response.completed`) is inherently lost on early abort — nothing to salvage there. Anthropic usage arrives at `message_start` and is now salvaged.

## Tests

New `tests/issue411-abort-usage.test.ts` (5 tests):

1. plugin stream abort keeps `lastInputTokens=1234` (from `message_start`) + logs info, not a bare error
2. 3-round abort storm leaves zero live upstream timers
3. upstream cut with client alive still lands usage and is NOT misclassified as a client abort
4. non-stream plugin abort mid-body: no crash, timer cleared
5. anonymous passthrough abort: info not error, timer cleared

Pre-flight: `npm run typecheck` ✅ · `npm test` 971/973 (2 fails are the known permanent `plugin-agent.test.ts` pair, reproduce on clean master) ✅ · `npm run build` ✅

## Design note

One subtlety worth flagging for reviewers: `clearUpstreamTimer()` also **removes the external-abort listener** (via fetch cleanup). Calling it early — e.g. right after response headers but before the body is consumed — would sever the client→upstream abort chain. An earlier draft of this PR did exactly that and broke `tests/vscode-copilot.test.ts:147` ("upstream fetch was not aborted after client cancel"). The final shape wraps to the end of `forward()` so clearing only happens at real exits.