### PR TITLE
fix: break the proxy-origin hijack chain (#405)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,9 @@ Two ways to use it — pick one:
 ### Option 1 — Launcher (`bili pi` / `bili codex` / `bili claude` / `bili omp` / `bili opencode` / `bili hermes` / `bili dsh`)
 
 The launcher wraps a client in one command: it starts a proxy on an
-independent port (a fresh instance is always spawned — a port is never
-reused), then points the client at it — **certificate-based MITM** where the
+independent port (an already-healthy instance on the preferred port is
+REUSED — #405; otherwise a fresh instance is spawned on a free port), then
+points the client at it — **certificate-based MITM** where the
 client honors proxy/CA env vars, or an isolated **`/bili/` config rewrite**
 where it doesn't. No real config file is ever edited; the client's own
 config is READ to discover which HTTPS upstream hosts it talks to, and those

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -332,11 +332,11 @@ export async function main(): Promise<void> {
         return;
     }
     if (command === "plugin") {
-        // Installers read resolveProxyOrigin() (env first) at dispatch time.
-        // Apply --origin BEFORE handling the subcommand: the generic env
-        // merge further down runs only on the server path, which this
-        // branch returns ahead of — without this, a stale ~/.bili/
-        // proxy-origin discovery file would silently win over the flag.
+        // Installers bake bakedProxyOrigin() (explicit BILI_MCP_PROXY wins,
+        // else the stable default — #405) at dispatch time. Apply --origin
+        // BEFORE handling the subcommand: the generic env merge further down
+        // runs only on the server path, which this branch returns ahead of —
+        // without this, the flag would be ignored.
         if (overrides.BILI_MCP_PROXY !== undefined) process.env.BILI_MCP_PROXY = overrides.BILI_MCP_PROXY;
         if (pluginAction === "list") {
             for (const row of pluginStatusAll()) {

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -122,7 +122,8 @@ export interface LaunchOptions {
 export interface ProxyHandle {
     origin: string;
     port: number;
-    child: SpawnChild;
+    /** Absent when an already-healthy instance was reused (#405) — stopProxy is a no-op then. */
+    child?: SpawnChild;
     logPath?: string;
 }
 
@@ -1499,6 +1500,19 @@ export async function ensureProxyRunning(
     const spawnImpl = deps.spawnImpl ?? (spawn as SpawnFn);
     const now = deps.now ?? Date.now;
     const sleepImpl = deps.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+
+    // #405 fix #3: a healthy instance on the preferred port is REUSED. The old
+    // behavior always spawned a second instance on an ephemeral port, which
+    // hijacked the global proxy-origin pointer and forked session state across
+    // two processes (whoever saved last won).
+    const preferredOrigin = proxyOrigin(opts.host, opts.port);
+    if (await probeHealth(preferredOrigin, fetchImpl)) {
+        console.error(`bili: reusing healthy proxy at ${preferredOrigin} (no second instance spawned)`);
+        if (opts.mitmDomains && opts.mitmDomains.length > 0) {
+            console.error(`bili: note: custom MITM domains (${opts.mitmDomains.join(",")}) only apply to instances started with them — the reused instance keeps its own whitelist`);
+        }
+        return { origin: preferredOrigin, port: opts.port };
+    }
 
     const port = await findFreePort(opts.port, opts.host);
     const spawnedOrigin = proxyOrigin(opts.host, port);

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -9,7 +9,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { proxyOriginFile } from "./paths.js";
+import { probeOrigin, readPointerOrigin } from "./proxy-origin.js";
 
 const VERSION = (() => {
     try {
@@ -32,17 +32,60 @@ type McpToolDef = {
 // every model request (x-claude-code-session-id), so binding is by identity.
 // BILI_CONVERSATION_ID (launcher-spawned hosts like codex) has no matching
 // request id — binding is headless (next NEW session).
-const DEFAULT_PROXY_ORIGIN = "http://127.0.0.1:8787";
+/** Stable discovery default baked into host configs by `bili plugin install`
+ *  (#405): never an ephemeral launcher port, or one install would point the
+ *  host at a dead port forever. */
+export const DEFAULT_PROXY_ORIGIN = "http://127.0.0.1:8787";
 
 export function resolveProxyOrigin(): string {
     const fromEnv = process.env.BILI_MCP_PROXY?.trim();
     if (fromEnv && fromEnv.length > 0) return fromEnv;
+    return readPointerOrigin() ?? DEFAULT_PROXY_ORIGIN;
+}
+
+const LIVE_PROBE_TIMEOUT_MS = 1500;
+let liveOrigin: { origin: string; instanceId?: string } | null = null;
+
+function noteRebind(msg: string): void {
     try {
-        const discovered = fs.readFileSync(proxyOriginFile(), "utf8").trim();
-        if (/^https?:\/\/\S+$/.test(discovered)) return discovered;
-    } catch {
+        process.stderr.write(`[bili-mcp] ${msg}\n`);
+    } catch {}
+}
+
+/** Liveness-checked origin resolution (#405 fix #1): env → pointer file →
+ *  default, probing /__bili/health on each and returning the first LIVE one.
+ *  A killed ephemeral proxy therefore self-heals on the NEXT tool call — no
+ *  host-client restart. The result is cached; any network failure invalidates
+ *  it so the next call re-resolves against the current pointer file. */
+export async function resolveLiveOrigin(): Promise<string> {
+    if (liveOrigin) return liveOrigin.origin;
+    const candidates: string[] = [];
+    const push = (o: string | null | undefined): void => {
+        if (o && o.length > 0 && !candidates.includes(o)) candidates.push(o);
+    };
+    push(process.env.BILI_MCP_PROXY?.trim());
+    push(readPointerOrigin());
+    push(DEFAULT_PROXY_ORIGIN);
+    for (const origin of candidates) {
+        const probe = await probeOrigin(origin, LIVE_PROBE_TIMEOUT_MS);
+        if (probe.live) {
+            if (candidates.length > 1 && origin !== candidates[0]) {
+                noteRebind(`proxy origin rebound ${candidates[0]} -> ${origin}${probe.instanceId ? ` (instance ${probe.instanceId.slice(0, 8)})` : ""}`);
+            }
+            liveOrigin = { origin, instanceId: probe.instanceId };
+            return origin;
+        }
     }
-    return DEFAULT_PROXY_ORIGIN;
+    return candidates[0];
+}
+
+export function forgetLiveOrigin(): void {
+    liveOrigin = null;
+}
+
+/** Test hook: drop the cached live origin between cases. */
+export function _resetMcpLiveOriginForTest(): void {
+    liveOrigin = null;
 }
 
 const TOOL_TIMEOUT_MS = 60_000;
@@ -67,7 +110,14 @@ function sendError(id: JsonRpcId, code: number, message: string): void {
 }
 
 async function fetchManifest(): Promise<void> {
-    const res = await fetch(`${resolveProxyOrigin()}/__bili/plugin/manifest`, { signal: AbortSignal.timeout(5000) });
+    const origin = await resolveLiveOrigin();
+    let res: Response;
+    try {
+        res = await fetch(`${origin}/__bili/plugin/manifest`, { signal: AbortSignal.timeout(5000) });
+    } catch (err) {
+        forgetLiveOrigin();
+        throw err;
+    }
     if (!res.ok) throw new Error(`manifest fetch failed: ${res.status}`);
     const data = (await res.json()) as { tools?: Record<string, { name: string; description?: string; input_schema?: unknown }[]> };
     // Anthropic wire shape is the canonical MCP-compatible schema source.
@@ -86,15 +136,17 @@ function ensureManifest(): Promise<void> {
 }
 
 export async function forwardTool(tool: string, args: unknown, timeoutMs: number = TOOL_TIMEOUT_MS): Promise<string> {
+    const origin = await resolveLiveOrigin();
     let res: Response;
     try {
-        res = await fetch(`${resolveProxyOrigin()}/__bili/plugin/tool`, {
+        res = await fetch(`${origin}/__bili/plugin/tool`, {
             method: "POST",
             headers: { "content-type": "application/json" },
             body: JSON.stringify({ conversationId, tool, args }),
             signal: AbortSignal.timeout(timeoutMs),
         });
     } catch (err) {
+        forgetLiveOrigin();
         if (err instanceof Error && err.name === "TimeoutError") throw new Error(`tool forward timed out after ${timeoutMs}ms: ${tool}`);
         throw err;
     }
@@ -128,12 +180,20 @@ async function handleMessage(msg: {
             if (fromMeta) conversationId ??= fromMeta;
             initialized = true;
             if (conversationId && !registered) {
-                const registerFetch = fetch(`${resolveProxyOrigin()}/__bili/plugin/register`, {
-                    method: "POST",
-                    headers: { "content-type": "application/json" },
-                    body: JSON.stringify({ conversationId, agent: "mcp", identity: IDENTITY_BINDING }),
-                    signal: AbortSignal.timeout(5000),
-                });
+                const registerFetch = (async () => {
+                    const origin = await resolveLiveOrigin();
+                    try {
+                        return await fetch(`${origin}/__bili/plugin/register`, {
+                            method: "POST",
+                            headers: { "content-type": "application/json" },
+                            body: JSON.stringify({ conversationId, agent: "mcp", identity: IDENTITY_BINDING }),
+                            signal: AbortSignal.timeout(5000),
+                        });
+                    } catch (err) {
+                        forgetLiveOrigin();
+                        throw err;
+                    }
+                })();
                 registered = true; // issue-once: a repeated initialize must not re-register
                 if (IDENTITY_BINDING) {
                     // Identity-mode binding survives any arrival order —

--- a/src/persist.ts
+++ b/src/persist.ts
@@ -48,8 +48,11 @@ import type { Session, BlockContent } from "./session.js";
  *  - No fsync of temp file or directory entry — a power loss can lose the
  *    most recent debounce window. Process crashes (SIGKILL) are safe up to
  *    the last successful write.
- *  - No cross-process lock — two proxy processes sharing BILI_SESSIONS_DIR
- *    will clobber each other's writes. Single-instance only.
+ *  - No cross-process LOCK — two proxy processes sharing BILI_SESSIONS_DIR
+ *    can still interleave writes. What IS protected (#405): a snapshot OLDER
+ *    than the on-disk one (monotonic stats.requests / state.nextBlockId) is
+ *    rejected instead of rolling counters back. Single-instance remains the
+ *    supported deployment.
  *  - All writes within a process are serialized per-session by the kernel
  *    store's write chains; there is no per-session *request* serialization
  *    (two concurrent HTTP requests for the same session can interleave
@@ -162,21 +165,26 @@ function relPathFor(id: string, protocol?: string, upstreamOrigin?: string): str
 /** Session persistence policy over the kernel StateStore mechanism. The
  *  public API predates the extraction and is kept stable for session.ts /
  *  server.ts / export.ts. */
+const STALE_WARN_THROTTLE_MS = 60_000;
+
 export class SessionStore {
     readonly enabled: boolean;
     private readonly dir: string;
     private readonly store: StateStore<PersistedSession>;
+    private readonly log: Logger;
+    private readonly staleWarnAt = new Map<string, number>();
 
     constructor(opts?: { dir?: string; debounceMs?: number; enabled?: boolean; log?: Logger }) {
         const debounceMs = opts?.debounceMs ?? defaultDebounce();
         this.enabled = (opts?.enabled ?? true) && debounceMs >= 0;
         this.dir = opts?.dir ?? defaultDir();
+        this.log = opts?.log ?? defaultLogger;
         this.store = new StateStore<PersistedSession>({
             dir: this.dir,
             version: PERSIST_VERSION,
             debounceMs: Math.max(0, debounceMs),
             enabled: this.enabled,
-            log: opts?.log ?? defaultLogger,
+            log: this.log,
             relPath: (id, payload) =>
                 relPathFor(id, payload.meta?.protocol ?? payload.protocol, payload.meta?.upstreamOrigin ?? payload.upstreamOrigin),
             // Adopt the pre-envelope flat format this store itself wrote
@@ -289,14 +297,14 @@ export class SessionStore {
      *  session state is persisted. Safe to call on the hot path. No-op if
      *  disabled. */
     scheduleSave(session: Session): void {
-        this.store.scheduleSave(session.id, () => buildRecord(session));
+        this.store.scheduleSave(session.id, this.guardedBuild(session));
     }
 
     /** Asynchronously persist a session right now (skips the debounce). Throws
      *  on write failure so callers can react (e.g. avoid evicting). Serialized
      *  per-session by the kernel store's write chains. */
     async writeNow(session: Session): Promise<void> {
-        await this.store.writeNow(session.id, () => buildRecord(session));
+        await this.store.writeNow(session.id, this.guardedBuild(session));
     }
 
     /** Synchronous flush for a single session. Used on memory eviction so a
@@ -305,7 +313,45 @@ export class SessionStore {
      *  Returns true on success, false on failure (caller must NOT evict on
      *  failure for a never-persisted session or it is lost permanently). */
     flushSync(session: Session): boolean {
-        return this.store.flushSync(session.id, () => buildRecord(session));
+        return this.store.flushSync(session.id, this.guardedBuild(session));
+    }
+
+    /** #405 fix #4: dual-instance rollback guard. When two proxy processes
+     *  share BILI_SESSIONS_DIR, whoever saves last used to win — an instance
+     *  holding a STALE in-memory copy would roll counters back (requests:3 →
+     *  2). Both signals below are monotonic per session id, so either being
+     *  strictly smaller proves staleness. Returns the fresher-on-disk payload
+     *  when the incoming record is stale, else null. */
+    private staleDiskPayload(incoming: PersistedSession): PersistedSession | null {
+        const envelope = this.store.loadSync(incoming.id, relPathFor(incoming.id, incoming.meta?.protocol, incoming.meta?.upstreamOrigin));
+        if (!envelope) return null;
+        const disk = envelope.payload;
+        const diskRequests = disk.stats?.requests ?? disk.requests ?? 0;
+        const incRequests = incoming.stats?.requests ?? incoming.requests ?? 0;
+        if (incRequests < diskRequests) return disk;
+        if (incRequests === diskRequests) {
+            const diskBlocks = disk.state?.nextBlockId ?? 0;
+            const incBlocks = incoming.state?.nextBlockId ?? 0;
+            if (incBlocks < diskBlocks) return disk;
+        }
+        return null;
+    }
+
+    private guardedBuild(session: Session): () => PersistedSession {
+        return () => {
+            const record = buildRecord(session);
+            const disk = this.staleDiskPayload(record);
+            if (disk === null) return record;
+            const now = Date.now();
+            const last = this.staleWarnAt.get(record.id) ?? 0;
+            if (now - last >= STALE_WARN_THROTTLE_MS) {
+                this.staleWarnAt.set(record.id, now);
+                this.log("warn", `[persist] rejected stale snapshot for session ${record.id}: in-memory copy is older than the on-disk one (another bili instance holds newer state) — keeping disk state, no rollback (#405)`);
+            }
+            // Rewrite the disk's own payload: content-identical no-op that
+            // preserves the newer state while satisfying the write chain.
+            return disk;
+        };
     }
 
     /** Flush all dirty sessions with a pending debounce timer. Called on

--- a/src/plugin-install.ts
+++ b/src/plugin-install.ts
@@ -17,7 +17,7 @@ import os from "node:os";
 import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { resolvePiHome } from "./client-config.js";
-import { resolveProxyOrigin } from "./mcp.js";
+import { DEFAULT_PROXY_ORIGIN } from "./mcp.js";
 
 export const PLUGIN_AGENTS = ["pi", "omp", "claude", "codex", "opencode"] as const;
 export type PluginAgent = (typeof PLUGIN_AGENTS)[number];
@@ -26,6 +26,16 @@ export function selfPackageRoot(): string {
     // dist/plugin-install.js -> package root two levels up.
     const here = fileURLToPath(import.meta.url);
     return path.resolve(path.dirname(here), "..");
+}
+
+/** #405 fix #4: the origin baked into host configs must be STABLE — never the
+ *  ephemeral port a launcher just spawned (one install, permanent mismatch).
+ *  Explicit user intent still wins (BILI_MCP_PROXY env / `bili plugin --origin`);
+ *  runtime discovery of custom-port instances happens inside the MCP shell via
+ *  the pointer file, not at install time. */
+export function bakedProxyOrigin(): string {
+    const explicit = process.env.BILI_MCP_PROXY?.trim();
+    return explicit && explicit.length > 0 ? explicit : DEFAULT_PROXY_ORIGIN;
 }
 
 function homeFile(rel: string, envOverride?: string): string {
@@ -250,7 +260,7 @@ function claudeInstall(): string {
     requireDistFile(mcpJs);
     const claude = process.env.CLAUDE?.trim() || "claude";
     try {
-        execFileSync(claude, ["mcp", "add", "bili", "--scope", "user", "-e", `BILI_MCP_PROXY=${resolveProxyOrigin()}`, "--", process.execPath, mcpJs], { stdio: ["ignore", "pipe", "pipe"], timeout: CLAUDE_EXEC_TIMEOUT_MS });
+        execFileSync(claude, ["mcp", "add", "bili", "--scope", "user", "-e", `BILI_MCP_PROXY=${bakedProxyOrigin()}`, "--", process.execPath, mcpJs], { stdio: ["ignore", "pipe", "pipe"], timeout: CLAUDE_EXEC_TIMEOUT_MS });
         return `claude: installed via \`claude mcp add\` (user scope) -> ${claudeMcpJson()}`;
     } catch (err) {
         const stderr = err instanceof Error && "stderr" in err ? String((err as { stderr?: Buffer | string }).stderr ?? "") : "";
@@ -283,7 +293,7 @@ function codexToml(): string {
 }
 
 function codexBlock(): string {
-    return `\n[mcp_servers.bili]\ncommand = ${JSON.stringify(process.execPath)}\nargs = [${JSON.stringify(path.join(selfPackageRoot(), "dist", "mcp.js"))}]\nenv = { BILI_MCP_PROXY = ${JSON.stringify(resolveProxyOrigin())} }\n`;
+    return `\n[mcp_servers.bili]\ncommand = ${JSON.stringify(process.execPath)}\nargs = [${JSON.stringify(path.join(selfPackageRoot(), "dist", "mcp.js"))}]\nenv = { BILI_MCP_PROXY = ${JSON.stringify(bakedProxyOrigin())} }\n`;
 }
 
 function codexInstall(): string {
@@ -292,7 +302,7 @@ function codexInstall(): string {
     const existing = /^[ \t]*\[mcp_servers\.bili\][ \t]*$/m.exec(text);
     if (existing !== null) {
         const block = text.slice(existing.index, text.indexOf("\n[", existing.index + 1) === -1 ? undefined : text.indexOf("\n[", existing.index + 1));
-        if (block.includes(`BILI_MCP_PROXY = ${JSON.stringify(resolveProxyOrigin())}`)) return `codex: already installed (${file})`;
+        if (block.includes(`BILI_MCP_PROXY = ${JSON.stringify(bakedProxyOrigin())}`)) return `codex: already installed (${file})`;
         const refreshed = text.slice(0, existing.index) + codexBlock().replace(/^\n/, "") + text.slice(existing.index + block.length);
         backupOnce(file);
         fs.writeFileSync(file, refreshed);
@@ -346,7 +356,7 @@ function opencodeInstall(): string {
     const data = readJson(file);
     const mcp = (data.mcp as Record<string, unknown> | undefined) ?? {};
     if ("bili" in mcp) return `opencode: already installed (${file})`;
-    mcp.bili = { type: "local", command: [process.execPath, mcpJs], environment: { BILI_MCP_PROXY: resolveProxyOrigin() }, enabled: true };
+    mcp.bili = { type: "local", command: [process.execPath, mcpJs], environment: { BILI_MCP_PROXY: bakedProxyOrigin() }, enabled: true };
     data.mcp = mcp;
     writeJson(file, data);
     return `opencode: installed -> ${file} mcp.bili`;

--- a/src/proxy-origin.ts
+++ b/src/proxy-origin.ts
@@ -1,0 +1,152 @@
+// Global proxy-origin pointer protocol (#405).
+//
+// The pointer file (stateDir()/proxy-origin) tells host-spawned MCP shells
+// which proxy to dial. Two rules keep it honest:
+//
+//   WRITERS (proxy boot, src/server.ts): never clobber a pointer that a LIVE
+//   instance owns — claim only when the existing origin is dead or absent.
+//   A sidecar lease (stateDir()/proxy-origin.lease) records who claimed it
+//   (port + pid + bootedAt + instanceId) so readers can prove ownership and
+//   graceful shutdowns can release exactly their own pointer.
+//
+//   READERS (MCP shell, src/mcp.ts): never trust the pointer blindly — probe
+//   /__bili/health before dialing, fall through candidate origins on a dead
+//   one, and re-resolve after any network failure.
+//
+// The main file keeps its historical format (one URL line) so older shells
+// keep reading it; the lease is additive and ignored by them.
+
+import fs from "node:fs";
+import path from "node:path";
+import { stateDir } from "./paths.js";
+
+export interface OriginLease {
+    v: 2;
+    origin: string;
+    pid: number;
+    bootedAt: number;
+    instanceId: string;
+}
+
+export interface OriginClaim extends Omit<OriginLease, "v"> {}
+
+type OriginLogger = (level: "info" | "warn", msg: string) => void;
+
+const ORIGIN_RE = /^https?:\/\/\S+$/;
+const PROBE_TIMEOUT_MS = 1500;
+
+export function proxyOriginPath(): string {
+    return path.join(stateDir(), "proxy-origin");
+}
+
+export function proxyLeasePath(): string {
+    return path.join(stateDir(), "proxy-origin.lease");
+}
+
+function readPointerRaw(): string | null {
+    try {
+        const raw = fs.readFileSync(proxyOriginPath(), "utf8").trim();
+        return raw.length > 0 ? raw : null;
+    } catch {
+        return null;
+    }
+}
+
+/** The origin URL currently in the pointer file, or null when absent /
+ *  unreadable / not a valid http(s) URL. */
+export function readPointerOrigin(): string | null {
+    const raw = readPointerRaw();
+    return raw !== null && ORIGIN_RE.test(raw) ? raw : null;
+}
+
+/** The sidecar lease describing who owns the pointer, or null when absent /
+ *  malformed. Never throws. */
+export function readPointerLease(): OriginLease | null {
+    try {
+        const parsed: unknown = JSON.parse(fs.readFileSync(proxyLeasePath(), "utf8"));
+        if (!parsed || typeof parsed !== "object") return null;
+        const l = parsed as Partial<OriginLease>;
+        if (typeof l.origin !== "string" || typeof l.pid !== "number" || typeof l.bootedAt !== "number" || typeof l.instanceId !== "string") return null;
+        return l as OriginLease;
+    } catch {
+        return null;
+    }
+}
+
+/** Liveness probe for a bili instance: GET <origin>/__bili/health. The
+ *  response's `instanceId` proves WHICH instance answers (attribution for
+ *  rebind logging); older versions answer without it — still live. */
+export async function probeOrigin(origin: string, timeoutMs: number = PROBE_TIMEOUT_MS): Promise<{ live: boolean; instanceId?: string }> {
+    try {
+        const res = await fetch(`${origin}/__bili/health`, { signal: AbortSignal.timeout(timeoutMs) });
+        if (!res.ok) return { live: false };
+        const data = (await res.json()) as { ok?: boolean; instanceId?: string };
+        return { live: data.ok === true, instanceId: typeof data.instanceId === "string" && data.instanceId.length > 0 ? data.instanceId : undefined };
+    } catch {
+        return { live: false };
+    }
+}
+
+function writeFileAtomic(file: string, content: string): void {
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    const tmp = `${file}.tmp-${process.pid}-${Date.now()}`;
+    try {
+        fs.writeFileSync(tmp, content);
+        fs.renameSync(tmp, file);
+    } catch (err) {
+        try {
+            fs.unlinkSync(tmp);
+        } catch {}
+        throw err;
+    }
+}
+
+function removeIfExists(file: string): void {
+    try {
+        fs.unlinkSync(file);
+    } catch {}
+}
+
+/** Claim the global pointer for this instance at bili boot (#405 fix #2).
+ *  If another origin is HEALTHY we keep it — that running instance owns the
+ *  pointer, and overwriting it was exactly how launcher-spawned ephemeral
+ *  proxies used to hijack discovery (dual-instance fork). Dead pointers get
+ *  reclaimed. Best-effort: never throws. Returns true when we hold the file. */
+export async function claimProxyOrigin(myOrigin: string, lease: OriginClaim, log: OriginLogger): Promise<boolean> {
+    try {
+        const existing = readPointerOrigin();
+        if (existing !== null && existing !== myOrigin) {
+            const probe = await probeOrigin(existing);
+            if (probe.live) {
+                log("info", `[origin] kept existing proxy-origin ${existing}${probe.instanceId ? ` (live instance ${probe.instanceId.slice(0, 8)})` : ""}; this instance ${myOrigin} did not take the pointer`);
+                return false;
+            }
+            log("info", `[origin] reclaiming dead proxy-origin ${existing} -> ${myOrigin}`);
+        }
+        writeFileAtomic(proxyOriginPath(), `${myOrigin}\n`);
+        const full: OriginLease = { v: 2, origin: lease.origin, pid: lease.pid, bootedAt: lease.bootedAt, instanceId: lease.instanceId };
+        writeFileAtomic(proxyLeasePath(), `${JSON.stringify(full)}\n`);
+        log("info", `[origin] proxy-origin -> ${myOrigin} (instance ${lease.instanceId.slice(0, 8)}, pid ${lease.pid})`);
+        return true;
+    } catch (err) {
+        log("warn", `[origin] failed to update proxy-origin: ${err instanceof Error ? err.message : String(err)}`);
+        return false;
+    }
+}
+
+/** Graceful shutdown (#405 fix #2): release the pointer IFF it still points at
+ *  us — file origin match, or lease (origin + instanceId) match. When a newer
+ *  instance already reclaimed it, neither matches and we leave it alone.
+ *  Removing (rather than restoring) the file sends readers down their
+ *  fallback chain instead of leaving a dead pointer behind. Never throws. */
+export function releaseProxyOrigin(myOrigin: string, instanceId: string, log: OriginLogger): void {
+    try {
+        const current = readPointerOrigin();
+        const lease = readPointerLease();
+        const ours = current === myOrigin || (lease !== null && lease.origin === myOrigin && lease.instanceId === instanceId);
+        if (!ours) return;
+        removeIfExists(proxyOriginPath());
+        removeIfExists(proxyLeasePath());
+        log("info", `[origin] released proxy-origin (was ${current ?? "?"})`);
+    } catch {}
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -50,7 +50,8 @@ import { renderUI, handleConfigGet, handleConfigPut } from "./web/index.js";
 import { reapOrphanBlocks } from "./orphan-gc.js";
 import { getStore } from "./persist.js";
 import { log as loggerLog, configureLogger, getLogPath, closeLogger } from "./logger.js";
-import { defaultLogFile, stateDir, proxyOriginFile } from "./paths.js";
+import { defaultLogFile, stateDir } from "./paths.js";
+import { claimProxyOrigin, releaseProxyOrigin } from "./proxy-origin.js";
 import { compressLoopResponsesJson } from "./compress-loop-responses.js";
 import { runCompressLoop, pickAdapter } from "./loop/index.js";
 import { containsToolCallXmlFragment } from "./loop/tag-echo-filter.js";
@@ -293,6 +294,7 @@ export async function startServer(opts: ProxyOptions): Promise<http.Server> {
     // (tests) are distinct instances; a restart changing the id is harmless
     // (the chain check only compares against the other running instance).
     const instanceId = randomUUID();
+    let claimedOrigin: string | null = null;
     // Reload persisted compression state before accepting traffic so sessions
     // that survived a restart keep their folded view (otherwise long sessions
     // re-send oversized raw history and hang).
@@ -353,17 +355,15 @@ export async function startServer(opts: ProxyOptions): Promise<http.Server> {
         // chose to expose the proxy — hiding it behind "localhost" made
         // remote setups look broken in the log, see #240).
         const displayHost = nonLoopbackBind ? opts.host : opts.host === "0.0.0.0" ? "localhost" : opts.host;
-        try {
-            fs.mkdirSync(stateDir(), { recursive: true });
-            // Discovery origin local MCP shells dial: collapse wildcard
-            // binds to loopback (localhost may resolve to ::1, where an
-            // IPv4-only listener is absent) and bracket bare IPv6 literals
-            // so the file always holds a valid URL.
-            const originHost = opts.host === "0.0.0.0" || opts.host === "::" || opts.host === "localhost" ? "127.0.0.1" : opts.host.includes(":") && !opts.host.startsWith("[") ? `[${opts.host}]` : opts.host;
-            fs.writeFileSync(proxyOriginFile(), `http://${originHost}:${server.address() === null ? opts.port : (server.address() as { port: number }).port}\n`);
-        } catch {
-            // best-effort discovery hint for host-spawned MCP shells
-        }
+        // Discovery origin local MCP shells dial: collapse wildcard
+        // binds to loopback (localhost may resolve to ::1, where an
+        // IPv4-only listener is absent) and bracket bare IPv6 literals
+        // so the pointer always holds a valid URL.
+        const originHost = opts.host === "0.0.0.0" || opts.host === "::" || opts.host === "localhost" ? "127.0.0.1" : opts.host.includes(":") && !opts.host.startsWith("[") ? `[${opts.host}]` : opts.host;
+        claimedOrigin = `http://${originHost}:${server.address() === null ? opts.port : (server.address() as { port: number }).port}`;
+        // #405 fix #2: claim, don't clobber — if another LIVE instance owns
+        // the pointer we keep it instead of hijacking discovery.
+        void claimProxyOrigin(claimedOrigin, { origin: claimedOrigin, pid: process.pid, bootedAt: Date.now(), instanceId }, (level, msg) => log(level, msg));
         const nOverrides = Object.keys(opts.routes).length;
         log(
             "info",
@@ -421,6 +421,9 @@ export async function startServer(opts: ProxyOptions): Promise<http.Server> {
         if (shuttingDown) return;
         shuttingDown = true;
         log("info", `${sig} received — flushing sessions…`);
+        // #405 fix #2: give back the discovery pointer we own so readers fall
+        // through to the next live instance instead of dialing a dead port.
+        if (claimedOrigin !== null) releaseProxyOrigin(claimedOrigin, instanceId, (level, msg) => log(level, msg));
         // Stop accepting new requests BEFORE flushing, otherwise a late request
         // could mutate state after its snapshot is taken and be lost.
         // server.close(cb) waits for all keep-alive connections to drain
@@ -569,12 +572,12 @@ async function handle(
             return;
         }
         res.writeHead(200, { "content-type": "application/json" });
-        res.end(JSON.stringify({ ok: true, upstream: opts.upstream }));
+        res.end(JSON.stringify({ ok: true, upstream: opts.upstream, instanceId }));
         return;
     }
     if (req.method === "GET" && req.url === "/__bili/health") {
         res.writeHead(200, { "content-type": "application/json" });
-        res.end(JSON.stringify({ ok: true, upstream: opts.upstream }));
+        res.end(JSON.stringify({ ok: true, upstream: opts.upstream, instanceId }));
         return;
     }
     // Web config UI (served as HTML, separate from the JSON health check above).

--- a/tests/launcher.test.ts
+++ b/tests/launcher.test.ts
@@ -516,7 +516,7 @@ function makeFakeChild(pid: number): SpawnChild {
     };
 }
 
-test("ensureProxyRunning: always spawns a fresh proxy, never reuses a listener", async () => {
+test("ensureProxyRunning: healthy instance on preferred port is reused, nothing spawned (#405)", async () => {
     let spawnCalls = 0;
     const spawnImpl: SpawnFn = () => {
         spawnCalls++;
@@ -527,10 +527,31 @@ test("ensureProxyRunning: always spawns a fresh proxy, never reuses a listener",
         { host: "127.0.0.1", port: 8787, passthrough: false, debug: false },
         { fetchImpl, spawnImpl },
     );
+    assert.equal(spawnCalls, 0, "no second instance spawned");
+    assert.equal(handle.child, undefined, "reused handle owns no child");
+    assert.equal(handle.origin, "http://127.0.0.1:8787", "points at the existing instance");
+    assert.doesNotThrow(() => stopProxy(handle), "stopProxy is a no-op on a reused handle");
+});
+
+test("ensureProxyRunning: unhealthy preferred port still spawns on a free port", async () => {
+    let spawnCalls = 0;
+    const spawnImpl: SpawnFn = () => {
+        spawnCalls++;
+        return makeFakeChild(42423);
+    };
+    // first probe = preferred-port check (dead); later probes = spawned-instance poll (healthy)
+    let probes = 0;
+    const fetchImpl = async () => {
+        probes++;
+        return { ok: probes >= 2 };
+    };
+    const handle = await ensureProxyRunning(
+        { host: "127.0.0.1", port: 8787, passthrough: false, debug: false },
+        { fetchImpl, spawnImpl, sleep: () => Promise.resolve() },
+    );
     assert.equal(spawnCalls, 1);
-    assert.ok(handle.child);
-    assert.equal(handle.origin, `http://127.0.0.1:${handle.port}`);
-    assert.notEqual(handle.child, null);
+    assert.equal(handle.child?.pid, 42423);
+    assert.equal(handle.origin, `http://127.0.0.1:${handle.port}`, "handle points at the spawned instance");
 });
 
 test("ensureProxyRunning: spawns when not healthy, polls until healthy", async () => {
@@ -1878,7 +1899,12 @@ test("runLaunch omp: launcher hands per-model windows to the spawned proxy", asy
         proxyEnvs.push((opts as { env?: NodeJS.ProcessEnv } | undefined)?.env);
         return makeFakeChild(42422);
     };
-    const fetchImpl = async () => ({ ok: true });
+    // first probe = preferred-port check (dead) so a proxy IS spawned; later probes = health poll
+    let probes = 0;
+    const fetchImpl = async () => {
+        probes++;
+        return { ok: probes >= 2 };
+    };
 
     const prevExit = process.exit;
     const exitCalls: number[] = [];

--- a/tests/mcp-live-origin.test.ts
+++ b/tests/mcp-live-origin.test.ts
@@ -1,0 +1,146 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { DEFAULT_PROXY_ORIGIN, _resetMcpLiveOriginForTest, forgetLiveOrigin, resolveLiveOrigin } from "../src/mcp.ts";
+
+interface LiveProbe {
+    server: http.Server;
+    origin: string;
+    close: () => Promise<void>;
+}
+
+async function startBiliStub(): Promise<LiveProbe> {
+    const server = http.createServer((req, res) => {
+        if (req.url === "/__bili/health") {
+            res.writeHead(200, { "content-type": "application/json" });
+            res.end(JSON.stringify({ ok: true, upstream: "https://upstream.example", instanceId: "stub-instance" }));
+            return;
+        }
+        res.writeHead(404);
+        res.end();
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const addr = server.address() as AddressInfo;
+    const origin = `http://127.0.0.1:${addr.port}`;
+    return {
+        server,
+        origin,
+        close: () => new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve()))),
+    };
+}
+
+function pointerFile(stateDir: string): string {
+    return path.join(stateDir, "billion-context", "proxy-origin");
+}
+
+async function withEnv<T>(vars: Record<string, string | undefined>, fn: () => Promise<T>): Promise<T> {
+    const prev: Record<string, string | undefined> = {};
+    for (const [k, v] of Object.entries(vars)) {
+        prev[k] = process.env[k];
+        if (v === undefined) delete process.env[k];
+        else process.env[k] = v;
+    }
+    try {
+        return await fn();
+    } finally {
+        for (const [k, v] of Object.entries(prev)) {
+            if (v === undefined) delete process.env[k];
+            else process.env[k] = v;
+        }
+    }
+}
+
+function freshStateDir(): string {
+    const state = mkdtempSync(path.join(tmpdir(), "bili-mcp-state-"));
+    mkdirSync(path.dirname(pointerFile(state)), { recursive: true });
+    return state;
+}
+
+test("resolveLiveOrigin: dead env origin falls through to live pointer-file origin (#405)", async () => {
+    const stub = await startBiliStub();
+    const state = freshStateDir();
+    let captured = "";
+    const origWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((chunk: unknown) => {
+        captured += String(chunk);
+        return true;
+    }) as typeof process.stderr.write;
+    try {
+        writeFileSync(pointerFile(state), `${stub.origin}\n`);
+        await withEnv({ XDG_STATE_HOME: state, BILI_MCP_PROXY: "http://127.0.0.1:1" }, async () => {
+            _resetMcpLiveOriginForTest();
+            assert.equal(await resolveLiveOrigin(), stub.origin, "skips the dead env origin");
+            assert.match(captured, /rebound http:\/\/127\.0\.0\.1:1 -> /, "rebind declared on stderr");
+        });
+    } finally {
+        process.stderr.write = origWrite;
+        rmSync(state, { recursive: true, force: true });
+        await stub.close();
+    }
+});
+
+test("resolveLiveOrigin: result is cached (no re-probe on later calls)", async () => {
+    const stub = await startBiliStub();
+    const state = freshStateDir();
+    const realFetch = globalThis.fetch;
+    let healthProbes = 0;
+    globalThis.fetch = ((input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+        const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+        if (url.includes("/__bili/health")) healthProbes++;
+        return realFetch(input, init);
+    }) as typeof fetch;
+    try {
+        writeFileSync(pointerFile(state), `${stub.origin}\n`);
+        await withEnv({ XDG_STATE_HOME: state, BILI_MCP_PROXY: stub.origin }, async () => {
+            _resetMcpLiveOriginForTest();
+            assert.equal(await resolveLiveOrigin(), stub.origin);
+            assert.equal(await resolveLiveOrigin(), stub.origin);
+            assert.equal(await resolveLiveOrigin(), stub.origin);
+            assert.equal(healthProbes, 1, "only the first resolution probes");
+        });
+    } finally {
+        globalThis.fetch = realFetch;
+        rmSync(state, { recursive: true, force: true });
+        await stub.close();
+    }
+});
+
+test("resolveLiveOrigin: after the cached instance dies, re-resolution finds the next live one (#405 self-heal)", async () => {
+    const a = await startBiliStub();
+    const b = await startBiliStub();
+    const state = freshStateDir();
+    try {
+        writeFileSync(pointerFile(state), `${b.origin}\n`);
+        await withEnv({ XDG_STATE_HOME: state, BILI_MCP_PROXY: a.origin }, async () => {
+            _resetMcpLiveOriginForTest();
+            assert.equal(await resolveLiveOrigin(), a.origin, "env origin wins while alive");
+            await a.close();
+            forgetLiveOrigin();
+            assert.equal(await resolveLiveOrigin(), b.origin, "next call re-resolves to the live pointer-file origin");
+        });
+    } finally {
+        rmSync(state, { recursive: true, force: true });
+        await b.close();
+    }
+});
+
+test("resolveLiveOrigin: all candidates dead → first candidate returned, no throw", async () => {
+    const state = freshStateDir();
+    try {
+        writeFileSync(pointerFile(state), "http://127.0.0.1:2\n");
+        await withEnv({ XDG_STATE_HOME: state, BILI_MCP_PROXY: "http://127.0.0.1:1" }, async () => {
+            _resetMcpLiveOriginForTest();
+            assert.equal(await resolveLiveOrigin(), "http://127.0.0.1:1", "callers get a dial target even when everything is down");
+        });
+    } finally {
+        rmSync(state, { recursive: true, force: true });
+    }
+});
+
+test("DEFAULT_PROXY_ORIGIN is the stable 8787 default (never ephemeral)", () => {
+    assert.equal(DEFAULT_PROXY_ORIGIN, "http://127.0.0.1:8787");
+});

--- a/tests/plugin-agent.test.ts
+++ b/tests/plugin-agent.test.ts
@@ -11,7 +11,7 @@ process.env.NODE_ENV = "test";
 import { proxyBaseFromUrl, proxyBaseFromEnv, detectProxyBase, fetchManifest, forwardTool, fetchStatus } from "../src/agent/shared.ts";
 import biliPlugin, { createBiliPlugin } from "../src/agent/pi.ts";
 import ompPlugin from "../src/agent/omp.ts";
-import { pluginInstall, pluginRemove, pluginStatusAll, PLUGIN_AGENTS, selfPackageRoot } from "../src/plugin-install.ts";
+import { pluginInstall, pluginRemove, pluginStatusAll, PLUGIN_AGENTS, selfPackageRoot, bakedProxyOrigin } from "../src/plugin-install.ts";
 import { resolveProxyOrigin, forwardTool as mcpForwardTool } from "../src/mcp.ts";
 
 function withEnv(vars: Record<string, string | undefined>, fn: () => void | Promise<void>): Promise<void> {
@@ -637,6 +637,23 @@ test("resolveProxyOrigin discovers the running proxy via the state file", async 
     });
     await withEnv({ XDG_STATE_HOME: state, BILI_MCP_PROXY: "http://10.0.0.5:9000" }, () => {
         assert.equal(resolveProxyOrigin(), "http://10.0.0.5:9000");
+    });
+    fs.rmSync(state, { recursive: true, force: true });
+});
+
+test("bakedProxyOrigin never freezes a transient pointer into persistent config (#405)", async () => {
+    const state = fs.mkdtempSync(path.join(os.tmpdir(), "bili-state-"));
+    fs.mkdirSync(path.join(state, "billion-context"), { recursive: true });
+    fs.writeFileSync(path.join(state, "billion-context", "proxy-origin"), "http://127.0.0.1:57645\n");
+    await withEnv({ XDG_STATE_HOME: state, BILI_MCP_PROXY: undefined }, () => {
+        assert.equal(
+            bakedProxyOrigin(),
+            "http://127.0.0.1:8787",
+            "a transient ephemeral pointer must not be frozen into persistent client config",
+        );
+    });
+    await withEnv({ XDG_STATE_HOME: state, BILI_MCP_PROXY: "http://10.0.0.5:9000" }, () => {
+        assert.equal(bakedProxyOrigin(), "http://10.0.0.5:9000", "explicit operator intent still wins");
     });
     fs.rmSync(state, { recursive: true, force: true });
 });

--- a/tests/proxy-origin.test.ts
+++ b/tests/proxy-origin.test.ts
@@ -1,0 +1,165 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { claimProxyOrigin, probeOrigin, readPointerLease, readPointerOrigin, releaseProxyOrigin, proxyOriginPath, proxyLeasePath } from "../src/proxy-origin.ts";
+
+function withStateDir<T>(fn: (stateDir: string) => Promise<T> | T): Promise<T> {
+    const state = mkdtempSync(path.join(tmpdir(), "bili-state-"));
+    const prev = process.env.XDG_STATE_HOME;
+    process.env.XDG_STATE_HOME = state;
+    return Promise.resolve(fn(state)).finally(() => {
+        if (prev === undefined) delete process.env.XDG_STATE_HOME;
+        else process.env.XDG_STATE_HOME = prev;
+        rmSync(state, { recursive: true, force: true });
+    });
+}
+
+function stateFile(stateDir: string, name: string): string {
+    return path.join(stateDir, "billion-context", name);
+}
+
+interface LiveProbe {
+    server: http.Server;
+    origin: string;
+    close: () => Promise<void>;
+}
+
+async function startBiliStub(instanceId: string): Promise<LiveProbe> {
+    const server = http.createServer((req, res) => {
+        if (req.url === "/__bili/health") {
+            res.writeHead(200, { "content-type": "application/json" });
+            res.end(JSON.stringify({ ok: true, upstream: "https://upstream.example", instanceId }));
+            return;
+        }
+        res.writeHead(404);
+        res.end();
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const addr = server.address() as AddressInfo;
+    const origin = `http://127.0.0.1:${addr.port}`;
+    return {
+        server,
+        origin,
+        close: () => new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve()))),
+    };
+}
+
+const silentLog = (): void => {};
+
+test("readPointerOrigin: absent / valid / garbage", async () => {
+    await withStateDir(async (state) => {
+        assert.equal(readPointerOrigin(), null);
+        const file = stateFile(state, "proxy-origin");
+        mkdirSync(path.dirname(file), { recursive: true });
+        writeFileSync(file, "http://127.0.0.1:9999\n");
+        assert.equal(readPointerOrigin(), "http://127.0.0.1:9999");
+        writeFileSync(file, "ftp://bad\ngarbage");
+        assert.equal(readPointerOrigin(), null);
+    });
+});
+
+test("readPointerLease: absent / valid / malformed", async () => {
+    await withStateDir(async (state) => {
+        assert.equal(readPointerLease(), null);
+        const lease = stateFile(state, "proxy-origin.lease");
+        mkdirSync(path.dirname(lease), { recursive: true });
+        writeFileSync(lease, JSON.stringify({ v: 2, origin: "http://127.0.0.1:8787", pid: 42, bootedAt: 123, instanceId: "abc" }) + "\n");
+        assert.deepEqual(readPointerLease(), { v: 2, origin: "http://127.0.0.1:8787", pid: 42, bootedAt: 123, instanceId: "abc" });
+        writeFileSync(lease, "{ not json");
+        assert.equal(readPointerLease(), null);
+        writeFileSync(lease, JSON.stringify({ v: 2, origin: 5 }) + "\n");
+        assert.equal(readPointerLease(), null);
+    });
+});
+
+test("probeOrigin: live with instanceId / dead port / non-ok health", async () => {
+    const stub = await startBiliStub("instance-xyz");
+    try {
+        const live = await probeOrigin(stub.origin);
+        assert.equal(live.live, true);
+        assert.equal(live.instanceId, "instance-xyz");
+        const dead = await probeOrigin("http://127.0.0.1:1");
+        assert.equal(dead.live, false);
+        assert.equal(dead.instanceId, undefined);
+    } finally {
+        await stub.close();
+    }
+});
+
+test("claimProxyOrigin: absent pointer is claimed (file + lease written)", async () => {
+    await withStateDir(async (state) => {
+        const claimed = await claimProxyOrigin("http://127.0.0.1:8787", { origin: "http://127.0.0.1:8787", pid: process.pid, bootedAt: 111, instanceId: "owner-1" }, silentLog);
+        assert.equal(claimed, true);
+        assert.equal(readPointerOrigin(), "http://127.0.0.1:8787");
+        assert.equal(readPointerLease()?.instanceId, "owner-1");
+        assert.equal(existsSync(proxyLeasePath()), true);
+    });
+});
+
+test("claimProxyOrigin: healthy existing owner keeps the pointer (#405)", async () => {
+    const stub = await startBiliStub("other-instance");
+    try {
+        await withStateDir(async (state) => {
+            const file = stateFile(state, "proxy-origin");
+            mkdirSync(path.dirname(file), { recursive: true });
+            writeFileSync(file, `${stub.origin}\n`);
+            const claimed = await claimProxyOrigin("http://127.0.0.1:59999", { origin: "http://127.0.0.1:59999", pid: process.pid, bootedAt: 222, instanceId: "latecomer" }, silentLog);
+            assert.equal(claimed, false, "did not take the pointer");
+            assert.equal(readPointerOrigin(), stub.origin, "existing owner's pointer untouched");
+            assert.equal(readPointerLease(), null, "no lease written by the non-claiming instance");
+        });
+    } finally {
+        await stub.close();
+    }
+});
+
+test("claimProxyOrigin: dead existing pointer is reclaimed", async () => {
+    await withStateDir(async (state) => {
+        const file = stateFile(state, "proxy-origin");
+        mkdirSync(path.dirname(file), { recursive: true });
+        writeFileSync(file, "http://127.0.0.1:1\n");
+        const claimed = await claimProxyOrigin("http://127.0.0.1:8787", { origin: "http://127.0.0.1:8787", pid: process.pid, bootedAt: 333, instanceId: "reclaimer" }, silentLog);
+        assert.equal(claimed, true);
+        assert.equal(readPointerOrigin(), "http://127.0.0.1:8787");
+        assert.equal(readPointerLease()?.instanceId, "reclaimer");
+    });
+});
+
+test("claimProxyOrigin: same origin is idempotent (rewrite, still claimed)", async () => {
+    await withStateDir(async (state) => {
+        const args = { origin: "http://127.0.0.1:8787", pid: process.pid, bootedAt: 444, instanceId: "same" };
+        assert.equal(await claimProxyOrigin(args.origin, args, silentLog), true);
+        assert.equal(await claimProxyOrigin(args.origin, { ...args, bootedAt: 555 }, silentLog), true);
+        assert.equal(readPointerOrigin(), "http://127.0.0.1:8787");
+        assert.equal(readPointerLease()?.bootedAt, 555);
+    });
+});
+
+test("releaseProxyOrigin: removes our pointer (file or lease ownership)", async () => {
+    await withStateDir(async (state) => {
+        await claimProxyOrigin("http://127.0.0.1:8787", { origin: "http://127.0.0.1:8787", pid: process.pid, bootedAt: 1, instanceId: "owner" }, silentLog);
+        releaseProxyOrigin("http://127.0.0.1:8787", "owner", silentLog);
+        assert.equal(existsSync(proxyOriginPath()), false);
+        assert.equal(existsSync(proxyLeasePath()), false);
+    });
+});
+
+test("releaseProxyOrigin: leaves a foreign pointer alone", async () => {
+    await withStateDir(async (state) => {
+        await claimProxyOrigin("http://127.0.0.1:8787", { origin: "http://127.0.0.1:8787", pid: process.pid, bootedAt: 1, instanceId: "owner-a" }, silentLog);
+        releaseProxyOrigin("http://127.0.0.1:9999", "owner-b", silentLog);
+        assert.equal(readPointerOrigin(), "http://127.0.0.1:8787", "foreign pointer untouched");
+        assert.equal(readPointerLease()?.instanceId, "owner-a");
+    });
+});
+
+test("releaseProxyOrigin: no-op when nothing was ever written", async () => {
+    await withStateDir(async () => {
+        assert.doesNotThrow(() => releaseProxyOrigin("http://127.0.0.1:8787", "nobody", silentLog));
+        assert.equal(readPointerOrigin(), null);
+    });
+});

--- a/tests/proxy-persist.test.ts
+++ b/tests/proxy-persist.test.ts
@@ -383,3 +383,75 @@ await withTempStore("one-time migration re-keys legacy hash-id sessions to their
         cold.cancelAll();
     }
 });
+
+// #405: two proxy processes sharing BILI_SESSIONS_DIR used to fork session
+// state — the instance holding the STALER in-memory copy rolled counters back
+// whenever it saved later (atomic writes prevent torn files, not rollbacks).
+await withTempStore("rollback guard: stale snapshot rejected, on-disk state kept (#405)", async (store, dir) => {
+    const warnings: string[] = [];
+    const fresh = makeSession("fork-1");
+    fresh.stats.requests = 3;
+    fresh.state.nextBlockId = 6;
+    await store.writeNow(fresh);
+
+    // A second "process": its in-memory copy was loaded earlier and never saw
+    // requests 3 — it saves AFTER the first instance did.
+    const cold = new SessionStore({ dir, debounceMs: 5, enabled: true, log: (_level, msg) => warnings.push(msg) });
+    try {
+        const stale = makeSession("fork-1");
+        stale.stats.requests = 2;
+        stale.state.nextBlockId = 5;
+        await cold.writeNow(stale);
+        assert.equal(store.loadSync("fork-1")!.stats.requests, 3, "requests did NOT roll back");
+        assert.equal(store.loadSync("fork-1")!.state.nextBlockId, 6, "block progress did NOT roll back");
+        assert.ok(warnings.some((w) => w.includes("rejected stale snapshot")), `warn logged: ${warnings.join(" | ")}`);
+
+        // flushSync on a stale copy reports success: disk already holds the
+        // newer state, so eviction may safely drop the stale in-memory copy.
+        assert.equal(cold.flushSync(stale), true);
+        assert.equal(store.loadSync("fork-1")!.stats.requests, 3);
+
+        // A genuinely newer snapshot still lands.
+        const newer = makeSession("fork-1");
+        newer.stats.requests = 4;
+        await cold.writeNow(newer);
+        assert.equal(store.loadSync("fork-1")!.stats.requests, 4, "newer snapshot accepted");
+    } finally {
+        cold.cancelAll();
+    }
+});
+
+await withTempStore("rollback guard: equal requests but fewer blocks is stale (#405)", async (store, dir) => {
+    const fresh = makeSession("fork-2");
+    fresh.stats.requests = 3;
+    fresh.state.nextBlockId = 7;
+    await store.writeNow(fresh);
+
+    const cold = new SessionStore({ dir, debounceMs: 5, enabled: true });
+    try {
+        const stale = makeSession("fork-2");
+        stale.stats.requests = 3; // same request count…
+        stale.state.nextBlockId = 4; // …but missing compression progress
+        await cold.writeNow(stale);
+        assert.equal(store.loadSync("fork-2")!.state.nextBlockId, 7, "compression progress did NOT roll back");
+    } finally {
+        cold.cancelAll();
+    }
+});
+
+await withTempStore("rollback guard: scheduleSave path is guarded too (#405)", async (store, dir) => {
+    const fresh = makeSession("fork-3");
+    fresh.stats.requests = 9;
+    await store.writeNow(fresh);
+
+    const cold = new SessionStore({ dir, debounceMs: 5, enabled: true });
+    try {
+        const stale = makeSession("fork-3");
+        stale.stats.requests = 1;
+        cold.scheduleSave(stale);
+        await settle(50);
+        assert.equal(store.loadSync("fork-3")!.stats.requests, 9, "debounced stale write rejected");
+    } finally {
+        cold.cancelAll();
+    }
+});


### PR DESCRIPTION
## What

Fixes #405 — four independent defects in the proxy-origin lifecycle, each with its own fix + regression tests:

1. **Read side had zero liveness** (`src/mcp.ts`) — new async `resolveLiveOrigin()` probes candidates `env → pointer file → default` via `GET /__bili/health`, caches after success, and invalidates the cache on fetch failure (incl. timeout). A dead ephemeral pointer self-heals on the *next* MCP call — no host-client restart. Rebinds are declared on stderr with the instance id.
2. **Write side clobbered unconditionally** (`src/server.ts` + new `src/proxy-origin.ts`) — the listen callback now *claims* instead of clobbers: a different existing origin that is healthy keeps the pointer (logged); otherwise it is reclaimed. Main file format unchanged (plain URL line, old shells keep working); a new sidecar lease (`proxy-origin.lease`: origin/pid/bootedAt/instanceId) carries ownership proof. Graceful shutdown releases the pointer only if it still points at this instance. `/__bili/health` now reports `instanceId`.
3. **Launcher spawned a second instance even when one was healthy** (`src/launcher.ts`) — `ensureProxyRunning` probes the preferred port first and reuses a healthy one (`ProxyHandle.child` now optional; `stopProxy` no-ops on reused handles). Warns if MITM domains were requested on a reused shared instance (domains only apply to instances started with them).
4. **plugin-install froze the transient origin into persistent configs** (`src/plugin-install.ts`) — all four bake sites (claude/codex/opencode) now bake the stable `DEFAULT_PROXY_ORIGIN`; explicit `BILI_MCP_PROXY`/`--origin` still wins. Custom-port instances keep working at runtime because the shell's env→file→default chain finds them (and dead pointers now heal per #1).
5. **Dual-instance snapshot rollback** (`src/persist.ts`, the concrete landing spot for #394's direction) — when two processes share `BILI_SESSIONS_DIR`, a stale full snapshot (monotonic signals `stats.requests` / `state.nextBlockId` regressing) is rejected with a throttled warn and the disk state is kept; `flushSync` on a stale copy reports success so eviction drops the stale in-memory copy (self-heal).

## Acceptance criteria

- [x] kill the launch-spawned ephemeral proxy (:8787 alive) → next MCP call recovers — `tests/mcp-live-origin.test.ts` (self-heal test); cache invalidation covers ECONNREFUSED/timeouts
- [x] `bili claude` with healthy :8787 present → no second spawn, no origin rewrite — `tests/launcher.test.ts` reuse test + `tests/proxy-origin.test.ts` claim tests
- [x] dual instances: later-saved older snapshot rejected + warn, counters do not roll back — three new tests in `tests/proxy-persist.test.ts`
- [x] any `plugin install` artifact bakes the stable BILI_MCP_PROXY — new test in `tests/plugin-agent.test.ts` (pointer file holding an ephemeral port → bakes :8787; explicit env still honored)

## Pre-flight

- `npm run typecheck` ✅
- `npm test`: 887/888 pass. The single failure (`resolveClientCommand: codex/claude resolve to themselves`) is **pre-existing and environment-dependent**: it fails identically on clean master here because this machine has `/usr/bin/codex` while the test hardcodes a bare-name expectation for `PATH=/usr/bin`. Not caused by this change (reported below as a minor issue).
- `npm run build` ✅ (tsup bundles `proxy-origin.ts` inline into `dist/index.js`)
- E2E preflight (`E2E_CHECK=1`): codex CLI + dist OK; full e2e skipped — the `127.0.0.1:8199` upstream is not reachable from this sandbox (expected, see `tests/e2e/README.md`).

## Notes

- Deliberate deviation from the issue proposal: an explicitly set `BILI_MCP_PROXY` (or `--origin`) still wins at bake time — operator intent preserved; the default path (the actual bug) bakes the stable port.
- No lockfile changes, no version bump.
