### PR TITLE
fix: reject stale in-memory snapshots that would roll back persisted session state (#405)

### DIFF
--- a/src/persist.ts
+++ b/src/persist.ts
@@ -65,6 +65,8 @@ const PERSIST_VERSION = 3;
  *  successful #286 migration pass so later boots skip the scan entirely. */
 const MIGRATION_MARKER = ".bili-migration-286.done";
 
+const STALE_WARN_THROTTLE_MS = 60_000;
+
 interface PersistedSession {
     version: number;
     savedAt: number;
@@ -182,12 +184,15 @@ export class SessionStore {
     readonly enabled: boolean;
     private readonly dir: string;
     private readonly store: StateStore<PersistedSession>;
+    private readonly log: Logger;
+    private readonly staleWarnAt = new Map<string, number>();
 
     constructor(opts?: { dir?: string; debounceMs?: number; enabled?: boolean; log?: Logger }) {
         const debounceMs = opts?.debounceMs ?? defaultDebounce();
         this.enabled = (opts?.enabled ?? true) && debounceMs >= 0;
         this.dir = opts?.dir ?? defaultDir();
         const baseLog = opts?.log ?? defaultLogger;
+        this.log = baseLog;
         const epermAlert = new PersistEpermAlert({
             dir: this.dir,
             threshold: epermAlertThreshold(),
@@ -358,32 +363,77 @@ export class SessionStore {
         }
     }
 
+    /** Shared envelope probe for the sync read paths: namespaced path
+     *  first, then the _unknown/ location, letting the kernel store layer
+     *  also check its discovered map and the flat legacy name. */
+    private loadEnvelope(id: string, meta?: { protocol?: string; upstreamOrigin?: string }): PersistedEnvelope<PersistedSession> | null {
+        const envelopes = [
+            this.store.loadSync(id, relPathFor(id, meta?.protocol, meta?.upstreamOrigin)),
+            meta?.protocol ? this.store.loadSync(id, relPathFor(id)) : null,
+        ];
+        for (const envelope of envelopes) {
+            if (envelope) return envelope;
+        }
+        return null;
+    }
+
     /** Synchronous reload of a single session. Used on a memory miss (after
      *  LRU eviction). Sync fs is acceptable here because a miss is rare and
      *  reads a single small file (~1ms). Returns null if missing/corrupt or the
      *  body id does not match what we asked for. */
     loadSync(id: string, meta?: { protocol?: string; upstreamOrigin?: string }): Session | null {
         if (!this.enabled) return null;
-        // Namespaced path first (current convention), then the _unknown/
-        // location for sessions persisted before protocol meta was captured.
-        // The kernel store also probes the flat legacy name on each call.
-        const envelopes = [
-            this.store.loadSync(id, relPathFor(id, meta?.protocol, meta?.upstreamOrigin)),
-            meta?.protocol ? this.store.loadSync(id, relPathFor(id)) : null,
-        ];
-        for (const envelope of envelopes) {
-            if (envelope) {
-                const session = buildSession(envelope.payload);
-                if (hasNegativePersistedTokens(envelope.payload)) {
-                    // #408: sync context — debounce the stale-file rewrite
-                    // (buildSession already clamped the in-memory value).
-                    this.scheduleSave(session);
-                    loggerLog("info", `[persist] clamped negative token stats on reload for ${id} (#408)`);
-                }
-                return session;
-            }
+        const envelope = this.loadEnvelope(id, meta);
+        if (!envelope) return null;
+        const session = buildSession(envelope.payload);
+        if (hasNegativePersistedTokens(envelope.payload)) {
+            // #408: sync context — debounce the stale-file rewrite
+            // (buildSession already clamped the in-memory value).
+            this.scheduleSave(session);
+            loggerLog("info", `[persist] clamped negative token stats on reload for ${id} (#408)`);
+        }
+        return session;
+    }
+
+    /** #405 fix #4: dual-instance rollback guard. When two proxy processes
+     *  share BILI_SESSIONS_DIR, whoever saves last used to win — an instance
+     *  holding a STALE in-memory copy would roll counters back (requests:3 →
+     *  2). Both signals below are monotonic per session id, so either being
+     *  strictly smaller proves staleness. Returns the fresher-on-disk payload
+     *  when the incoming record is stale, else null. */
+    private staleDiskPayload(incoming: PersistedSession): PersistedSession | null {
+        const envelope = this.loadEnvelope(incoming.id, incoming.meta);
+        if (!envelope) return null;
+        const disk = envelope.payload;
+        const diskRequests = disk.stats?.requests ?? disk.requests ?? 0;
+        const incRequests = incoming.stats?.requests ?? incoming.requests ?? 0;
+        if (incRequests < diskRequests) return disk;
+        if (incRequests === diskRequests) {
+            const diskBlocks = disk.state?.nextBlockId ?? 0;
+            const incBlocks = incoming.state?.nextBlockId ?? 0;
+            if (incBlocks < diskBlocks) return disk;
         }
         return null;
+    }
+
+    private guardedBuild(session: Session): () => PersistedSession {
+        return () => {
+            const record = buildRecord(session);
+            const disk = this.staleDiskPayload(record);
+            if (disk === null) return record;
+            const now = Date.now();
+            const last = this.staleWarnAt.get(record.id) ?? 0;
+            if (now - last >= STALE_WARN_THROTTLE_MS) {
+                this.staleWarnAt.set(record.id, now);
+                this.log(
+                    "warn",
+                    `[persist] rejected stale snapshot for session ${record.id}: in-memory copy is older than the on-disk one (another bili instance holds newer state) — keeping disk state, no rollback (#405)`,
+                );
+            }
+            // Rewrite the disk's own payload: content-identical no-op that
+            // preserves the newer state while satisfying the write chain.
+            return disk;
+        };
     }
 
     /** Schedule a debounced write for a session. Multiple calls within the
@@ -391,14 +441,14 @@ export class SessionStore {
      *  session state is persisted. Safe to call on the hot path. No-op if
      *  disabled. */
     scheduleSave(session: Session): void {
-        this.store.scheduleSave(session.id, () => buildRecord(session));
+        this.store.scheduleSave(session.id, this.guardedBuild(session));
     }
 
     /** Asynchronously persist a session right now (skips the debounce). Throws
      *  on write failure so callers can react (e.g. avoid evicting). Serialized
      *  per-session by the kernel store's write chains. */
     async writeNow(session: Session): Promise<void> {
-        await this.store.writeNow(session.id, () => buildRecord(session));
+        await this.store.writeNow(session.id, this.guardedBuild(session));
     }
 
     /** Synchronous flush for a single session. Used on memory eviction so a
@@ -407,7 +457,7 @@ export class SessionStore {
      *  Returns true on success, false on failure (caller must NOT evict on
      *  failure for a never-persisted session or it is lost permanently). */
     flushSync(session: Session): boolean {
-        return this.store.flushSync(session.id, () => buildRecord(session));
+        return this.store.flushSync(session.id, this.guardedBuild(session));
     }
 
     /** Flush all dirty sessions with a pending debounce timer. Called on

--- a/tests/persist-rollback-guard.test.ts
+++ b/tests/persist-rollback-guard.test.ts
@@ -1,0 +1,120 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { tmpdir } from "node:os";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { SessionStore } from "../src/persist.ts";
+import type { Session } from "../src/session.ts";
+import { createInitialState } from "acp-kernel";
+
+function makeSession(id: string): Session {
+    return {
+        id,
+        meta: { protocol: "openai", upstreamOrigin: "http://upstream" },
+        stats: { requests: 0, tokensSaved: 0, inputTokens: 0, cachedTokens: 0, outputTokens: 0, cacheSamples: 0, lastInputTokens: 0, contextTokens: 0 },
+        metadata: {},
+        state: createInitialState(),
+        createdAt: Date.now(),
+        lastSeen: Date.now(),
+        blockContents: new Map(),
+        inFlight: 0,
+        persisted: false,
+    };
+}
+
+type Warnings = string[];
+
+function withTempStore(name: string, fn: (store: SessionStore, dir: string, warnings: Warnings) => Promise<void> | void): Promise<void> {
+    return test(name, async () => {
+        const dir = mkdtempSync(join(tmpdir(), "bili-rollback-"));
+        const warnings: Warnings = [];
+        const store = new SessionStore({ dir, debounceMs: 5, enabled: true, log: (level, msg) => {
+            if (level === "warn") warnings.push(msg);
+        } });
+        try {
+            await fn(store, dir, warnings);
+        } finally {
+            store.cancelAll();
+            rmSync(dir, { recursive: true, force: true });
+        }
+    }) as unknown as Promise<void>;
+}
+
+await withTempStore("writeNow rejects a stale snapshot and keeps the newer disk state", async (store, _dir, warnings) => {
+    const s = makeSession("sess-stale");
+    s.stats.requests = 5;
+    s.state.nextBlockId = 3;
+    await store.writeNow(s);
+    // Simulate the OTHER instance having advanced disk state, while this
+    // process holds an older in-memory copy (e.g. dual-instance sharing the
+    // sessions dir): requests rolled back 5 -> 4.
+    s.stats.requests = 4;
+    await store.writeNow(s);
+    const reloaded = store.loadSync("sess-stale", { protocol: "openai", upstreamOrigin: "http://upstream" });
+    assert.ok(reloaded);
+    assert.equal(reloaded.stats.requests, 5, "disk keeps the newer counter — no rollback");
+    assert.ok(warnings.some((w) => w.includes("rejected stale snapshot") && w.includes("sess-stale")));
+});
+
+await withTempStore("tie on requests but stale nextBlockId is still rejected", async (store, _dir, warnings) => {
+    const s = makeSession("sess-blocks");
+    s.stats.requests = 5;
+    s.state.nextBlockId = 3;
+    await store.writeNow(s);
+    s.stats.requests = 5;
+    s.state.nextBlockId = 2;
+    await store.writeNow(s);
+    const reloaded = store.loadSync("sess-blocks", { protocol: "openai", upstreamOrigin: "http://upstream" });
+    assert.ok(reloaded);
+    assert.equal(reloaded.state.nextBlockId, 3, "disk keeps the newer block cursor");
+    assert.ok(warnings.some((w) => w.includes("sess-blocks")));
+});
+
+await withTempStore("fresher incoming snapshot passes through untouched", async (store, _dir, warnings) => {
+    const s = makeSession("sess-fresh");
+    s.stats.requests = 5;
+    s.state.nextBlockId = 3;
+    await store.writeNow(s);
+    s.stats.requests = 6;
+    s.state.nextBlockId = 4;
+    await store.writeNow(s);
+    const reloaded = store.loadSync("sess-fresh", { protocol: "openai", upstreamOrigin: "http://upstream" });
+    assert.ok(reloaded);
+    assert.equal(reloaded.stats.requests, 6);
+    assert.equal(reloaded.state.nextBlockId, 4);
+    assert.equal(warnings.length, 0, "no warning on legitimate writes");
+});
+
+await withTempStore("flushSync of a stale snapshot returns true so eviction stays safe", async (store) => {
+    const s = makeSession("sess-flush");
+    s.stats.requests = 9;
+    await store.writeNow(s);
+    s.stats.requests = 2;
+    assert.equal(store.flushSync(s), true, "write of the disk's own payload counts as success");
+    const reloaded = store.loadSync("sess-flush", { protocol: "openai", upstreamOrigin: "http://upstream" });
+    assert.ok(reloaded);
+    assert.equal(reloaded.stats.requests, 9);
+});
+
+await withTempStore("stale warning is throttled to once per window", async (store, _dir, warnings) => {
+    const s = makeSession("sess-throttle");
+    s.stats.requests = 5;
+    await store.writeNow(s);
+    s.stats.requests = 4;
+    await store.writeNow(s);
+    await store.writeNow(s);
+    await store.writeNow(s);
+    assert.equal(warnings.filter((w) => w.includes("sess-throttle")).length, 1, "one warn per 60s window");
+});
+
+await withTempStore("debounced scheduleSave also guards against rollback", async (store) => {
+    const s = makeSession("sched-1");
+    s.stats.requests = 7;
+    await store.writeNow(s);
+    s.stats.requests = 6;
+    store.scheduleSave(s);
+    await new Promise((r) => setTimeout(r, 30));
+    const reloaded = store.loadSync("sched-1", { protocol: "openai", upstreamOrigin: "http://upstream" });
+    assert.ok(reloaded);
+    assert.equal(reloaded.stats.requests, 7, "debounced write does not roll back");
+});


### PR DESCRIPTION
Closes #598 — tracking issue for this PR.

Split from #514 (fix 5 of 5, the other piece still unique — see review there). Addresses the dual-instance count fork (计数分叉) symptom at the heart of #403/#394 — persist-side only; the write-side was already fixed by the instance registry (#419). (Note: #514's body cited #405, but that issue is the unrelated ACP_PASSTHROUGH observability bug; no auto-close intended.)

## Problem

When two proxy processes share `BILI_SESSIONS_DIR` (the misconfiguration #394 warns about), whoever saves last wins. An instance holding a stale in-memory copy silently rolls the monotonic counters back — e.g. disk `requests: 3` gets overwritten with `requests: 2`, and block cursors regress the same way. Restarting the healthy instance then loads the regressed state.

## Fix

Every write entry point (`scheduleSave` / `writeNow` / `flushSync` in src/persist.ts) now builds through `guardedBuild`:

1. `staleDiskPayload` loads the current disk record via the same envelope probe as `loadSync` (namespaced path, `_unknown/` fallback, kernel flat-legacy probe) and compares the two monotonic signals: `stats.requests` (v1 flat fallback included), then `state.nextBlockId` on a tie. Either being strictly smaller proves the in-memory copy is stale.
2. On staleness the write proceeds with **the disk's own payload** — a content-identical no-op that satisfies the write chain while preserving the newer state — plus a per-session warning throttled to once per 60s (`STALE_WARN_THROTTLE_MS`).
3. `flushSync` of a stale snapshot still returns `true`: the disk already holds newer state, so memory eviction stays safe.

Read paths are factored through a shared `loadEnvelope` helper so the guard and `loadSync` can never disagree about where the record lives.

## Tests

tests/persist-rollback-guard.test.ts (6 tests): stale writeNow keeps disk + warns; tie-on-requests with older `nextBlockId` rejected; fresh snapshots pass through with no warning; stale `flushSync` returns true; warning throttled to once per window; debounced `scheduleSave` guarded too.

## Pre-flight

typecheck ✅ · full suite 1036/1038 (2 known plugin-agent env fails, unchanged baseline; +6 new tests) · build ✅
