### PR TITLE
release v0.1.80

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.79",
+  "version": "0.1.80",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.79",
+      "version": "0.1.80",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.79",
+  "version": "0.1.80",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Why

#505 (v0.1.79 pin bump) was merged BEFORE #504, so the in-flight 0.1.79 publish carries only the acp-kernel 0.0.51 pin — the #499 host-side fixes in #504 landed on master unpublished. This release ships them.

## Changes since v0.1.79

- **#504**: #498 weak-overflow learning (`src/weak-overflow.ts`, 3-signal shrink-only fallback), #499 P1a prefix-affinity persistence (`src/affinity-persist.ts`, atomic snapshot + hydrate), P1b cache-collapse diagnostic warn (`src/cache-warn.ts`). 20 new tests.

## Pre-flight

- typecheck ✅ · tests 1018/1020 (2 known env fails in `plugin-agent.test.ts`) ✅ · build ✅
- Commit is version-bump only (`package.json` + lockfile version).