### PR TITLE
feat: index billion-context on the pi.dev gallery

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "codex",
     "aider",
     "anthropic",
-    "openai"
+    "openai",
+    "pi-package"
   ],
   "license": "MIT",
   "author": "ranxianglei",


### PR DESCRIPTION
## Why

`billion-context` is missing from https://pi.dev/packages while `billion-context-pi` shows up.

Pi's gallery catalogues exactly the npm keyword `pi-package` (pi docs, `packages/coding-agent/docs/packages.md`: "The package gallery displays packages tagged with `pi-package`"). Verified against the live catalog: every listed package (`billion-context-pi`, `context-mode`, `bigpowers`, `pi-mcp-adapter`, `pi-lens`) carries it; `billion-context` (0.1.80) does not.

The detail page https://pi.dev/packages/billion-context does render on demand (it reads the `pi` manifest, so "Types: extension" is correct), but its Downloads row says "not available" — proof it is not in the gallery DB, hence no listing/search entry.

## Change

One keyword in `package.json`: `pi-package`. No code, no version bump.

Legitimate: the package really does ship a pi extension (`"pi": { "extensions": ["./dist/agent/pi.js"] }`, `src/agent/pi.ts`), and the plugin self-disables when there is no proxy (`src/agent/pi.ts:156-157`), so a pi user installing it standalone gets a no-op.

## Pre-flight

- `npm run typecheck` — clean
- `npm test` — 1022 pass / 0 fail
- `npm run build` — not run (metadata-only change, no code touched)

Note: `tests/plugin-agent.test.ts` initially reported 2 failures (`4 == 0` at :273 and :325). Reproduced on clean master, then traced to the harness exporting `BILLION_CONTEXT_PROXY` into the test process — `src/agent/shared.ts:40 proxyBaseFromEnv()` treats it as proxy detection, so the plugin registered 4 tools where the inert tests expect 0. With the var unset the file is 27/27 green. Environment contamination, not a repo defect; flagging it because `npm test` is not hermetic against that var.

## Follow-up

npm keywords are read from the latest published version, so this only takes effect on the next publish. After merge I will open a `*_release-v0.1.81` branch with an isolated `release v0.1.81` commit; CI publishes and pi.dev re-reads the keywords.
