### PR TITLE
fix: single-copy leaf blocks + one-pass session boot (#401)

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -634,6 +634,10 @@ Compression state (blocks, summaries, original message cache) lives **in the pro
 - If you point the client back at the real upstream (or stop the proxy), the client replays its **full local history** every turn. After a long compressed session this can exceed the model's context window (`context_window_exceeded`).
 - There is no way to "unpack" a compression block into the client's local history — the client never saw the compressed form.
 
+### Storage lifecycle at boot (#401)
+
+The proxy boots session storage with a **single** directory walk+parse (load and the one-time #286 identity migration run over the same parsed map). Sessions are kept permanently — the design goal is that a year-long conversation is never lost — so there is no retention or size-budget pruning. The #286 migration writes a `.bili-migration-286.done` marker after its first pass, so it never re-scans or re-logs on later boots.
+
 ### Migrating off the proxy
 
 Export the session and paste it into a fresh conversation as a handoff:

--- a/src/decompress-shared.ts
+++ b/src/decompress-shared.ts
@@ -91,7 +91,9 @@ export function resolveDecompress(
         // Honor the full flag: `one` = direct msgs + nested child summaries,
         // `full` = all original messages. Returning the cached full text
         // unconditionally would break the default one-level semantics.
-        const view = full ? cached.full : cached.one;
+        // `one === null` means the two views were byte-identical at cache
+        // time and deduped to one copy (#401).
+        const view = full ? cached.full : (cached.one ?? cached.full);
         body = view.text;
         count = view.count;
     } else {

--- a/src/persist.ts
+++ b/src/persist.ts
@@ -1,11 +1,12 @@
 import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import * as path from "node:path";
 import { StateStore, flatFileNameFor, type PersistedEnvelope } from "acp-kernel/persist";
 import { sessionsDir } from "./paths.js";
 import { log as loggerLog } from "./logger.js";
 import { createInitialState, type CompressionState, type CoreMessage } from "acp-kernel";
-import type { Session, BlockContent } from "./session.js";
+import type { Session, BlockContent, BlockView } from "./session.js";
 
 /**
  * On-disk persistence for proxy sessions.
@@ -59,6 +60,9 @@ import type { Session, BlockContent } from "./session.js";
  */
 
 const PERSIST_VERSION = 3;
+/** Dotfile (invisible to the kernel's .json walk): written after the first
+ *  successful #286 migration pass so later boots skip the scan entirely. */
+const MIGRATION_MARKER = ".bili-migration-286.done";
 
 interface PersistedSession {
     version: number;
@@ -199,6 +203,22 @@ export class SessionStore {
         return out;
     }
 
+    /** Single-pass boot (#401): ONE loadAll walk+parse, then the #286
+     *  identity migration over the SAME parsed map (no extra directory
+     *  walk), then hydration into Sessions. initSessions calls this instead
+     *  of migrateLegacyIds()+loadAll(), which walked and parsed the whole
+     *  tree twice per start. */
+    async boot(): Promise<Map<string, Session>> {
+        if (!this.enabled) return new Map();
+        const loaded = await this.store.loadAll();
+        await this.applyLegacyMigration(loaded);
+        const out = new Map<string, Session>();
+        for (const [id, envelope] of loaded) {
+            out.set(id, buildSession(envelope.payload));
+        }
+        return out;
+    }
+
     /** One-time migration for the #286 identity change: sessions persisted
      *  under the old derived hash id are re-keyed to the client-provided
      *  conversation value stored in meta.label (which is now the session id
@@ -207,10 +227,27 @@ export class SessionStore {
      *  session, are deleted. Records without a label cannot be mapped and are
      *  left in place (they load under their old id but are never requested
      *  again — the new proxy 400s anonymous requests). Self-terminating:
-     *  after one pass no loaded id differs from its label. */
+     *  after one pass no loaded id differs from its label. A completion
+     *  marker makes it run ONCE EVER (#401): the old code re-scanned the tree
+     *  on every boot because unlabeled files are intentionally kept, so the
+     *  "one-time" log line repeated forever. */
     async migrateLegacyIds(): Promise<void> {
         if (!this.enabled) return;
+        if (existsSync(this.markerPath())) return;
         const loaded = await this.store.loadAll();
+        await this.applyLegacyMigration(loaded);
+    }
+
+    private markerPath(): string {
+        return path.join(this.dir, MIGRATION_MARKER);
+    }
+
+    private async applyLegacyMigration(loaded: Map<string, PersistedEnvelope<PersistedSession>>): Promise<void> {
+        // Marker gate lives HERE (not just in migrateLegacyIds) because boot()
+        // invokes this directly — unlabeled files are intentionally kept
+        // forever, so without the gate the "one-time" pass would re-run and
+        // re-log on every single start (#401 root cause 3).
+        if (existsSync(this.markerPath())) return;
         const claimed = new Set<string>();
         const byLabel = new Map<string, { id: string; savedAt: number; session: Session }>();
         let unlabeled = 0;
@@ -234,23 +271,39 @@ export class SessionStore {
             }
             const prev = byLabel.get(label);
             if (!prev || envelope.savedAt >= prev.savedAt) {
-                if (prev) await this.removeLegacyFile(prev.id, prev.session);
+                if (prev) {
+                    await this.removeLegacyFile(prev.id, prev.session);
+                    loaded.delete(prev.id);
+                }
                 byLabel.set(label, { id, savedAt: envelope.savedAt, session });
             } else {
                 await this.removeLegacyFile(id, session);
+                loaded.delete(id);
             }
         }
         let rekeyed = 0;
         for (const [label, { id, session }] of byLabel) {
             if (claimed.has(label)) {
                 await this.removeLegacyFile(id, session);
+                loaded.delete(id);
                 continue;
             }
             session.id = label;
             await this.store.writeNow(label, () => buildRecord(session));
             await this.removeLegacyFile(id, session);
+            const envelope = loaded.get(id);
+            if (envelope) {
+                loaded.set(label, { ...envelope, id: label, payload: { ...envelope.payload, id: label } });
+            }
+            loaded.delete(id);
             claimed.add(label);
             rekeyed++;
+        }
+        try {
+            mkdirSync(this.dir, { recursive: true });
+            writeFileSync(this.markerPath(), String(Date.now()), "utf8");
+        } catch {
+            // Read-only dir — migration re-runs next boot (it is idempotent).
         }
         if (rekeyed || unlabeled) {
             loggerLog("info", `[persist] one-time migration (#286): rekeyed ${rekeyed} legacy session(s), left ${unlabeled} unlabeled legacy file(s) in place`);
@@ -349,10 +402,24 @@ function buildRecord(session: Session): PersistedSession {
     };
 }
 
+function isBlockView(v: unknown): v is BlockView {
+    return !!v && typeof v === "object" && typeof (v as BlockView).text === "string" && typeof (v as BlockView).count === "number";
+}
+
 function buildSession(parsed: PersistedSession): Session {
     const blockContents = new Map<string, BlockContent>();
     for (const [bid, content] of Object.entries(parsed.blockContents ?? {})) {
-        if (content && typeof content === "object") blockContents.set(bid, content);
+        if (!content || typeof content !== "object") continue;
+        const full = (content as Record<string, unknown>).full;
+        if (!isBlockView(full)) continue;
+        // Legacy files stored byte-identical one/full pairs (#401); normalize
+        // to the single-copy form on load so the next write persists it once.
+        const one = (content as Record<string, unknown>).one;
+        const oneView = isBlockView(one) ? one : null;
+        blockContents.set(bid, {
+            one: oneView && !(oneView.text === full.text && oneView.count === full.count) ? oneView : null,
+            full,
+        });
     }
     // Read grouped shape (v2+); fall back to flat fields for v1 files.
     const meta = parsed.meta ?? {};

--- a/src/session.ts
+++ b/src/session.ts
@@ -1,9 +1,18 @@
 import { createInitialState, type CompressionState, type CoreMessage } from "acp-kernel";
 import { getStore } from "./persist.js";
 
+export type BlockView = { text: string; count: number };
+
+/** Original content of a compressed block, captured at compress time. `full`
+ *  (all original messages) is always stored. `one` (one-level: direct messages
+ *  + nested child summaries) is `null` when it is byte-identical to `full` —
+ *  always the case for leaf blocks, since nested children are deactivated at
+ *  creation and the one-level view skips inactive children — and is persisted
+ *  as a single copy in that case (#401: the duplicated copy was 50% of
+ *  blockContents bytes on disk). */
 export type BlockContent = {
-    one: { text: string; count: number };
-    full: { text: string; count: number };
+    one: BlockView | null;
+    full: BlockView;
 };
 
 /** One successful compress, recorded for #189 observability: correlating a
@@ -89,9 +98,11 @@ export type Session = {
      *  the source messages are still present in the request. decompress reads
      *  from here instead of scanning ctx.messages (which only holds the
      *  post-compression / folded view and loses originals across rounds).
-     *  Two views are cached: `one` (one-level: direct messages + nested
+     *  Two views are cached — `one` (one-level: direct messages + nested
      *  child summaries) and `full` (all original messages), matching the
-     *  collectBlockContent full flag semantics.
+     *  collectBlockContent full flag semantics — but when the views are
+     *  byte-identical (leaf blocks) only one copy is kept (`one: null`,
+     *  #401).
      *  Unbounded in memory by design — block summaries are small relative to
      *  the history they replace, and disk persistence keeps the source of
      *  truth; the MAX_SESSIONS cap bounds the number of concurrent sessions
@@ -139,18 +150,19 @@ let MAX_SESSIONS = Math.max(1, Number.parseInt(process.env.BILI_MAX_SESSIONS ?? 
 let initialized = false;
 
 /** Bulk-load persisted sessions from disk into the in-memory map. Called once
- *  at server startup before listening. Caps at MAX_SESSIONS by the most
- *  recently active of createdAt/lastSeen-from-disk (keeps the freshest; a
- *  session that is old but was active until recently must not lose its slot
- *  to a newer-created-but-idle one, #404) so a huge backlog cannot OOM on
- *  boot. Idempotent. */
+ *  at server startup before listening. boot() does ONE loadAll pass plus the
+ *  #286 migration over the same parsed map (#401: the
+ *  old migrateLegacyIds()+loadAll() pair walked and parsed the tree twice).
+ *  Caps at MAX_SESSIONS by the most recently active of createdAt/lastSeen-
+ *  from-disk (keeps the freshest; a session that is old but was active until
+ *  recently must not lose its slot to a newer-created-but-idle one, #404) so
+ *  a huge backlog cannot OOM on boot. Idempotent. */
 export async function initSessions(): Promise<void> {
     if (initialized) return;
     initialized = true;
     const store = getStore();
     if (!store.enabled) return;
-    await store.migrateLegacyIds();
-    const loaded = await store.loadAll();
+    const loaded = await store.boot();
     if (loaded.size > MAX_SESSIONS) {
         const freshness = (s: Session) => Math.max(s.createdAt ?? 0, s.lastSeen ?? 0);
         const entries = [...loaded.entries()].sort((a, b) => freshness(b[1]) - freshness(a[1]));

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -83,13 +83,17 @@ export function applyRanges(parsed: ReturnType<typeof parseCompressInput>, ctx: 
         // work in later rounds where ctx.messages no longer carries the originals.
         // Two views are cached so decompress can honor the `full` flag: `one`
         // (direct messages + nested child summaries) and `full` (all originals).
+        // Leaf blocks have no active nested children, so both kernel paths
+        // emit byte-identical text — persist a single copy in that case
+        // (#401: the duplicate was 50% of blockContents bytes on disk).
         for (const b of res.state.blocks) {
             if (beforeIds.has(b.blockId)) continue;
             const full = collectBlockContent(res.state, b, ctx.messages, { full: true });
             const one = collectBlockContent(res.state, b, ctx.messages, { full: false });
             if (full.count > 0 || one.count > 0) {
+                const sameView = one.text === full.text && one.count === full.count;
                 cacheBlockContent(ctx.session, b.blockId, {
-                    one: { text: one.text, count: one.count },
+                    one: sameView ? null : { text: one.text, count: one.count },
                     full: { text: full.text, count: full.count },
                 });
             }

--- a/tests/fix-401-storage.test.ts
+++ b/tests/fix-401-storage.test.ts
@@ -1,0 +1,147 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { tmpdir } from "node:os";
+import fsShared from "node:fs";
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { createInitialState } from "acp-kernel";
+import { SessionStore } from "../src/persist.ts";
+import type { Session } from "../src/session.ts";
+import { setLogCapture } from "../src/logger.ts";
+
+function jsonFilesUnder(dir: string): string[] {
+    const out: string[] = [];
+    for (const name of readdirSync(dir)) {
+        if (name.startsWith(".tmp-")) continue;
+        const full = join(dir, name);
+        if (statSync(full).isDirectory()) out.push(...jsonFilesUnder(full));
+        else if (name.endsWith(".json")) out.push(full);
+    }
+    return out;
+}
+
+function makeSession(id: string, meta: Session["meta"] = {}): Session {
+    return {
+        id,
+        meta,
+        stats: { requests: 0, tokensSaved: 0, inputTokens: 0, cachedTokens: 0, outputTokens: 0, cacheSamples: 0, lastInputTokens: 0, contextTokens: 0 },
+        metadata: {},
+        state: createInitialState(),
+        createdAt: Date.now(),
+        lastSeen: Date.now(),
+        blockContents: new Map(),
+        inFlight: 0,
+        persisted: false,
+    };
+}
+
+function withDir<T>(name: string, fn: (dir: string) => Promise<T> | T): Promise<unknown> {
+    return test(name, async () => {
+        const dir = mkdtempSync(join(tmpdir(), "bili-401-"));
+        try {
+            await fn(dir);
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+}
+
+await withDir("leaf block persists a single copy (one:null) and round-trips", async (dir) => {
+    const store = new SessionStore({ dir, debounceMs: 5, enabled: true });
+    const s = makeSession("leaf-1");
+    s.blockContents.set("b1", { one: null, full: { text: "body-text", count: 2 } });
+    await store.writeNow(s);
+
+    const [file] = jsonFilesUnder(dir);
+    const raw = JSON.parse(readFileSync(file, "utf8")).payload;
+    assert.equal(raw.blockContents.b1.one, null, "byte-identical leaf view is stored once");
+    assert.deepEqual(raw.blockContents.b1.full, { text: "body-text", count: 2 });
+
+    const loaded = store.loadSync("leaf-1");
+    assert.ok(loaded, "loaded from disk");
+    const bc = loaded!.blockContents.get("b1");
+    assert.equal(bc!.one, null, "null one-view survives the round-trip");
+    assert.deepEqual(bc!.full, { text: "body-text", count: 2 });
+});
+
+await withDir("legacy byte-identical one/full pair normalizes to single copy on load", async (dir) => {
+    const store = new SessionStore({ dir, debounceMs: 5, enabled: true });
+    const s = makeSession("dup-1");
+    s.blockContents.set("b1", { one: { text: "same", count: 1 }, full: { text: "same", count: 1 } });
+    await store.writeNow(s);
+    // Simulate a pre-fix file: both views persisted, byte-identical.
+    const [file] = jsonFilesUnder(dir);
+    const env = JSON.parse(readFileSync(file, "utf8"));
+    env.payload.blockContents.b1 = { one: { text: "same", count: 1 }, full: { text: "same", count: 1 } };
+    writeFileSync(file, JSON.stringify(env));
+
+    const loaded = store.loadSync("dup-1");
+    assert.ok(loaded);
+    assert.equal(loaded!.blockContents.get("b1")!.one, null, "identical pair collapses to full-only");
+    assert.deepEqual(loaded!.blockContents.get("b1")!.full, { text: "same", count: 1 });
+
+    await store.writeNow(loaded!);
+    const raw2 = JSON.parse(readFileSync(jsonFilesUnder(dir)[0], "utf8")).payload;
+    assert.equal(raw2.blockContents.b1.one, null, "next persist stores the collapsed form");
+});
+
+// The kernel walks with `fs.readFileSync` on the shared node:fs object
+// (dist/persist/index.js: `import fs from "fs"`), so patching the default
+// export counts every file read during boot — a second loadAll pass would
+// double the count. Sessions are permanent (#401: a year-long conversation
+// must never be lost), so boot must not delete anything either.
+await withDir("boot() loads everything in a single directory walk and deletes nothing", async (dir) => {
+    const store = new SessionStore({ dir, debounceMs: 5, enabled: true });
+    for (let i = 0; i < 300; i++) await store.writeNow(makeSession(`keep-${i}`));
+    await store.writeNow(makeSession("keep-300"));
+    await store.writeNow(makeSession("keep-301"));
+    assert.equal(jsonFilesUnder(dir).length, 302);
+    writeFileSync(join(dir, ".bili-migration-286.done"), String(Date.now()), "utf8");
+
+    const cold = new SessionStore({ dir, debounceMs: 5, enabled: true });
+    const origReadFileSync = fsShared.readFileSync;
+    let reads = 0;
+    Object.assign(fsShared, {
+        readFileSync: (...args: Parameters<typeof fsShared.readFileSync>): unknown => {
+            reads++;
+            return origReadFileSync(...args);
+        },
+    });
+    let map: Map<string, Session>;
+    try {
+        map = await cold.boot();
+    } finally {
+        Object.assign(fsShared, { readFileSync: origReadFileSync });
+    }
+
+    assert.equal(reads, 302, "exactly one read per session file — a single walk+parse pass");
+    assert.equal(map.size, 302, "every session loads");
+    assert.ok(map.has("keep-0") && map.has("keep-301"));
+    assert.equal(jsonFilesUnder(dir).length, 302, "nothing deleted — sessions are permanent");
+});
+
+await withDir("#286 migration runs exactly once ever (completion marker)", async (dir) => {
+    const store = new SessionStore({ dir, debounceMs: 5, enabled: true });
+    await store.writeNow(makeSession("old-hash-id", { label: "conv-123" }));
+
+    const lines: string[] = [];
+    setLogCapture((_level, msg) => lines.push(msg));
+    try {
+        const cold1 = new SessionStore({ dir, debounceMs: 5, enabled: true });
+        const map1 = await cold1.boot();
+        assert.ok(map1.has("conv-123"), "rekeyed under the client conversation id");
+        assert.ok(!map1.has("old-hash-id"));
+        assert.equal(lines.filter((m) => m.includes("one-time migration")).length, 1);
+        assert.ok(existsSync(join(dir, ".bili-migration-286.done")), "completion marker written");
+        assert.equal(jsonFilesUnder(dir).length, 1, "loser file deleted");
+
+        lines.length = 0;
+        const cold2 = new SessionStore({ dir, debounceMs: 5, enabled: true });
+        const map2 = await cold2.boot();
+        assert.ok(map2.has("conv-123"));
+        assert.equal(lines.filter((m) => m.includes("one-time migration")).length, 0, "marker suppresses the rescan");
+        assert.equal(jsonFilesUnder(dir).length, 1, "second boot changes nothing");
+    } finally {
+        setLogCapture(null);
+    }
+});


### PR DESCRIPTION
Supersedes #479 (and #478) with the scope agreed in the #401 thread: **sessions are permanent — the GC half of #479 is dropped entirely** (design goal: a session is used for a year and must never be lost); what remains is the storage-growth halving and the boot-cost fix.

## What's in

1. **Single-copy leaf blocks** — `blockContents` caches two rendered views (`one` one-level / `full` all-originals); on leaf blocks they are byte-identical, which was 50% of the field's bytes. Leaves now persist as `one: null` + `full`; legacy duplicate pairs normalize to the single-copy form on load, so every file shrinks by its leaf-duplicate half the next time it is written.
2. **One-pass boot** — `boot()` = ONE `loadAll` walk+parse, then the #286 identity migration over the same parsed map. The old `migrateLegacyIds()+loadAll()` pair walked and parsed the whole tree twice per start.
3. **Once-ever migration marker** — `.bili-migration-286.done` dotfile (invisible to the kernel's `.json` walk) written after the first migration pass, so it never re-scans/re-logs on later boots.
4. **No deletion, ever** — no retention window, no size budget, no env knobs. Boot on the real corpus below deleted 0 files.

## Real-corpus validation (copy of the live sessions dir: 453 files / 240.2MB)

| metric | before | after |
|---|---|---|
| boot | ~1.8s (2x walk+parse) | **814ms** (single pass) |
| leaf blocks one/full byte-identical | 518/518 (duplicated) | 518/518 collapsed on load |
| leaf-duplicate bytes reclaimable on rewrite | — | **38.1MB** (50% of blockContents, 16% of corpus) |
| files deleted at boot | n/a | **0** (permanent) |

## What is deliberately NOT here (see #401 comment for numbers)

The 63% storage hog is `messages` (lastMessages full-conversation snapshot, 152MB of the 240MB corpus, sole consumer `bili export`). Fixing it needs a design call (gzip field / snapshot-on-export / accept) and possibly kernel cooperation — tracked in the issue, not stuffed into this PR. Lazy boot (stat-only walk) is likewise future work.

## Preflight

- typecheck clean
- 1038 tests / 1036 pass / 2 known env fails (`plugin-agent.test.ts`, pre-existing on master)
- build ok
- 4 new tests in `tests/fix-401-storage.test.ts` (single-copy round-trip, legacy-pair normalize, one-walk boot that deletes nothing, once-ever marker)