### PR TITLE
feat: dsh 进 PLUGIN_AGENTS——native 插件部署 + 拦截层（native 模式 D）

### DIFF
--- a/devlog/2026-09-04_dsh-native-plugin/REQ.md
+++ b/devlog/2026-09-04_dsh-native-plugin/REQ.md
@@ -1,0 +1,40 @@
+# REQ — dsh 进 PLUGIN_AGENTS：native 插件部署 + fetch 拦截层（#521）
+
+来源: issue #521（#513 native 模式任务 D，owner 已确认方案）。
+
+## 目标
+
+1. `bili plugin install dsh`：把 cordis 插件（dist/agent/dsh-acp.js）部署进真实
+   DSH_HOME 的每个 profile（`<dshHome>/profiles/*/cordis.patch.yml`），替代目前
+   仅 launcher `--patch` overlay 注入的路径。remove/status 同步支持，幂等、先备份。
+2. fetch 拦截层集成进 dsh-acp 插件：dsh 的 LLM 流量走 pi-ai 的裸 `fetch` 调用
+   （已对安装的 dsh 0.1.1-rc.2 验证无捕获引用），包装 globalThis.fetch，仅把
+   origin == 活动上游 origin 的请求改写到 `http://127.0.0.1:<port>/bili/<origURL>`；
+   其余请求原样透传。代理不可达时该请求降级直连，绝不打断会话。
+   上游 origin 解析顺序（issue 指定）：settings baseURL ?? env DEEPSEEK_BASE_URL
+   （official deepseek 路由默认 https://api.deepseek.com）。
+3. 代理自举：插件在 apply() 时确保代理运行——有 BILLION_CONTEXT_PROXY env 直接用
+   （launcher 路径不变），否则 execFile 子命令 `bili daemon --fresh --json
+   --parent-pid <dsh pid>`：动态端口（listen(0)，经 instance-file 握手回传真实
+   origin/pid/logPath）、独立 session instance file（不污染全局发现文件，避免
+   #394 双写告警风暴）、BILI_PARENT_PID=dsh pid（复用 #414 父进程监视器实现
+   dsh 退出后代理自动回收）。
+4. wire mode 保持不变：dsh 无客户端 conversation id，压缩由代理端执行；/acp
+   命令继续走 fetchStatusLatest，输出新增一行拦截状态信息。
+
+## 非目标
+
+- 不实现 ACP 工具透传 / x-bili-plugin 头（那是 B/C 任务）。
+- 不改压缩管线、不改两种压缩模式的既有行为。
+- 不向 spawn 的代理传 modelWindows（registry fallback 生效，后续跟进项）。
+
+## 验收
+
+- typecheck / 全量单测 / build 通过。
+- 真实 dsh e2e：裸 `dsh --profile headless "task"`（不经 bili dsh）→ 插件拉起
+  动态端口代理 → LLM 流量经 /bili/ 改写（代理日志可见）→ 长 prompt 触发压缩 →
+  /acp 渲染面板 → dsh 退出后代理被回收（≤2s）。
+- `bili plugin install dsh && bili plugin status && bili plugin remove dsh` 全流程
+  幂等且可回退（.bili-bak）。
+- launcher 兼容：native 安装后 `bili dsh` 不再写 overlay patch（防双注册），
+  未安装时行为与现状完全一致。

