### PR TITLE
fix: stop legacy-id migration destroying anonymous pfa sessions (#499 prerequisite)

### DIFF
--- a/src/persist.ts
+++ b/src/persist.ts
@@ -215,6 +215,13 @@ export class SessionStore {
         const byLabel = new Map<string, { id: string; savedAt: number; session: Session }>();
         let unlabeled = 0;
         for (const [id, envelope] of loaded) {
+            // #499: anonymous prefix-affinity sessions (#309) carry the shared
+            // display label "prefix-affinity" ≠ their pfa- id — they are
+            // CURRENT-format, not legacy derived-hash sessions. Migrating them
+            // would rekey every pfa session to the single id "prefix-affinity"
+            // and DELETE all but the newest sibling on every boot (silent data
+            // loss of saved compression state).
+            if (id.startsWith("pfa-")) continue;
             const session = buildSession(envelope.payload);
             const label = session.meta.label;
             if (!label) {

--- a/tests/proxy-persist.test.ts
+++ b/tests/proxy-persist.test.ts
@@ -383,3 +383,47 @@ await withTempStore("one-time migration re-keys legacy hash-id sessions to their
         cold.cancelAll();
     }
 });
+
+await withTempStore("migration leaves anonymous pfa sessions untouched (#499)", async (store, dir) => {
+    // Anonymous prefix-affinity sessions (#309) all share the display label
+    // "prefix-affinity" ≠ their id, which trips the #286 self-termination
+    // invariant: without the guard, every boot re-keys them all to the single
+    // id "prefix-affinity" and deletes every sibling but the newest — silent
+    // loss of saved compression state for anonymous clients.
+    const mk = (id: string, requests: number) => {
+        const s = makeSession(id);
+        s.meta.label = "prefix-affinity";
+        s.meta.protocol = "openai";
+        s.meta.upstreamOrigin = "https://relay.example/v1";
+        s.stats.requests = requests;
+        return s;
+    };
+    await store.writeNow(mk("pfa-bc1eaaaaaaaaaaaa", 7));
+    await store.writeNow(mk("pfa-8588bbbbbbbbbbbb", 3));
+
+    const fileB = jsonFilesUnder(dir).find((f) => JSON.parse(readFileSync(f, "utf8")).id === "pfa-8588bbbbbbbbbbbb")!;
+    const envB = JSON.parse(readFileSync(fileB, "utf8"));
+    envB.savedAt -= 1000; // bc1e is newer → it would win a label collision if migrated
+    writeFileSync(fileB, JSON.stringify(envB));
+
+    const legacy = makeSession("legacy-" + "c".repeat(24));
+    legacy.meta.label = "conv-legacy-499";
+    legacy.meta.protocol = "responses";
+    legacy.meta.upstreamOrigin = "https://chatgpt.com";
+    legacy.stats.requests = 2;
+    await store.writeNow(legacy);
+
+    const cold = new SessionStore({ dir, debounceMs: 5, enabled: true });
+    try {
+        await cold.migrateLegacyIds();
+        const all = await cold.loadAll();
+        assert.ok(all.has("pfa-bc1eaaaaaaaaaaaa"), "newer anonymous session survives");
+        assert.ok(all.has("pfa-8588bbbbbbbbbbbb"), "older anonymous sibling survives (no shared-label deletion)");
+        assert.equal(all.get("pfa-bc1eaaaaaaaaaaaa")!.stats.requests, 7, "state intact");
+        assert.ok(!all.has("legacy-" + "c".repeat(24)), "true legacy session is still re-keyed");
+        assert.ok(all.has("conv-legacy-499"), "legacy re-key still works alongside the guard");
+        assert.equal(all.size, 3, "exactly the two pfa sessions plus the re-keyed legacy one");
+    } finally {
+        cold.cancelAll();
+    }
+});


### PR DESCRIPTION
## Scope change (was: full restart-resume fix)

This PR originally shipped the complete #499 restart-resume fix (persist chain snapshots in session metadata + `reseed()` + `initSessions()` hook). **PR #504 now covers that half** via a dedicated affinity-table snapshot (`src/affinity-persist.ts`, hydrate on boot / flush on shutdown) — a strictly more complete mechanism (preserves `lastSeen` for TTL, independent of session-file lifecycle, covers the whole table). Keeping both would mean two competing persistence paths for the same table, so this PR was **shrunk to its unique remaining piece**: the bug neither PR addressed.

## The bug: `migrateLegacyIds()` destroys every anonymous session on each boot

The #286 one-time migration re-keys sessions whose stored label ≠ their id, deleting all but the newest sibling per label. Anonymous prefix-affinity sessions (#309) all carry the **shared display label** `"prefix-affinity"` ≠ their `pfa-` id — which trips the migration's self-termination invariant. Result, verified empirically before fixing:

```
before migrateLegacyIds(): [pfa-bc1e….json, pfa-8588….json]   ← two anonymous sessions
after  migrateLegacyIds(): [prefix-affinity.json]              ← one file, newest state only
```

On **every startup**, all but the newest anonymous session's saved compression state is silently deleted, and the survivor is re-keyed away from its `pfa-` id.

## Why this is a prerequisite for #504 P1a

P1a restores the *routing table* across restarts — it tells the proxy "this replay belongs to `pfa-8588…`". But the folded view itself lives in the **session state file**, which the migration deletes/re-keys at boot before any request arrives. Without this guard, post-restart resolution lands on a non-existent session id → fresh empty session → raw history forwarded → 0% cache again. The two fixes are complementary: P1a restores routing, this guard keeps the routed-to state alive.

## Change

One guard in `migrateLegacyIds()`: skip ids with the `pfa-` prefix (`src/persist.ts`). True legacy derived-hash sessions are still re-keyed exactly as before.

## Tests

New regression test in `tests/proxy-persist.test.ts` (same style as the existing #286 migration test): two pfa sessions with the shared label + one true legacy session → after migration both pfa files survive intact (state round-trips) while the legacy session is still re-keyed under its label.

Pre-flight: typecheck ✅ · `tests/proxy-persist.test.ts` 22/22 ✅ · full suite 1000/1001 ✅ (the one failure, `launcher.test.ts` codex PATH resolution, pre-exists on master in environments where `/usr/bin/codex` is installed) · no build impact (no dist-affecting surface beyond persist.ts).

Merge order: this can land before or alongside #504 — zero file overlap.