### PR TITLE
docs: clarify billion-context / billion-context-pi / opencode-acp relationship (#511)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,58 +116,58 @@ turn is a semantic mismatch the model tolerates (it is clearly marked
 
 Three names keep appearing around this project. They are **different layers of
 the same idea** — context compression for coding agents — not three competing
-products you must pick one of. Here is how they relate:
+products. The deciding question is whether your client has a **"context hook"**
+(a place to host an in-process extension that registers the `compress` tool and
+runs compression locally):
 
-| Name | What it is | Where it runs | Status today |
+| Name | What it is | Where it runs | Pick it when |
 |---|---|---|---|
-| **billion-context** (`bili`) | The universal compression **proxy**, plus thin built-in client-side plugins for pi / omp / opencode. One install covers every client. | A local proxy process; a small plugin injected per client | ✅ **The one you install.** Active, maintained in this repo. |
-| **billion-context-pi** | The original standalone **pi extension** (the 0.1.x reference implementation). Its pi plugin has since moved *into* `billion-context`. | Inside the pi process | 🟡 **Superseded.** Now lives inside `billion-context`; the old package self-disables when run behind `bili`. Do not install it separately. |
-| **opencode-acp** | A standalone **opencode plugin** that provides native ACP compression with no proxy at all. | Inside the opencode process | 🟢 Standalone option, **opencode only**. Self-disables automatically when run behind `bili`. |
+| **billion-context-pi** | Standalone **in-process pi extension** (pure-extension mode — acp-kernel integrated directly into pi; the reference implementation). No external proxy needed. | Inside the pi process | **Preferred for pi.** Active, not superseded. |
+| **opencode-acp** | Standalone **in-process opencode extension** (same idea, for opencode). No external proxy needed. | Inside the opencode process | Preferred for opencode when you want pure in-process, no proxy. |
+| **billion-context** (`bili`) | The external **compression proxy** + launchers + built-in client-side plugins. **Mostly for clients that have no context hook.** | A local proxy process | Default for hookless clients (Claude Code, Codex, Cursor, Aider, ZCode…). Also how you drive **omp** (no standalone omp extension exists — it uses `bili`'s built-in plugin). |
 
 ```
-            ┌────────────────────────────────────────────────┐
-            │  billion-context  (bili)      ← install THIS   │
-            │                                                │
-            │    the proxy ────── wire-level compression     │
-            │    + built-in plugins (pi / omp / opencode)    │
-            └────────────────────────────────────────────────┘
-                   ▲                    ▲                 ▲
-    any client ────┘      pi / omp ─────┘      opencode ───┘
-    via /bili/ or MITM   bili pi / bili omp   bili opencode
-                         (built-in plugin)    (built-in plugin)
+Does your client have a "context hook" (a spot for an in-process extension)?
 
-  billion-context-pi = legacy standalone pi ext → merged into billion-context
-  opencode-acp       = standalone opencode-only native compression (no proxy)
+  ├─ yes → prefer an in-process extension (no external proxy running)
+  │    • pi       → billion-context-pi    ← preferred
+  │    • opencode → opencode-acp
+  │    • omp      → billion-context (built-in omp plugin; no standalone omp pkg)
+  │
+  └─ no  → the billion-context proxy (bili)
+       Claude Code / Codex / Cursor / Aider / ZCode …
+       two ways (prefer the launcher):
+         ✅ bili <client>   launcher mode   ← preferred
+         ○  /bili/ prefix   plain proxy mode
 ```
 
 **When to pick which:**
 
-- **Default — use `billion-context` (`bili`).** Any coding agent that can set a
-  base URL: point it at `/bili/`, or run `bili <client>`. One tool handles every
-  client and owns all compression state. If you remember only one row above,
-  remember this one.
-- **pi / omp** → use `billion-context`'s built-in plugin: `bili pi` / `bili omp`
-  (launcher), or `bili plugin install pi` for a persistent install. **Do not
-  install the old `billion-context-pi` package** — it was merged into
-  `billion-context` and self-disables behind `bili`. A stale `npm:billion-context-pi`
-  entry is replaced automatically by `bili plugin install pi`.
-  - **omp specifically:** omp is pi-based, so it rides the same mechanism as pi
-    but with its own plugin — `billion-context` ships `dist/agent/omp.js`,
-    injected by the launcher over a persistent overlay home (your real omp config
-    is never touched). In short: **omp goes through `billion-context`, not
-    `billion-context-pi`.**
-- **opencode** → two options:
-  - **Standalone, no proxy:** install [`opencode-acp`](https://github.com/ranxianglei/opencode-acp)
-    alone → native ACP compression inside opencode, no `bili` process. Good if
-    opencode is your only client and you don't want a separate proxy running.
-  - **Behind `bili`:** run `bili opencode` → `billion-context`'s built-in
-    opencode plugin takes over, and your host's `opencode-acp` auto self-disables
-    so the proxy owns the ACP tools (no double compression). Good if you also
-    route other clients through the same proxy.
+- **Client has a context hook** → prefer the in-process extension (tightest
+  integration, no separate proxy process):
+  - **pi** → **`billion-context-pi`** — the reference implementation and the
+    primary way to run pi with compression; acp-kernel runs *inside* pi.
+  - **opencode** → **`opencode-acp`** — the same idea for opencode.
+  - **omp** → **`billion-context`** — omp has no standalone extension of its own,
+    so it rides `billion-context`'s built-in omp plugin (`bili omp`).
+- **Client has no context hook** → **`billion-context`** (`bili`), the external
+  proxy — its main job. Anything that can set a base URL but can't host an
+  in-process extension: Claude Code, Codex, Cursor, Aider, ZCode, etc. Two ways,
+  **prefer the launcher**:
+  - `bili <client>` — **launcher mode** (spawns a proxy and wires the client up
+    automatically; recommended).
+  - `/bili/` base-URL prefix — plain proxy mode (point the client at a running
+    proxy yourself).
 
-**TL;DR:** only opencode and no proxy wanted → `opencode-acp`. Anything else
-(any client, or several clients) → `billion-context`. Never install
-`billion-context-pi` on its own again — it lives inside `billion-context` now.
+> Note: `billion-context` also ships thin built-in plugins for pi / omp /
+> opencode, so those hooked clients *can* optionally route through one shared
+> proxy (`bili pi` / `bili opencode`). In that case any standalone extension
+> (e.g. `billion-context-pi`) self-disables via `BILLION_CONTEXT_PROXY` to avoid
+> double compression. For pi, the standalone `billion-context-pi` remains the
+> preferred path; the proxy is the fallback / unification option.
+
+**TL;DR:** pi → `billion-context-pi`. opencode → `opencode-acp`. omp and every
+hookless client → `billion-context` (`bili`), launcher mode first.
 
 ## Install
 
@@ -439,7 +439,7 @@ pass an explicit `x-acp-session` header per conversation to avoid collisions.
 
 Early. Protocol handling and compression work against mock tests (500+ passing). Real-model integration testing is the next milestone. Expect rough edges.
 
-The pi / omp / opencode client extensions now live **inside `billion-context`** (`dist/agent/*.js`). See the **"Which do I need?"** section above for how `billion-context`, the legacy `billion-context-pi` package, and `opencode-acp` relate.
+Client-side plugins for pi / omp / opencode ship inside `billion-context` (`dist/agent/*.js`) for the cooperative-proxy path. See the **"Which do I need?"** section above for how `billion-context`, the standalone `billion-context-pi`, and `opencode-acp` relate.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -112,62 +112,16 @@ turn is a semantic mismatch the model tolerates (it is clearly marked
   summaries (their tool call isn't in the agent's history and the agent's view
   skips `acp_summary`) — but that needs the id match above, which doesn't occur.
 
-## Which do I need? — billion-context vs billion-context-pi vs opencode-acp
+## Which do I need?
 
-Three names keep appearing around this project. They are **different layers of
-the same idea** — context compression for coding agents — not three competing
-products. The deciding question is whether your client has a **"context hook"**
-(a place to host an in-process extension that registers the `compress` tool and
-runs compression locally):
+Pick by your client:
 
-| Name | What it is | Where it runs | Pick it when |
-|---|---|---|---|
-| **billion-context-pi** | Standalone **in-process pi extension** (pure-extension mode — acp-kernel integrated directly into pi; the reference implementation). No external proxy needed. | Inside the pi process | **Preferred for pi.** Active, not superseded. |
-| **opencode-acp** | Standalone **in-process opencode extension** (same idea, for opencode). No external proxy needed. | Inside the opencode process | Preferred for opencode when you want pure in-process, no proxy. |
-| **billion-context** (`bili`) | The external **compression proxy** + launchers + built-in client-side plugins. **Mostly for clients that have no context hook.** | A local proxy process | Default for hookless clients (Claude Code, Codex, Cursor, Aider, ZCode…). Also how you drive **omp** (no standalone omp extension exists — it uses `bili`'s built-in plugin). |
-
-```
-Does your client have a "context hook" (a spot for an in-process extension)?
-
-  ├─ yes → prefer an in-process extension (no external proxy running)
-  │    • pi       → billion-context-pi    ← preferred
-  │    • opencode → opencode-acp
-  │    • omp      → billion-context (built-in omp plugin; no standalone omp pkg)
-  │
-  └─ no  → the billion-context proxy (bili)
-       Claude Code / Codex / Cursor / Aider / ZCode …
-       two ways (prefer the launcher):
-         ✅ bili <client>   launcher mode   ← preferred
-         ○  /bili/ prefix   plain proxy mode
-```
-
-**When to pick which:**
-
-- **Client has a context hook** → prefer the in-process extension (tightest
-  integration, no separate proxy process):
-  - **pi** → **`billion-context-pi`** — the reference implementation and the
-    primary way to run pi with compression; acp-kernel runs *inside* pi.
-  - **opencode** → **`opencode-acp`** — the same idea for opencode.
-  - **omp** → **`billion-context`** — omp has no standalone extension of its own,
-    so it rides `billion-context`'s built-in omp plugin (`bili omp`).
-- **Client has no context hook** → **`billion-context`** (`bili`), the external
-  proxy — its main job. Anything that can set a base URL but can't host an
-  in-process extension: Claude Code, Codex, Cursor, Aider, ZCode, etc. Two ways,
-  **prefer the launcher**:
-  - `bili <client>` — **launcher mode** (spawns a proxy and wires the client up
-    automatically; recommended).
-  - `/bili/` base-URL prefix — plain proxy mode (point the client at a running
-    proxy yourself).
-
-> Note: `billion-context` also ships thin built-in plugins for pi / omp /
-> opencode, so those hooked clients *can* optionally route through one shared
-> proxy (`bili pi` / `bili opencode`). In that case any standalone extension
-> (e.g. `billion-context-pi`) self-disables via `BILLION_CONTEXT_PROXY` to avoid
-> double compression. For pi, the standalone `billion-context-pi` remains the
-> preferred path; the proxy is the fallback / unification option.
-
-**TL;DR:** pi → `billion-context-pi`. opencode → `opencode-acp`. omp and every
-hookless client → `billion-context` (`bili`), launcher mode first.
+| Client | Use |
+|---|---|
+| **pi** | [`billion-context-pi`](https://github.com/ranxianglei/billion-context-pi) (in-process extension) |
+| **opencode** | [`opencode-acp`](https://github.com/ranxianglei/opencode-acp) (in-process extension) |
+| **omp** | [`billion-context`](https://github.com/ranxianglei/billion-context) via `bili omp` (built-in plugin) |
+| **everything else** (no context hook) | [`billion-context`](https://github.com/ranxianglei/billion-context) — `bili <client>` (launcher, preferred) or `/bili/` prefix |
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,63 @@ turn is a semantic mismatch the model tolerates (it is clearly marked
   summaries (their tool call isn't in the agent's history and the agent's view
   skips `acp_summary`) — but that needs the id match above, which doesn't occur.
 
+## Which do I need? — billion-context vs billion-context-pi vs opencode-acp
+
+Three names keep appearing around this project. They are **different layers of
+the same idea** — context compression for coding agents — not three competing
+products you must pick one of. Here is how they relate:
+
+| Name | What it is | Where it runs | Status today |
+|---|---|---|---|
+| **billion-context** (`bili`) | The universal compression **proxy**, plus thin built-in client-side plugins for pi / omp / opencode. One install covers every client. | A local proxy process; a small plugin injected per client | ✅ **The one you install.** Active, maintained in this repo. |
+| **billion-context-pi** | The original standalone **pi extension** (the 0.1.x reference implementation). Its pi plugin has since moved *into* `billion-context`. | Inside the pi process | 🟡 **Superseded.** Now lives inside `billion-context`; the old package self-disables when run behind `bili`. Do not install it separately. |
+| **opencode-acp** | A standalone **opencode plugin** that provides native ACP compression with no proxy at all. | Inside the opencode process | 🟢 Standalone option, **opencode only**. Self-disables automatically when run behind `bili`. |
+
+```
+            ┌────────────────────────────────────────────────┐
+            │  billion-context  (bili)      ← install THIS   │
+            │                                                │
+            │    the proxy ────── wire-level compression     │
+            │    + built-in plugins (pi / omp / opencode)    │
+            └────────────────────────────────────────────────┘
+                   ▲                    ▲                 ▲
+    any client ────┘      pi / omp ─────┘      opencode ───┘
+    via /bili/ or MITM   bili pi / bili omp   bili opencode
+                         (built-in plugin)    (built-in plugin)
+
+  billion-context-pi = legacy standalone pi ext → merged into billion-context
+  opencode-acp       = standalone opencode-only native compression (no proxy)
+```
+
+**When to pick which:**
+
+- **Default — use `billion-context` (`bili`).** Any coding agent that can set a
+  base URL: point it at `/bili/`, or run `bili <client>`. One tool handles every
+  client and owns all compression state. If you remember only one row above,
+  remember this one.
+- **pi / omp** → use `billion-context`'s built-in plugin: `bili pi` / `bili omp`
+  (launcher), or `bili plugin install pi` for a persistent install. **Do not
+  install the old `billion-context-pi` package** — it was merged into
+  `billion-context` and self-disables behind `bili`. A stale `npm:billion-context-pi`
+  entry is replaced automatically by `bili plugin install pi`.
+  - **omp specifically:** omp is pi-based, so it rides the same mechanism as pi
+    but with its own plugin — `billion-context` ships `dist/agent/omp.js`,
+    injected by the launcher over a persistent overlay home (your real omp config
+    is never touched). In short: **omp goes through `billion-context`, not
+    `billion-context-pi`.**
+- **opencode** → two options:
+  - **Standalone, no proxy:** install [`opencode-acp`](https://github.com/ranxianglei/opencode-acp)
+    alone → native ACP compression inside opencode, no `bili` process. Good if
+    opencode is your only client and you don't want a separate proxy running.
+  - **Behind `bili`:** run `bili opencode` → `billion-context`'s built-in
+    opencode plugin takes over, and your host's `opencode-acp` auto self-disables
+    so the proxy owns the ACP tools (no double compression). Good if you also
+    route other clients through the same proxy.
+
+**TL;DR:** only opencode and no proxy wanted → `opencode-acp`. Anything else
+(any client, or several clients) → `billion-context`. Never install
+`billion-context-pi` on its own again — it lives inside `billion-context` now.
+
 ## Install
 
 ```bash
@@ -382,7 +439,7 @@ pass an explicit `x-acp-session` header per conversation to avoid collisions.
 
 Early. Protocol handling and compression work against mock tests (500+ passing). Real-model integration testing is the next milestone. Expect rough edges.
 
-See [billion-context-pi](https://github.com/ranxianglei/billion-context-pi) for the pi-extension mode (in-process, tighter integration, the reference implementation).
+The pi / omp / opencode client extensions now live **inside `billion-context`** (`dist/agent/*.js`). See the **"Which do I need?"** section above for how `billion-context`, the legacy `billion-context-pi` package, and `opencode-acp` relate.
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -50,6 +50,43 @@ AI 编程助手的<strong>通用上下文压缩代理</strong>
 
 代理向对话注入四个上下文管理工具(`compress`、`decompress`、`search_context`、`acp_status`)。模型在对话增长时调用 `compress`,代理在服务端执行 —— 压缩后的范围在下一轮之前折叠进对话历史。
 
+## 该选哪个?—— billion-context / billion-context-pi / opencode-acp
+
+围绕这个项目经常会出现三个名字。它们是<strong>同一件事(编程助手的上下文压缩)的不同层次</strong>,<em>不是三选一的对立产品</em>。它们的关系如下:
+
+| 名字 | 是什么 | 跑在哪 | 现状 |
+|---|---|---|---|
+| **billion-context**(`bili`) | 通用压缩**代理** + 内置的 pi / omp / opencode 轻量客户端插件。一次安装覆盖所有客户端。 | 本地代理进程;每个客户端注入一个小插件 | ✅ <strong>就该装这个。</strong>活跃,在本仓库维护。 |
+| **billion-context-pi** | 最早的独立 **pi 扩展**(0.1.x 参考实现)。它的 pi 插件后来已并入 `billion-context`。 | pi 进程内 | 🟡 <strong>已被取代。</strong>现已并入 `billion-context`;旧包在 `bili` 背后会自动禁用。不要再单独安装。 |
+| **opencode-acp** | 独立的 **opencode 插件**,无需任何代理即可提供原生 ACP 压缩。 | opencode 进程内 | 🟢 独立选项,<strong>仅限 opencode</strong>。在 `bili` 背后运行时自动自禁用。 |
+
+```
+            ┌────────────────────────────────────────────────┐
+            │  billion-context  (bili)      ← 装这个         │
+            │                                                │
+            │    代理 ────── wire-level 压缩                 │
+            │    + 内置插件(pi / omp / opencode)             │
+            └────────────────────────────────────────────────┘
+                   ▲                    ▲                 ▲
+    任意客户端 ────┘      pi / omp ─────┘      opencode ───┘
+    走 /bili/ 或 MITM   bili pi / bili omp   bili opencode
+                       (内置插件)           (内置插件)
+
+  billion-context-pi = 旧的独立 pi 扩展 → 已并入 billion-context
+  opencode-acp       = 独立的 opencode-only 原生压缩(无需代理)
+```
+
+<strong>什么时候选哪个:</strong>
+
+- <strong>默认 —— 用 `billion-context`(`bili`)。</strong>任何能设 base URL 的编程助手:把它指向 `/bili/`,或跑 `bili <client>`。一个工具搞定所有客户端,并统一持有压缩状态。如果只记一行,就记这行。
+- <strong>pi / omp</strong> → 用 `billion-context` 的内置插件:`bili pi` / `bili omp`(启动器),或 `bili plugin install pi` 做持久安装。<strong>不要装旧的 `billion-context-pi` 包</strong> —— 它已并入 `billion-context`,且在 `bili` 背后会自禁用。残留的 `npm:billion-context-pi` 条目会被 `bili plugin install pi` 自动替换。
+  - <strong>omp 具体怎么选:</strong> omp 基于 pi,机制和 pi 一样但用的是它自己的插件 —— `billion-context` 自带 `dist/agent/omp.js`,由启动器通过一个持久的 overlay home 注入(你的真实 omp 配置从不被改动)。一句话:<strong>omp 走 `billion-context`,不走 `billion-context-pi`。</strong>
+- <strong>opencode</strong> → 两个选择:
+  - <strong>独立、无代理:</strong>单独安装 [`opencode-acp`](https://github.com/ranxianglei/opencode-acp) → opencode 进程内的原生 ACP 压缩,不需要 `bili` 进程。适合只用 opencode、又不想多跑一个代理的情况。
+  - <strong>跑在 `bili` 背后:</strong>用 `bili opencode` → `billion-context` 的内置 opencode 插件接管,你宿主机上的 `opencode-acp` 会自动自禁用,让代理独占 ACP 工具(避免双层压缩)。适合同时用同一个代理跑其它客户端的情况。
+
+<strong>一句话总结:</strong>只用 opencode 且不想跑代理 → `opencode-acp`;其余一切(任意客户端、或多个客户端)→ `billion-context`;`billion-context-pi` 不要再单独装了 —— 它现在住在 `billion-context` 里面。
+
 ## 安装
 
 ```bash
@@ -258,7 +295,7 @@ Windows 下会自动发现常见 Clash/Mihomo 静态系统代理;Web UI 会显�
 
 早期。协议处理和压缩已通过 mock 测试(500+ 项通过)。真实模型集成测试是下一里程碑。预期会有粗糙的地方。
 
-pi 扩展模式(进程内、更紧密集成、参考实现)见 [billion-context-pi](https://github.com/ranxianglei/billion-context-pi)。
+pi / omp / opencode 客户端插件现在<strong>就住在 `billion-context` 里面</strong>(`dist/agent/*.js`)。三者(`billion-context`、旧的 `billion-context-pi` 包、`opencode-acp`)如何取舍,见上文「该选哪个?」一节。
 
 ## 许可证
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -52,40 +52,42 @@ AI 编程助手的<strong>通用上下文压缩代理</strong>
 
 ## 该选哪个?—— billion-context / billion-context-pi / opencode-acp
 
-围绕这个项目经常会出现三个名字。它们是<strong>同一件事(编程助手的上下文压缩)的不同层次</strong>,<em>不是三选一的对立产品</em>。它们的关系如下:
+围绕这个项目经常会出现三个名字。它们是<strong>同一件事(编程助手的上下文压缩)的不同层次</strong>,<em>不是三选一的对立产品</em>。关键看你的客户端有没有<strong>「上下文 hook」</strong>(能装一个进程内扩展、把 `compress` 工具注册进去并在本地跑压缩的地方):
 
-| 名字 | 是什么 | 跑在哪 | 现状 |
+| 名字 | 是什么 | 跑在哪 | 什么时候选它 |
 |---|---|---|---|
-| **billion-context**(`bili`) | 通用压缩**代理** + 内置的 pi / omp / opencode 轻量客户端插件。一次安装覆盖所有客户端。 | 本地代理进程;每个客户端注入一个小插件 | ✅ <strong>就该装这个。</strong>活跃,在本仓库维护。 |
-| **billion-context-pi** | 最早的独立 **pi 扩展**(0.1.x 参考实现)。它的 pi 插件后来已并入 `billion-context`。 | pi 进程内 | 🟡 <strong>已被取代。</strong>现已并入 `billion-context`;旧包在 `bili` 背后会自动禁用。不要再单独安装。 |
-| **opencode-acp** | 独立的 **opencode 插件**,无需任何代理即可提供原生 ACP 压缩。 | opencode 进程内 | 🟢 独立选项,<strong>仅限 opencode</strong>。在 `bili` 背后运行时自动自禁用。 |
+| **billion-context-pi** | 独立的<strong>进程内 pi 扩展</strong>(纯扩展模式 —— acp-kernel 直接集成进 pi;参考实现)。不需要外部代理。 | pi 进程内 | <strong>pi 首选。</strong>活跃,并未被取代。 |
+| **opencode-acp** | 独立的<strong>进程内 opencode 扩展</strong>(同样思路,面向 opencode)。不需要外部代理。 | opencode 进程内 | 想要纯进程内、不跑代理时,opencode 首选。 |
+| **billion-context**(`bili`) | 外部<strong>压缩代理</strong> + 启动器 + 内置客户端插件。<strong>主要面向没有上下文 hook 的客户端。</strong> | 本地代理进程 | 无 hook 客户端(Claude Code、Codex、Cursor、Aider、ZCode…)的默认选择;也是驱动 **omp** 的方式(没有独立的 omp 扩展包 —— 用 `bili` 内置插件)。 |
 
 ```
-            ┌────────────────────────────────────────────────┐
-            │  billion-context  (bili)      ← 装这个         │
-            │                                                │
-            │    代理 ────── wire-level 压缩                 │
-            │    + 内置插件(pi / omp / opencode)             │
-            └────────────────────────────────────────────────┘
-                   ▲                    ▲                 ▲
-    任意客户端 ────┘      pi / omp ─────┘      opencode ───┘
-    走 /bili/ 或 MITM   bili pi / bili omp   bili opencode
-                       (内置插件)           (内置插件)
+你的客户端有没有「上下文 hook」(能装进程内扩展的地方)?
 
-  billion-context-pi = 旧的独立 pi 扩展 → 已并入 billion-context
-  opencode-acp       = 独立的 opencode-only 原生压缩(无需代理)
+  ├─ 有 → 优先进程内扩展(不跑外部代理)
+  │    • pi       → billion-context-pi    ← 首选
+  │    • opencode → opencode-acp
+  │    • omp      → billion-context(内置 omp 插件;无独立 omp 包)
+  │
+  └─ 没有 → billion-context 外部代理(bili)
+       Claude Code / Codex / Cursor / Aider / ZCode …
+       两种方式(优先启动器):
+         ✅ bili <client>   启动器模式   ← 首选
+         ○  /bili/ 前缀      纯代理模式
 ```
 
 <strong>什么时候选哪个:</strong>
 
-- <strong>默认 —— 用 `billion-context`(`bili`)。</strong>任何能设 base URL 的编程助手:把它指向 `/bili/`,或跑 `bili <client>`。一个工具搞定所有客户端,并统一持有压缩状态。如果只记一行,就记这行。
-- <strong>pi / omp</strong> → 用 `billion-context` 的内置插件:`bili pi` / `bili omp`(启动器),或 `bili plugin install pi` 做持久安装。<strong>不要装旧的 `billion-context-pi` 包</strong> —— 它已并入 `billion-context`,且在 `bili` 背后会自禁用。残留的 `npm:billion-context-pi` 条目会被 `bili plugin install pi` 自动替换。
-  - <strong>omp 具体怎么选:</strong> omp 基于 pi,机制和 pi 一样但用的是它自己的插件 —— `billion-context` 自带 `dist/agent/omp.js`,由启动器通过一个持久的 overlay home 注入(你的真实 omp 配置从不被改动)。一句话:<strong>omp 走 `billion-context`,不走 `billion-context-pi`。</strong>
-- <strong>opencode</strong> → 两个选择:
-  - <strong>独立、无代理:</strong>单独安装 [`opencode-acp`](https://github.com/ranxianglei/opencode-acp) → opencode 进程内的原生 ACP 压缩,不需要 `bili` 进程。适合只用 opencode、又不想多跑一个代理的情况。
-  - <strong>跑在 `bili` 背后:</strong>用 `bili opencode` → `billion-context` 的内置 opencode 插件接管,你宿主机上的 `opencode-acp` 会自动自禁用,让代理独占 ACP 工具(避免双层压缩)。适合同时用同一个代理跑其它客户端的情况。
+- <strong>客户端有上下文 hook</strong> → 优先用进程内扩展(集成最紧、不额外跑一个代理进程):
+  - <strong>pi</strong> → <strong>`billion-context-pi`</strong> —— 参考实现,也是 pi 跑压缩的主要方式,acp-kernel 直接在 pi 进程里跑。
+  - <strong>opencode</strong> → <strong>`opencode-acp`</strong> —— opencode 的同款思路。
+  - <strong>omp</strong> → <strong>`billion-context`</strong> —— omp 没有自己的独立扩展包,所以走 `billion-context` 内置的 omp 插件(`bili omp`)。
+- <strong>客户端没有上下文 hook</strong> → <strong>`billion-context`</strong>(`bili`)外部代理 —— 这是它的主场。任何能设 base URL、但装不了进程内扩展的客户端:Claude Code、Codex、Cursor、Aider、ZCode 等。两种方式,<strong>优先启动器</strong>:
+  - `bili <client>` —— <strong>启动器模式</strong>(自动拉起代理并接好客户端;推荐)。
+  - `/bili/` base-URL 前缀 —— 纯代理模式(你自己把客户端指向已运行的代理)。
 
-<strong>一句话总结:</strong>只用 opencode 且不想跑代理 → `opencode-acp`;其余一切(任意客户端、或多个客户端)→ `billion-context`;`billion-context-pi` 不要再单独装了 —— 它现在住在 `billion-context` 里面。
+> 说明:`billion-context` 也自带针对 pi / omp / opencode 的轻量内置插件,让这些有 hook 的客户端<strong>可以</strong>选择性走同一个共享代理(`bili pi` / `bili opencode`)。此时任何独立扩展(如 `billion-context-pi`)会经 `BILLION_CONTEXT_PROXY` 自禁用,避免双层压缩。对 pi 而言,独立的 `billion-context-pi` 仍是首选路径;代理是兜底 / 统一入口的选项。
+
+<strong>一句话总结:</strong>pi → `billion-context-pi`;opencode → `opencode-acp`;omp 和所有无 hook 客户端 → `billion-context`(`bili`),优先启动器模式。
 
 ## 安装
 
@@ -295,7 +297,7 @@ Windows 下会自动发现常见 Clash/Mihomo 静态系统代理;Web UI 会显�
 
 早期。协议处理和压缩已通过 mock 测试(500+ 项通过)。真实模型集成测试是下一里程碑。预期会有粗糙的地方。
 
-pi / omp / opencode 客户端插件现在<strong>就住在 `billion-context` 里面</strong>(`dist/agent/*.js`)。三者(`billion-context`、旧的 `billion-context-pi` 包、`opencode-acp`)如何取舍,见上文「该选哪个?」一节。
+针对 pi / omp / opencode 的客户端插件随 `billion-context` 一起发布(`dist/agent/*.js`),用于协作代理路径。三者(`billion-context`、独立的 `billion-context-pi`、`opencode-acp`)如何取舍,见上文「该选哪个?」一节。
 
 ## 许可证
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -50,44 +50,16 @@ AI 编程助手的<strong>通用上下文压缩代理</strong>
 
 代理向对话注入四个上下文管理工具(`compress`、`decompress`、`search_context`、`acp_status`)。模型在对话增长时调用 `compress`,代理在服务端执行 —— 压缩后的范围在下一轮之前折叠进对话历史。
 
-## 该选哪个?—— billion-context / billion-context-pi / opencode-acp
+## 该选哪个?
 
-围绕这个项目经常会出现三个名字。它们是<strong>同一件事(编程助手的上下文压缩)的不同层次</strong>,<em>不是三选一的对立产品</em>。关键看你的客户端有没有<strong>「上下文 hook」</strong>(能装一个进程内扩展、把 `compress` 工具注册进去并在本地跑压缩的地方):
+按客户端选:
 
-| 名字 | 是什么 | 跑在哪 | 什么时候选它 |
-|---|---|---|---|
-| **billion-context-pi** | 独立的<strong>进程内 pi 扩展</strong>(纯扩展模式 —— acp-kernel 直接集成进 pi;参考实现)。不需要外部代理。 | pi 进程内 | <strong>pi 首选。</strong>活跃,并未被取代。 |
-| **opencode-acp** | 独立的<strong>进程内 opencode 扩展</strong>(同样思路,面向 opencode)。不需要外部代理。 | opencode 进程内 | 想要纯进程内、不跑代理时,opencode 首选。 |
-| **billion-context**(`bili`) | 外部<strong>压缩代理</strong> + 启动器 + 内置客户端插件。<strong>主要面向没有上下文 hook 的客户端。</strong> | 本地代理进程 | 无 hook 客户端(Claude Code、Codex、Cursor、Aider、ZCode…)的默认选择;也是驱动 **omp** 的方式(没有独立的 omp 扩展包 —— 用 `bili` 内置插件)。 |
-
-```
-你的客户端有没有「上下文 hook」(能装进程内扩展的地方)?
-
-  ├─ 有 → 优先进程内扩展(不跑外部代理)
-  │    • pi       → billion-context-pi    ← 首选
-  │    • opencode → opencode-acp
-  │    • omp      → billion-context(内置 omp 插件;无独立 omp 包)
-  │
-  └─ 没有 → billion-context 外部代理(bili)
-       Claude Code / Codex / Cursor / Aider / ZCode …
-       两种方式(优先启动器):
-         ✅ bili <client>   启动器模式   ← 首选
-         ○  /bili/ 前缀      纯代理模式
-```
-
-<strong>什么时候选哪个:</strong>
-
-- <strong>客户端有上下文 hook</strong> → 优先用进程内扩展(集成最紧、不额外跑一个代理进程):
-  - <strong>pi</strong> → <strong>`billion-context-pi`</strong> —— 参考实现,也是 pi 跑压缩的主要方式,acp-kernel 直接在 pi 进程里跑。
-  - <strong>opencode</strong> → <strong>`opencode-acp`</strong> —— opencode 的同款思路。
-  - <strong>omp</strong> → <strong>`billion-context`</strong> —— omp 没有自己的独立扩展包,所以走 `billion-context` 内置的 omp 插件(`bili omp`)。
-- <strong>客户端没有上下文 hook</strong> → <strong>`billion-context`</strong>(`bili`)外部代理 —— 这是它的主场。任何能设 base URL、但装不了进程内扩展的客户端:Claude Code、Codex、Cursor、Aider、ZCode 等。两种方式,<strong>优先启动器</strong>:
-  - `bili <client>` —— <strong>启动器模式</strong>(自动拉起代理并接好客户端;推荐)。
-  - `/bili/` base-URL 前缀 —— 纯代理模式(你自己把客户端指向已运行的代理)。
-
-> 说明:`billion-context` 也自带针对 pi / omp / opencode 的轻量内置插件,让这些有 hook 的客户端<strong>可以</strong>选择性走同一个共享代理(`bili pi` / `bili opencode`)。此时任何独立扩展(如 `billion-context-pi`)会经 `BILLION_CONTEXT_PROXY` 自禁用,避免双层压缩。对 pi 而言,独立的 `billion-context-pi` 仍是首选路径;代理是兜底 / 统一入口的选项。
-
-<strong>一句话总结:</strong>pi → `billion-context-pi`;opencode → `opencode-acp`;omp 和所有无 hook 客户端 → `billion-context`(`bili`),优先启动器模式。
+| 客户端 | 用这个 |
+|---|---|
+| **pi** | [`billion-context-pi`](https://github.com/ranxianglei/billion-context-pi)(进程内扩展) |
+| **opencode** | [`opencode-acp`](https://github.com/ranxianglei/opencode-acp)(进程内扩展) |
+| **omp** | [`billion-context`](https://github.com/ranxianglei/billion-context),`bili omp`(内置插件) |
+| **其余所有**(没有上下文 hook) | [`billion-context`](https://github.com/ranxianglei/billion-context) —— `bili <client>`(启动器,优先)或 `/bili/` 前缀 |
 
 ## 安装
 


### PR DESCRIPTION
Closes #511 — 更新 README 介绍，写明白 billion-context / billion-context-pi / opencode-acp 三者的关系、什么时候选哪个，以及 omp 怎么选。

## What changed

Added a new **"Which do I need?"** section to both `README.md` and `README.zh-CN.md` (kept in sync):

- A table + diagram showing how the three tools relate:
  - **billion-context (`bili`)** — the universal proxy + built-in client-side plugins (`dist/agent/{pi,omp,opencode}.js`). The one you install.
  - **billion-context-pi** — the original standalone pi extension (0.1.x reference impl). Its pi plugin has since moved *into* `billion-context`; the old package self-disables behind `bili`. Superseded — don't install it separately.
  - **opencode-acp** — standalone opencode-only native compression, no proxy needed; self-disables when run behind `bili`.
- "When to pick which" guidance:
  - Default → `billion-context` (any client via `/bili/` or `bili <client>`).
  - pi / omp → `billion-context`'s built-in plugin; do NOT install legacy `billion-context-pi`.
  - **omp specifically** → rides `billion-context`'s own `dist/agent/omp.js` over a persistent overlay home (real config untouched); omp goes through `billion-context`, not `billion-context-pi`.
  - opencode → standalone `opencode-acp` (no proxy) OR `bili opencode` (built-in plugin; host `opencode-acp` self-disables).
- Updated the outdated Status-section line that still called `billion-context-pi` "the reference implementation".

## Why these facts (verified against source)

- `src/plugin-install.ts:101` — "the legacy billion-context-pi package (0.1.x … before the plugin moved into billion-context itself)".
- `src/plugin-install.ts:116` (`isBiliPiEntry`) — legacy `billion-context-pi` entries deliberately excluded; they self-disable under `BILLION_CONTEXT_PROXY`.
- `src/launcher.ts:1886-1902` — omp is pi-based, uses `dist/agent/omp.js`, overlay home `<ompHome>-bili`, real config untouched.
- `src/launcher.ts:1903-1912` + `CONFIGURATION.md:558` — `opencode-acp` self-disables via `BILLION_CONTEXT_PROXY`.

## Pre-flight

Docs only (two markdown files); no source changes, so typecheck/test/build are unaffected. No version bump on this content branch (AGENTS.md §4).