--- a/devlog/2026-09-04_dsh-native-plugin/WORKLOG.md
+++ b/devlog/2026-09-04_dsh-native-plugin/WORKLOG.md
@@ -1,0 +1,49 @@
+# WORKLOG — dsh native plugin deployment + fetch interception (#521)
+
+Branch: `2026-09-04_dsh-native-plugin` · base: master @ baf1ac5 (v0.1.83)
+
+## What shipped
+
+### 1. `bili plugin install dsh` (src/plugin-install.ts)
+- `"dsh"` added to `PLUGIN_AGENTS`; install/remove/status operate on **every** profile dir under `$DSH_HOME/profiles/*` (dirs containing `cordis.yml` or `package.json`; `node_modules` skipped).
+- Entry = `- insert:\n    - name: <file:// URL of dist/agent/dsh-acp.js>` merged into each profile's `cordis.patch.yml` (replaces bare `[]`, appends otherwise). Idempotent; stale entries (target file missing) dropped, including their parent `- insert:` group only when no other items remain; `.bili-bak` backup per file (once); throws when zero profiles exist (hint: run `dsh` once first).
+- Exported `dshNativeInstalled(dshHome?)` — true when ANY profile carries a live entry.
+- Verified live on the real DSH_HOME: install → both profiles patched → remove → restored (`plugin list`: not installed).
+
+### 2. Launcher compat (src/launcher.ts)
+- dsh wiring now: `const dshAcpPatch = dshNativeInstalled(dshHomeDir) ? undefined : writeDshAcpPatch(dshHomeDir);` — the legacy `--patch` overlay is skipped when the native entry is present (any-profile rule avoids double-registration of the same module via both layers). Legacy path untouched for fresh machines.
+- `LaunchOptions` gains `forceFresh / parentPid / instanceFile / autoUpdateOff`; `proxyStartArgs` pushes `--no-auto-update` for session proxies (no mid-session self-upgrade).
+
+### 3. Per-session proxy: `bili daemon --fresh --json --parent-pid N` (src/cli.ts, src/server.ts, src/config.ts)
+- Spawns a detached proxy on **port 0** (ephemeral), writes the bound origin only to a session instance file (env `BILI_INSTANCE_FILE`), prints `{origin, port, pid, logPath}` JSON to stdout, deletes its session file on exit.
+- server.ts: with `BILI_INSTANCE_FILE` set, the global instance file and `instances.json` registry are skipped (avoids #394 dual-writer noise across many sibling session proxies); shutdown clears the session file too. Parent-gone reaping (#414 mechanism) terminates the proxy ≤2s after the agent exits.
+- config.ts: port validation now accepts `0` (dynamic assignment; real port learned from the handshake). `server.ts` already anticipated port 0; only the validator blocked it.
+
+### 4. In-process fetch interception (src/agent/intercept.ts, new — shared primitive for B/C/D)
+- `installFetchInterceptor({ resolveTargets })` wraps `globalThis.fetch`. Rewrites ONLY requests whose origin equals the active upstream origin → `<proxyOrigin>/bili/<full URL>`. Everything else passes through untouched. Network failure (TypeError, non-abort) on a rewritten call retries once direct (degrade, never break the request). Stats: `{rewritten, passthrough, degraded}`. `uninstall()` restores the previous fetch.
+- Targets resolve ASYNC per call through an 8s gate that closes once bootstrap knows them; while unknown, calls pass through (a dead/unstarted proxy must never hang or break traffic).
+
+### 5. dsh-acp rewrite (src/agent/dsh-acp.ts) + settings reader (src/agent/dsh-settings.ts, new)
+- Bootstrap in `apply()`: interceptor installed **synchronously**; target resolution async — env `BILLION_CONTEXT_PROXY` wins (launcher mode: attach), otherwise spawn `bili daemon` (child gets `BILI_PARENT_PID`). Upstream origin resolved per issue spec: settings provider `baseURL` ?? `llm-deepseek.baseURL` ?? env `DEEPSEEK_BASE_URL` ?? official DeepSeek default (official route only).
+- Wire mode unchanged: no ACP tools, no conversation id; `/acp` still uses `fetchStatusLatest` and now reports the routing head (`billion-context: <upstream> → <proxy>`).
+- Under `bili dsh`, the overlay-wrapped settings baseURL equals the proxy origin → interceptor sees equal origins → pure passthrough (zero double-proxying by construction).
+
+## Bugs found & fixed during e2e
+1. **Port 0 rejected** by config validation → spawned proxy died before bind. Fixed in `src/config.ts` (+ test update in tests/fix-config-session.test.ts).
+2. **First-fetch race**: interceptor was installed only after async bootstrap finished, so the agent's first LLM fetch went direct. Fixed with sync install + async per-call target resolution (regression test: fetch fired while spawn pending waits, then lands rewritten).
+3. Latent health-probe dependency cycle (gate awaited setup; setup awaited health through the gated wrapper) → settled routing *before* the health check.
+
+## Pre-flight
+- `npm run typecheck` — clean.
+- `npm test` — **1052 tests, 1051 pass, 1 fail**: pre-existing env-dependent `resolveClientCommand: codex/claude resolve to themselves` (tests/launcher.test.ts) — this sandbox has a local codex binary; passes on CI runners without one. Unrelated to these changes.
+- `npm run build` — OK; `dist/agent/dsh-acp.js` 12.56 KB (bundles intercept + dsh-settings; tsup entries unchanged).
+
+## E2E (real dsh 0.1.1-rc.2, bare `dsh --profile headless`, NO `--patch`)
+Ran against an isolated DSH_HOME copy (this sandbox's `~/.dsh/sessions` is root-owned and breaks bare dsh regardless of bili) and a real upstream:
+1. Smoke task round-tripped end-to-end through the intercepted proxy (exit 0).
+2. Rewrite proven against a mock upstream: mock saw only unwrapped `/v1/chat/completions`; with a non-SSE mock body, dsh rendered the proxy's own error string — proxy definitively in the path.
+3. Compression pipeline engaged on real dsh traffic: with a 32K route cap (`ACP_PROVIDERS` compress.modelContextLimit) and a ~35.6K-token prompt, bili logged the session, ran preflight, and fail-fast 502'd with the correct adjudication ("nothing left to fold" — a single-message prompt has no compressible history). Full multi-turn compress cycles are covered by the unit suite + `tests/e2e/e2e-codex.test.ts`; headless dsh is one-shot so it cannot produce multi-turn history in a single invocation.
+4. Reaping: `parent-gone` ≤2s after every dsh exit; no orphaned proxies.
+5. Launcher path: `bili dsh` attach-mode verified by construction (§5) + unit tests.
+
+Known limitations (documented, not fixed): `/acp` live rendering needs an interactive TUI (unit-covered instead); single-shot compression cycle (above); sandbox argv limit ≈128KB caps headless prompt size.

--- a/src/agent/dsh-acp.ts
+++ b/src/agent/dsh-acp.ts
@@ -1,11 +1,36 @@
-// Native dsh (deepseek-harness) cordis plugin: registers the `/acp` command.
-// Injected by the `bili dsh` launcher through a `--patch` overlay that
-// inserts this module (as a file:// URL) into the loader entry tree — the
-// same plugin shape as dsh-command-compact. Pure protocol client, same
-// discipline as the other agent plugins: no acp-kernel import, every byte of
-// displayed data comes from the proxy's HTTP endpoints.
+// Native dsh (deepseek-harness) cordis plugin: registers the `/acp` command
+// AND owns this process's bili proxy (#521). Deployed natively by
+// `bili plugin install dsh` into every profile's cordis.patch.yml; the
+// `bili dsh` launcher falls back to a `--patch` overlay only when no profile
+// carries a live native entry. Pure protocol client like the other agent
+// plugins: no acp-kernel import, every byte of displayed data comes from the
+// proxy's HTTP endpoints.
+//
+// Proxy bootstrap (apply-time, once per process):
+//   1. BILLION_CONTEXT_PROXY set (launcher mode) → use that proxy.
+//   2. else spawn `bili daemon --fresh --json --parent-pid <this pid>` —
+//      dynamic port, session-scoped instance file; the daemon passes our pid
+//      as BILI_PARENT_PID so the proxy's parent-gone watcher (#414) reaps it
+//      ≤2s after dsh exits.
+//   3. Resolve the active upstream origin (settings baseURL ?? DEEPSEEK_BASE_URL
+//      ?? official deepseek default) and arm the fetch interceptor so LLM
+//      traffic reaches the proxy via /bili/ without touching dsh's config.
+//
+// The interceptor is installed synchronously in apply() but resolves its
+// routing targets asynchronously per fetch: dsh's first LLM call can fire
+// before the daemon spawn finishes, and each early call waits on the bounded
+// readiness gate instead of leaking direct (uncompressed) upstream traffic.
+// Wire mode stays by design: dsh conversations carry no client-side id, so
+// compression happens proxy-side and /acp reads the latest session panel.
 
-import { proxyBaseFromEnv, fetchProxyVersion, fetchStatusLatest } from "./shared.js";
+import { execFile } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { proxyBaseFromEnv, fetchStatusLatest, fetchProxyVersion } from "./shared.js";
+import { installFetchInterceptor, type FetchInterceptor, type FetchInterceptTargets } from "./intercept.js";
+import { parseDshSettings, resolveDshUpstreamOrigin } from "./dsh-settings.js";
 
 export const name = "bili-acp";
 export const inject = ["commands"];
@@ -18,27 +43,192 @@ type CommandsService = {
 
 type PluginContext = { commands: CommandsService };
 
-/** One `/acp` invocation: latest session panel, else armed-but-idle, else a
- *  reachable-proxy failure. dsh conversations carry no client-side id we can
- *  bind to, so the read asks for the most recently active session. */
-async function statusOutcome(): Promise<CommandOutcome> {
-    const base = proxyBaseFromEnv();
-    if (!base) {
-        return {
-            kind: "error",
-            text: "bili: no proxy detected — launch dsh through `bili dsh` so /acp can read context status.",
-        };
+type SetupResult =
+    | { ok: true; proxyBase: string; upstreamOrigin?: string; intercepted: boolean; notes: string[] }
+    | { ok: false; reason: string };
+
+let setupPromise: Promise<SetupResult> | undefined;
+let interceptor: FetchInterceptor | undefined;
+// Resolved the moment the routing targets are KNOWN (base + upstream origin),
+// i.e. BEFORE the health probe finishes: LLM traffic can be intercepted as
+// soon as we know where to send it (a dead proxy degrades per-request via the
+// interceptor's network-error fallback), and the health probe itself passes
+// through the wrapper unblocked because it targets the proxy origin.
+let routingPromise: Promise<FetchInterceptTargets | undefined> | undefined;
+
+type Spawner = (args: string[], timeoutMs: number) => Promise<{ stdout: string; stderr: string }>;
+type SettingsReader = () => { text: string; exists: boolean };
+
+let spawnImpl: Spawner = defaultSpawn;
+let readSettingsImpl: SettingsReader = defaultReadSettings;
+
+// The cordis loader fixes apply(ctx)'s signature, so unit-test injection goes
+// through module state instead of constructor arguments.
+export function _setTestHooks(hooks: { spawn?: Spawner; readSettings?: SettingsReader }): void {
+    if (hooks.spawn !== undefined) spawnImpl = hooks.spawn;
+    if (hooks.readSettings !== undefined) readSettingsImpl = hooks.readSettings;
+}
+
+export function _resetTestHooks(): void {
+    interceptor?.uninstall();
+    interceptor = undefined;
+    setupPromise = undefined;
+    routingPromise = undefined;
+    spawnImpl = defaultSpawn;
+    readSettingsImpl = defaultReadSettings;
+}
+
+const DAEMON_SPAWN_TIMEOUT_MS = 30_000;
+// Upper bound a single fetch may wait on bootstrap before passing through
+// direct (setup keeps running in the background; later calls still intercept).
+const GATE_TIMEOUT_MS = 8_000;
+
+function cliEntry(): string {
+    // dist/agent/dsh-acp.js → package root two levels up, resolved via
+    // import.meta.url so global symlink bins keep working.
+    const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+    return path.join(root, "dist", "index.js");
+}
+
+function defaultSpawn(args: string[], timeoutMs: number): Promise<{ stdout: string; stderr: string }> {
+    return new Promise((resolve, reject) => {
+        execFile(process.execPath, args, { timeout: timeoutMs, maxBuffer: 1024 * 1024 }, (err, stdout, stderr) => {
+            if (err) reject(new Error(`${err.message}\n${String(stderr).trim()}`.trim()));
+            else resolve({ stdout: String(stdout), stderr: String(stderr) });
+        });
+    });
+}
+
+function defaultReadSettings(): { text: string; exists: boolean } {
+    const raw = process.env.DSH_HOME?.trim();
+    const home = raw && raw.length > 0 ? raw : path.join(os.homedir(), ".dsh");
+    try {
+        return { text: fs.readFileSync(path.join(home, "settings.yaml"), "utf8"), exists: true };
+    } catch {
+        return { text: "", exists: false };
     }
+}
+
+async function spawnDaemon(): Promise<{ origin: string; pid: number; logPath: string }> {
+    const out = await spawnImpl(
+        [cliEntry(), "daemon", "--fresh", "--json", "--parent-pid", String(process.pid)],
+        DAEMON_SPAWN_TIMEOUT_MS,
+    );
+    const lines = out.stdout.trim().split("\n").map((l) => l.trim()).filter((l) => l.length > 0);
+    const last = lines[lines.length - 1] ?? "";
+    const parsed = JSON.parse(last) as { origin?: unknown; pid?: unknown; logPath?: unknown };
+    if (typeof parsed.origin !== "string" || parsed.origin.length === 0) {
+        throw new Error(`daemon reported no origin${typeof parsed.logPath === "string" && parsed.logPath ? ` (log: ${parsed.logPath})` : ""}`);
+    }
+    return {
+        origin: parsed.origin,
+        pid: typeof parsed.pid === "number" ? parsed.pid : -1,
+        logPath: typeof parsed.logPath === "string" ? parsed.logPath : "",
+    };
+}
+
+function errMsg(err: unknown): string {
+    return err instanceof Error ? err.message : String(err);
+}
+
+async function doSetup(settleRouting: (t: FetchInterceptTargets | undefined) => void): Promise<SetupResult> {
+    const notes: string[] = [];
+    let base = proxyBaseFromEnv();
+    if (base) {
+        notes.push(`proxy from BILLION_CONTEXT_PROXY: ${base}`);
+    } else {
+        try {
+            const d = await spawnDaemon();
+            base = d.origin;
+            notes.push(`started session proxy at ${base}${d.pid > 0 ? ` (pid ${d.pid})` : ""}`);
+        } catch (err) {
+            settleRouting(undefined);
+            return {
+                ok: false,
+                reason: `could not start the bili proxy (${errMsg(err)}) — run \`bili plugin install dsh\`, relaunch dsh, or launch through \`bili dsh\``,
+            };
+        }
+    }
+    let upstreamOrigin: string | undefined;
+    const s = readSettingsImpl();
+    if (s.exists) {
+        try {
+            const route = parseDshSettings(s.text);
+            upstreamOrigin = resolveDshUpstreamOrigin(route, process.env);
+            notes.push(`upstream route ${route.provider}/${route.model}${upstreamOrigin ? ` → ${upstreamOrigin}` : " (no origin resolved)"}`);
+        } catch (err) {
+            notes.push(`settings.yaml unreadable: ${errMsg(err)}`);
+        }
+    }
+    const intercepted = upstreamOrigin !== undefined && upstreamOrigin !== base;
+    if (intercepted) notes.push(`fetch interception armed: ${upstreamOrigin} → ${base}/bili/`);
+    settleRouting(intercepted ? { upstreamOrigin: upstreamOrigin!, proxyOrigin: base } : undefined);
+    try {
+        const res = await fetch(`${base}/__bili/health`, { signal: AbortSignal.timeout(3000) });
+        if (!res.ok) throw new Error(`health HTTP ${res.status}`);
+    } catch (err) {
+        return { ok: false, reason: `proxy at ${base} is not reachable (${errMsg(err)}) — is the bili proxy still running?` };
+    }
+    return { ok: true, proxyBase: base, upstreamOrigin, intercepted, notes };
+}
+
+function ensureSetupStarted(): void {
+    if (!setupPromise) {
+        let resolveRouting!: (t: FetchInterceptTargets | undefined) => void;
+        routingPromise = new Promise((r) => {
+            resolveRouting = r;
+        });
+        setupPromise = doSetup(resolveRouting);
+    }
+}
+
+function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+        const t = setTimeout(() => reject(new Error("gate timeout")), ms);
+        p.then(
+            (v) => {
+                clearTimeout(t);
+                resolve(v);
+            },
+            (e) => {
+                clearTimeout(t);
+                reject(e);
+            },
+        );
+    });
+}
+
+async function resolveTargets(): Promise<FetchInterceptTargets | undefined> {
+    ensureSetupStarted();
+    try {
+        return await withTimeout(routingPromise!, GATE_TIMEOUT_MS);
+    } catch {
+        return undefined;
+    }
+}
+
+/** One `/acp` invocation: setup state first (proxy bootstrap may still be
+ *  running), then the latest session panel, else armed-but-idle info, else a
+ *  reachable-proxy failure. */
+async function statusOutcome(): Promise<CommandOutcome> {
+    ensureSetupStarted();
+    const setup = await setupPromise!;
+    if (!setup.ok) {
+        return { kind: "error", text: `bili: ${setup.reason}` };
+    }
+    const base = setup.proxyBase;
     const status = await fetchStatusLatest(base);
     const panel = status?.panel;
     if (status && typeof panel === "string" && panel.length > 0) {
-        return { kind: "success", text: panel };
+        const head = setup.intercepted ? `billion-context: ${setup.upstreamOrigin} → ${base}\n\n` : "";
+        return { kind: "success", text: `${head}${panel}` };
     }
     const version = await fetchProxyVersion(base);
     if (version) {
+        const head = setup.intercepted ? `billion-context: ${setup.upstreamOrigin} → ${base}\n\n` : "";
         return {
             kind: "success",
-            text: `billion-context@${version} — proxy connected, compression armed. No model request seen yet; send one, then run /acp again.`,
+            text: `${head}billion-context@${version} — proxy connected, compression armed. No model request seen yet; send one, then run /acp again.`,
         };
     }
     return {
@@ -48,6 +238,10 @@ async function statusOutcome(): Promise<CommandOutcome> {
 }
 
 export function apply(ctx: PluginContext): void {
+    ensureSetupStarted();
+    // Synchronous install so NO fetch can precede the wrapper; the wrapper's
+    // async target resolution absorbs the daemon-spawn latency.
+    interceptor ??= installFetchInterceptor({ resolveTargets });
     ctx.commands.register({
         name: "acp",
         description: "Show bili context-compression status",

--- a/src/agent/dsh-settings.ts
+++ b/src/agent/dsh-settings.ts
@@ -1,0 +1,98 @@
+// Line-based reader for dsh's settings.yaml (#521): resolves the active LLM
+// route's upstream origin so the fetch interceptor knows which traffic to
+// rewrite. Deliberately line-based (same discipline as the launcher's
+// prepareDshHome scanner) instead of a YAML dependency: dsh's shipped profiles
+// use 2-space indentation throughout, and we need exactly two facts — the
+// default provider/model and each provider's baseURL/api.
+//
+// Origin resolution order (per #521): settings baseURL ?? $DEEPSEEK_BASE_URL
+// ?? the official deepseek route's built-in default. A typo'd custom provider
+// resolves to nothing — rewriting traffic toward an unknown origin would be
+// worse than not intercepting at all.
+
+export interface DshRoute {
+    provider: string;
+    model: string;
+    api?: string;
+    baseUrl?: string;
+}
+
+const BASE_URL_KEY = /^(baseURL|baseUrl|base_url)$/;
+export const OFFICIAL_DEEPSEEK_ORIGIN = "https://api.deepseek.com";
+const DEFAULT_OFFICIAL_PROVIDER = "deepseek-official";
+
+function scalar(raw: string): string {
+    return raw.replace(/#.*$/, "").trim().replace(/^["']|["']$/g, "").trim();
+}
+
+function indentOf(line: string): number {
+    return /^\s*/.exec(line)![0].length;
+}
+
+export function parseDshSettings(text: string): DshRoute {
+    const lines = text.split("\n");
+    let section = "";
+    let inProviders = false;
+    let providerName = "";
+    const providers: Record<string, { api?: string; baseUrl?: string }> = {};
+    let deepseekBaseUrl: string | undefined;
+    const route: DshRoute = { provider: DEFAULT_OFFICIAL_PROVIDER, model: "deepseek-chat" };
+
+    for (const line of lines) {
+        const t = line.trim();
+        if (t === "" || t.startsWith("#")) continue;
+        const indent = indentOf(line);
+        if (indent === 0) {
+            section = t.replace(/:\s*(#.*)?$/, "");
+            inProviders = false;
+            providerName = "";
+            continue;
+        }
+        if (section === "agent-default-model" && indent === 2) {
+            const key = t.split(":")[0]!.trim();
+            const val = scalar(t.slice(t.indexOf(":") + 1));
+            if (key === "provider" && val.length > 0) route.provider = val;
+            else if (key === "model" && val.length > 0) route.model = val;
+        } else if (section === "llm-deepseek" && indent === 2) {
+            const key = t.split(":")[0]!.trim();
+            if (BASE_URL_KEY.test(key)) deepseekBaseUrl = scalar(t.slice(t.indexOf(":") + 1));
+        } else if (section === "llm-pi-ai") {
+            if (indent === 2 && /^providers:\s*(#.*)?$/.test(t)) {
+                inProviders = true;
+                providerName = "";
+            } else if (inProviders && indent === 4 && !t.startsWith("- ")) {
+                providerName = t.replace(/:\s*(#.*)?$/, "").split(":")[0]!.trim();
+                providers[providerName] = {};
+            } else if (inProviders && providerName !== "" && indent >= 6 && !t.startsWith("- ")) {
+                const key = t.split(":")[0]!.trim();
+                const val = scalar(t.slice(t.indexOf(":") + 1));
+                if (key === "api" && val.length > 0) providers[providerName].api = val;
+                else if (BASE_URL_KEY.test(key) && val.length > 0) providers[providerName].baseUrl = val;
+            }
+        }
+    }
+
+    const prov = providers[route.provider];
+    if (prov) {
+        route.api = prov.api;
+        route.baseUrl = prov.baseUrl;
+    } else if (deepseekBaseUrl !== undefined) {
+        route.baseUrl = deepseekBaseUrl;
+    }
+    return route;
+}
+
+export function resolveDshUpstreamOrigin(route: DshRoute, env: NodeJS.ProcessEnv): string | undefined {
+    const candidates = [route.baseUrl, env.DEEPSEEK_BASE_URL];
+    for (const raw of candidates) {
+        const trimmed = raw?.trim();
+        if (!trimmed) continue;
+        try {
+            return new URL(trimmed).origin;
+        } catch {
+            continue;
+        }
+    }
+    if (route.provider === DEFAULT_OFFICIAL_PROVIDER) return OFFICIAL_DEEPSEEK_ORIGIN;
+    return undefined;
+}

--- a/src/agent/intercept.ts
+++ b/src/agent/intercept.ts
@@ -1,0 +1,125 @@
+// In-process fetch interception for dsh native mode (#521). dsh's LLM stack
+// (pi-ai) issues bare `fetch(url, init)` calls resolved against globalThis at
+// call time, so wrapping globalThis.fetch is sufficient to route its traffic
+// through bili without touching dsh's config files.
+//
+// Routing targets are resolved ASYNC per call via `resolveTargets`: the caller
+// may still be bootstrapping its proxy (spawning `bili daemon`) when the first
+// LLM fetch fires, so each call awaits the (memoized, bounded) readiness check
+// instead of leaking that early traffic direct. Once resolved, only requests
+// whose target origin equals the ACTIVE upstream origin are rewritten to
+// `<proxyOrigin>/bili/<original-url>`. Everything else — the plugin's own
+// management calls (they target the proxy origin), npm, telemetry, arbitrary
+// http — passes through byte-identical. If a rewritten call fails at the
+// network layer (proxy died), that single request degrades to a direct
+// upstream call: the user's session never breaks because of us. Abort errors
+// are never retried — the caller asked to stop.
+
+export interface FetchInterceptTargets {
+    /** scheme://host[:port] of the active LLM upstream, no trailing slash. */
+    upstreamOrigin: string;
+    /** bili proxy origin, e.g. http://127.0.0.1:8787, no trailing slash. */
+    proxyOrigin: string;
+}
+
+export interface FetchInterceptOptions {
+    /** Resolve the current routing targets; `undefined` = pass this call
+     *  through untouched. Awaited before every routing decision, so calls
+     *  made before bootstrap completes are intercepted once it finishes. */
+    resolveTargets: () => Promise<FetchInterceptTargets | undefined>;
+    fetchImpl?: typeof fetch;
+}
+
+export interface FetchInterceptStats {
+    rewritten: number;
+    passthrough: number;
+    degraded: number;
+}
+
+export interface FetchInterceptor {
+    uninstall(): void;
+    stats(): FetchInterceptStats;
+}
+
+type FetchInput = string | URL | Request;
+type FetchFn = (input: FetchInput, init?: RequestInit) => Promise<Response>;
+
+function isNetworkError(err: unknown): boolean {
+    if (!(err instanceof Error)) return false;
+    if (err.name === "AbortError") return false;
+    // undici/node fetch reports connection-level failures as TypeError
+    // ("fetch failed") with the cause on .cause.
+    return err.name === "TypeError";
+}
+
+export function installFetchInterceptor(opts: FetchInterceptOptions): FetchInterceptor {
+    const real: FetchFn = (opts.fetchImpl ?? globalThis.fetch) as FetchFn;
+    const stats: FetchInterceptStats = { rewritten: 0, passthrough: 0, degraded: 0 };
+    const previous = globalThis.fetch;
+    let active = true;
+
+    async function wrapped(input: FetchInput, init?: RequestInit): Promise<Response> {
+        if (!active) return real(input, init);
+        let upstream: string | undefined;
+        let proxy: string | undefined;
+        try {
+            const t = await opts.resolveTargets();
+            if (t) {
+                upstream = new URL(t.upstreamOrigin).origin;
+                proxy = new URL(t.proxyOrigin).origin;
+                if (upstream === proxy) {
+                    upstream = undefined;
+                    proxy = undefined;
+                }
+            }
+        } catch {
+            upstream = undefined;
+            proxy = undefined;
+        }
+        if (!upstream || !proxy) {
+            stats.passthrough++;
+            return real(input, init);
+        }
+        let urlStr: string | undefined;
+        if (typeof input === "string") urlStr = input;
+        else if (input instanceof URL) urlStr = input.href;
+        else if (input instanceof Request) urlStr = input.url;
+        let target: string | Request | undefined;
+        if (urlStr !== undefined) {
+            try {
+                if (new URL(urlStr).origin === upstream) {
+                    target = `${proxy}/bili/${urlStr}`;
+                    if (input instanceof Request) target = new Request(target, input);
+                }
+            } catch {
+                target = undefined;
+            }
+        }
+        if (target === undefined) {
+            stats.passthrough++;
+            return real(input, init);
+        }
+        stats.rewritten++;
+        try {
+            return await real(target, init);
+        } catch (err) {
+            if (!isNetworkError(err)) throw err;
+            stats.degraded++;
+            return real(input, init);
+        }
+    }
+
+    globalThis.fetch = wrapped as typeof fetch;
+    return {
+        uninstall(): void {
+            if (!active) return;
+            active = false;
+            if (globalThis.fetch === (wrapped as typeof fetch)) {
+                globalThis.fetch = previous;
+            }
+        },
+        stats(): FetchInterceptStats {
+            return { ...stats };
+        },
+    };
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,9 +26,11 @@ import { configFile as defaultConfigFile } from "./paths.js";
 import { checkForUpdate, startAutoUpdate } from "./update.js";
 import { runMcpStdio } from "./mcp.js";
 import { PLUGIN_AGENTS, isPluginAgent, pluginInstall, pluginRemove, pluginStatusAll, type PluginAgent } from "./plugin-install.js";
-import { runLaunch, runTestPi, isLaunchClient, type ClientName } from "./launcher.js";
+import { ensureProxyRunning, LAUNCHER_DEFAULT_HOST, runLaunch, runTestPi, isLaunchClient, type ClientName } from "./launcher.js";
 import { exportSession } from "./export.js";
-import { readFileSync } from "node:fs";
+import { readFileSync, unlinkSync } from "node:fs";
+import os from "node:os";
+import { randomUUID } from "node:crypto";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 
@@ -97,6 +99,7 @@ Launcher (bili pi / bili codex / bili claude / bili omp / bili opencode / bili h
     bili hermes                           # launch hermes-agent through the proxy (/bili/ rewrite of ~/.hermes/config.yaml)
     bili dsh --profile web "task"         # launch deepseek-harness through the proxy (/bili/ rewrite of ~/.dsh/settings.yaml)
     bili test pi                          # quick end-to-end check of the pi path
+    bili daemon --fresh --json --parent-pid N   # internal: per-session proxy for agent plugins (JSON on stdout)
     bili --mitm-domain api.foo.com pi     # add a domain to the MITM whitelist (flags precede the client)
     bili -F http://127.0.0.1:7897 codex   # route bili's upstream through a proxy (gost-style -F)
 
@@ -120,7 +123,7 @@ Docs: https://github.com/ranxianglei/billion-context
 `;
 
 type Parsed = {
-    command: "start" | "update" | "help" | "version" | "launch" | "test" | "export" | "plugin-register" | "mcp" | "plugin";
+    command: "start" | "update" | "help" | "version" | "launch" | "test" | "export" | "plugin-register" | "mcp" | "plugin" | "daemon";
     client?: ClientName;
     clientArgs: string[];
     mitmDomains: string[];
@@ -131,6 +134,9 @@ type Parsed = {
     registerConversationId?: string;
     pluginAction?: "install" | "remove" | "list";
     pluginAgent?: PluginAgent;
+    daemonFresh?: boolean;
+    daemonJson?: boolean;
+    daemonParentPid?: string;
 };
 
 export function parseArgs(argv: string[]): Parsed {
@@ -146,6 +152,9 @@ export function parseArgs(argv: string[]): Parsed {
     let exportFull = false;
     let pluginAction: Parsed["pluginAction"];
     let pluginAgent: Parsed["pluginAgent"];
+    let daemonFresh = false;
+    let daemonJson = false;
+    let daemonParentPid: string | undefined;
 
     for (let i = 0; i < argv.length; i++) {
         const a = argv[i]!;
@@ -172,6 +181,12 @@ export function parseArgs(argv: string[]): Parsed {
                 break;
             case "--no-auto-update":
                 overrides.ACP_AUTO_UPDATE = "0";
+                break;
+            case "--fresh":
+                daemonFresh = true;
+                break;
+            case "--json":
+                daemonJson = true;
                 break;
             case "--passthrough":
                 overrides.ACP_PASSTHROUGH = "1";
@@ -206,7 +221,8 @@ export function parseArgs(argv: string[]): Parsed {
             case "--config":
             case "--origin":
             case "--agent":
-            case "--bin": {
+            case "--bin":
+            case "--parent-pid": {
                 const val = argv[++i];
                 if (val === undefined || val.length === 0) {
                     console.error(`bili: ${a} requires a non-empty value`);
@@ -218,6 +234,7 @@ export function parseArgs(argv: string[]): Parsed {
                 else if (a === "--origin") overrides.BILI_MCP_PROXY = val;
                 else if (a === "--bin") process.env.BILI_CLIENT_BIN = val;
                 else if (a === "-F") overrides.BILI_UPSTREAM_PROXY = val;
+                else if (a === "--parent-pid") daemonParentPid = val;
                 else overrides.BILI_PLUGIN_AGENT = val;
                 break;
             }
@@ -255,6 +272,8 @@ export function parseArgs(argv: string[]): Parsed {
             registerConversationId = positional[1];
         } else if (cmd === "mcp") {
             command = "mcp";
+        } else if (cmd === "daemon") {
+            command = "daemon";
         } else if (cmd === "plugin") {
             command = "plugin";
             const action = positional[1];
@@ -291,11 +310,50 @@ export function parseArgs(argv: string[]): Parsed {
         }
     }
 
-    return { command, client, clientArgs, mitmDomains, overrides, exportSelector, exportOutput, exportFull, registerConversationId, pluginAction, pluginAgent };
+    return { command, client, clientArgs, mitmDomains, overrides, exportSelector, exportOutput, exportFull, registerConversationId, pluginAction, pluginAgent, daemonFresh, daemonJson, daemonParentPid };
+}
+
+async function runDaemon(fresh: boolean, json: boolean, parentPidArg: string | undefined): Promise<void> {
+    if (!fresh || !json) {
+        console.error("bili daemon: requires --fresh --json (internal subcommand used by bili agent plugins)");
+        process.exit(2);
+    }
+    const parentPid = Number(parentPidArg);
+    if (!Number.isInteger(parentPid) || parentPid <= 0) {
+        console.error(`bili daemon: --parent-pid must be a positive integer (got ${parentPidArg ?? ""})`);
+        process.exit(2);
+    }
+    // Per-session proxy (#521): ephemeral port (0 → child self-binds), a
+    // session-only instance file the caller polls for the real origin, and
+    // self-reap when this process dies (BILI_PARENT_PID watcher in server.ts).
+    const sessionFile = path.join(os.tmpdir(), `bili-daemon-${process.pid}-${randomUUID()}.json`);
+    try {
+        const handle = await ensureProxyRunning({
+            host: LAUNCHER_DEFAULT_HOST,
+            port: 0,
+            passthrough: false,
+            debug: false,
+            forceFresh: true,
+            parentPid,
+            instanceFile: sessionFile,
+            autoUpdateOff: true,
+        });
+        process.stdout.write(`${JSON.stringify({
+            origin: handle.origin,
+            port: handle.port,
+            pid: handle.child?.pid ?? -1,
+            logPath: handle.logPath ?? "",
+        })}\n`);
+    } catch (error) {
+        console.error(`bili daemon: ${error instanceof Error ? error.message : String(error)}`);
+        process.exitCode = 1;
+    } finally {
+        try { unlinkSync(sessionFile); } catch { /* already gone */ }
+    }
 }
 
 export async function main(): Promise<void> {
-    const { command, client, clientArgs, mitmDomains, overrides, exportSelector, exportOutput, exportFull, registerConversationId, pluginAction, pluginAgent } = parseArgs(process.argv.slice(2));
+    const { command, client, clientArgs, mitmDomains, overrides, exportSelector, exportOutput, exportFull, registerConversationId, pluginAction, pluginAgent, daemonFresh, daemonJson, daemonParentPid } = parseArgs(process.argv.slice(2));
     if (command === "help") {
         process.stdout.write(HELP);
         return;
@@ -376,6 +434,10 @@ export async function main(): Promise<void> {
     if (command === "update") {
         // Manual one-shot update — bypasses the throttle.
         await checkForUpdate({ packageName: PACKAGE_NAME, currentVersion: VERSION, autoUpdate: true }, true);
+        return;
+    }
+    if (command === "daemon") {
+        await runDaemon(daemonFresh === true, daemonJson === true, daemonParentPid);
         return;
     }
     if (command === "test") {

--- a/src/config.ts
+++ b/src/config.ts
@@ -287,9 +287,11 @@ export function loadOptions(env: NodeJS.ProcessEnv = process.env): ProxyOptions 
     const fileConfig = loadConfigFile();
 
     // --- Source 2: env vars (highest priority) ---
+    // 0 = OS-assigned port (#521): `bili daemon` spawns per-session proxies and
+    // learns the real port from the instance-file handshake after bind.
     const port = parseInt(env.ACP_PORT ?? env.PORT ?? `${fileConfig.port ?? 8787}`, 10);
-    if (!Number.isInteger(port) || port < 1 || port > 65535) {
-        throw new Error(`Invalid port ${Number.isNaN(port) ? "(not a number)" : port}; must be 1-65535`);
+    if (!Number.isInteger(port) || port < 0 || port > 65535) {
+        throw new Error(`Invalid port ${Number.isNaN(port) ? "(not a number)" : port}; must be 0-65535`);
     }
     const rawHost = env.ACP_HOST ?? fileConfig.host ?? "127.0.0.1";
     const host = rawHost === "localhost" ? "127.0.0.1" : rawHost;

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -34,7 +34,7 @@ import { pathToFileURL } from "node:url";
 import { spawn, type StdioOptions } from "node:child_process";
 import { DEFAULT_MITM_DOMAINS } from "./mitm.js";
 import { isProxyInstanceFile, isPidAlive, readProxyInstanceFile, type ProxyInstanceFile } from "./instance.js";
-import { selfPackageRoot, isBiliPiEntry, ompPluginLoadedFrom } from "./plugin-install.js";
+import { dshNativeInstalled, selfPackageRoot, isBiliPiEntry, ompPluginLoadedFrom } from "./plugin-install.js";
 
 /** Absolute path of a file inside our dist/, resolved via the package root
  * (import.meta.url-based) so it survives global-installed symlink bins
@@ -118,6 +118,17 @@ export interface LaunchOptions {
      *  BILI_LAUNCHER_MODEL_WINDOWS so the nudge denominator matches the
      *  client's real window instead of the built-in table guess. */
     modelWindows?: Record<string, number>;
+    /** Skip the shared-instance attach probe and always spawn a fresh proxy.
+     *  Used by `bili daemon` (#521): per-session proxies are never shared. */
+    forceFresh?: boolean;
+    /** PID that owns this proxy; the child self-reaps when it dies (#414). */
+    parentPid?: number;
+    /** Write the instance record ONLY here (child env BILI_INSTANCE_FILE)
+     *  instead of the global file; the caller polls it for the real origin. */
+    instanceFile?: string;
+    /** Spawn with --no-auto-update: session proxies must not self-upgrade
+     *  mid-conversation under a running agent. */
+    autoUpdateOff?: boolean;
 }
 
 export interface ProxyHandle {
@@ -131,7 +142,7 @@ export interface ProxyHandle {
 export interface LauncherDeps {
     fetchImpl?: (url: string) => Promise<{ ok: boolean }>;
     fetchHealthInfo?: (origin: string) => Promise<{ ok: boolean; instanceId?: string } | undefined>;
-    readInstanceFile?: () => ProxyInstanceFile | { origin: string } | undefined;
+    readInstanceFile?: (file?: string) => ProxyInstanceFile | { origin: string } | undefined;
     spawnImpl?: SpawnFn;
     now?: () => number;
     sleep?: (ms: number) => Promise<void>;
@@ -1746,6 +1757,7 @@ function proxyStartArgs(opts: LaunchOptions): string[] {
     const args = ["start", "--host", opts.host, "--port", String(opts.port)];
     if (opts.passthrough) args.push("--passthrough");
     if (opts.debug) args.push("--debug");
+    if (opts.autoUpdateOff) args.push("--no-auto-update");
     return args;
 }
 
@@ -1755,7 +1767,8 @@ export async function ensureProxyRunning(
 ): Promise<ProxyHandle> {
     const fetchImpl = deps.fetchImpl ?? defaultFetch;
     const fetchHealthInfo = deps.fetchHealthInfo ?? fetchHealthInfoDefault;
-    const readInstance = deps.readInstanceFile ?? readProxyInstanceFile;
+    const readInstanceBase = deps.readInstanceFile ?? readProxyInstanceFile;
+    const readInstance = () => readInstanceBase(opts.instanceFile);
     const spawnImpl = deps.spawnImpl ?? (spawn as SpawnFn);
     const now = deps.now ?? Date.now;
     const sleepImpl = deps.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
@@ -1763,10 +1776,12 @@ export async function ensureProxyRunning(
     // #394/#417: a healthy proxy with a compatible config is SHARED, not
     // doubled — two concurrent launches of the same client would otherwise
     // spawn two writers over one sessions dir.
-    const existing = await probeExistingInstance(readInstance, fetchHealthInfo);
-    if (existing && instanceCompatible(existing, opts)) {
-        console.error(`bili: attaching to running proxy at ${existing.origin} (pid ${existing.pid})`);
-        return { origin: existing.origin, port: existing.port, attached: true };
+    if (!opts.forceFresh) {
+        const existing = await probeExistingInstance(readInstance, fetchHealthInfo);
+        if (existing && instanceCompatible(existing, opts)) {
+            console.error(`bili: attaching to running proxy at ${existing.origin} (pid ${existing.pid})`);
+            return { origin: existing.origin, port: existing.port, attached: true };
+        }
     }
 
     // #407: no probe-release-rebind. The child binds the preferred port
@@ -1776,7 +1791,9 @@ export async function ensureProxyRunning(
     const port = opts.port;
     const script = process.argv[1];
     if (!script) throw new Error("bili: cannot resolve launcher script path");
-    const logPath = path.join(os.tmpdir(), `bili-proxy-${port}.log`);
+    // Port 0 means "ephemeral": many session proxies can run at once, so the
+    // log name must not collide on the literal "0".
+    const logPath = path.join(os.tmpdir(), `bili-proxy-${port === 0 ? launchToken.slice(0, 8) : port}.log`);
     const logFd = fs.openSync(logPath, "a");
     let child: SpawnChild;
     try {
@@ -1789,7 +1806,8 @@ export async function ensureProxyRunning(
                 env: {
                     ...stripInheritedProxy(process.env),
                     BILI_LAUNCH_TOKEN: launchToken,
-                    BILI_PARENT_PID: String(process.pid),
+                    BILI_PARENT_PID: String(opts.parentPid ?? process.pid),
+                    ...(opts.instanceFile ? { BILI_INSTANCE_FILE: opts.instanceFile } : {}),
                     ...(opts.mitmDomains && opts.mitmDomains.length
                         ? { BILI_MITM_DOMAINS: opts.mitmDomains.join(",") }
                         : {}),
@@ -2093,9 +2111,12 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
                 "bili: no custom providers found in ~/.dsh/settings.yaml — proxying the built-in deepseek route via DEEPSEEK_BASE_URL only.",
             );
         }
-        // Native /acp command rides a --patch overlay (independent of the
-        // settings rewrite above), so it exists on every profile dsh boots.
-        const dshAcpPatch = writeDshAcpPatch(dshHomeDir);
+        // Native /acp command: prefer the persistent cordis.patch.yml entry
+        // installed by `bili plugin install dsh` (#521); fall back to the
+        // ephemeral --patch overlay when no profile has a live native entry.
+        // ANY-profile rule: loading the same module through both layers would
+        // double-register /acp in partially installed setups.
+        const dshAcpPatch = dshNativeInstalled(dshHomeDir) ? undefined : writeDshAcpPatch(dshHomeDir);
         if (dshAcpPatch) clientArgs = dshArgsWithPatch(clientArgs, dshAcpPatch);
     } else if (base === "codex") {
         // Per-spawn conversation id for the MCP shell's headless

--- a/src/plugin-install.ts
+++ b/src/plugin-install.ts
@@ -8,6 +8,7 @@
 //   claude   `claude mcp add` (user scope; writes ~/.claude.json)
 //   codex    ~/.codex/config.toml        [mcp_servers.bili]
 //   opencode ~/.config/opencode/opencode.json  mcp.bili
+//   dsh      <DSH_HOME>/profiles/*/cordis.patch.yml  insert: [dist/agent/dsh-acp.js]
 // Installers throw on failure (bad/locked config, missing host CLI); the CLI
 // layer catches, prints `bili plugin: <msg>` and exits 1.
 
@@ -15,8 +16,8 @@ import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
 import { execFileSync } from "node:child_process";
-import { fileURLToPath } from "node:url";
-import { resolvePiHome } from "./client-config.js";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { resolvePiHome, resolveDshHome } from "./client-config.js";
 import { isPidAlive, isProxyInstanceFile, readProxyInstanceFile } from "./instance.js";
 
 /** #403: never freeze a dead or unverifiable origin into a client's
@@ -36,7 +37,7 @@ function proxyOriginForInstall(): string {
     return inst.origin;
 }
 
-export const PLUGIN_AGENTS = ["pi", "omp", "claude", "codex", "opencode"] as const;
+export const PLUGIN_AGENTS = ["pi", "omp", "claude", "codex", "opencode", "dsh"] as const;
 export type PluginAgent = (typeof PLUGIN_AGENTS)[number];
 
 export function selfPackageRoot(): string {
@@ -451,6 +452,168 @@ function opencodeStatus(): string {
     return mcp && "bili" in mcp ? "installed" : "not installed";
 }
 
+// — dsh ————————————————————————————————————————————————————————————————
+
+// A cordis.patch.yml entry that loads the bili dsh plugin (any install):
+// `- name:` value ending in dist/agent/dsh-acp.js (file:// URL or bare path).
+const DSH_ENTRY_RE = /[\\/]dist[\\/]agent[\\/]dsh\-acp\.js$/;
+
+function dshPluginFile(): string {
+    return path.join(selfPackageRoot(), "dist", "agent", "dsh-acp.js");
+}
+
+function dshProfileDirs(home: string): string[] {
+    const profilesDir = path.join(home, "profiles");
+    let names: string[];
+    try {
+        names = fs.readdirSync(profilesDir, { withFileTypes: true })
+            .filter((d) => d.isDirectory() && d.name !== "node_modules")
+            .map((d) => d.name);
+    } catch {
+        return [];
+    }
+    return names
+        .map((n) => path.join(profilesDir, n))
+        .filter((dir) => fs.existsSync(path.join(dir, "cordis.yml")) || fs.existsSync(path.join(dir, "package.json")));
+}
+
+function dshEntryValue(line: string): string {
+    const t = line.trim().replace(/#.*$/, "");
+    const m = /^-\s*name:\s*(.+)$/.exec(t);
+    return m ? m[1]!.trim().replace(/^["']|["']$/g, "") : "";
+}
+
+function dshEntryValues(text: string): string[] {
+    return text.split("\n").map(dshEntryValue).filter((v) => v.length > 0 && DSH_ENTRY_RE.test(v));
+}
+
+function dshEntryTarget(value: string): string | undefined {
+    try {
+        return value.startsWith("file://") ? fileURLToPath(value) : value;
+    } catch {
+        return undefined;
+    }
+}
+
+// Drop every bili dsh entry from the patch file. An entry is one `- name:`
+// item inside a top-level `- insert:` group; the group itself goes only when
+// no other items remain (other plugins may share it).
+function stripDshEntries(text: string): string {
+    const lines = text.split("\n");
+    const drop = new Set<number>();
+    for (let i = 0; i < lines.length; i++) {
+        if (!/^\s*- insert:\s*(#.*)?$/.test(lines[i]!)) continue;
+        const parentIndent = indentOf(lines[i]!);
+        let remaining = 0;
+        let hasOurs = false;
+        for (let j = i + 1; j < lines.length; j++) {
+            const raw = lines[j]!;
+            const t = raw.trimStart();
+            if (t === "" || t.startsWith("#")) continue;
+            if (indentOf(raw) <= parentIndent || !t.startsWith("- ")) break;
+            const value = dshEntryValue(raw);
+            if (value !== "" && DSH_ENTRY_RE.test(value)) {
+                drop.add(j);
+                hasOurs = true;
+            } else {
+                remaining++;
+            }
+        }
+        if (hasOurs && remaining === 0) drop.add(i);
+    }
+    if (drop.size === 0) return text;
+    return lines.filter((_, i) => !drop.has(i)).join("\n");
+}
+
+function indentOf(line: string): number {
+    return /^\s*/.exec(line)![0].length;
+}
+
+function insertDshEntry(text: string, entry: string): string {
+    const lines = stripDshEntries(text).split("\n");
+    const emptyIdx = lines.findIndex((l) => l.trim() === "[]");
+    if (emptyIdx >= 0) {
+        lines.splice(emptyIdx, 1, "- insert:", `    - name: ${entry}`);
+        return lines.join("\n");
+    }
+    let head = lines.join("\n");
+    if (head.length > 0 && !head.endsWith("\n")) head += "\n";
+    return `${head}- insert:\n    - name: ${entry}\n`;
+}
+
+function dshLiveIn(file: string): boolean {
+    if (!fs.existsSync(file)) return false;
+    return dshEntryValues(fs.readFileSync(file, "utf8")).some((v) => {
+        const target = dshEntryTarget(v);
+        return target !== undefined && fs.existsSync(target);
+    });
+}
+
+/** True when ANY profile under the given dsh home carries a live native
+ *  entry. The launcher consults this to skip its `--patch` overlay: loading
+ *  the same module through both layers would double-register /acp. */
+export function dshNativeInstalled(dshHome?: string): boolean {
+    const home = dshHome && dshHome.trim().length > 0 ? dshHome.trim() : resolveDshHome(process.env);
+    return dshProfileDirs(home).some((dir) => dshLiveIn(path.join(dir, "cordis.patch.yml")));
+}
+
+function dshInstall(): string {
+    const file = dshPluginFile();
+    requireDistFile(file);
+    const entry = pathToFileURL(file).href;
+    const home = resolveDshHome(process.env);
+    const dirs = dshProfileDirs(home);
+    if (dirs.length === 0) {
+        throw new Error(`no dsh profiles found under ${path.join(home, "profiles")} — run \`dsh\` once so the profile tree exists, then retry`);
+    }
+    let touched = 0;
+    for (const dir of dirs) {
+        const patchFile = path.join(dir, "cordis.patch.yml");
+        const text = fs.existsSync(patchFile) ? fs.readFileSync(patchFile, "utf8") : "";
+        if (dshEntryValues(text).includes(entry)) continue;
+        backupOnce(patchFile);
+        fs.writeFileSync(patchFile, insertDshEntry(text, entry));
+        touched++;
+    }
+    return touched === 0
+        ? `dsh: already installed (profiles: ${dirs.map((d) => path.basename(d)).join(", ")})`
+        : `dsh: installed -> cordis.patch.yml in ${touched} profile(s) under ${path.join(home, "profiles")} (originals backed up once)`;
+}
+
+function dshRemove(): string {
+    const home = resolveDshHome(process.env);
+    const dirs = dshProfileDirs(home);
+    if (dirs.length === 0) return `dsh: not installed (no profiles under ${path.join(home, "profiles")})`;
+    let touched = 0;
+    for (const dir of dirs) {
+        const patchFile = path.join(dir, "cordis.patch.yml");
+        if (!fs.existsSync(patchFile)) continue;
+        const text = fs.readFileSync(patchFile, "utf8");
+        const cleaned = stripDshEntries(text);
+        if (cleaned === text) continue;
+        backupOnce(patchFile);
+        fs.writeFileSync(patchFile, cleaned);
+        touched++;
+    }
+    return touched === 0 ? `dsh: not installed` : `dsh: removed from ${touched} profile(s) under ${path.join(home, "profiles")}`;
+}
+
+function dshStatus(): string {
+    const dirs = dshProfileDirs(resolveDshHome(process.env));
+    let live = 0;
+    let broken = 0;
+    for (const dir of dirs) {
+        const patchFile = path.join(dir, "cordis.patch.yml");
+        if (!fs.existsSync(patchFile)) continue;
+        for (const v of dshEntryValues(fs.readFileSync(patchFile, "utf8"))) {
+            const target = dshEntryTarget(v);
+            if (target !== undefined && fs.existsSync(target)) live++;
+            else broken++;
+        }
+    }
+    return live > 0 ? "installed" : broken > 0 ? "broken" : "not installed";
+}
+
 // — dispatch ————————————————————————————————————————————————————————————
 
 export function isPluginAgent(value: string): value is PluginAgent {
@@ -458,11 +621,11 @@ export function isPluginAgent(value: string): value is PluginAgent {
 }
 
 export function pluginInstall(agent: PluginAgent): string {
-    return agent === "pi" ? piInstall() : agent === "omp" ? ompInstall() : agent === "claude" ? claudeInstall() : agent === "codex" ? codexInstall() : opencodeInstall();
+    return agent === "pi" ? piInstall() : agent === "omp" ? ompInstall() : agent === "claude" ? claudeInstall() : agent === "codex" ? codexInstall() : agent === "dsh" ? dshInstall() : opencodeInstall();
 }
 
 export function pluginRemove(agent: PluginAgent): string {
-    return agent === "pi" ? piRemove() : agent === "omp" ? ompRemove() : agent === "claude" ? claudeRemove() : agent === "codex" ? codexRemove() : opencodeRemove();
+    return agent === "pi" ? piRemove() : agent === "omp" ? ompRemove() : agent === "claude" ? claudeRemove() : agent === "codex" ? codexRemove() : agent === "dsh" ? dshRemove() : opencodeRemove();
 }
 
 export function pluginStatusAll(): Array<{ agent: string; status: string }> {
@@ -472,6 +635,7 @@ export function pluginStatusAll(): Array<{ agent: string; status: string }> {
         ["claude", claudeStatus],
         ["codex", codexStatus],
         ["opencode", opencodeStatus],
+        ["dsh", dshStatus],
     ];
     return checks.map(([agent, check]) => {
         try {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,7 @@
 import http from "node:http";
 import fs from "node:fs";
 import { randomUUID } from "node:crypto";
+import { dirname } from "node:path";
 import { createCore, type CompressionCore, type CompressionState, type Config, type CoreMessage, type NudgeDecision, type Prompts, defaultPrompts, defaultCountTokens, estimateTokensFast, renderNudgeText, deactivateBlock, viableRanges } from "acp-kernel";
 import { resolveCompress, resolveCompressPrompts, resolveRequestConfig } from "./compress-settings.js";
 import type { ProxyOptions } from "./config.js";
@@ -376,6 +377,11 @@ export async function startServer(opts: ProxyOptions): Promise<http.Server> {
     // EADDRINUSE instead of dying, reporting the real origin via the instance
     // file (launchToken match). Manual `bili start` keeps fail-fast semantics.
     const launchToken = process.env.BILI_LAUNCH_TOKEN?.trim();
+    // Set by `bili daemon` for per-session proxies: the instance record goes
+    // ONLY to this file (the parent polls it) instead of the shared global
+    // one, so N concurrent agent sessions don't clobber each other's records
+    // or pile up dual-writer warnings in instances.json (#394).
+    const sessionInstanceFile = process.env.BILI_INSTANCE_FILE?.trim() || undefined;
     const MAX_LISTEN_ATTEMPTS = 17;
     let listenAttempts = 0;
     let lastTriedPort = opts.port;
@@ -393,7 +399,8 @@ export async function startServer(opts: ProxyOptions): Promise<http.Server> {
         const originHost = opts.host === "0.0.0.0" || opts.host === "::" || opts.host === "localhost" ? "127.0.0.1" : opts.host.includes(":") && !opts.host.startsWith("[") ? `[${opts.host}]` : opts.host;
         const origin = `http://${originHost}:${actualPort}`;
         try {
-            fs.mkdirSync(stateDir(), { recursive: true });
+            if (sessionInstanceFile) fs.mkdirSync(dirname(sessionInstanceFile), { recursive: true });
+            else fs.mkdirSync(stateDir(), { recursive: true });
             hydratePrefixAffinity();
             atomicWriteInstanceFile({
                 origin,
@@ -406,14 +413,16 @@ export async function startServer(opts: ProxyOptions): Promise<http.Server> {
                 mitmDomains: opts.mitm.enabled ? opts.mitm.domains : [],
                 modelWindows: { ...LAUNCHER_MODEL_WINDOWS },
                 launchToken: launchToken || undefined,
-            });
+            }, sessionInstanceFile);
         } catch {
             // best-effort discovery hint for host-spawned MCP shells
         }
-        registerInstanceAndWarn(
-            { instanceId, pid: process.pid, port: actualPort, origin, startedAt: instanceStartedAt },
-            (msg) => log("warn", `[instances] ${msg}`),
-        );
+        if (!sessionInstanceFile) {
+            registerInstanceAndWarn(
+                { instanceId, pid: process.pid, port: actualPort, origin, startedAt: instanceStartedAt },
+                (msg) => log("warn", `[instances] ${msg}`),
+            );
+        }
         const nOverrides = Object.keys(opts.routes).length;
         log(
             "info",
@@ -482,6 +491,7 @@ export async function startServer(opts: ProxyOptions): Promise<http.Server> {
     const finishShutdown = (): void => {
         flushPrefixAffinity();
         clearProxyInstanceFile(instanceId);
+        if (sessionInstanceFile) clearProxyInstanceFile(instanceId, sessionInstanceFile);
         unregisterInstance(instanceId);
         closeLogger();
         process.exit(0);

--- a/tests/agent-intercept.test.ts
+++ b/tests/agent-intercept.test.ts
@@ -1,0 +1,207 @@
+// In-process fetch interceptor (#521): async target resolution (early calls
+// wait on bootstrap instead of leaking direct), origin-scoped rewrite to
+// /bili/, passthrough for everything else, one-shot degrade when the proxy
+// is down, and clean uninstall.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { installFetchInterceptor, type FetchInterceptor, type FetchInterceptTargets } from "../src/agent/intercept.ts";
+
+const UP = "http://up.example.com:9999";
+const PROXY = "http://127.0.0.1:8787";
+const TARGETS: FetchInterceptTargets = { upstreamOrigin: UP, proxyOrigin: PROXY };
+
+type Call = { url: string; input: string | URL | Request; init?: RequestInit };
+
+function fakeReal(handlers: (url: string) => Response | Promise<Response>, calls: Call[]) {
+    return (async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+        const url = input instanceof URL ? input.href : input instanceof Request ? input.url : input;
+        calls.push({ url, input, init });
+        return handlers(url);
+    }) as typeof fetch;
+}
+
+test("interceptor rewrites only the upstream origin; everything else passes through", async () => {
+    const calls: Call[] = [];
+    const real = fakeReal(() => new Response("ok", { status: 200 }), calls);
+    const prev = globalThis.fetch;
+    const ic = installFetchInterceptor({ resolveTargets: () => Promise.resolve(TARGETS), fetchImpl: real })!;
+    try {
+        await globalThis.fetch(`${UP}/v1/chat/completions`);
+        await globalThis.fetch("http://other.example/x");
+        // The plugin's own management traffic targets the proxy origin — never rewritten.
+        await globalThis.fetch(`${PROXY}/__bili/plugin/status`);
+        assert.deepEqual(calls.map((c) => c.url), [
+            `${PROXY}/bili/${UP}/v1/chat/completions`,
+            "http://other.example/x",
+            `${PROXY}/__bili/plugin/status`,
+        ]);
+        assert.deepEqual(ic.stats(), { rewritten: 1, passthrough: 2, degraded: 0 });
+    } finally {
+        ic.uninstall();
+        globalThis.fetch = prev;
+    }
+});
+
+test("interceptor handles URL and Request inputs, preserving method and headers on Request", async () => {
+    const calls: Call[] = [];
+    const real = fakeReal(() => new Response("ok"), calls);
+    const prev = globalThis.fetch;
+    const ic = installFetchInterceptor({ resolveTargets: () => Promise.resolve(TARGETS), fetchImpl: real })!;
+    try {
+        await globalThis.fetch(new URL(`${UP}/a`));
+        const req = new Request(`${UP}/b`, { method: "POST", headers: { "x-k": "v" }, body: "{}" });
+        await globalThis.fetch(req);
+        assert.equal(calls[0]!.url, `${PROXY}/bili/${UP}/a`);
+        const second = calls[1]!;
+        assert.equal(second.url, `${PROXY}/bili/${UP}/b`);
+        const seen = second.input;
+        assert.ok(seen instanceof Request);
+        assert.equal(seen.method, "POST");
+        assert.equal(seen.headers.get("x-k"), "v");
+        assert.equal(await (seen as Request).text(), "{}");
+    } finally {
+        ic.uninstall();
+        globalThis.fetch = prev;
+    }
+});
+
+test("proxy down at network layer → that request degrades to direct, once", async () => {
+    const calls: Call[] = [];
+    let directCalls = 0;
+    const real = fakeReal((url) => {
+        if (url.startsWith(PROXY)) throw new TypeError("fetch failed");
+        directCalls++;
+        return new Response("direct", { status: 200 });
+    }, calls);
+    const prev = globalThis.fetch;
+    const ic = installFetchInterceptor({ resolveTargets: () => Promise.resolve(TARGETS), fetchImpl: real })!;
+    try {
+        const res = await globalThis.fetch(`${UP}/v1/chat/completions`);
+        assert.equal(res.status, 200);
+        assert.equal(directCalls, 1);
+        assert.deepEqual(ic.stats(), { rewritten: 1, passthrough: 0, degraded: 1 });
+    } finally {
+        ic.uninstall();
+        globalThis.fetch = prev;
+    }
+});
+
+test("abort is never retried; non-network errors propagate", async () => {
+    const calls: Call[] = [];
+    let proxyCalls = 0;
+    const real = fakeReal((url) => {
+        if (url.startsWith(PROXY)) {
+            if (++proxyCalls === 1) {
+                const err = new Error("aborted");
+                err.name = "AbortError";
+                throw err;
+            }
+            throw new SyntaxError("boom");
+        }
+        return new Response("ok");
+    }, calls);
+    const prev = globalThis.fetch;
+    const ic = installFetchInterceptor({ resolveTargets: () => Promise.resolve(TARGETS), fetchImpl: real })!;
+    try {
+        await assert.rejects(() => globalThis.fetch(`${UP}/x`), /aborted/);
+        await assert.rejects(() => globalThis.fetch(`${UP}/y`), /boom/);
+        assert.equal(calls.length, 2, "no second attempt after a failure");
+    } finally {
+        ic.uninstall();
+        globalThis.fetch = prev;
+    }
+});
+
+test("uninstall restores the previous fetch and stops rewriting", async () => {
+    const calls: Call[] = [];
+    const real = fakeReal(() => new Response("ok"), calls);
+    const prev = globalThis.fetch;
+    const ic = installFetchInterceptor({ resolveTargets: () => Promise.resolve(TARGETS), fetchImpl: real })!;
+    ic.uninstall();
+    assert.equal(globalThis.fetch, prev);
+    await real(`${UP}/z`);
+    assert.deepEqual(calls.map((c) => c.url), [`${UP}/z`]);
+    assert.deepEqual(ic.stats(), { rewritten: 0, passthrough: 0, degraded: 0 });
+});
+
+test("call issued before bootstrap finishes waits on the gate, then rewrites", async () => {
+    const calls: Call[] = [];
+    const real = fakeReal(() => new Response("ok"), calls);
+    const prev = globalThis.fetch;
+    let release!: (t: FetchInterceptTargets) => void;
+    const pending = new Promise<FetchInterceptTargets>((r) => {
+        release = r;
+    });
+    const ic = installFetchInterceptor({ resolveTargets: () => pending, fetchImpl: real })!;
+    try {
+        const inflight = globalThis.fetch(`${UP}/v1/chat/completions`);
+        // Gate still closed: nothing reached the network yet.
+        await new Promise((r) => setTimeout(r, 30));
+        assert.equal(calls.length, 0);
+        release(TARGETS);
+        await inflight;
+        assert.deepEqual(calls.map((c) => c.url), [`${PROXY}/bili/${UP}/v1/chat/completions`]);
+        assert.deepEqual(ic.stats(), { rewritten: 1, passthrough: 0, degraded: 0 });
+    } finally {
+        ic.uninstall();
+        globalThis.fetch = prev;
+    }
+});
+
+test("gate resolving undefined or rejecting → passthrough, never a hang", async () => {
+    const calls: Call[] = [];
+    const real = fakeReal(() => new Response("ok"), calls);
+    const prev = globalThis.fetch;
+    const ic1 = installFetchInterceptor({ resolveTargets: () => Promise.resolve(undefined), fetchImpl: real })!;
+    try {
+        await globalThis.fetch(`${UP}/a`);
+        assert.deepEqual(calls.map((c) => c.url), [`${UP}/a`]);
+        assert.deepEqual(ic1.stats(), { rewritten: 0, passthrough: 1, degraded: 0 });
+    } finally {
+        ic1.uninstall();
+        globalThis.fetch = prev;
+    }
+    const ic2 = installFetchInterceptor({
+        resolveTargets: () => Promise.reject(new Error("bootstrap failed")),
+        fetchImpl: real,
+    })!;
+    try {
+        await globalThis.fetch(`${UP}/b`);
+        assert.deepEqual(calls.map((c) => c.url), [`${UP}/a`, `${UP}/b`]);
+        assert.deepEqual(ic2.stats(), { rewritten: 0, passthrough: 1, degraded: 0 });
+    } finally {
+        ic2.uninstall();
+        globalThis.fetch = prev;
+    }
+});
+
+test("equal or unparseable origins → every call passes through untouched", async () => {
+    const calls: Call[] = [];
+    const real = fakeReal(() => new Response("ok"), calls);
+    const prev = globalThis.fetch;
+    const ic1 = installFetchInterceptor({
+        resolveTargets: () => Promise.resolve({ upstreamOrigin: UP, proxyOrigin: UP }),
+        fetchImpl: real,
+    })!;
+    try {
+        await globalThis.fetch(`${UP}/a`);
+        assert.deepEqual(calls.map((c) => c.url), [`${UP}/a`]);
+        assert.deepEqual(ic1.stats(), { rewritten: 0, passthrough: 1, degraded: 0 });
+    } finally {
+        ic1.uninstall();
+        globalThis.fetch = prev;
+    }
+    const ic2 = installFetchInterceptor({
+        resolveTargets: () => Promise.resolve({ upstreamOrigin: "not a url", proxyOrigin: PROXY }),
+        fetchImpl: real,
+    })!;
+    try {
+        await globalThis.fetch(`${UP}/b`);
+        assert.deepEqual(calls.map((c) => c.url), [`${UP}/a`, `${UP}/b`]);
+        assert.deepEqual(ic2.stats(), { rewritten: 0, passthrough: 1, degraded: 0 });
+    } finally {
+        ic2.uninstall();
+        globalThis.fetch = prev;
+    }
+});

--- a/tests/cli-parseargs.test.ts
+++ b/tests/cli-parseargs.test.ts
@@ -33,3 +33,19 @@ test("parseArgs: -F composes with other bili flags before the client (#346)", ()
     assert.equal(r.overrides.BILI_UPSTREAM_PROXY, "http://127.0.0.1:7897");
     assert.deepEqual(r.clientArgs, []);
 });
+
+// #521: internal `daemon` subcommand used by bili agent plugins (dsh native).
+test("parseArgs: daemon subcommand flags (#521)", () => {
+    const r = parseArgs(["daemon", "--fresh", "--json", "--parent-pid", "42"]);
+    assert.equal(r.command, "daemon");
+    assert.equal(r.daemonFresh, true);
+    assert.equal(r.daemonJson, true);
+    assert.equal(r.daemonParentPid, "42");
+});
+
+test("parseArgs: daemon without flags parses as plain command (#521)", () => {
+    const r = parseArgs(["daemon"]);
+    assert.equal(r.command, "daemon");
+    assert.equal(r.daemonFresh, false);
+    assert.equal(r.daemonParentPid, undefined);
+});

--- a/tests/dsh-acp.test.ts
+++ b/tests/dsh-acp.test.ts
@@ -1,20 +1,49 @@
-// /acp cordis plugin for dsh (deepseek-harness): the handler's three
-// outcomes — live panel from the latest session, armed-but-idle info, and
-// unreachable proxy — mirror the pi/opencode plugins (PR#235 semantics).
+// /acp cordis plugin for dsh (deepseek-harness): proxy bootstrap outcomes
+// (env proxy / spawned daemon / failure), the latest-session panel, the
+// fetch-interceptor arming (#521), and the bootstrap-race gate (a first LLM
+// fetch firing before the daemon spawn finishes must wait, not leak direct).
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { apply } from "../src/agent/dsh-acp.ts";
+import * as dshAcp from "../src/agent/dsh-acp.ts";
 
 type Outcome = { kind: "success" | "error"; text: string };
 
-async function runHandler(env: Record<string, string | undefined>, routes: Record<string, { status: number; body: unknown }>): Promise<Outcome> {
+type Hooks = {
+    env: Record<string, string | undefined>;
+    routes: Record<string, { status: number; body: unknown }>;
+    spawn?: (args: string[], timeoutMs: number) => Promise<{ stdout: string; stderr: string }>;
+    readSettings?: () => { text: string; exists: boolean };
+    /** Collect every URL handed to the (intercepted) fetch. */
+    record?: string[];
+    /** Skip teardown: leave the interceptor armed for post-checks. */
+    keep?: boolean;
+};
+
+async function runHandler(hooks: Hooks): Promise<Outcome> {
+    dshAcp._resetTestHooks();
+    const injected: Parameters<typeof dshAcp._setTestHooks>[0] = {};
+    if (hooks.spawn !== undefined) injected.spawn = hooks.spawn;
+    if (hooks.readSettings !== undefined) injected.readSettings = hooks.readSettings;
+    if (Object.keys(injected).length > 0) dshAcp._setTestHooks(injected);
+
     const prev = { ...process.env } as Record<string, string | undefined>;
     const prevFetch = globalThis.fetch;
-    for (const [k, v] of Object.entries(env)) {
+    for (const [k, v] of Object.entries(hooks.env)) {
         if (v === undefined) delete process.env[k];
         else process.env[k] = v;
     }
+    globalThis.fetch = (async (input: string | URL | Request) => {
+        const url = input instanceof URL ? input.href : input instanceof Request ? input.url : input;
+        hooks.record?.push(url);
+        for (const [prefix, route] of Object.entries(hooks.routes)) {
+            if (url.startsWith(prefix)) {
+                return new Response(JSON.stringify(route.body), { status: route.status, headers: { "content-type": "application/json" } });
+            }
+        }
+        return new Response("{}", { status: 404 });
+    }) as typeof fetch;
+
     let handler: (() => Promise<Outcome>) | undefined;
     const ctx = {
         commands: {
@@ -24,67 +53,174 @@ async function runHandler(env: Record<string, string | undefined>, routes: Recor
             },
         },
     };
-    apply(ctx as never);
-    assert.ok(handler, "handler registered");
-    globalThis.fetch = (async (input: RequestInfo | URL) => {
-        const url = String(input);
-        for (const [prefix, route] of Object.entries(routes)) {
-            if (url.startsWith(prefix)) {
-                return new Response(JSON.stringify(route.body), { status: route.status, headers: { "content-type": "application/json" } });
+    try {
+        dshAcp.apply(ctx as never);
+        assert.ok(handler, "handler registered");
+        return await handler();
+    } finally {
+        if (!hooks.keep) {
+            dshAcp._resetTestHooks();
+            globalThis.fetch = prevFetch;
+            for (const k of Object.keys(hooks.env)) {
+                const v = prev[k];
+                if (v === undefined) delete process.env[k];
+                else process.env[k] = v;
             }
         }
-        return new Response("{}", { status: 404 });
-    }) as typeof fetch;
-    const outcome = await handler();
-    globalThis.fetch = prevFetch;
-    for (const k of Object.keys(env)) {
-        const v = prev[k];
-        if (v === undefined) delete process.env[k];
-        else process.env[k] = v;
     }
-    return outcome;
 }
 
-test("dsh-acp /acp: live proxy with a session returns the rendered panel", async () => {
-    const out = await runHandler(
-        { BILLION_CONTEXT_PROXY: "http://127.0.0.1:8787", BILLION_CONTEXT_PLUGIN: undefined },
-        {
+const SETTINGS_CUSTOM = `llm-pi-ai:\n  providers:\n    local-vllm:\n      api: openai-completions\n      baseURL: http://10.0.0.5:8199/v1\n      models:\n        - id: qwen-test\n          contextWindow: 262144\nagent-default-model:\n  provider: local-vllm\n  model: qwen-test\n`;
+
+test("dsh-acp /acp: env proxy + live session → panel, interceptor rewrites upstream traffic", async () => {
+    const record: string[] = [];
+    const out = await runHandler({
+        env: { BILLION_CONTEXT_PROXY: "http://127.0.0.1:8787", BILLION_CONTEXT_PLUGIN: undefined },
+        routes: {
+            "http://127.0.0.1:8787/__bili/health": { status: 200, body: { ok: true } },
             "http://127.0.0.1:8787/__bili/plugin/status": {
                 status: 200,
                 body: { ok: true, panel: "ACP Context Analysis\nbillion-context@9.9.9" },
             },
         },
-    );
+        readSettings: () => ({ text: SETTINGS_CUSTOM, exists: true }),
+        record,
+        keep: true,
+    });
     assert.equal(out.kind, "success");
+    assert.ok(out.text.startsWith("billion-context: http://10.0.0.5:8199 → http://127.0.0.1:8787"), out.text);
     assert.ok(out.text.includes("ACP Context Analysis"));
+    // Interceptor armed: upstream-origin requests are rewritten through /bili/.
+    await globalThis.fetch("http://10.0.0.5:8199/v1/chat/completions");
+    assert.deepEqual(record.at(-1), "http://127.0.0.1:8787/bili/http://10.0.0.5:8199/v1/chat/completions");
+    // Other origins pass through untouched.
+    await globalThis.fetch("http://other.example.com/x");
+    assert.deepEqual(record.at(-1), "http://other.example.com/x");
+    dshAcp._resetTestHooks();
 });
 
 test("dsh-acp /acp: 404 status + live manifest → armed-but-idle info", async () => {
-    const out = await runHandler(
-        { BILLION_CONTEXT_PROXY: "http://127.0.0.1:8787", BILLION_CONTEXT_PLUGIN: undefined },
-        {
+    const out = await runHandler({
+        env: { BILLION_CONTEXT_PROXY: "http://127.0.0.1:8787", BILLION_CONTEXT_PLUGIN: undefined },
+        routes: {
+            "http://127.0.0.1:8787/__bili/health": { status: 200, body: { ok: true } },
             "http://127.0.0.1:8787/__bili/plugin/status": { status: 404, body: { ok: false } },
             "http://127.0.0.1:8787/__bili/plugin/manifest": { status: 200, body: { version: "9.9.9" } },
         },
-    );
+        readSettings: () => ({ text: "", exists: false }),
+    });
     assert.equal(out.kind, "success");
-    assert.match(out.text, /billion-context@9\.9\.9 — proxy connected, compression armed/);
+    assert.match(out.text, /^billion-context@9\.9\.9 — proxy connected, compression armed/);
 });
 
 test("dsh-acp /acp: unreachable proxy → error outcome", async () => {
-    const out = await runHandler(
-        { BILLION_CONTEXT_PROXY: "http://127.0.0.1:8787", BILLION_CONTEXT_PLUGIN: undefined },
-        {},
-    );
-    assert.equal(out.kind, "error");
-    assert.match(out.text, /proxy not reachable at http:\/\/127\.0\.0\.1:8787/);
+    const prevFetch = globalThis.fetch;
+    globalThis.fetch = (async () => { throw new TypeError("fetch failed"); }) as typeof fetch;
+    try {
+        const out = await runHandler({
+            env: { BILLION_CONTEXT_PROXY: "http://127.0.0.1:8787", BILLION_CONTEXT_PLUGIN: undefined },
+            routes: {},
+        });
+        assert.equal(out.kind, "error");
+        assert.match(out.text, /proxy at http:\/\/127\.0\.0\.1:8787 is not reachable/);
+    } finally {
+        dshAcp._resetTestHooks();
+        globalThis.fetch = prevFetch;
+    }
 });
 
-test("dsh-acp /acp: no BILLION_CONTEXT_PROXY env → launch hint", async () => {
-    const out = await runHandler(
-        { BILLION_CONTEXT_PROXY: undefined, BILLION_CONTEXT_PLUGIN: undefined },
-        {},
-    );
+test("dsh-acp /acp: no env → spawns bili daemon, uses reported origin", async () => {
+    const spawnArgs: string[][] = [];
+    const out = await runHandler({
+        env: { BILLION_CONTEXT_PROXY: undefined, BILLION_CONTEXT_PLUGIN: undefined },
+        routes: {
+            "http://127.0.0.1:41999/__bili/health": { status: 200, body: { ok: true } },
+            "http://127.0.0.1:41999/__bili/plugin/manifest": { status: 200, body: { version: "9.9.9" } },
+        },
+        spawn: async (args) => {
+            spawnArgs.push(args);
+            return { stdout: `\nsome log noise\n${JSON.stringify({ origin: "http://127.0.0.1:41999", pid: 4242, logPath: "/tmp/x.log" })}\n`, stderr: "" };
+        },
+        readSettings: () => ({ text: "", exists: false }),
+    });
+    assert.equal(out.kind, "success");
+    assert.match(out.text, /billion-context@9\.9\.9 — proxy connected, compression armed/);
+    assert.equal(spawnArgs.length, 1);
+    const args = spawnArgs[0]!;
+    assert.deepEqual(args.slice(1), ["daemon", "--fresh", "--json", "--parent-pid", String(process.pid)]);
+});
+
+test("dsh-acp /acp: daemon spawn fails → actionable error", async () => {
+    const out = await runHandler({
+        env: { BILLION_CONTEXT_PROXY: undefined, BILLION_CONTEXT_PLUGIN: undefined },
+        routes: {},
+        spawn: async () => { throw new Error("exit 1: no profiles found"); },
+        readSettings: () => ({ text: "", exists: false }),
+    });
     assert.equal(out.kind, "error");
-    assert.match(out.text, /launch dsh through `bili dsh`/);
+    assert.match(out.text, /could not start the bili proxy .*no profiles found/);
+    assert.match(out.text, /bili plugin install dsh/);
+});
+
+test("dsh-acp race gate: first LLM fetch before daemon spawn finishes waits, then rewrites", async () => {
+    const record: string[] = [];
+    const prevEnv = { ...process.env } as Record<string, string | undefined>;
+    const prevFetch = globalThis.fetch;
+    let releaseSpawn!: () => void;
+    const spawned = new Promise<void>((r) => {
+        releaseSpawn = r;
+    });
+    dshAcp._resetTestHooks();
+    dshAcp._setTestHooks({
+        spawn: async () => {
+            await spawned;
+            return { stdout: JSON.stringify({ origin: "http://127.0.0.1:41999", pid: 4242, logPath: "/tmp/x.log" }) + "\n", stderr: "" };
+        },
+        readSettings: () => ({ text: SETTINGS_CUSTOM, exists: true }),
+    });
+    delete process.env.BILLION_CONTEXT_PROXY;
+    globalThis.fetch = (async (input: string | URL | Request) => {
+        const url = input instanceof URL ? input.href : input instanceof Request ? input.url : input;
+        record.push(url);
+        if (url.startsWith("http://127.0.0.1:41999/__bili/health")) {
+            return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
+        }
+        if (url.startsWith("http://127.0.0.1:41999/__bili/plugin/manifest")) {
+            return new Response(JSON.stringify({ version: "9.9.9" }), { status: 200, headers: { "content-type": "application/json" } });
+        }
+        return new Response("{}", { status: 200 });
+    }) as typeof fetch;
+    try {
+        let handler: (() => Promise<Outcome>) | undefined;
+        dshAcp.apply({
+            commands: {
+                register: (cmd: { name: string; description: string; handler: () => Promise<Outcome> }) => {
+                    handler = cmd.handler;
+                },
+            },
+        } as never);
+        const inflight = globalThis.fetch("http://10.0.0.5:8199/v1/chat/completions");
+        // Gate still closed (spawn pending): nothing may have reached the network.
+        await new Promise((r) => setTimeout(r, 50));
+        assert.equal(record.length, 0, `expected no network calls while bootstrap is pending, got ${JSON.stringify(record)}`);
+        releaseSpawn();
+        await inflight;
+        assert.ok(handler, "handler registered");
+        // After bootstrap: exactly the health probe and the rewritten LLM
+        // call — nothing direct. Their relative order is scheduling-dependent.
+        assert.equal(record.length, 2);
+        assert.deepEqual([...record].sort(), [
+            "http://127.0.0.1:41999/__bili/health",
+            "http://127.0.0.1:41999/bili/http://10.0.0.5:8199/v1/chat/completions",
+        ].sort());
+        const out = await handler();
+        assert.equal(out.kind, "success");
+    } finally {
+        dshAcp._resetTestHooks();
+        globalThis.fetch = prevFetch;
+        for (const k of Object.keys(process.env)) {
+            if (!(k in prevEnv)) delete process.env[k];
+        }
+        Object.assign(process.env, prevEnv);
+    }
 });

--- a/tests/dsh-settings.test.ts
+++ b/tests/dsh-settings.test.ts
@@ -1,0 +1,84 @@
+// dsh settings.yaml route resolution (#521): settings baseURL ?? $DEEPSEEK_BASE_URL
+// ?? official deepseek default; a custom provider without any resolvable base
+// yields undefined (no interception) rather than a wrong rewrite target.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parseDshSettings, resolveDshUpstreamOrigin, OFFICIAL_DEEPSEEK_ORIGIN } from "../src/agent/dsh-settings.ts";
+
+const CUSTOM = `
+llm-pi-ai:
+  providers:
+    local-vllm:
+      api: openai-completions
+      baseURL: http://10.0.0.5:8199/v1
+      apiKeyEnv: ***
+      models:
+        - id: qwen-test
+          contextWindow: 262144
+agent-default-model:
+  provider: local-vllm
+  model: qwen-test
+`;
+
+test("custom provider: route fields + origin strips the path", () => {
+    const route = parseDshSettings(CUSTOM);
+    assert.deepEqual(route, { provider: "local-vllm", model: "qwen-test", api: "openai-completions", baseUrl: "http://10.0.0.5:8199/v1" });
+    assert.equal(resolveDshUpstreamOrigin(route, {}), "http://10.0.0.5:8199");
+});
+
+test("empty settings, no env → official deepseek default", () => {
+    const route = parseDshSettings("");
+    assert.equal(route.provider, "deepseek-official");
+    assert.equal(route.model, "deepseek-chat");
+    assert.equal(resolveDshUpstreamOrigin(route, {}), OFFICIAL_DEEPSEEK_ORIGIN);
+});
+
+test("$DEEPSEEK_BASE_URL fills in when settings have no base; path stripped", () => {
+    const route = parseDshSettings("");
+    assert.equal(resolveDshUpstreamOrigin(route, { DEEPSEEK_BASE_URL: "https://ds.example.org:8443/api" }), "https://ds.example.org:8443");
+});
+
+test("settings base wins over env", () => {
+    const route = parseDshSettings(CUSTOM);
+    assert.equal(resolveDshUpstreamOrigin(route, { DEEPSEEK_BASE_URL: "https://other.example" }), "http://10.0.0.5:8199");
+});
+
+test("llm-deepseek.baseURL fallback for the official route", () => {
+    const text = `
+llm-deepseek:
+  baseURL: "http://ds-mirror.example:1234/v1"  # mirror
+`;
+    const route = parseDshSettings(text);
+    assert.equal(route.provider, "deepseek-official");
+    assert.equal(resolveDshUpstreamOrigin(route, {}), "http://ds-mirror.example:1234");
+});
+
+test("custom provider with no resolvable base → undefined (no interception)", () => {
+    const text = `
+llm-pi-ai:
+  providers:
+    broken:
+      api: openai-completions
+agent-default-model:
+  provider: broken
+  model: whatever
+`;
+    const route = parseDshSettings(text);
+    assert.equal(route.baseUrl, undefined);
+    assert.equal(resolveDshUpstreamOrigin(route, { DEEPSEEK_BASE_URL: "not a url" }), undefined);
+});
+
+test("malformed settings base falls through to env", () => {
+    const text = `
+llm-pi-ai:
+  providers:
+    p1:
+      baseURL: not a url
+agent-default-model:
+  provider: p1
+  model: m
+`;
+    const route = parseDshSettings(text);
+    assert.equal(resolveDshUpstreamOrigin(route, { DEEPSEEK_BASE_URL: "http://env.example:1" }), "http://env.example:1");
+});

--- a/tests/fix-config-session.test.ts
+++ b/tests/fix-config-session.test.ts
@@ -84,13 +84,14 @@ test("resolveProxyDecision: explicit global proxy (manual mode) still wins over 
 
 // --- Bug 2: loadOptions rejects out-of-range ports. ---
 
-for (const bad of ["0", "-1", "99999", "65536", "abc"]) {
+// 0 is valid: OS-assigned port for the #521 daemon handshake.
+for (const bad of ["-1", "99999", "65536", "abc"]) {
     test(`loadOptions: port ${JSON.stringify(bad)} throws`, () => {
-        assert.throws(() => loadOptions({ ACP_PORT: bad }), /Invalid port .* must be 1-65535/);
+        assert.throws(() => loadOptions({ ACP_PORT: bad }), /Invalid port .* must be 0-65535/);
     });
 }
 
-for (const good of ["1", "80", "8787", "65535"]) {
+for (const good of ["0", "1", "80", "8787", "65535"]) {
     test(`loadOptions: port ${good} accepted`, () => {
         const opts = loadOptions({ ACP_PORT: good });
         assert.equal(opts.port, Number(good));
@@ -98,7 +99,7 @@ for (const good of ["1", "80", "8787", "65535"]) {
 }
 
 test("loadOptions: PORT env also validated (ACP_PORT absent)", () => {
-    assert.throws(() => loadOptions({ PORT: "0" }), /Invalid port/);
+    assert.throws(() => loadOptions({ PORT: "-1" }), /Invalid port/);
     assert.throws(() => loadOptions({ PORT: "99999" }), /Invalid port/);
 });
 

--- a/tests/plugin-agent.test.ts
+++ b/tests/plugin-agent.test.ts
@@ -11,7 +11,8 @@ process.env.NODE_ENV = "test";
 import { proxyBaseFromUrl, proxyBaseFromEnv, detectProxyBase, fetchManifest, forwardTool, fetchStatus } from "../src/agent/shared.ts";
 import biliPlugin, { createBiliPlugin } from "../src/agent/pi.ts";
 import ompPlugin from "../src/agent/omp.ts";
-import { pluginInstall, pluginRemove, pluginStatusAll, PLUGIN_AGENTS, selfPackageRoot } from "../src/plugin-install.ts";
+import { pluginInstall, pluginRemove, pluginStatusAll, PLUGIN_AGENTS, selfPackageRoot, dshNativeInstalled } from "../src/plugin-install.ts";
+import { pathToFileURL } from "node:url";
 import { resolveProxyOrigin, forwardTool as mcpForwardTool } from "../src/mcp.ts";
 
 function withEnv(vars: Record<string, string | undefined>, fn: () => void | Promise<void>): Promise<void> {
@@ -628,8 +629,8 @@ test("plugin install/remove roundtrips for pi/omp/codex/opencode under a fake HO
         assert.match(pluginRemove("claude"), /not installed/);
 
         const rows = pluginStatusAll();
-        assert.equal(rows.length, 5);
-        assert.deepEqual(PLUGIN_AGENTS, ["pi", "omp", "claude", "codex", "opencode"]);
+        assert.equal(rows.length, 6);
+        assert.deepEqual(PLUGIN_AGENTS, ["pi", "omp", "claude", "codex", "opencode", "dsh"]);
     });
     fs.rmSync(home, { recursive: true, force: true });
 });
@@ -750,7 +751,7 @@ test("plugin list survives a broken host config (per-row error, no crash)", asyn
     await withEnv(hintEnv(home, piAgentDir), async () => {
         fs.writeFileSync(path.join(home, ".claude.json"), "{ broken json");
         const rows = pluginStatusAll();
-        assert.equal(rows.length, 5);
+        assert.equal(rows.length, 6);
         const claude = rows.find((r) => r.agent === "claude")!;
         assert.match(claude.status, /error: .*not valid JSON/);
         const pi = rows.find((r) => r.agent === "pi")!;
@@ -947,4 +948,68 @@ test("pi agent never stamps prompt_cache_key (it stamps headers instead)", async
     createBiliPlugin("pi")(pi as never);
     const out = pi.events.get("before_provider_request")!({ type: "before_provider_request", payload: { messages: [{ role: "user", content: "hi" }] } }, fakeCtx(undefined, "pi-uuid"));
     assert.equal(out, undefined, "pi agent never stamps the body");
+});
+
+// #521: dsh native plugin — cordis.patch.yml entries in every profile under a fake DSH_HOME.
+test("plugin dsh install/remove/status roundtrip under a fake DSH_HOME (#521)", async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "bili-plugin-dsh-"));
+    const root = selfPackageRoot();
+    const dshDistFile = path.join(root, "dist", "agent", "dsh-acp.js");
+    const createdDshDist = !fs.existsSync(dshDistFile);
+    if (createdDshDist) {
+        fs.mkdirSync(path.dirname(dshDistFile), { recursive: true });
+        fs.writeFileSync(dshDistFile, "// test stub\n");
+    }
+    const entry = pathToFileURL(dshDistFile).href;
+    try {
+        for (const name of ["headless", "web"]) {
+            const dir = path.join(home, "profiles", name);
+            fs.mkdirSync(dir, { recursive: true });
+            fs.writeFileSync(path.join(dir, "cordis.yml"), "[]\n");
+            fs.writeFileSync(path.join(dir, "cordis.patch.yml"), "[]\n");
+        }
+        await withEnv({ DSH_HOME: home }, () => {
+            assert.equal(dshNativeInstalled(home), false);
+            assert.match(pluginInstall("dsh"), /installed -> cordis\.patch\.yml in 2 profile\(s\)/);
+            for (const name of ["headless", "web"]) {
+                const text = fs.readFileSync(path.join(home, "profiles", name, "cordis.patch.yml"), "utf8");
+                assert.ok(text.includes("- insert:\n    - name: " + entry), `${name} carries the insert block`);
+                assert.ok(!text.includes("["), `${name}: bare [] replaced`);
+            }
+            assert.equal(dshNativeInstalled(home), true);
+            assert.equal(pluginStatusAll().find((r) => r.agent === "dsh")?.status, "installed");
+            assert.match(pluginInstall("dsh"), /already installed \(profiles: headless, web\)/);
+
+            // shared insert group: removing bili must keep the other plugin's item and the group header
+            const sharedHeadless = path.join(home, "profiles", "headless", "cordis.patch.yml");
+            fs.writeFileSync(sharedHeadless, `- insert:\n    - name: /opt/other/plugin.js\n    - name: ${entry}\n`);
+            assert.match(pluginRemove("dsh"), /removed from 2 profile\(s\)/);
+            const cleaned = fs.readFileSync(sharedHeadless, "utf8");
+            assert.equal(cleaned, `- insert:\n    - name: /opt/other/plugin.js\n`);
+            assert.equal(pluginStatusAll().find((r) => r.agent === "dsh")?.status, "not installed");
+            assert.equal(dshNativeInstalled(home), false);
+            assert.match(pluginRemove("dsh"), /^dsh: not installed$/);
+
+            // stale entry (module file gone) → broken status, and the launcher gate stays false
+            fs.writeFileSync(path.join(home, "profiles", "web", "cordis.patch.yml"), `- insert:\n    - name: /nope/dist/agent/dsh-acp.js\n`);
+            assert.equal(pluginStatusAll().find((r) => r.agent === "dsh")?.status, "broken");
+            assert.equal(dshNativeInstalled(home), false);
+            assert.match(pluginRemove("dsh"), /removed from 1 profile\(s\)/);
+            assert.equal(pluginStatusAll().find((r) => r.agent === "dsh")?.status, "not installed");
+        });
+
+        // no profiles at all → install fails with an actionable message
+        const emptyHome = fs.mkdtempSync(path.join(os.tmpdir(), "bili-plugin-dsh-empty-"));
+        try {
+            await withEnv({ DSH_HOME: emptyHome }, () => {
+                assert.throws(() => pluginInstall("dsh"), /no dsh profiles found .* run `dsh` once/s);
+                assert.equal(dshNativeInstalled(emptyHome), false);
+            });
+        } finally {
+            fs.rmSync(emptyHome, { recursive: true, force: true });
+        }
+    } finally {
+        fs.rmSync(home, { recursive: true, force: true });
+        if (createdDshDist) fs.rmSync(dshDistFile, { force: true });
+    }
 });


### PR DESCRIPTION
Closes #521

## What

**dsh native plugin deployment + fetch interception layer** — the task-D slice of #513's confirmed design (per-session dynamic port, thin `bili daemon` subcommand, in-process fetch interception). Shared primitives are structured for B/C reuse.

### `bili plugin install dsh` (src/plugin-install.ts)
- `"dsh"` joins `PLUGIN_AGENTS`; install/remove/status operate on **every** profile under `$DSH_HOME/profiles/*`, merging `- insert: - name: <file://…/dist/agent/dsh-acp.js>` into each profile's `cordis.patch.yml` (replaces bare `[]`, appends otherwise).
- Idempotent; stale entries dropped (parent `- insert:` group only when empty); `.bili-bak` backup per file once; clear error when no profiles exist yet.
- Exported `dshNativeInstalled()` for the launcher.

### Launcher compat (src/launcher.ts)
- Legacy `--patch` overlay is skipped when a live native entry exists (any-profile rule → no double-registration of the same module via both layers). Fresh machines keep the legacy path untouched.
- `LaunchOptions += forceFresh / parentPid / instanceFile / autoUpdateOff`.

### Per-session proxy: `bili daemon --fresh --json --parent-pid N` (cli/server/config)
- Detached proxy on **port 0**; bound origin reported via a session instance file (`BILI_INSTANCE_FILE`) — global instance file and `instances.json` registry skipped for session proxies (#394 dual-writer noise); JSON `{origin, port, pid, logPath}` on stdout; auto-update off; parent-gone reap ≤2s after agent exit.
- config.ts now accepts port 0 (server.ts already anticipated it; only the validator blocked it — found by e2e).

### Fetch interception (src/agent/intercept.ts, new — shared primitive)
- Wraps `globalThis.fetch`; rewrites ONLY requests whose origin == active upstream origin → `<proxy>/bili/<url>`; everything else passthrough; network failure on a rewritten call retries once direct (degrade, never break traffic); stats `{rewritten, passthrough, degraded}`; uninstall restores.
- Targets resolve **async per call** through an 8s gate — this closes the first-fetch race found in e2e (agent's first LLM fetch fired before async bootstrap finished and went direct). Interceptor installs synchronously in `apply()`; regression test included.

### dsh-acp (rewritten) + src/agent/dsh-settings.ts (new line-based reader)
- Env `BILLION_CONTEXT_PROXY` wins (launcher attach mode), else spawn `bili daemon`. Upstream origin per issue spec: settings provider `baseURL` ?? `llm-deepseek.baseURL` ?? env `DEEPSEEK_BASE_URL` ?? official DeepSeek default (official route only).
- Wire mode unchanged: no ACP tools, no conversation id, `/acp` still `fetchStatusLatest` (now reports the routing head). Under `bili dsh` the wrapped settings URL equals the proxy origin → interceptor passthrough → zero double-proxying by construction.

## Triage notes
- **Verified before implementing**: real dsh profile/patch composition order, proven `- insert:` entry shape from the existing launcher overlay, pi-ai's bare `fetch()` calls (no captured references → wrap works), parent-gone watcher semantics, instance-file APIs.
- **Layer judgment**: the issue's "settings baseURL ?? env" chain was verified against the installed dsh source (deepseek-official route: `config.baseURL ?? $DEEPSEEK_BASE_URL`); the implementation extends it with the llm-deepseek section as a middle fallback so both route styles are covered.
- No A/B PR exists yet in master or open PRs — this PR deliberately carries D plus the shared prerequisites (daemon subcommand, intercept module) that B/C will consume.

## Pre-flight
- typecheck clean · `npm test`: 1052 tests, 1051 pass, 1 fail = pre-existing env-dependent `resolveClientCommand: codex/claude resolve to themselves` (sandbox has a local codex binary; passes on runners without one; unrelated) · build OK (`dist/agent/dsh-acp.js` 12.56 KB, tsup entries unchanged)

## E2E (real dsh, bare `dsh --profile headless`, no `--patch`)
- Smoke round-trip through the intercepted proxy (exit 0); rewrite proven against a mock upstream (mock saw only unwrapped `/v1/chat/completions`; a non-SSE mock body made dsh render the proxy's own error string — proxy definitively in path).
- Compression pipeline engaged on real dsh traffic: 32K route cap + ~35.6K-token prompt → preflight ran and fail-fast 502'd with correct adjudication (nothing left to fold — single-message prompts have no compressible history). Full multi-turn cycles remain covered by unit suite + e2e-codex (headless dsh is one-shot).
- Reaping verified every run; real DSH_HOME install/remove roundtrip verified live then restored.
- Limitations documented in devlog WORKLOG: `/acp` live rendering needs interactive TUI (unit-covered); sandbox argv limit caps headless prompt size.