### PR TITLE
fix(launcher): spawn on an ephemeral port when no --port is given (#446)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -103,7 +103,7 @@ Launcher (bili pi / bili codex / bili claude / bili omp / bili opencode / bili h
 Options (override config file / env):
   -F <url>                         upstream proxy to forward through (gost-style;
                                    http://host:port; must precede the client name)
-  --port <N>                       listen port (default 8787)
+  --port <N>                       listen port (start: 8787; launcher default: random free port)
   --host <ADDR>                    listen host (default 127.0.0.1)
   --mitm-domain <domain>           extra MITM domain (repeatable; launcher only)
   --config <FILE>                  path to config JSON (default: XDG location)

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -82,7 +82,6 @@ export {
 } from "./client-config.js";
 
 export const LAUNCHER_DEFAULT_HOST = "127.0.0.1";
-export const LAUNCHER_DEFAULT_PORT = 8787;
 export const LAUNCH_CLIENTS = ["pi", "codex", "claude", "omp", "opencode", "hermes", "dsh", "pi-test"] as const;
 export type ClientName = (typeof LAUNCH_CLIENTS)[number];
 export type BaseClientName = "claude" | "codex" | "pi" | "omp" | "opencode" | "hermes" | "dsh";
@@ -1734,6 +1733,20 @@ export function findFreePort(preferred: number, host = LAUNCHER_DEFAULT_HOST): P
     });
 }
 
