### PR TITLE
release v0.1.76

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.75",
+  "version": "0.1.76",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.75",
+      "version": "0.1.76",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@types/node": "^22.0.0",
         "@types/node-forge": "^1.3.14",
-        "acp-kernel": "0.0.47",
+        "acp-kernel": "0.0.50",
         "fzstd": "0.1.1",
         "node-forge": "^1.4.0",
         "tar": "^7.5.22",
@@ -988,9 +988,9 @@
       }
     },
     "node_modules/acp-kernel": {
-      "version": "0.0.47",
-      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.47.tgz",
-      "integrity": "sha512-XxC8y/w1wPiaCA/euGb74XsWy9ndlZL+cHttKYCwAlmxHy9L9d2bY+Ed/h9cTctT4LI7EnpuKfJ3r3zSirq/yQ==",
+      "version": "0.0.50",
+      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.50.tgz",
+      "integrity": "sha512-ruwDMPcH4CYQDK9vDVdAcwc5vhAFxmracd1zSpDw/PHvfKOy0s3cj4FUtBBrfb1HVtUOVLJFPmad17CdWr0l5g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.75",
+  "version": "0.1.76",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/node-forge": "^1.3.14",
-    "acp-kernel": "0.0.47",
+    "acp-kernel": "0.0.50",
     "fzstd": "0.1.1",
     "node-forge": "^1.4.0",
     "tar": "^7.5.22",


### PR DESCRIPTION
## Changes since v0.1.75

- #490: `minCompressRangeChars` docs + `--min-compress-range` CLI alias + registry relay-conflict max-wins (bac8d91)
- #487 / #404: restored-session `lastSeen` fix (f037419)
- #486 / #473: plugin fake-completion detect + retry (37ecfce)
- #485 / #411: abort usage/timer leak fix (a3daf29)
- #335: codex compaction preflight-order fix (4f5fe7e, merged with #332 verbatim passthrough)

## Dependency

- acp-kernel `0.0.47` → `0.0.50` (exact pin). 0.0.50 is the revert release of the ref-reclamation change (#176) — restores the *message ids are never reused* invariant. Verified live on npm before bumping.

## Pre-flight

- `npm run typecheck` ✓
- `npm test` 988/990 — the 2 failures are the known permanent local-env plugin-agent fails (same on clean master)
- `npm run build` ✓
- Full diff: `package.json` + `package-lock.json` only (version + kernel pin)