### PR TITLE
fix(#436): scope launcher model windows to the launched client's own config

### DIFF
--- a/src/client-config.ts
+++ b/src/client-config.ts
@@ -566,17 +566,34 @@ export function loadClientConfig(env: NodeJS.ProcessEnv, cwd: string): ClientCon
     return config;
 }
 
-/** Collect per-model context windows from every client config the launcher
- *  can read (pi models.json, omp models.yml, opencode opencode.json, codex
- *  config.toml). Same model id under multiple providers → the LARGEST window
- *  wins (the client will route by id; the proxy only needs the denominator). */
-export function collectModelWindows(config: ClientConfig): Record<string, number> {
+/** The client a launcher run targets. Scopes model-window collection so a
+ *  launched client's own declarations are authoritative (#436: launching
+ *  `bili omp` with omp's models.yml declaring 131072 must not be overridden by
+ *  another client's larger declaration for the same model id). */
+export type ModelWindowScope = "claude" | "codex" | "pi" | "omp" | "opencode" | "hermes" | "dsh";
+
+/** Collect per-model context windows from client configs the launcher can
+ *  read (pi models.json, omp models.yml, opencode opencode.json, codex
+ *  config.toml). With `scope`, ONLY that client's declarations are collected —
+ *  the launched client's config is authoritative for its own proxy (#436:
+ *  cross-client max-wins silently discarded the user's smaller configured
+ *  window). Without `scope`, merges every client (legacy behavior). Same model
+ *  id under multiple providers of the same client → the LARGEST window wins
+ *  (the client will route by id; the proxy only needs the denominator). */
+export function collectModelWindows(config: ClientConfig, scope?: ModelWindowScope): Record<string, number> {
     const out: Record<string, number> = {};
     const add = (wins: ModelWindow[] | undefined): void => {
         for (const w of wins ?? []) {
             if (!out[w.id] || w.contextWindow > out[w.id]) out[w.id] = w.contextWindow;
         }
     };
+    if (scope) {
+        if (scope === "codex") add(config.codex?.modelWindows);
+        else if (scope === "pi") for (const p of Object.values(config.pi?.providers ?? {})) add(p.models);
+        else if (scope === "omp") for (const p of Object.values(config.omp?.providers ?? {})) add(p.models);
+        else if (scope === "opencode") for (const p of Object.values(config.opencode?.providers ?? {})) add(p.models);
+        return out;
+    }
     for (const p of Object.values(config.pi?.providers ?? {})) add(p.models);
     for (const p of Object.values(config.omp?.providers ?? {})) add(p.models);
     for (const p of Object.values(config.opencode?.providers ?? {})) add(p.models);

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -1945,7 +1945,7 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
     // used to resolve the budget-alignment window, #321).
     const biliRoutes = loadRoutes(process.env);
     const domains = dedupeInOrder([...routes.httpsDomains, ...(params.mitmDomains ?? [])]);
-    const handle = await ensureProxyRunning({ host, port, passthrough, debug, mitmDomains: domains, modelWindows: collectModelWindows(config) }, deps);
+    const handle = await ensureProxyRunning({ host, port, passthrough, debug, mitmDomains: domains, modelWindows: collectModelWindows(config, base) }, deps);
     console.error(
         `bili: started proxy at ${handle.origin} (MITM domains: ${domains.length ? domains.join(", ") : "defaults"})` +
             (routes.httpRewrites.length > 0 ? ` (HTTP /bili/ rewrites: ${routes.httpRewrites.length})` : "") +
@@ -2186,7 +2186,7 @@ export async function runTestPi(params: RunTestPiParams, deps: LauncherDeps = {}
         ...discoverDomains("pi", config),
         ...(params.mitmDomains ?? []),
     ]);
-    const handle = await ensureProxyRunning({ host, port, passthrough, debug, mitmDomains: domains, modelWindows: collectModelWindows(config) }, deps);
+    const handle = await ensureProxyRunning({ host, port, passthrough, debug, mitmDomains: domains, modelWindows: collectModelWindows(config, "pi") }, deps);
     console.error(
         `bili: started proxy at ${handle.origin} (MITM domains: ${domains.length ? domains.join(", ") : "defaults"})`,
     );

--- a/tests/model-windows.test.ts
+++ b/tests/model-windows.test.ts
@@ -140,6 +140,32 @@ test("collectModelWindows: same id across providers → largest window wins", ()
     assert.deepEqual(collectModelWindows(config), { m: 3000, "codex-m": 272000 });
 });
 
+test("collectModelWindows(scope): launched client's own declaration wins, other clients ignored (#436)", () => {
+    const config: ClientConfig = {
+        pi: { providers: { a: { baseUrl: "http://a", models: [{ id: "/mnt/m/qwen", contextWindow: 262144 }] } } },
+        omp: { providers: { b: { baseUrl: "http://b", models: [{ id: "/mnt/m/qwen", contextWindow: 131072 }] } } },
+        opencode: { providers: { c: { baseURL: "http://c", models: [{ id: "/mnt/m/qwen", contextWindow: 262144 }] } } },
+        codex: { providers: {}, modelWindows: [{ id: "codex-m", contextWindow: 272000 }] },
+    };
+    assert.deepEqual(collectModelWindows(config, "omp"), { "/mnt/m/qwen": 131072 });
+    assert.deepEqual(collectModelWindows(config, "pi"), { "/mnt/m/qwen": 262144 });
+    assert.deepEqual(collectModelWindows(config, "opencode"), { "/mnt/m/qwen": 262144 });
+    assert.deepEqual(collectModelWindows(config, "codex"), { "codex-m": 272000 });
+    assert.deepEqual(collectModelWindows(config, "hermes"), {});
+});
+
+test("collectModelWindows(scope): same id across providers of the SAME client → largest still wins", () => {
+    const config: ClientConfig = {
+        omp: {
+            providers: {
+                a: { baseUrl: "http://a", models: [{ id: "m", contextWindow: 1000 }] },
+                b: { baseUrl: "http://b", models: [{ id: "m", contextWindow: 3000 }] },
+            },
+        },
+    };
+    assert.deepEqual(collectModelWindows(config, "omp"), { m: 3000 });
+});
+
 test("parseLauncherModelWindows: valid JSON, invalid input, non-numeric filtered", () => {
     assert.deepEqual(parseLauncherModelWindows('{"qwen3.8-27b": 262144.9, "x": 100}'), { "qwen3.8-27b": 262144, x: 100 });
     assert.deepEqual(parseLauncherModelWindows(undefined), {});


### PR DESCRIPTION
## Root cause (#436)

The agent thread chased "131072 didn't reach the proxy" for a long time; the actual cause is one line: `collectModelWindows` merged **every** client's per-model declarations with **max-wins per model id** (`src/client-config.ts`), and both launcher call sites passed that merged map into `BILI_LAUNCHER_MODEL_WINDOWS`.

So with omp's models.yml declaring `contextWindow: 131072` for the path model and ANY other client config (pi models.json / codex config.toml / opencode.json) declaring the same id with the upstream's real serving limit (262144), the max-wins merge silently discarded the user's 120K:

- proxy window = 262144 → usage reads ~53%, 75%/95% pressure lines never crossed → no emergency compress;
- omp's own footer shows `100.5%/131K` (its real configured limit) → over-limit failures exactly as reported.

## Fix

`collectModelWindows(config, scope?)` — with `scope` (the launched client), ONLY that client's declarations are collected:

- `runLaunch` passes `base` (the client actually launched); `runTestPi` passes `"pi"`.
- Same model id across providers **of the same client** keeps largest-wins (documented per-client semantics, unchanged).
- Unscoped call keeps the legacy merged behavior (no other production call sites).
- Clients without window sources (claude/hermes/dsh) yield `{}` — their requests fall through to the registry/table fallbacks as before.

Result: `bili omp` now nudges against **omp's own 131072** — compression fires at 75%/95% of the window the user actually configured, and the `>100%` state can no longer be reached silently.

## Note for the reporter

This ships in the next release; after upgrade, restart bili (auto-update installs but does not restart the proxy process). Complementary fix already queued: PR #493 makes sglang's overflow error string recognizable so self-heal can also learn the real limit when it differs.

## Pre-flight

- `npm run typecheck` ✓
- `npm test` 990/992 — the 2 failures are the known permanent local-env plugin-agent fails (same on clean master)
- `npm run build` ✓
- New tests in `tests/model-windows.test.ts`: scoped collection ignores other clients; same-client multi-provider still max-wins; unscoped legacy unchanged