### PR TITLE
feat: add pi-package keyword so pi.dev gallery indexes billion-context (clean, un-bundled)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "codex",
     "aider",
     "anthropic",
-    "openai"
+    "openai",
+    "pi-package"
   ],
   "license": "MIT",
   "author": "ranxianglei",


### PR DESCRIPTION
Closing as redundant: #508 already merged (3e2252e) with exactly the clean one-line change — `"pi-package"` keyword added to `package.json` `keywords` (verified via `git show 3e2252e`). No further action needed; the keyword reaches the published artifact in v0.1.82 (PR #510).