### PR TITLE
release v0.1.83

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.82",
+  "version": "0.1.83",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.82",
+      "version": "0.1.83",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.82",
+  "version": "0.1.83",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Version-only release bump **0.1.82 → 0.1.83** (commit changes only `package.json` + `package-lock.json`).

## Changes since v0.1.82

- **#424** (fixes #392): registry variant relay scan — per-variant `*/<name>` context-window lookup with max-wins semantics, `warnedConflicts` once-per-name warn, fall through only on zero hits. Opus relay sessions no longer mis-resolve 1M windows down to 200K.
- **#398** (fixes #388): side-request isolation reworked — side requests (title-gen, max_tokens≤200) now go through a minimal `sidePassthrough` Prepared instead of `prepared=null`, so the #460 render-tag strip pipes still run (response hygiene) while kernel state stays untouched; fake-completion retry skipped for side; 3 small-budget fixtures bumped (they test main-path features).

## Pre-flight

- `npm run typecheck` ✅
- `npm test` 1030/1032 (2 known permanent env fails in `tests/plugin-agent.test.ts`, unchanged baseline)
- `npm run build` ✅