### PR TITLE
fix: skip dead-pid proxy-origin records in MCP shell origin resolution (#405)

### DIFF
--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -9,7 +9,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { readProxyInstanceFile } from "./instance.js";
+import { isPidAlive, isProxyInstanceFile, readProxyInstanceFile } from "./instance.js";
 
 const VERSION = (() => {
     try {
@@ -33,12 +33,27 @@ type McpToolDef = {
 // BILI_CONVERSATION_ID (launcher-spawned hosts like codex) has no matching
 // request id — binding is headless (next NEW session).
 const DEFAULT_PROXY_ORIGIN = "http://127.0.0.1:8787";
+let warnedStaleRecord = false;
 
 export function resolveProxyOrigin(): string {
     const fromEnv = process.env.BILI_MCP_PROXY?.trim();
     if (fromEnv && fromEnv.length > 0) return fromEnv;
     const discovered = readProxyInstanceFile();
-    if (discovered && /^https?:\/\/\S+$/.test(discovered.origin)) return discovered.origin;
+    if (discovered && /^https?:\/\/\S+$/.test(discovered.origin)) {
+        // #405: a JSON record naming a dead writer pid points at a port nothing
+        // listens on — skip it for the default origin instead of dialing it
+        // forever. The `pid > 0` guard is deliberate: pid 0 (foreign writer)
+        // and legacy plain-URL pointers make no liveness claim and keep the
+        // old trust semantics (unlike plugin-install, which refuses them).
+        if (isProxyInstanceFile(discovered) && discovered.pid > 0 && !isPidAlive(discovered.pid)) {
+            if (!warnedStaleRecord) {
+                warnedStaleRecord = true;
+                process.stderr.write(`[bili-mcp] recorded bili proxy (${discovered.origin}, pid ${discovered.pid}) is not running — falling back to ${DEFAULT_PROXY_ORIGIN}; set BILI_MCP_PROXY if your proxy listens elsewhere\n`);
+            }
+            return DEFAULT_PROXY_ORIGIN;
+        }
+        return discovered.origin;
+    }
     return DEFAULT_PROXY_ORIGIN;
 }
 

--- a/tests/instance-governance.test.ts
+++ b/tests/instance-governance.test.ts
@@ -110,6 +110,38 @@ test("resolveProxyOrigin: env wins, JSON file parsed, default fallback", () => {
     }
 });
 
+test("resolveProxyOrigin: dead-pid record falls back to default origin, live pid and pid 0 trusted (#405)", () => {
+    const st = tmpStateDir();
+    const prevEnv = process.env.BILI_MCP_PROXY;
+    const origStderrWrite = process.stderr.write;
+    const stderrOut: string[] = [];
+    process.stderr.write = ((chunk: string | Uint8Array) => {
+        stderrOut.push(String(chunk));
+        return true;
+    }) as typeof process.stderr.write;
+    try {
+        delete process.env.BILI_MCP_PROXY;
+
+        atomicWriteInstanceFile(sampleInstance({ origin: "http://127.0.0.1:4242", pid: deadPid() }));
+        assert.equal(resolveProxyOrigin(), "http://127.0.0.1:8787", "dead-pid record skipped");
+        assert.equal(resolveProxyOrigin(), "http://127.0.0.1:8787", "re-resolves on every call");
+        const notes = stderrOut.filter((l) => l.includes("is not running"));
+        assert.equal(notes.length, 1, "one-time stderr note");
+        assert.match(notes[0], /BILI_MCP_PROXY/);
+
+        atomicWriteInstanceFile(sampleInstance({ origin: "http://127.0.0.1:4242" }));
+        assert.equal(resolveProxyOrigin(), "http://127.0.0.1:4242", "live pid trusted");
+
+        atomicWriteInstanceFile(sampleInstance({ origin: "http://127.0.0.1:4242", pid: 0 }));
+        assert.equal(resolveProxyOrigin(), "http://127.0.0.1:4242", "pid 0 makes no liveness claim");
+    } finally {
+        process.stderr.write = origStderrWrite;
+        if (prevEnv === undefined) delete process.env.BILI_MCP_PROXY;
+        else process.env.BILI_MCP_PROXY = prevEnv;
+        st.restore();
+    }
+});
+
 test("isPidAlive: self alive, dead pid not", () => {
     assert.equal(isPidAlive(process.pid), true);
     assert.equal(isPidAlive(deadPid()), false);


### PR DESCRIPTION
Closes #599 — tracking issue for this PR.

Split from #514 (fix 1 of 5, the only part still a gap on master — see review there). Fixes #405 (MCP half).

## What

`resolveProxyOrigin()` (src/mcp.ts) resolved env → instance file → default origin with **no liveness check**. When a proxy crashes or is killed, its JSON instance record stays behind naming a port nothing listens on — spawned MCP shells then dial the dead origin forever, and every tool call fails until the host client is restarted (or a new proxy happens to bind that exact port).

Rebuilt on the `src/instance.ts` primitives (#394/#403/#417) rather than the HTTP-probe chain from #514:

- A JSON instance record with a **live** pid (`isPidAlive`, kill(0) — synchronous, no network on the hot path) is trusted as today.
- A record whose pid is **dead** is stale: skip to the default origin (`http://127.0.0.1:8787`, where a replacement proxy binds) with a **one-time** stderr note suggesting `BILI_MCP_PROXY` if the proxy runs elsewhere. Self-healing: the next tool call re-resolves, so a restarted proxy is picked up with no shell restart.
- `pid: 0` (record makes no liveness claim, foreign writer) and legacy plain-URL pointers keep the old trust semantics — deliberate asymmetry vs plugin-install, which refuses them.
- `BILI_MCP_PROXY` env still wins over everything (operator intent).

Why pid-check instead of #514's `/__bili/health` probe: the JSON record already carries the writer's pid, the check is synchronous (probe would have to become async + cached), and it exactly matches how the launcher attach and plugin-install already gate on the same file.

## Tests

tests/instance-governance.test.ts: dead-pid JSON record → default origin (re-resolved on every call); live pid → record origin; pid 0 → trusted; stderr note fires once and mentions BILI_MCP_PROXY.

## Pre-flight

- typecheck ✅
- full suite 947/948 — the single failure is the known env-dependent `resolveClientCommand: codex/claude resolve to themselves` test (machine has /usr/bin/codex), identical on clean master (baseline 946/947)
- build ✅ (dist/mcp.js contains the new behavior)
- manual E2E on built dist/mcp.js: stale record (dead pid, unrouted port) → one-time stderr note → tool-call error names the fallback origin http://127.0.0.1:8787, not the dead port

## Notes

- Known limitation (accepted): PID reuse — if the dead pid is later reused by an unrelated process, the stale record looks live again. Same exposure as the existing plugin-install/launcher gating.
- Shells spawned with an explicit `BILI_MCP_PROXY` env pointing at a dead port still dial it — env is operator intent by design; recovery = repoint/reinstall.
- No version bump, no lockfile change.