### PR TITLE
release v0.1.79

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.77",
+  "version": "0.1.79",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.77",
+      "version": "0.1.79",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@types/node": "^22.0.0",
         "@types/node-forge": "^1.3.14",
-        "acp-kernel": "0.0.50",
+        "acp-kernel": "0.0.51",
         "fzstd": "0.1.1",
         "node-forge": "^1.4.0",
         "tar": "^7.5.22",
@@ -988,9 +988,9 @@
       }
     },
     "node_modules/acp-kernel": {
-      "version": "0.0.50",
-      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.50.tgz",
-      "integrity": "sha512-ruwDMPcH4CYQDK9vDVdAcwc5vhAFxmracd1zSpDw/PHvfKOy0s3cj4FUtBBrfb1HVtUOVLJFPmad17CdWr0l5g==",
+      "version": "0.0.51",
+      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.51.tgz",
+      "integrity": "sha512-XFYPJwX9N3CU/VMAapG5d4CUJDazOVh/r8mPOKSYPTHmi8V2llUFcbY1O9ydxuVJIKVWqi6NTRzZMDyB9VBYQg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.78",
+  "version": "0.1.79",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/node-forge": "^1.3.14",
-    "acp-kernel": "0.0.50",
+    "acp-kernel": "0.0.51",
     "fzstd": "0.1.1",
     "node-forge": "^1.4.0",
     "tar": "^7.5.22",


### PR DESCRIPTION
## Changes since v0.1.78

- **acp-kernel 0.0.50 → 0.0.51** (exact pin, PR acp-kernel#196/#197): first-sight mass bypass in `decideNudge` — big-ingest sessions (stateless full-history / restored state) no longer wait a full growth floor of new tokens before the first compress; drain-until-under-band semantics with guardrails (ignored nudge keeps the stamp; below-band stays quiet; no schema change). Kernel half of the #351/#499 family. Host-side half is PR #504 (pending).

## Pre-flight

- typecheck ✅ · tests 998/1000 (2 known env fails in `plugin-agent.test.ts`, unrelated) ✅ · build ✅
- `npm view acp-kernel version` = 0.0.51 (live) ✅
- Commit is version+pin only (`package.json` + `package-lock.json`, same shape as v0.1.76)