### PR TITLE
release v0.1.84

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.83",
+  "version": "0.1.84",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.83",
+      "version": "0.1.84",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.83",
+  "version": "0.1.84",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Release v0.1.84 — carries three master commits since v0.1.83:

- #418 fix: debug banner guard (raw HTTP capture)
- #512 docs: README tool-relationships table
- #526 fix(launcher): spawn on an ephemeral port when no --port is given (#446)

Version bump only. Preflight on this branch: typecheck clean, tests 1032/1034 (2 known env-dependent fails in plugin-agent.test.ts, same as baseline), build ok.