### PR TITLE
fix: skip dead-pid proxy-origin records in MCP shell origin resolution (#405)

### DIFF
--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -9,7 +9,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { readProxyInstanceFile } from "./instance.js";
+import { isPidAlive, isProxyInstanceFile, readProxyInstanceFile, type ProxyInstanceFile } from "./instance.js";
 
 const VERSION = (() => {
     try {
@@ -34,11 +34,34 @@ type McpToolDef = {
 // request id — binding is headless (next NEW session).
 const DEFAULT_PROXY_ORIGIN = "http://127.0.0.1:8787";
 
+let staleOriginNoted = false;
+
+function noteStaleOrigin(rec: ProxyInstanceFile): void {
+    if (staleOriginNoted) return;
+    staleOriginNoted = true;
+    try {
+        process.stderr.write(
+            `[bili-mcp] proxy-origin record is stale (instance ${rec.instanceId.slice(0, 8)} pid ${rec.pid} not running) — falling back to ${DEFAULT_PROXY_ORIGIN}; if your proxy runs elsewhere, set BILI_MCP_PROXY (#405)\n`,
+        );
+    } catch {}
+}
+
 export function resolveProxyOrigin(): string {
     const fromEnv = process.env.BILI_MCP_PROXY?.trim();
     if (fromEnv && fromEnv.length > 0) return fromEnv;
     const discovered = readProxyInstanceFile();
-    if (discovered && /^https?:\/\/\S+$/.test(discovered.origin)) return discovered.origin;
+    if (discovered && /^https?:\/\/\S+$/.test(discovered.origin)) {
+        // #405: a JSON record left behind by a crashed/killed proxy names a
+        // port nothing listens on. pid liveness is the cheap check (no HTTP
+        // probe on the hot path); a dead record falls back to the default
+        // origin — where a replacement proxy binds. pid 0 means the record
+        // makes no liveness claim (foreign writer) — keep the legacy trust.
+        if (isProxyInstanceFile(discovered) && discovered.pid > 0 && !isPidAlive(discovered.pid)) {
+            noteStaleOrigin(discovered);
+            return DEFAULT_PROXY_ORIGIN;
+        }
+        return discovered.origin;
+    }
     return DEFAULT_PROXY_ORIGIN;
 }
 

--- a/tests/instance-governance.test.ts
+++ b/tests/instance-governance.test.ts
@@ -110,6 +110,24 @@ test("resolveProxyOrigin: env wins, JSON file parsed, default fallback", () => {
     }
 });
 
+test("resolveProxyOrigin: dead-pid JSON record falls back to default, live pid honored", () => {
+    const st = tmpStateDir();
+    const prevEnv = process.env.BILI_MCP_PROXY;
+    try {
+        delete process.env.BILI_MCP_PROXY;
+        atomicWriteInstanceFile(sampleInstance({ origin: "http://127.0.0.1:4242", pid: deadPid() }));
+        assert.equal(resolveProxyOrigin(), "http://127.0.0.1:8787");
+        atomicWriteInstanceFile(sampleInstance({ origin: "http://127.0.0.1:4242", pid: process.pid }));
+        assert.equal(resolveProxyOrigin(), "http://127.0.0.1:4242");
+        atomicWriteInstanceFile(sampleInstance({ origin: "http://127.0.0.1:4242", pid: 0 }));
+        assert.equal(resolveProxyOrigin(), "http://127.0.0.1:4242");
+    } finally {
+        if (prevEnv === undefined) delete process.env.BILI_MCP_PROXY;
+        else process.env.BILI_MCP_PROXY = prevEnv;
+        st.restore();
+    }
+});
+
 test("isPidAlive: self alive, dead pid not", () => {
     assert.equal(isPidAlive(process.pid), true);
     assert.equal(isPidAlive(deadPid()), false);


### PR DESCRIPTION
Split from #514 (fix 1 of 5, the only part still a gap on master — see review there). Completes the read-side (零验活) half of #403 — the piece the instance registry (#419) did not cover. (Note: #514's body cited #405, but that issue is the unrelated ACP_PASSTHROUGH observability bug; no auto-close intended.)

## Problem

`resolveProxyOrigin()` (src/mcp.ts) resolves env → instance file → default with **no liveness check**. When a proxy crashes or is killed, its JSON instance record stays behind naming a port nothing listens on — spawned MCP shells then dial the dead origin forever, and every tool call fails until the host client is restarted (or a new proxy happens to bind that exact port).

## Fix

Rebuilt on the `src/instance.ts` primitives (#394/#403/#417) rather than the HTTP-probe chain from #514:

- A JSON instance record with a live pid (`isPidAlive`, kill-0 — synchronous, no network on the hot path) is trusted as today.
- A record whose pid is dead is stale: skip to the default origin (`http://127.0.0.1:8787`, where a replacement proxy binds) with a **one-time** stderr note suggesting `BILI_MCP_PROXY` if the proxy runs elsewhere. Self-healing: the next tool call re-resolves, so a restarted proxy on the default port is picked up with no shell restart.
- `pid: 0` (record makes no liveness claim, foreign writer) and legacy plain-URL pointers keep the old trust semantics.

Why pid-check instead of #514's `/__bili/health` probe: the JSON record already carries the writer's pid, the check is synchronous (probe would have to become async + cached), and it exactly matches how the launcher attach and plugin-install already gate on the same file.

## Tests

tests/instance-governance.test.ts: dead-pid JSON record → default origin; live pid → record origin; pid 0 → trusted.

## Pre-flight

typecheck ✅ · full suite 1031/1033 (2 known plugin-agent env fails, unchanged baseline) · build ✅
