### PR TITLE
release v0.1.78

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.77",
+  "version": "0.1.78",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Ships the two fixes merged after v0.1.77 went out:

- **#501** — fix #436: scope launcher model windows to the launched client (`collectModelWindows(config, scope)`), so `bili omp` honors omp's own models.yml 131072 instead of taking another client's 262144 via cross-client max-wins.
- **#493** — recognize sglang's overflow error format (`The input (N tokens) is longer than the model's context length (...)`) in context-window self-heal, so sglang users' over-limit 400s actually trigger it.

Version bump only (0.1.77 → 0.1.78). No acp-kernel change (stays 0.0.50), no `src/update.ts` change.

Pre-flight: typecheck ✓ · tests 998/1000 (2 known permanent local-env fails in plugin-agent.test.ts) · build ✓

Users must restart bili after auto-update for the launcher-window fix to take effect.