### PR TITLE
fix: recognize sglang's overflow error format in context-window self-heal

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -111,6 +111,7 @@ const CONTEXT_OVERFLOW_PATTERNS: RegExp[] = [
     /maximum context length/i,
     /max context length/i,
     /maximum context size/i,
+    /longer than the model'?s context length/i,
     /exceeds the context window/i,
     /out of room in the model/i,
     /exceeded model token limit/i,
@@ -140,6 +141,7 @@ function parseOverflowWindow(text: string): number | undefined {
         text.match(/maximum context length of (\d[\d,]*)/i) ??
         text.match(/maximum context size (?:is|of) (\d[\d,]*)/i) ??
         text.match(/(?:maximum|max)\s+(?:context\s+)?length\s+(?:is\s+)?(\d[\d,]*)/i) ??
+        text.match(/context length\s*\((\d[\d,]*)\s*token/i) ??
         text.match(/limit of (\d[\d,]*)\s*token/i) ??
         text.match(/(\d[\d,]*)\s*maximum\b/i);
     if (m) return toTokenNumber(m[1]);

--- a/tests/context-overflow.test.ts
+++ b/tests/context-overflow.test.ts
@@ -38,6 +38,20 @@ test("OpenAI Responses: 'exceeds the model's maximum context size of N' → over
     assert.equal(info.isOverflow, true);
     assert.equal(info.window, 128000);
 });
+test("sglang: 'input (N tokens) is longer than the model's context length (M tokens)' → overflow + window M", () => {
+    // Captured verbatim from a real sglang server; both wire formats share the
+    // message. The learned window must be the LIMIT (M), not the input size (N)
+    // — learning N would self-heal to a window larger than the real one.
+    const message = "The input (400013 tokens) is longer than the model's context length (262144 tokens).";
+    const chatBody = JSON.stringify({ object: "error", message, type: "BadRequestError", param: null, code: 400 });
+    const info = inspectContextOverflow(400, chatBody);
+    assert.equal(info.isOverflow, true);
+    assert.equal(info.window, 262144);
+    const responsesBody = JSON.stringify({ error: { message, type: "invalid_request_error", param: null, code: 400 } });
+    const info2 = inspectContextOverflow(400, responsesBody);
+    assert.equal(info2.isOverflow, true);
+    assert.equal(info2.window, 262144);
+});
 
 test("Anthropic: 'prompt is too long: X tokens > Y maximum' → window is Y", () => {    const body = JSON.stringify({
         type: "error",


### PR DESCRIPTION
## Problem

sglang's context-overflow error is not recognized by `inspectContextOverflow`, so the window self-heal never fires for sglang-backed sessions.

Captured verbatim from a running sglang server (both wire formats share the message):

```
HTTP 400
{"object":"error","message":"The input (400013 tokens) is longer than the model's context length (262144 tokens).","type":"BadRequestError","param":null,"code":400}
```

None of the existing `CONTEXT_OVERFLOW_PATTERNS` match this phrasing ("is longer than the model's context length"), so `isOverflow` stays `false`, the error is passed through as an ordinary 400, and bili never learns the real window. A session whose configured window exceeds sglang's actual limit then overflows on every retry — permanently stuck, because the one signal that could correct the window is ignored.

Found while investigating #436 (sglang-backed local model, window never self-heals).

## Fix (`src/util.ts`)

- Add pattern `/longer than the model'?s context length/i` to `CONTEXT_OVERFLOW_PATTERNS`.
- Add parser entry `/context length\s*\((\d[\d,]*)\s*token/i` to `parseOverflowWindow` — captures the LIMIT (the number after "context length"), never the input size that appears earlier in the same message.

## Test

New regression test in `tests/context-overflow.test.ts` using the verbatim captured bodies for both `/chat/completions` and `/responses` formats; asserts `isOverflow === true` and `window === 262144` (the limit, not the 400013 input size).

## Pre-flight

- `npm run typecheck` ✓
- `npm test`: `tests/context-overflow.test.ts` 20/20 ✓; full suite has 2 pre-existing environment-dependent failures in `tests/plugin-agent.test.ts` ("pi extension is inert without a proxy", "before_provider_headers stays silent when the manifest fetch keeps failing") — identical failures on clean master (verified via worktree), unrelated to this change
- `npm run build` ✓