### PR TITLE
release v0.1.82

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.81",
+  "version": "0.1.82",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.81",
+      "version": "0.1.82",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.81",
+  "version": "0.1.82",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## What

Version bump only: `0.1.81` → `0.1.82` in `package.json` (+ the two matching `package-lock.json` version fields). No code changes — isolated `release v0.1.82` commit `ede8f93`.

## Why

The keyword fix (#508, `pi-package`) landed on master **after** the v0.1.81 branch was cut from `4606219`, so the artifact 0.1.81 publishes does not carry the keyword. npm keywords are read from the latest published version, so pi.dev keeps ignoring `billion-context` until a version that contains them goes out. This release is the one that gets the package listed at https://pi.dev/packages.

## Changes since v0.1.81

- `3e2252e` feat: add pi-package keyword so pi.dev gallery indexes billion-context (#508)

## Pre-flight (same checks CI runs)

- `npm run typecheck` — clean
- `npm test` — 1022 pass / 0 fail (run with `BILLION_CONTEXT_PROXY` unset; see the hermeticity note in #508)
- `npm run build` — success (`dist/index.js` 2.63 MB, inlined acp-kernel 0.0.51)

`git log v0.1.80..HEAD -- src/update.ts` is empty — the auto-update path is untouched, so no no-op validation release is required (AGENTS.md §5).

## Ordering note

The v0.1.81 Release run (`b9a933c`) was still in progress when this was opened. Merging after it publishes is the clean order: `latest` moves 0.1.80 → 0.1.81 → 0.1.82, and only 0.1.82 carries the pi keyword.