+export function pickEphemeralPort(host = LAUNCHER_DEFAULT_HOST): Promise<number> {
+    return new Promise((resolve, reject) => {
+        const srv = net.createServer();
+        srv.once("error", reject);
+        srv.listen(0, host, () => {
+            const addr = srv.address();
+            srv.close(() => {
+                if (addr && typeof addr === "object") resolve(addr.port);
+                else reject(new Error("could not allocate a free port"));
+            });
+        });
+    });
+}
+
 const INHERITED_PROXY_VARS = ["http_proxy", "https_proxy", "all_proxy", "HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY"];
 
 export function stripInheritedProxy(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
@@ -1773,7 +1786,11 @@ export async function ensureProxyRunning(
     // itself and retries on EADDRINUSE, reporting the real origin through
     // the instance file via this launchToken.
     const launchToken = randomUUID();
-    const port = opts.port;
+    // #446: with no explicit --port the launcher binds an OS-assigned
+    // ephemeral port — its private proxy never squats on 8787, so clients
+    // pointed there only ever reach an explicitly-started `bili start`.
+    // The child's EADDRINUSE retry covers the pick/spawn race.
+    const port = opts.port > 0 ? opts.port : await pickEphemeralPort(opts.host);
     const script = process.argv[1];
     if (!script) throw new Error("bili: cannot resolve launcher script path");
     const logPath = path.join(os.tmpdir(), `bili-proxy-${port}.log`);
@@ -1782,7 +1799,7 @@ export async function ensureProxyRunning(
     try {
         child = spawnImpl(
             process.execPath,
-            [script, ...proxyStartArgs(opts)],
+            [script, ...proxyStartArgs({ ...opts, port })],
             {
                 detached: true,
                 stdio: ["ignore", logFd, logFd],
@@ -1924,8 +1941,10 @@ export interface RunLaunchParams {
 }
 
 function parsePort(raw: string | undefined): number {
-    const port = raw && raw.trim() ? parseInt(raw, 10) : LAUNCHER_DEFAULT_PORT;
-    if (!Number.isFinite(port) || port <= 0 || port > 65535) {
+    // 0 = no explicit --port → spawn on an OS-assigned ephemeral port (#446)
+    if (!raw || !raw.trim()) return 0;
+    const port = parseInt(raw, 10);
+    if (!Number.isFinite(port) || port < 1 || port > 65535) {
         console.error(`bili: invalid --port "${raw}"`);
         process.exit(2);
     }

--- a/tests/launcher.test.ts
+++ b/tests/launcher.test.ts
@@ -656,6 +656,41 @@ test("ensureProxyRunning: dead recorded pid is ignored (no attach)", async () =>
     assert.equal(spawnCalls, 1);
 });
 
+test("ensureProxyRunning: port 0 (no explicit --port) spawns on an OS-assigned ephemeral port (#446)", async () => {
+    let spawnedArgs: string[] | null = null;
+    const spawnImpl: SpawnFn = (_cmd, args) => {
+        spawnedArgs = [...args];
+        return makeFakeChild(42437);
+    };
+    const handle = await ensureProxyRunning(
+        { host: "127.0.0.1", port: 0, passthrough: false, debug: false },
+        { fetchImpl: async () => ({ ok: true }), spawnImpl, sleep: () => Promise.resolve(), readInstanceFile: () => undefined },
+    );
+    assert.ok(spawnedArgs !== null);
+    const portIdx = spawnedArgs.indexOf("--port");
+    assert.ok(portIdx >= 0, "spawn args include --port");
+    const childPort = Number(spawnedArgs[portIdx + 1]);
+    assert.ok(Number.isInteger(childPort) && childPort >= 1024 && childPort <= 65535, `ephemeral port assigned, got ${childPort}`);
+    assert.equal(handle.port, childPort);
+    assert.equal(handle.origin, `http://127.0.0.1:${childPort}`);
+});
+
+test("ensureProxyRunning: explicit port is honored verbatim (no ephemeral reassignment)", async () => {
+    let spawnedArgs: string[] | null = null;
+    const spawnImpl: SpawnFn = (_cmd, args) => {
+        spawnedArgs = [...args];
+        return makeFakeChild(42438);
+    };
+    const handle = await ensureProxyRunning(
+        { host: "127.0.0.1", port: 8787, passthrough: false, debug: false },
+        { fetchImpl: async () => ({ ok: true }), spawnImpl, sleep: () => Promise.resolve(), readInstanceFile: () => undefined },
+    );
+    assert.ok(spawnedArgs !== null);
+    const portIdx = spawnedArgs.indexOf("--port");
+    assert.equal(spawnedArgs[portIdx + 1], "8787");
+    assert.equal(handle.port, 8787);
+});
+
 test("ensureProxyRunning: launchToken handshake returns the child's real port (#407)", async () => {
     let handshaked: InstanceFile | undefined;
     const spawnImpl: SpawnFn = (_cmd, _args, options) => {
@@ -2090,7 +2125,9 @@ test("runLaunch dsh: DSH_HOME overlay + DEEPSEEK_BASE_URL env, real home untouch
     try {
         await runLaunch(
             { client: "dsh", clientArgs: ["--profile", "headless", "task"], overrides: {} },
-            { fetchImpl: async () => ({ ok: true }), spawnImpl, sleep: () => Promise.resolve() },
+            // hermetic: never attach to / handshake against a real proxy
+            // whose instance file happens to live on this machine
+            { fetchImpl: async () => ({ ok: true }), spawnImpl, sleep: () => Promise.resolve(), readInstanceFile: () => undefined },
         );
         assert.equal(envSeen.length, 1);
         const seenEnv = envSeen[0];


### PR DESCRIPTION
## What

Launcher mode (`bili pi`, `bili codex`, …) with no explicit `--port` now spawns its proxy on an **OS-assigned ephemeral port** instead of defaulting to 8787. `bili start` is unchanged (still 8787).

Fixes #446 — supersede plan 1 (port isolation only) confirmed by @ranxianglei [here](https://github.com/ranxianglei/billion-context/issues/446#issuecomment-5536214000): keep the #417 attach-or-spawn share path, stop squatting on the well-known port.

## Changes

- `src/launcher.ts` `parsePort`: no explicit `--port` → `0` sentinel (explicit values still validated 1–65535).
- `src/launcher.ts` `ensureProxyRunning` spawn branch: `port 0` → `pickEphemeralPort()` (bind-0) before spawn; the child gets the concrete port, so the log file (`/tmp/bili-proxy-<port>.log`) stays unique per launcher. The existing #407 EADDRINUSE retry still covers the pick/spawn race.
- `LAUNCHER_DEFAULT_PORT` removed (dead after the change).
- `src/cli.ts` help text updated.
- **Attach path untouched**: a healthy compatible instance (any port — including `bili start` on 8787) is still attached per #417; `instanceCompatible` never looked at the port.

## Why this is safe for #446's crash scenario

External clients pointed at `http://127.0.0.1:8787` can now only ever reach an explicitly-started long-lived `bili start` — a launcher's private proxy lives on an ephemeral port nobody else knows. The residual launcher-to-launcher chain (B attaches to A's proxy; A exits and kills its child) was accepted in the issue thread: B restarts.

## Test fixes

- 2 new cases in `tests/launcher.test.ts`: port 0 → concrete ephemeral `--port` in spawn args; explicit 8787 → verbatim.
- Made the `runLaunch dsh` rig hermetic (`readInstanceFile: () => undefined`): it was reading the machine's real `~/.local/state/billion-context/proxy-origin` and timing out (20s) whenever any bili proxy was running on the dev box — verified failing on clean master.

## Side-finding while verifying (reported in #446 thread)

`unregisterInstance` (graceful shutdown, runs *after* an async session flush) races a concurrently-starting proxy's `registerInstanceAndWarn` — the old process reads the registry, the new one registers, then the old one writes back the stale list and wipes the new entry. Observed live at the 13:45 restart: pid 2212910 has been running since then with **no** entry in `instances.json`. Read-modify-write with no cross-process lock; both files (`instances.json`, `proxy-origin`) are affected.

## Pre-flight

- `npm run typecheck` — clean
- `npm test` — 1032/1034 (the 2 known env-only `plugin-agent.test.ts` fails)
- `npm run build` — success
- End-to-end smoke on dist: `BILI_CLIENT_BIN=/bin/true node dist/index.js --mitm-domain smoke.test.example pi` → `started proxy at http://127.0.0.1:38997` (ephemeral, not 8787), graceful SIGTERM flush, registry entry added and removed cleanly.