### PR TITLE
fix: instance registry lost-update — per-instance marker files (#527)

### DIFF
--- a/src/instance.ts
+++ b/src/instance.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { stateDir } from "./paths.js";
@@ -71,15 +71,15 @@ export function instanceFilePath(): string {
 }
 
 /** tmp+fsync+rename (same shape as web/api.ts atomicWriteConfig) — a torn
- *  write must never leave a half-origin behind (#406 family). */
-export function atomicWriteInstanceFile(info: ProxyInstanceFile, file?: string): void {
-    const filePath = file ?? instanceFilePath();
+ *  write must never leave a half-file behind (#406 family). Shared by the
+ *  proxy-origin record and every registry marker. */
+function atomicWriteJson(obj: unknown, filePath: string): void {
     fs.mkdirSync(path.dirname(filePath), { recursive: true });
     const tempPath = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
     let descriptor: number | undefined;
     try {
         descriptor = fs.openSync(tempPath, "wx", 0o644);
-        fs.writeSync(descriptor, JSON.stringify(info) + "\n", null, "utf8");
+        fs.writeSync(descriptor, JSON.stringify(obj) + "\n", null, "utf8");
         fs.fsyncSync(descriptor);
         fs.closeSync(descriptor);
         descriptor = undefined;
@@ -95,6 +95,10 @@ export function atomicWriteInstanceFile(info: ProxyInstanceFile, file?: string):
         } catch {}
         throw error;
     }
+}
+
+export function atomicWriteInstanceFile(info: ProxyInstanceFile, file?: string): void {
+    atomicWriteJson(info, file ?? instanceFilePath());
 }
 
 /** Remove our record on shutdown — but only if the file still carries OUR
@@ -129,46 +133,113 @@ interface RegistryEntry {
     startedAt: number;
 }
 
-function registryFilePath(): string {
+/** Cross-instance liveness registry (#394/#527): one marker file per instance
+ *  under <state>/instances/<id>.json, so the registry IS the directory listing
+ *  and removal unlinks exactly one file — no shared read-modify-write, hence no
+ *  cross-process lost update. Dead owners are reaped on the next registration;
+ *  legacy instances.json is folded in read-only. Best-effort. */
+function registryDirPath(): string {
+    return path.join(stateDir(), "instances");
+}
+
+function legacyRegistryFilePath(): string {
     return path.join(stateDir(), "instances.json");
 }
 
-/** Cross-instance liveness registry (#394): every proxy registers itself at
- *  listen time; a second live registrant triggers the dual-writer warning.
- *  Entries whose pid is dead are pruned on read. Best-effort throughout. */
-export function registerInstanceAndWarn(entry: RegistryEntry, warn: (msg: string) => void): void {
-    const file = registryFilePath();
-    const entries: RegistryEntry[] = [];
+const SAFE_NAME_RE = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+function safeRegistryName(instanceId: string): string {
+    if (instanceId !== "." && instanceId !== ".." && instanceId.length <= 128 && SAFE_NAME_RE.test(instanceId)) {
+        return instanceId;
+    }
+    return createHash("sha256").update(instanceId).digest("hex");
+}
+
+function registryEntryFile(instanceId: string): string {
+    return path.join(registryDirPath(), `${safeRegistryName(instanceId)}.json`);
+}
+
+function safeReadJson(file: string): unknown {
     try {
-        const parsed = JSON.parse(fs.readFileSync(file, "utf8")) as { instances?: RegistryEntry[] };
-        if (Array.isArray(parsed.instances)) {
-            for (const e of parsed.instances) {
-                if (e && typeof e.instanceId === "string" && e.instanceId !== entry.instanceId && isPidAlive(e.pid)) {
-                    entries.push(e);
-                }
+        return JSON.parse(fs.readFileSync(file, "utf8"));
+    } catch {
+        return undefined;
+    }
+}
+
+function coerceEntry(value: unknown): RegistryEntry | undefined {
+    if (!value || typeof value !== "object") return undefined;
+    const o = value as Record<string, unknown>;
+    if (typeof o.instanceId !== "string" || o.instanceId === "") return undefined;
+    return {
+        instanceId: o.instanceId,
+        pid: typeof o.pid === "number" ? o.pid : 0,
+        port: typeof o.port === "number" ? o.port : 0,
+        origin: typeof o.origin === "string" ? o.origin : "",
+        startedAt: typeof o.startedAt === "number" ? o.startedAt : 0,
+    };
+}
+
+function readMarkerNames(): string[] {
+    try {
+        return fs.readdirSync(registryDirPath());
+    } catch {
+        return [];
+    }
+}
+
+function readAllRegistryEntries(): RegistryEntry[] {
+    const seen = new Set<string>();
+    const out: RegistryEntry[] = [];
+    for (const name of readMarkerNames()) {
+        if (!name.endsWith(".json")) continue;
+        const entry = coerceEntry(safeReadJson(path.join(registryDirPath(), name)));
+        if (entry && !seen.has(entry.instanceId)) {
+            seen.add(entry.instanceId);
+            out.push(entry);
+        }
+    }
+    const legacy = safeReadJson(legacyRegistryFilePath()) as { instances?: unknown } | undefined;
+    if (legacy && Array.isArray(legacy.instances)) {
+        for (const raw of legacy.instances) {
+            const entry = coerceEntry(raw);
+            if (entry && !seen.has(entry.instanceId)) {
+                seen.add(entry.instanceId);
+                out.push(entry);
             }
         }
-    } catch {}
-    for (const other of entries) {
+    }
+    return out;
+}
+
+function reapDeadMarkers(ours: string): void {
+    for (const name of readMarkerNames()) {
+        if (!name.endsWith(".json")) continue;
+        const file = path.join(registryDirPath(), name);
+        const entry = coerceEntry(safeReadJson(file));
+        if (!entry || entry.instanceId === ours || isPidAlive(entry.pid)) continue;
+        try {
+            fs.unlinkSync(file);
+        } catch {}
+    }
+}
+
+export function registerInstanceAndWarn(entry: RegistryEntry, warn: (msg: string) => void): void {
+    const others = readAllRegistryEntries().filter((e) => e.instanceId !== entry.instanceId && isPidAlive(e.pid));
+    for (const other of others) {
         warn(
             `another bili instance is running (pid ${other.pid}, ${other.origin}) — both processes will write the same sessions directory; stop one to avoid state pollution (#394)`,
         );
     }
-    entries.push(entry);
+    reapDeadMarkers(entry.instanceId);
     try {
-        fs.mkdirSync(path.dirname(file), { recursive: true });
-        fs.writeFileSync(file, JSON.stringify({ instances: entries }) + "\n");
+        atomicWriteJson(entry, registryEntryFile(entry.instanceId));
     } catch {}
 }
 
+/** Unlinks only our own marker; cannot clobber another instance's entry (#527). */
 export function unregisterInstance(instanceId: string): void {
-    const file = registryFilePath();
     try {
-        const parsed = JSON.parse(fs.readFileSync(file, "utf8")) as { instances?: RegistryEntry[] };
-        if (!Array.isArray(parsed.instances)) return;
-        const kept = parsed.instances.filter(
-            (e) => !(e && typeof e.instanceId === "string" && e.instanceId === instanceId) && isPidAlive(e.pid),
-        );
-        fs.writeFileSync(file, JSON.stringify({ instances: kept }) + "\n");
+        fs.unlinkSync(registryEntryFile(instanceId));
     } catch {}
 }

--- a/tests/instance-governance.test.ts
+++ b/tests/instance-governance.test.ts
@@ -133,13 +133,38 @@ test("instance registry: registers, warns on a second live instance, prunes dead
         );
         assert.equal(warnings.length, 1);
         assert.match(warnings[0], /another bili instance is running/);
-        const file = path.join(st.dir, "billion-context", "instances.json");
-        const after = JSON.parse(fs.readFileSync(file, "utf8")) as { instances: { instanceId: string }[] };
-        assert.equal(after.instances.length, 2);
+        const regDir = path.join(st.dir, "billion-context", "instances");
+        const markerNames = () => fs.readdirSync(regDir).filter((n) => n.endsWith(".json")).sort();
+        assert.deepEqual(markerNames(), ["a.json", "b.json"]);
 
         unregisterInstance("a");
-        const after2 = JSON.parse(fs.readFileSync(file, "utf8")) as { instances: { instanceId: string }[] };
-        assert.deepEqual(after2.instances.map((e) => e.instanceId), ["b"]);
+        assert.deepEqual(markerNames(), ["b.json"]);
+    } finally {
+        setLogCapture(null);
+        st.restore();
+    }
+});
+
+test("instance registry folds a live legacy instances.json entry read-only (no rewrite)", () => {
+    const st = tmpStateDir();
+    const warnings: string[] = [];
+    setLogCapture((_level, msg) => warnings.push(msg));
+    try {
+        const stateRoot = path.join(st.dir, "billion-context");
+        fs.mkdirSync(stateRoot, { recursive: true });
+        fs.writeFileSync(
+            path.join(stateRoot, "instances.json"),
+            JSON.stringify({ instances: [{ instanceId: "legacy", pid: process.pid, port: 9, origin: "http://127.0.0.1:9", startedAt: 1 }] }),
+        );
+        registerInstanceAndWarn(
+            { instanceId: "new", pid: process.pid, port: 10, origin: "http://127.0.0.1:10", startedAt: 2 },
+            (msg) => warnings.push(msg),
+        );
+        assert.equal(warnings.length, 1);
+        assert.match(warnings[0], /another bili instance is running/);
+        assert.ok(fs.existsSync(path.join(stateRoot, "instances", "new.json")));
+        const legacyAfter = JSON.parse(fs.readFileSync(path.join(stateRoot, "instances.json"), "utf8")) as { instances: { instanceId: string }[] };
+        assert.deepEqual(legacyAfter.instances.map((e) => e.instanceId), ["legacy"]);
     } finally {
         setLogCapture(null);
         st.restore();


### PR DESCRIPTION
Fixes #527.

## What & why

The multi-instance liveness registry (`instances.json`, #394/#417) was an unsynchronized, non-atomic read-modify-write. On the normal `bili start`/launcher restart cadence — SIGTERM A while A is still flushing sessions, immediately start B — A's `finishShutdown` runs `unregisterInstance(A)` *after* its async `flushAllSessions()` completes, which can land *after* B's `registerInstanceAndWarn` already wrote. A's stale computed list then overwrites B's entry, wiping B's registration while B stays alive. Observed live at the 2026-09-04 13:45 restart (pid 2212910 / port 8787 alive, `instances.json` = `{"instances":[]}`).

## Fix

Replace the shared file with **one marker file per instance** under `<state>/instances/<id>.json`. The registry IS the directory listing, so:

- `unregisterInstance(id)` unlinks exactly **one** file (ownership-scoped by filename), so a stale unregister can no longer clobber a concurrently-starting instance. This removes the defect class rather than papering over it with a lock.
- `registerInstanceAndWarn` writes only its own marker atomically (tmp+fsync+rename), warns on each live non-self entry (unchanged #394 warning text), and opportunistically reaps dead owners' markers (liveness-gated; never touches live/self entries).
- Legacy `instances.json` is folded in **read-only** for one-restart continuity and is never written back.

`registerInstanceAndWarn` / `unregisterInstance` signatures are unchanged; `src/server.ts` is untouched. `proxy-origin` (single-instance discovery) was already ownership-guarded and is unaffected.

## Trade-off considered

The issue suggested a cross-process lock directory as an alternative. Chose per-instance marker files because it eliminates the shared rewrite entirely — no lock lifecycle, no stale-lock break-by-pid (unsafe on Linux due to pid reuse) — and matches the file's existing atomic-write idiom.

## Tests / pre-flight

- `tests/instance-governance.test.ts`: registry test now asserts against the marker dir (`a.json`, `b.json` → unregister `a` → `b.json`); added a legacy-fold read-only test (a live legacy entry triggers the warning and the legacy file is left unrewritten).
- `npm run typecheck` pass, `npm run build` pass, full `npm test` = 947 pass / 1 fail.
- The 1 failure (`resolveClientCommand: codex/claude resolve to themselves`) is **pre-existing and environment-dependent**: this sandbox has `/usr/bin/codex` and `/usr/bin/claude` installed (needed by the e2e suite), so the bare-name assertion fails. Verified it fails identically on the unmodified tree (my changes stashed). Unrelated to this change.
