### PR TITLE
release v0.1.77

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.76",
+  "version": "0.1.77",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.76",
+      "version": "0.1.77",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.76",
+  "version": "0.1.77",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Changes since v0.1.76

- **#489 / #488 — 多模态 token 统计 + Responses preflight `store:false`**:
  - 图片字节计入所有尺寸决策(preflight 触发、fit 门、self-heal 学窗、输出预算钳制),新增 `src/image-tokens.ts`(b64 = 长度/4,远程 URL 固定 4096,`BILI_IMAGE_TOKEN_CAP` 可钳制);图片单项超窗时 fail-fast 给出可操作提示,不再 400 死循环。
  - preflight 摘要请求(Responses 协议)补 `store: false`,修复 codex relay `Store must be set to false` 400 导致救援失败。

残留设计风险(不阻塞,已立案 #496):b64/4 默认计费在像素 tile 计费的官方 Anthropic/OpenAI 上图片单项估算 ≥ 窗口时会硬 502 误杀。

## Release commit

仅 `package.json` + `package-lock.json` 的 version 三处:`0.1.76` → `0.1.77`(2794d80)。acp-kernel 保持 `0.0.17` 精确 pin,未动。

## Pre-flight (本机)

- `npm run typecheck` ✅
- `npm test` 995/997 — 2 个失败为 `plugin-agent.test.ts` 的 `pi extension is inert without a proxy` / `before_provider_headers stays silent…`,在本沙箱纯净 master 上同样失败(环境依赖,非本改动引入)
- `npm run build` ✅
- #489 已在本机通过全量 codex e2e(真实 codex 0.147.0 + sglang,452s)

合并后 CI 自动 publish + tag `v0.1.77`。