### PR TITLE
feat(pi): native mode — self-spawned per-session proxy via in-process fetch interception (#519)

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,40 @@ bili daemon --parent-pid <agent-pid>
   parallel daemons never clobber each other. The global instance file is still
   written (last-writer-wins) for MCP-shell/install discovery.
 
+### Native mode (`bili plugin install pi --native`)
+
+For hosts where the proxy must not be started by a launcher at all — the user
+just runs their plain client and everything works in-process:
+
+```bash
+bili plugin install pi --native   # installs the plugin + enables native mode
+pi                               # that's it — no bili wrapper, no env vars
+```
+
+How it works:
+
+1. The installed pi extension sees the native-mode marker
+   (`~/.local/state/billion-context/native.json`) and starts its own
+   per-session proxy via `bili daemon --parent-pid <pi-pid>` (dynamic port).
+2. It then wraps `globalThis.fetch` inside the running pi process: requests
+   whose target origin matches the active model's upstream are rewritten to
+   `http://127.0.0.1:<port>/bili/<original-url>`; everything else passes
+   through untouched.
+3. When pi exits, the proxy reaps itself via the parent-pid watcher.
+
+Notes:
+
+- The first provider request of a session can outrun daemon startup (~1s);
+  it goes direct to the upstream unproxied. From the second request on, all
+  traffic flows through the proxy, and since agents resend full history,
+  context tracking self-heals within one turn.
+- A launcher-provided proxy (env or `/bili/` URL) always wins over native
+  mode — running `bili pi` with a native install behaves exactly like before.
+- No marker → the plugin stays inert (current behavior), so launcher-mode
+  users are never surprised by auto-spawned proxies.
+- `bili plugin remove pi` clears the marker again. Currently supported for
+  `pi` only (the validated host); other agents keep launcher/MCP wiring.
+
 ### Remote agents (`--host`)
 
 By default the proxy binds `127.0.0.1` and only accepts loopback

--- a/src/agent/intercept.ts
+++ b/src/agent/intercept.ts
@@ -1,0 +1,114 @@
+/**
+ * Runtime egress interception for native mode (#519).
+ *
+ * Wraps globalThis.fetch inside the host agent's Node process so requests
+ * destined for an active model's upstream origin are routed through a
+ * per-session bili proxy (`<proxyOrigin>/bili/<original-url>` — the same
+ * zero-config prefix format the proxy already terminates). Everything else
+ * passes through untouched, so a host process that makes unrelated HTTP
+ * calls (telemetry, update checks) is unaffected.
+ *
+ * JS identifiers resolve to globals dynamically at call time, and provider
+ * SDKs pass bare `fetch` identifiers (no local shadowing), so patching the
+ * global intercepts real provider traffic without touching client config.
+ */
+
+export interface InterceptOptions {
+    /** Proxy origin, e.g. `http://127.0.0.1:43210`. Trailing slash tolerated. */
+    proxyOrigin: string;
+    /** Exact origins (scheme+host+port) whose outgoing requests get rewritten. */
+    upstreamOrigins: Iterable<string>;
+}
+
+type FetchFn = typeof globalThis.fetch;
+
+interface ActiveInterceptor {
+    original: FetchFn;
+    wrapped: FetchFn;
+}
+
+type FetchInput = string | URL | Request;
+
+let active: ActiveInterceptor | null = null;
+
+function normalizeOrigins(entries: Iterable<string>): Set<string> {
+    const set = new Set<string>();
+    for (const entry of entries) {
+        const s = entry.trim();
+        if (!s) continue;
+        try {
+            set.add(new URL(s).origin);
+        } catch {
+            // Unparseable entry — skip rather than poison the whole set.
+        }
+    }
+    return set;
+}
+
+function inputUrl(input: FetchInput): string | null {
+    if (typeof input === "string") return input;
+    if (input instanceof URL) return input.href;
+    if (input instanceof Request) return input.url;
+    return null;
+}
+
+export function installFetchInterceptor(opts: InterceptOptions): () => void {
+    if (!opts.proxyOrigin || typeof opts.proxyOrigin !== "string") {
+        throw new Error("installFetchInterceptor: proxyOrigin is required");
+    }
+    const proxyOrigin = opts.proxyOrigin.replace(/\/+$/, "");
+    const origins = normalizeOrigins(opts.upstreamOrigins);
+    if (origins.size === 0) {
+        throw new Error("installFetchInterceptor: no valid upstreamOrigins");
+    }
+
+    // Re-installing replaces any prior wrapper (model/provider switches, tests).
+    if (active && globalThis.fetch === active.wrapped) {
+        globalThis.fetch = active.original;
+    }
+    const original = globalThis.fetch;
+    if (typeof original !== "function") {
+        throw new Error("installFetchInterceptor: globalThis.fetch unavailable");
+    }
+
+    const rewrite = (urlStr: string): string | null => {
+        let u: URL;
+        try {
+            u = new URL(urlStr);
+        } catch {
+            return null;
+        }
+        if (u.protocol !== "http:" && u.protocol !== "https:") return null;
+        // Already proxied — never double-wrap (#519).
+        if (u.pathname.startsWith("/bili/")) return null;
+        if (!origins.has(u.origin)) return null;
+        return `${proxyOrigin}/bili/${urlStr}`;
+    };
+
+    const wrapped: FetchFn = ((input: FetchInput, init?: RequestInit) => {
+        const url = inputUrl(input);
+        const target = url !== null ? rewrite(url) : null;
+        if (target === null) return original.call(globalThis, input, init);
+        if (typeof input === "string" || input instanceof URL) {
+            return original.call(globalThis, target, init);
+        }
+        const req: Request = input;
+        const rinit: RequestInit & { duplex?: "half" } = {
+            method: req.method,
+            headers: req.headers,
+            signal: req.signal,
+        };
+        if (req.body != null) {
+            rinit.body = req.body;
+            rinit.duplex = "half";
+        }
+        return original.call(globalThis, target, rinit);
+    }) as FetchFn;
+
+    globalThis.fetch = wrapped;
+    active = { original, wrapped };
+
+    return () => {
+        if (globalThis.fetch === wrapped) globalThis.fetch = original;
+    };
+}

--- a/src/agent/pi.ts
+++ b/src/agent/pi.ts
@@ -5,6 +5,12 @@
 // minimal structural declarations — the bundled artifact imports NOTHING
 // from the host at runtime (the host duck-types us in).
 
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { installFetchInterceptor } from "./intercept.js";
 import { detectProxyBase, fetchManifest, forwardTool, fetchStatus, fetchProxyVersion, type ManifestTool } from "./shared.js";
 
 type Ctx = {
@@ -61,6 +67,202 @@ function agentName(override: string | undefined): string {
 
 function proxyBaseForCtx(ctx: Ctx): string | undefined {
     return detectProxyBase(ctx.model?.baseUrl);
+}
+
+// --- Native mode (#519): no launcher in front — the plugin itself starts a
+// per-session proxy (`bili daemon --fresh --json`) and intercepts outgoing
+// provider traffic in-process so the user's plain `pi`/`omp` works unmodified.
+// Enabled only by an explicit marker file (written by
+// `bili plugin install <agent> --native`); without it this whole section is
+// inert and behavior is byte-identical to before. A launcher-provided proxy
+// (detectProxyBase hit) always wins over native spawning.
+
+type DaemonInfo = { origin: string; port: number; pid?: number };
+
+const DAEMON_TIMEOUT_MS = 20000;
+
+function packageEntryPath(): string | undefined {
+    try {
+        // Bundled artifact lives at <root>/dist/agent/<name>.js — two levels up
+        // is the package root whose dist/index.js is the bili CLI entry.
+        const here = fileURLToPath(import.meta.url);
+        const root = path.resolve(path.dirname(here), "..", "..");
+        const entry = path.join(root, "dist", "index.js");
+        return fs.existsSync(entry) ? entry : undefined;
+    } catch {
+        return undefined;
+    }
+}
+
+function readNativeMarker(agent: string): boolean {
+    try {
+        const stateDir = process.env.XDG_STATE_HOME || path.join(os.homedir(), ".local", "state");
+        const raw = fs.readFileSync(path.join(stateDir, "billion-context", "native.json"), "utf8");
+        const obj: unknown = JSON.parse(raw);
+        return obj !== null && typeof obj === "object" && (obj as Record<string, unknown>)[agent] === true;
+    } catch {
+        return false;
+    }
+}
+
+// Local copy of launcher.ts' stripInheritedProxy: importing it would pull the
+// server-side module graph into this thin agent bundle (tsup inlines per-entry).
+const INHERITED_PROXY_VARS = ["http_proxy", "https_proxy", "all_proxy", "HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY"];
+
+function stripInheritedProxy(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+    const cleaned = { ...env };
+    for (const key of INHERITED_PROXY_VARS) delete cleaned[key];
+    return cleaned;
+}
+
+function spawnDaemon(entry: string, parentPid: number, agent: string): Promise<DaemonInfo | undefined> {
+    return new Promise((resolve) => {
+        let out = "";
+        let settled = false;
+        const finish = (v: DaemonInfo | undefined): void => {
+            if (!settled) {
+                settled = true;
+                clearTimeout(timer);
+                resolve(v);
+            }
+        };
+        let child: ReturnType<typeof spawn>;
+        try {
+            child = spawn(process.execPath, [entry, "daemon", "--parent-pid", String(parentPid)], {
+                stdio: ["ignore", "pipe", "inherit"],
+                env: stripInheritedProxy(process.env),
+            });
+        } catch (err) {
+            console.error(`bili-plugin(${agent}): daemon spawn failed: ${err instanceof Error ? err.message : String(err)}`);
+            finish(undefined);
+            return;
+        }
+        const timer = setTimeout(() => {
+            try {
+                child.kill("SIGKILL");
+            } catch {
+                // child already gone
+            }
+            console.error(`bili-plugin(${agent}): daemon start timed out after ${DAEMON_TIMEOUT_MS / 1000}s`);
+            finish(undefined);
+        }, DAEMON_TIMEOUT_MS);
+        child.stdout?.on("data", (d: Buffer) => {
+            out += d.toString("utf8");
+        });
+        child.on("error", (err) => {
+            console.error(`bili-plugin(${agent}): daemon spawn error: ${err.message}`);
+            finish(undefined);
+        });
+        child.on("close", (code) => {
+            if (code !== 0) {
+                console.error(`bili-plugin(${agent}): daemon exited with code ${code} — native mode unavailable`);
+                finish(undefined);
+                return;
+            }
+            const line = out.trim().split("\n").pop()?.trim();
+            if (line !== undefined) {
+                try {
+                    const j: unknown = JSON.parse(line);
+                    if (j !== null && typeof j === "object") {
+                        const rec = j as { origin?: unknown; port?: unknown; pid?: unknown };
+                        if (typeof rec.origin === "string" && typeof rec.port === "number") {
+                            finish({ origin: rec.origin, port: rec.port, pid: typeof rec.pid === "number" ? rec.pid : undefined });
+                            return;
+                        }
+                    }
+                } catch {
+                    // fall through to unparseable
+                }
+            }
+            console.error(`bili-plugin(${agent}): daemon output unparseable — native mode unavailable`);
+            finish(undefined);
+        });
+    });
+}
+
+function startDaemon(state: RegisterState, agent: string): void {
+    if (state.daemon !== undefined) return;
+    // BILLION_CONTEXT_PLUGIN=0 is the global plugin kill switch (shared.ts
+    // honors it); native spawning must honor it too or a disabled plugin would
+    // silently start proxies. NODE_ENV=test keeps unit tests from spawning real
+    // daemons on machines that have a live marker file.
+    if (process.env.BILLION_CONTEXT_PLUGIN === "0" || process.env.NODE_ENV === "test") return;
+    if (!readNativeMarker(agent)) return;
+    const entry = packageEntryPath();
+    if (entry === undefined) {
+        console.error(`bili-plugin(${agent}): native mode enabled but package entry not found — staying disabled`);
+        return;
+    }
+    state.daemon = spawnDaemon(entry, process.pid, agent);
+}
+
+// Installs (or re-points, on model/provider switch) the in-process egress
+// interceptor for the given upstream origin. Takes the upstream base URL as a
+// plain string (snapshotted by the caller BEFORE any await — pi's ctx is a
+// proxy whose getters assert session liveness, so post-await ctx reads throw
+// on replaced sessions). Returns false when the upstream cannot be determined
+// — in that case nativeBase must NOT be set, because claiming plugin ownership
+// while traffic bypasses the proxy would wedge the session in a mode where
+// compression never sees its traffic.
+function installInterceptorFor(upstreamBaseUrl: string | undefined, state: RegisterState, agent: string, origin: string): boolean {
+    if (upstreamBaseUrl === undefined || upstreamBaseUrl.length === 0) return false;
+    let upstreamOrigin: string;
+    try {
+        upstreamOrigin = new URL(upstreamBaseUrl).origin;
+    } catch {
+        return false;
+    }
+    if (state.uninstallIntercept !== undefined && state.nativeUpstream === upstreamOrigin) return true;
+    try {
+        state.uninstallIntercept?.();
+        state.uninstallIntercept = installFetchInterceptor({ proxyOrigin: origin, upstreamOrigins: [upstreamOrigin] });
+        state.nativeUpstream = upstreamOrigin;
+        return true;
+    } catch (err) {
+        console.error(`bili-plugin(${agent}): interceptor install failed: ${err instanceof Error ? err.message : String(err)}`);
+        return false;
+    }
+}
+
+async function ensureNativeReady(ctx: Ctx, state: RegisterState, agent: string): Promise<void> {
+    // pi's ctx getters assert session liveness (reads throw once the session
+    // was replaced), so snapshot host data before the first await and touch
+    // ctx nowhere below it.
+    const baseUrl = ctx.model?.baseUrl;
+    if (state.nativeBase !== undefined) {
+        installInterceptorFor(baseUrl, state, agent, state.nativeBase);
+        return;
+    }
+    if (proxyBaseForCtx(ctx) !== undefined) return;
+    if (state.daemon === undefined) {
+        if (state.nativeRetryAt !== undefined && Date.now() < state.nativeRetryAt) return;
+        startDaemon(state, agent);
+    }
+    if (state.daemon === undefined) return;
+    const info = await state.daemon;
+    if (info === undefined) {
+        state.nativeRetryAt = Date.now() + state.retryIntervalMs;
+        return;
+    }
+    if (!installInterceptorFor(baseUrl, state, agent, info.origin)) return;
+    state.childPid = info.pid;
+    state.nativeBase = info.origin;
+}
+
+function shutdownNative(state: RegisterState): void {
+    state.uninstallIntercept?.();
+    state.uninstallIntercept = undefined;
+    state.nativeUpstream = undefined;
+    if (state.childPid !== undefined) {
+        try {
+            process.kill(state.childPid, "SIGTERM");
+        } catch {
+            // already gone
+        }
+    }
+    state.childPid = undefined;
+    state.nativeBase = undefined;
+    state.daemon = undefined;
 }
 
 function sessionIdOf(ctx: Ctx): string | undefined {
@@ -173,7 +375,21 @@ function parseProviderRewrites(env: NodeJS.ProcessEnv): Record<string, string> |
 
 const RETRY_INTERVAL_MS = 10000;
 
-type RegisterState = { sid?: string; toolsFor?: string; toolsReady?: boolean; pending?: Promise<void>; retryAt?: number; identityAt?: string; retryIntervalMs: number };
+type RegisterState = {
+    sid?: string;
+    toolsFor?: string;
+    toolsReady?: boolean;
+    pending?: Promise<void>;
+    retryAt?: number;
+    identityAt?: string;
+    retryIntervalMs: number;
+    daemon?: Promise<DaemonInfo | undefined>;
+    nativeBase?: string;
+    nativeUpstream?: string;
+    nativeRetryAt?: number;
+    uninstallIntercept?: () => void;
+    childPid?: number;
+};
 
 // omp never emits before_provider_headers, so the x-bili-plugin marker cannot
 // be stamped per request. Register the conversation id once (after tools are
@@ -190,7 +406,7 @@ async function postIdentityRegister(proxyBase: string, conversationId: string, a
 }
 
 async function registerTools(pi: ExtensionAPI, ctx: Ctx, state: RegisterState, agent: string): Promise<void> {
-    const proxyBase = proxyBaseForCtx(ctx);
+    const proxyBase = proxyBaseForCtx(ctx) ?? state.nativeBase;
     if (proxyBase === undefined) return;
     // Cache on the session id; "" (host has no sessionManager) still caches,
     // so a successful registration is not re-fetched on every provider
@@ -336,7 +552,7 @@ export function createBiliPlugin(agentOverride?: string, opts?: { retryIntervalM
                             // host UI unavailable — the command is best-effort
                         }
                     };
-                    const proxyBase = detectProxyBase(ctx.model?.baseUrl);
+                    const proxyBase = detectProxyBase(ctx.model?.baseUrl) ?? state.nativeBase;
                     if (proxyBase === undefined) {
                         notify("bili: no proxy detected (run via `bili <client>` or set a /bili/ baseURL)", "warning");
                         return;
@@ -391,7 +607,7 @@ export function createBiliPlugin(agentOverride?: string, opts?: { retryIntervalM
         }
         pi.on("before_provider_headers", (event, ctx) => {
             try {
-                if (proxyBaseForCtx(ctx) === undefined) return;
+                if (proxyBaseForCtx(ctx) === undefined && state.nativeBase === undefined) return;
                 const headers = (event as unknown as { headers?: Record<string, string> }).headers;
                 if (headers === undefined || typeof headers !== "object" || Array.isArray(headers)) return;
                 // The x-bili-plugin marker tells the proxy "the client owns the
@@ -414,18 +630,34 @@ export function createBiliPlugin(agentOverride?: string, opts?: { retryIntervalM
             } catch (err) {
                 console.error(`bili-plugin(${agent}): header stamp skipped (${err instanceof Error ? err.message : String(err)})`);
             }
-            void registerTools(pi, ctx, state, agent).catch((err: unknown) => console.error(`bili-plugin(${agent}): ${err instanceof Error ? err.message : String(err)}`));
+            arm(ctx);
         });
+        const arm = (ctx: Ctx): void => {
+            // The two steps must NOT be chained across the daemon-spawn await:
+            // pi invalidates captured host references on session replacement
+            // (-p print mode replaces the session right after startup), and a
+            // registerTool call from the stale continuation throws. Registration
+            // is therefore driven by these per-request events, which always
+            // carry fresh references; registerTools is a no-op until nativeBase
+            // exists, so nothing is out of order. ensureNativeReady resolves
+            // immediately in every non-native case, preserving the original
+            // registration timing there.
+            void ensureNativeReady(ctx, state, agent).catch((err: unknown) => console.error(`bili-plugin(${agent}): ${err instanceof Error ? err.message : String(err)}`));
+            void registerTools(pi, ctx, state, agent).catch((err: unknown) => console.error(`bili-plugin(${agent}): ${err instanceof Error ? err.message : String(err)}`));
+        };
         pi.on("before_provider_request", (event, ctx) => {
             // omp emits this per model request (but never before_provider_headers);
             // it doubles as the retry driver when the session_start manifest
             // fetch raced the proxy startup. Cached by sid, throttled by retryAt.
-            void registerTools(pi, ctx, state, agent).catch((err: unknown) => console.error(`bili-plugin(${agent}): ${err instanceof Error ? err.message : String(err)}`));
+            arm(ctx);
             return stampPromptCacheKey(event, ctx, agent);
         });
         pi.on("session_start", (_event, ctx) => {
             state.sid = undefined;
-            void registerTools(pi, ctx, state, agent).catch((err: unknown) => console.error(`bili-plugin(${agent}): ${err instanceof Error ? err.message : String(err)}`));
+            arm(ctx);
+        });
+        pi.on("session_shutdown", (_event, _ctx) => {
+            shutdownNative(state);
         });
         // omp fires session_compact on in-session native compaction (sid does
         // not rotate), so the proxy reuses stale state — notify it to archive

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -74,8 +74,11 @@ Usage:
    bili daemon [--parent-pid N]     start a per-session proxy on a dynamic port
                                      (always a fresh instance; prints one JSON line
                                      {origin,port,pid,logPath} to stdout, exit 0)
-   bili plugin install <agent>      install the thin plugin into a host (pi/omp/
-                                    claude/codex/opencode; original backed up once)
+   bili plugin install <agent> [--native]
+                                install the thin plugin into a host (pi/omp/
+                                    claude/codex/opencode; original backed up once;
+                                    --native (pi only): the plugin starts its own
+                                    per-session proxy — no launcher needed)
   bili plugin remove <agent>       remove it again
   bili plugin list                 show install status for every host
   bili mcp                         run the bili MCP server standalone (stdio)
@@ -138,6 +141,7 @@ type Parsed = {
     parentPid?: number;
     pluginAction?: "install" | "remove" | "list";
     pluginAgent?: PluginAgent;
+    pluginNative?: boolean;
 };
 
 export function parseArgs(argv: string[]): Parsed {
@@ -154,6 +158,7 @@ export function parseArgs(argv: string[]): Parsed {
     let exportFull = false;
     let pluginAction: Parsed["pluginAction"];
     let pluginAgent: Parsed["pluginAgent"];
+    let pluginNative = false;
 
     for (let i = 0; i < argv.length; i++) {
         const a = argv[i]!;
@@ -205,6 +210,9 @@ export function parseArgs(argv: string[]): Parsed {
                 parentPid = Number(val);
                 break;
             }
+            case "--native":
+                pluginNative = true;
+                break;
             case "--full":
                 exportFull = true;
                 break;
@@ -310,11 +318,11 @@ export function parseArgs(argv: string[]): Parsed {
         }
     }
 
-    return { command, client, clientArgs, mitmDomains, overrides, exportSelector, exportOutput, exportFull, registerConversationId, parentPid, pluginAction, pluginAgent };
+    return { command, client, clientArgs, mitmDomains, overrides, exportSelector, exportOutput, exportFull, registerConversationId, parentPid, pluginAction, pluginAgent, pluginNative };
 }
 
 export async function main(): Promise<void> {
-    const { command, client, clientArgs, mitmDomains, overrides, exportSelector, exportOutput, exportFull, registerConversationId, parentPid, pluginAction, pluginAgent } = parseArgs(process.argv.slice(2));
+    const { command, client, clientArgs, mitmDomains, overrides, exportSelector, exportOutput, exportFull, registerConversationId, parentPid, pluginAction, pluginAgent, pluginNative } = parseArgs(process.argv.slice(2));
     if (command === "help") {
         process.stdout.write(HELP);
         return;
@@ -359,13 +367,13 @@ export async function main(): Promise<void> {
         if (overrides.BILI_MCP_PROXY !== undefined) process.env.BILI_MCP_PROXY = overrides.BILI_MCP_PROXY;
         if (pluginAction === "list") {
             for (const row of pluginStatusAll()) {
-                console.log(`${row.agent.padEnd(10)} ${row.status}`);
+                console.log(`${row.agent.padEnd(10)} ${row.status}${row.native ? " (native)" : ""}`);
             }
             return;
         }
         if (pluginAction === "install") {
             try {
-                console.log(pluginInstall(pluginAgent!));
+                console.log(pluginInstall(pluginAgent!, { native: pluginNative }));
             } catch (error) {
                 console.error(`bili plugin: ${error instanceof Error ? error.message : String(error)}`);
                 process.exit(1);

--- a/src/plugin-install.ts
+++ b/src/plugin-install.ts
@@ -18,6 +18,7 @@ import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { resolvePiHome } from "./client-config.js";
 import { isPidAlive, isProxyInstanceFile, readProxyInstanceFile } from "./instance.js";
+import { stateDir } from "./paths.js";
 
 /** #403: never freeze a dead or unverifiable origin into a client's
  *  persistent config — the MCP shell would dial it forever. An explicit
@@ -451,22 +452,70 @@ function opencodeStatus(): string {
     return mcp && "bili" in mcp ? "installed" : "not installed";
 }
 
+// — native mode marker (#519) ————————————————————————————————————————
+// `bili plugin install <agent> --native` records that the extension may start
+// its own per-session proxy (`bili daemon --fresh`) when no launcher proxy is
+// detected. The key must stay in step with readNativeMarker() in
+// src/agent/pi.ts: <stateDir>/native.json, one boolean per agent.
+
+// Native spawning lives in the bundled extension (src/agent/pi.ts factory).
+// Only agents whose fetch interception has been validated may opt in; the MCP
+// shells (claude/codex/opencode) have no in-process hook at all.
+const NATIVE_CAPABLE_AGENTS: readonly PluginAgent[] = ["pi"];
+
+function nativeMarkerFile(): string {
+    return path.join(stateDir(), "native.json");
+}
+
+function readNativeMarkers(): Record<string, unknown> {
+    try {
+        const obj: unknown = JSON.parse(fs.readFileSync(nativeMarkerFile(), "utf8"));
+        if (obj !== null && typeof obj === "object" && !Array.isArray(obj)) return obj as Record<string, unknown>;
+    } catch {
+        // missing or corrupt → treat as empty
+    }
+    return {};
+}
+
+function setNativeMarker(agent: PluginAgent, enabled: boolean): void {
+    if (readNativeMarkers()[agent] === enabled) return;
+    const markers = readNativeMarkers();
+    if (enabled) markers[agent] = true;
+    else delete markers[agent];
+    const file = nativeMarkerFile();
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    backupOnce(file);
+    fs.writeFileSync(file, JSON.stringify(markers, null, 2) + "\n");
+}
+
+function nativeEnabled(agent: PluginAgent): boolean {
+    return readNativeMarkers()[agent] === true;
+}
+
 // — dispatch ————————————————————————————————————————————————————————————
 
 export function isPluginAgent(value: string): value is PluginAgent {
     return (PLUGIN_AGENTS as readonly string[]).includes(value);
 }
 
-export function pluginInstall(agent: PluginAgent): string {
-    return agent === "pi" ? piInstall() : agent === "omp" ? ompInstall() : agent === "claude" ? claudeInstall() : agent === "codex" ? codexInstall() : opencodeInstall();
+export function pluginInstall(agent: PluginAgent, opts?: { native?: boolean }): string {
+    const msg = agent === "pi" ? piInstall() : agent === "omp" ? ompInstall() : agent === "claude" ? claudeInstall() : agent === "codex" ? codexInstall() : opencodeInstall();
+    if (opts?.native !== true) return msg;
+    if (!(NATIVE_CAPABLE_AGENTS as readonly string[]).includes(agent)) {
+        throw new Error(`--native supports: ${NATIVE_CAPABLE_AGENTS.join(", ")} (not ${agent})`);
+    }
+    setNativeMarker(agent, true);
+    return `${msg} (native mode enabled)`;
 }
 
 export function pluginRemove(agent: PluginAgent): string {
-    return agent === "pi" ? piRemove() : agent === "omp" ? ompRemove() : agent === "claude" ? claudeRemove() : agent === "codex" ? codexRemove() : opencodeRemove();
+    const msg = agent === "pi" ? piRemove() : agent === "omp" ? ompRemove() : agent === "claude" ? claudeRemove() : agent === "codex" ? codexRemove() : opencodeRemove();
+    setNativeMarker(agent, false);
+    return msg;
 }
 
-export function pluginStatusAll(): Array<{ agent: string; status: string }> {
-    const checks: Array<[string, () => string]> = [
+export function pluginStatusAll(): Array<{ agent: string; status: string; native: boolean }> {
+    const checks: Array<[PluginAgent, () => string]> = [
         ["pi", piStatus],
         ["omp", ompStatus],
         ["claude", claudeStatus],
@@ -475,9 +524,9 @@ export function pluginStatusAll(): Array<{ agent: string; status: string }> {
     ];
     return checks.map(([agent, check]) => {
         try {
-            return { agent, status: check() };
+            return { agent, status: check(), native: nativeEnabled(agent) };
         } catch (err) {
-            return { agent, status: `error: ${err instanceof Error ? err.message : String(err)}` };
+            return { agent, status: `error: ${err instanceof Error ? err.message : String(err)}`, native: nativeEnabled(agent) };
         }
     });
 }

--- a/tests/intercept.test.ts
+++ b/tests/intercept.test.ts
@@ -1,0 +1,168 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { installFetchInterceptor } from "../src/agent/intercept.ts";
+
+type FetchFn = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+type Call = [RequestInfo | URL, RequestInit?];
+
+const REAL_FETCH: FetchFn = globalThis.fetch;
+
+function withMockedFetch(fn: (calls: Call[]) => void | Promise<void>) {
+    const calls: Call[] = [];
+    const mock: FetchFn = (input, init) => {
+        calls.push([input, init]);
+        return Promise.resolve(new Response("ok"));
+    };
+    globalThis.fetch = mock;
+    return Promise.resolve()
+        .then(() => fn(calls))
+        .finally(() => {
+            globalThis.fetch = REAL_FETCH;
+        });
+}
+
+test("intercept: rewrites matching-origin string URLs with preserved path+query", async () => {
+    await withMockedFetch(async (calls) => {
+        const un = installFetchInterceptor({
+            proxyOrigin: "http://127.0.0.1:43210",
+            upstreamOrigins: ["https://api.anthropic.com"],
+        });
+        try {
+            const res = await fetch("https://api.anthropic.com/v1/messages?beta=a", { method: "POST", body: "{}" });
+            assert.equal(await res.text(), "ok");
+            assert.equal(calls.length, 1);
+            assert.equal(calls[0][0], "http://127.0.0.1:43210/bili/https://api.anthropic.com/v1/messages?beta=a");
+            assert.deepEqual(calls[0][1], { method: "POST", body: "{}" });
+        } finally {
+            un();
+        }
+    });
+});
+
+test("intercept: passes through non-matching origins untouched", async () => {
+    await withMockedFetch(async (calls) => {
+        const un = installFetchInterceptor({
+            proxyOrigin: "http://127.0.0.1:43210",
+            upstreamOrigins: ["https://api.anthropic.com"],
+        });
+        try {
+            await fetch("http://localhost:9999/telemetry");
+            await fetch("https://other.example.com/x");
+            assert.equal(calls.length, 2);
+            assert.equal(calls[0][0], "http://localhost:9999/telemetry");
+            assert.equal(calls[1][0], "https://other.example.com/x");
+        } finally {
+            un();
+        }
+    });
+});
+
+test("intercept: non-http(s) protocols pass through", async () => {
+    await withMockedFetch(async (calls) => {
+        const un = installFetchInterceptor({
+            proxyOrigin: "http://127.0.0.1:43210",
+            upstreamOrigins: ["https://api.anthropic.com"],
+        });
+        try {
+            await fetch("data:text/plain,hi");
+            assert.equal(calls.length, 1);
+            assert.equal(calls[0][0], "data:text/plain,hi");
+        } finally {
+            un();
+        }
+    });
+});
+
+test("intercept: never double-wraps /bili/-prefixed URLs even when origin matches", async () => {
+    await withMockedFetch(async (calls) => {
+        const un = installFetchInterceptor({
+            proxyOrigin: "http://127.0.0.1:43210",
+            upstreamOrigins: ["https://api.anthropic.com"],
+        });
+        try {
+            await fetch("https://api.anthropic.com/bili/https://api.anthropic.com/v1");
+            assert.equal(calls.length, 1);
+            assert.equal(calls[0][0], "https://api.anthropic.com/bili/https://api.anthropic.com/v1");
+        } finally {
+            un();
+        }
+    });
+});
+
+test("intercept: URL object input rewritten, Request input reconstructed with body+duplex", async () => {
+    await withMockedFetch(async (calls) => {
+        const un = installFetchInterceptor({
+            proxyOrigin: "http://127.0.0.1:43210",
+            upstreamOrigins: ["https://api.anthropic.com"],
+        });
+        try {
+            await fetch(new URL("https://api.anthropic.com/v1/models"));
+            assert.equal(calls.length, 1);
+            assert.equal(calls[0][0], "http://127.0.0.1:43210/bili/https://api.anthropic.com/v1/models");
+
+            const req = new Request("https://api.anthropic.com/v1/messages", {
+                method: "POST",
+                headers: { authorization: "Bearer t" },
+                body: "hello",
+            });
+            await fetch(req);
+            assert.equal(calls.length, 2);
+            assert.equal(calls[1][0], "http://127.0.0.1:43210/bili/https://api.anthropic.com/v1/messages");
+            const init = calls[1][1] as RequestInit & { duplex?: string };
+            assert.equal(init.method, "POST");
+            assert.equal(await new Response(init.body).text(), "hello");
+            assert.equal(init.duplex, "half");
+            assert.equal(init.headers.get("authorization"), "Bearer t");
+        } finally {
+            un();
+        }
+    });
+});
+
+test("intercept: proxyOrigin trailing slash normalized; origins parsed to bare origin", async () => {
+    await withMockedFetch(async (calls) => {
+        const un = installFetchInterceptor({
+            proxyOrigin: "http://127.0.0.1:43210/",
+            upstreamOrigins: ["https://api.anthropic.com/v1"],
+        });
+        try {
+            await fetch("https://api.anthropic.com/v1/messages");
+            assert.equal(calls[0][0], "http://127.0.0.1:43210/bili/https://api.anthropic.com/v1/messages");
+        } finally {
+            un();
+        }
+    });
+});
+
+test("intercept: reinstall replaces prior wrapper (no stacking); stale uninstaller is a no-op", async () => {
+    await withMockedFetch(async (calls) => {
+        const unA = installFetchInterceptor({
+            proxyOrigin: "http://127.0.0.1:1111",
+            upstreamOrigins: ["https://a.example"],
+        });
+        const unB = installFetchInterceptor({
+            proxyOrigin: "http://127.0.0.1:2222",
+            upstreamOrigins: ["https://b.example"],
+        });
+        try {
+            await fetch("https://b.example/x");
+            await fetch("https://a.example/x");
+            assert.equal(calls[0][0], "http://127.0.0.1:2222/bili/https://b.example/x");
+            assert.equal(calls[1][0], "https://a.example/x");
+            unB();
+            unA();
+            await fetch("https://a.example/x");
+            assert.equal(calls[2][0], "https://a.example/x");
+        } finally {
+            unB();
+            unA();
+        }
+    });
+});
+
+test("intercept: invalid options throw", () => {
+    assert.throws(() => installFetchInterceptor({ proxyOrigin: "", upstreamOrigins: ["https://a.example"] }));
+    assert.throws(() => installFetchInterceptor({ proxyOrigin: "http://127.0.0.1:1", upstreamOrigins: [] }));
+    assert.throws(() => installFetchInterceptor({ proxyOrigin: "http://127.0.0.1:1", upstreamOrigins: ["not a url"] }));
+});

--- a/tests/native-pi.test.ts
+++ b/tests/native-pi.test.ts
@@ -1,0 +1,195 @@
+import assert from "node:assert";
+import http from "node:http";
+import { once } from "node:events";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+process.env.NODE_ENV = "test";
+
+import biliPlugin from "../src/agent/pi.ts";
+
+const REAL_FETCH = globalThis.fetch;
+
+function withEnv(vars: Record<string, string | undefined>, fn: () => void | Promise<void>): Promise<void> {
+    const saved = new Map<string, string | undefined>();
+    for (const [k, v] of Object.entries(vars)) {
+        saved.set(k, process.env[k]);
+        if (v === undefined) delete process.env[k];
+        else process.env[k] = v;
+    }
+    return Promise.resolve(fn()).finally(() => {
+        for (const [k, v] of saved) {
+            if (v === undefined) delete process.env[k];
+            else process.env[k] = v;
+        }
+    });
+}
+
+type RecordedTool = { name: string };
+type FakePi = {
+    events: Map<string, (event: unknown, ctx: unknown) => unknown>;
+    tools: RecordedTool[];
+    on: (event: string, handler: (event: never, ctx: never) => unknown) => void;
+    registerTool: (tool: RecordedTool) => void;
+    registerCommand: () => void;
+};
+
+function makeFakePi(): FakePi {
+    const events = new Map<string, (event: unknown, ctx: unknown) => unknown>();
+    const tools: RecordedTool[] = [];
+    return {
+        events,
+        tools,
+        on: (event, handler) => events.set(event, handler as (event: never, ctx: never) => unknown),
+        registerTool: (tool) => {
+            const i = tools.findIndex((t) => t.name === tool.name);
+            if (i >= 0) tools[i] = tool;
+            else tools.push(tool);
+        },
+        registerCommand: () => {},
+    };
+}
+
+function plainCtx(sessionId = "native-sess"): Record<string, unknown> {
+    return {
+        sessionManager: { getSessionId: () => sessionId },
+        model: { contextWindow: 1000000, baseUrl: "https://api.example.com/v1" },
+        cwd: "/tmp",
+    };
+}
+
+async function flush(): Promise<void> {
+    await new Promise((r) => setTimeout(r, 50));
+}
+
+async function waitForTools(pi: FakePi, count: number, timeoutMs = 15000): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    while (pi.tools.length < count) {
+        if (Date.now() > deadline) throw new Error(`timed out waiting for ${count} registered tools; got ${pi.tools.length}`);
+        await new Promise((r) => setTimeout(r, 25));
+    }
+}
+
+async function startManifestProxy(): Promise<{ origin: string; close: () => Promise<void> }> {
+    const server = http.createServer((req, res) => {
+        if (req.url === "/__bili/plugin/manifest") {
+            res.writeHead(200, { "content-type": "application/json" });
+            res.end(JSON.stringify({ tools: { anthropic: [
+                { name: "compress", description: "Compress context ranges", input_schema: { type: "object", properties: { content: { type: "array" } }, required: ["content"] } },
+                { name: "acp_status", description: "Status", input_schema: { type: "object", properties: {} } },
+            ] } }));
+            return;
+        }
+        res.writeHead(404);
+        res.end("{}");
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const origin = `http://127.0.0.1:${(server.address() as { port: number }).port}`;
+    return { origin, close: () => new Promise<void>((resolve) => server.close(() => resolve())) };
+}
+
+function writeMarker(stateDir: string, agents: Record<string, boolean>): void {
+    fs.mkdirSync(path.join(stateDir, "billion-context"), { recursive: true });
+    fs.writeFileSync(path.join(stateDir, "billion-context", "native.json"), JSON.stringify(agents, null, 2) + "\n");
+}
+
+// NODE_ENV is deleted inside these scopes so startDaemon gets past its test
+// guard and exercises the real marker/kill-switch/entry logic.
+test("native mode stays inert without a marker", async () => {
+    const state = fs.mkdtempSync(path.join(os.tmpdir(), "bili-native-state-"));
+    try {
+        await withEnv({ XDG_STATE_HOME: state, BILLION_CONTEXT_PROXY: undefined, BILLION_CONTEXT_PLUGIN: undefined, NODE_ENV: undefined }, async () => {
+            const pi = makeFakePi();
+            biliPlugin(pi as never);
+            const headers: Record<string, string> = {};
+            pi.events.get("before_provider_headers")!({ headers }, plainCtx());
+            assert.deepEqual(headers, {}, "no header stamped without a proxy");
+            await pi.events.get("session_start")!({}, plainCtx());
+            await flush();
+            assert.equal(pi.tools.length, 0);
+            assert.equal(globalThis.fetch, REAL_FETCH, "no interceptor installed");
+        });
+    } finally {
+        fs.rmSync(state, { recursive: true, force: true });
+    }
+});
+
+test("BILLION_CONTEXT_PLUGIN=0 wins over an enabled marker", async () => {
+    const state = fs.mkdtempSync(path.join(os.tmpdir(), "bili-native-state-"));
+    try {
+        writeMarker(state, { pi: true });
+        await withEnv({ XDG_STATE_HOME: state, BILLION_CONTEXT_PROXY: undefined, BILLION_CONTEXT_PLUGIN: "0", NODE_ENV: undefined }, async () => {
+            const pi = makeFakePi();
+            biliPlugin(pi as never);
+            await pi.events.get("session_start")!({}, plainCtx());
+            await flush();
+            assert.equal(pi.tools.length, 0);
+            assert.equal(globalThis.fetch, REAL_FETCH, "kill switch blocks daemon spawn");
+        });
+    } finally {
+        fs.rmSync(state, { recursive: true, force: true });
+    }
+});
+
+test("a launcher-provided proxy beats native spawning (marker ignored)", async () => {
+    const proxy = await startManifestProxy();
+    const state = fs.mkdtempSync(path.join(os.tmpdir(), "bili-native-state-"));
+    try {
+        writeMarker(state, { pi: true });
+        await withEnv({ XDG_STATE_HOME: state, BILLION_CONTEXT_PROXY: undefined, BILLION_CONTEXT_PLUGIN: undefined, NODE_ENV: undefined }, async () => {
+            const pi = makeFakePi();
+            biliPlugin(pi as never);
+            const ctx = {
+                sessionManager: { getSessionId: () => "native-sess" },
+                model: { contextWindow: 1000000, baseUrl: `${proxy.origin}/bili/https://api.example.com/v1` },
+                cwd: "/tmp",
+            };
+            await pi.events.get("session_start")!({}, ctx);
+            await waitForTools(pi, 2);
+            assert.equal(globalThis.fetch, REAL_FETCH, "no interceptor when a launcher proxy is detected");
+            const headers: Record<string, string> = {};
+            pi.events.get("before_provider_headers")!({ headers }, ctx);
+            assert.equal(headers["x-bili-plugin"], "pi", "normal plugin path intact");
+            await pi.events.get("session_shutdown")!({}, ctx);
+        });
+    } finally {
+        fs.rmSync(state, { recursive: true, force: true });
+        await proxy.close();
+    }
+});
+
+test("marker enabled but package entry absent → warn and stay inert", async (t) => {
+    // With dist/index.js present this scope would spawn a REAL daemon, so the
+    // test only runs where the entry genuinely cannot exist (fresh checkout, CI).
+    const entry = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "dist", "index.js");
+    if (fs.existsSync(entry)) {
+        t.skip("dist/index.js present — would spawn a real daemon");
+        return;
+    }
+    const state = fs.mkdtempSync(path.join(os.tmpdir(), "bili-native-state-"));
+    try {
+        writeMarker(state, { pi: true });
+        const origErr = console.error;
+        const errs: string[] = [];
+        console.error = (...args: unknown[]): void => { errs.push(args.map(String).join(" ")); };
+        try {
+            await withEnv({ XDG_STATE_HOME: state, BILLION_CONTEXT_PROXY: undefined, BILLION_CONTEXT_PLUGIN: undefined, NODE_ENV: undefined }, async () => {
+                const pi = makeFakePi();
+                biliPlugin(pi as never);
+                await pi.events.get("session_start")!({}, plainCtx());
+                await flush();
+                assert.equal(pi.tools.length, 0);
+                assert.equal(globalThis.fetch, REAL_FETCH);
+            });
+        } finally {
+            console.error = origErr;
+        }
+        assert.ok(errs.some((e) => e.includes("package entry not found")), `expected entry-missing warning, got: ${errs.join(" | ")}`);
+    } finally {
+        fs.rmSync(state, { recursive: true, force: true });
+    }
+});


### PR DESCRIPTION
## What

The second half of issue #513 ("探索如何发布为native模式"): a thorough native plugin for pi where the user runs plain `pi` — no launcher, no env vars — and context compression works transparently. Builds directly on #523 (daemon subcommand); **merge #523 first** (this PR is based on its branch).

- `src/agent/intercept.ts` (new): `installFetchInterceptor({proxyOrigin, upstreamOrigins})` wraps `globalThis.fetch` and rewrites only http(s) requests whose target origin matches the active model's upstream to `<proxyOrigin>/bili/<original-url>` (the existing zero-config prefix format). Everything else passes through untouched; responses stream back as-is (SSE-safe); reinstall replaces rather than stacks; uninstall restores the original fetch.
- `src/agent/pi.ts`: marker-gated native path inside the existing extension factory. With `<stateDir>/billion-context/native.json` `{"pi": true}` and no launcher proxy detected, `session_start` spawns `node <pkgroot>/dist/index.js daemon --parent-pid <pi-pid>` (package root self-located from the plugin file position — no PATH lookup), parses the single-line JSON handshake, and installs the interceptor for the current model's upstream origin. Launcher-provided proxies always win (byte-identical legacy behavior); no marker → inert; spawn failure → warn + self-disable (never breaks the client). Host ctx data is snapshotted before the first await because pi's ctx getters throw once the session is replaced (ExtensionRunner.assertActive). Interceptor uninstall + daemon SIGTERM on `session_shutdown`; the parent-pid watcher (#414) is the fallback reaper.
- `bili plugin install pi --native` / `remove`: writes/clears the per-agent marker key (other agents preserved, `.bili-bak` backup); `plugin list` shows `(native)`; `--native` rejected for non-capable agents — pi is the only validated host so far.
- README: "Native mode" section under Running the proxy.

## Why this shape

- pi's official extension hooks can replace the request body but not its URL (`before_provider_request` result = payload only; `before_provider_headers` return ignored — verified against earendil-works/pi source), so runtime egress interception is the only way to route an already-running process through a proxy started at session time. Spawn-time launcher wiring (MITM env, overlay homes, `-e`) by definition cannot apply to a live process.
- The daemon subcommand + parent-pid reaping + per-session handshake all come from #523 unchanged — this PR adds zero proxy-side code except the marker/install plumbing.

## Known behavior (documented in README)

Round 1 of each session can outrun daemon startup (~1s) and goes direct to the upstream unproxied; from request 2 on everything flows through the proxy, and since agents resend full history, context tracking self-heals within one turn. Same failure class as the existing launcher-mode manifest race.

## Pre-flight

- typecheck clean; build clean (dist/agent/pi.js 19.9KB)
- full suite: 971 tests, 969 pass, 1 skip (entry-missing test skips when dist exists), 1 fail = pre-existing env-specific `resolveClientCommand: codex/claude resolve to themselves` (verified failing identically on pristine master)
- real-pi e2e (pi 0.83.6, isolated PI_CODING_AGENT_DIR/XDG_STATE_HOME, mock OpenAI upstream): marker present → plain `pi -p` turn spawns the per-session daemon (dynamic port), round-1 completion goes direct, the SDK retry is intercepted and forwarded through the proxy (`forward POST → …/v1/chat/completions`, SSE PONG streamed back through it), pi exits 0, daemon reaps itself ≤3s after exit via the parent-pid watcher. Validated against this branch's combined build (#523's daemon + this PR's plugin).

Follow-ups (not here): omp native (needs its own fetch-path validation, #520), dsh into PLUGIN_AGENTS (#521), gated e2e harness for the pi-native path.