### PR TITLE
release v0.1.81

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.80",
+  "version": "0.1.81",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.80",
+      "version": "0.1.81",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.80",
+  "version": "0.1.81",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Changes since v0.1.80

- **#502**: stop `migrateLegacyIds` destroying anonymous pfa sessions — anonymous prefix-affinity sessions (label `"prefix-affinity"` ≠ id `pfa-<hash>`) were misclassified as legacy on every boot, deleting all but the newest sibling and orphaning the survivor; prerequisite for #504's affinity-table hydration.
- **#500** (#496): forward-once-then-learn for image-dominated payloads — the default `b64/4` image estimate overestimates pixel-tile upstreams (official Anthropic/OpenAI) up to ~200×, hard-failing multimodal requests with `502 preflight_compress_failed` on estimate alone; now forwarded once so the upstream arbitrates billing, with the existing self-heal learning from any rejection (no 400-loop regression).

Both independently reviewed on the PR threads (incl. combined-tree pre-flight on post-0.1.80 master).

## Pre-flight

- typecheck ✅ · tests 1020/1022 (2 known env fails in `plugin-agent.test.ts`) ✅ · build ✅
- Commit is version-bump only.