### PR TITLE
fix(launcher): merge omp overlay config.yml edits back into real home (#531)

### DIFF
--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -1247,6 +1247,164 @@ function mergeOmpCompactionDisabledYaml(text: string): string {
     return lines.join("\n");
 }
 
+/** Index of the top-level `compaction:` header, scanning with the same rules
+ *  as mergeOmpCompactionDisabledYaml (blank/comment lines skipped, indent-0
+ *  key only). -1 when absent. */
+function topLevelCompactionHeader(lines: string[]): number {
+    for (let i = 0; i < lines.length; i++) {
+        const raw = lines[i];
+        const trimmed = raw.trim();
+        if (!trimmed || trimmed.startsWith("#")) continue;
+        if (raw.length - raw.trimStart().length !== 0) continue;
+        if (/^compaction:\s*(#.*)?$/.test(trimmed)) return i;
+    }
+    return -1;
+}
+
+/** The compaction block's first `enabled:` child under the top-level header —
+ *  the exact line mergeOmpCompactionDisabledYaml would replace/insert. */
+function findCompactionEnabledLine(lines: string[]): number {
+    const header = topLevelCompactionHeader(lines);
+    if (header === -1) return -1;
+    for (let i = header + 1; i < lines.length; i++) {
+        const raw = lines[i];
+        const trimmed = raw.trim();
+        if (!trimmed || trimmed.startsWith("#")) continue;
+        if (raw.length - raw.trimStart().length === 0) break;
+        if (/^enabled:/.test(trimmed)) return i;
+    }
+    return -1;
+}
+
+/** True when the top-level compaction block exists and has no children left. */
+function compactionBlockEmpty(lines: string[]): boolean {
+    const header = topLevelCompactionHeader(lines);
+    if (header === -1) return false;
+    for (let i = header + 1; i < lines.length; i++) {
+        const raw = lines[i];
+        const trimmed = raw.trim();
+        if (!trimmed || trimmed.startsWith("#")) continue;
+        return raw.length - raw.trimStart().length > 0;
+    }
+    return true;
+}
+
+/** #531: inverse of mergeOmpCompactionDisabledYaml — undo bili's
+ *  `compaction.enabled: false` injection so the overlay's generated config.yml
+ *  can be merged back into the real home without baking the flag into it.
+ *  When the real file has its own `enabled:` line it is copied back verbatim
+ *  (a user's own `enabled: false` therefore survives); otherwise the injected
+ *  line is removed and an emptied block collapses away. With no user edits the
+ *  result is byte-identical to the real file, which makes the merge-back a
+ *  clean no-op. A non-`false` value means the user overrode the injection in
+ *  the overlay — that choice propagates to the real home untouched. */
+function stripOmpCompactionInjection(overlayText: string, realText: string | undefined): string {
+    const oLines = overlayText.split("\n");
+    const oe = findCompactionEnabledLine(oLines);
+    if (oe === -1) return overlayText;
+    const m = /^enabled:\s*(\S+)/.exec(oLines[oe].trim());
+    if (!m || m[1] !== "false") return overlayText;
+    const rLines = realText !== undefined ? realText.split("\n") : undefined;
+    const re = rLines ? findCompactionEnabledLine(rLines) : -1;
+    if (re !== -1 && rLines) {
+        oLines[oe] = rLines[re];
+        return oLines.join("\n");
+    }
+    oLines.splice(oe, 1);
+    if (compactionBlockEmpty(oLines)) {
+        const h = topLevelCompactionHeader(oLines);
+        if (h !== -1) oLines.splice(h, 1);
+    }
+    return oLines.join("\n");
+}
+
+/**
+ * #531: merge user edits made in the overlay's generated config.yml back into
+ * the real home before the next regeneration clobbers them. Since #449 the
+ * file sits in the generated set (skipped by refreshOverlayHome's merge-back),
+ * so settings omp saves inside a `bili omp` session evaporated on restart.
+ * This file is safe to merge back — unlike models.yml it carries no per-launch
+ * proxy content (#410), only the strippable compaction injection. Adjudication
+ * mirrors every other overlay entry: byte-identical-after-strip → no-op;
+ * overlay newer → its content becomes the real file (no fossil — the main
+ * flow must stay fossil-free); real newer → the real side wins and the
+ * divergent overlay version is preserved as a `.bili-conflict` fossil unless a
+ * concurrent bili launch still holds the overlay (its running session keeps
+ * reading this file, so it is left in place for the next clean launch).
+ */
+function mergeBackOmpOverlayConfig(ompHome: string, overlay: string, holderActive: boolean): void {
+    try {
+        const overlayCfg = path.join(overlay, "config.yml");
+        let oSt: fs.Stats;
+        try {
+            oSt = fs.lstatSync(overlayCfg);
+        } catch {
+            return;
+        }
+        if (!oSt.isFile()) return;
+        // Target resolution mirrors writeOmpCompactionDisabledConfig's base
+        // priority, restricted to the YAML names it reads first.
+        let target: string | undefined;
+        for (const name of ["config.yml", "config.yaml"]) {
+            try {
+                const st = fs.lstatSync(path.join(ompHome, name));
+                if (st.isFile()) {
+                    target = path.join(ompHome, name);
+                    break;
+                }
+            } catch {}
+        }
+        let realText: string | undefined;
+        if (target) {
+            try {
+                realText = fs.readFileSync(target, "utf8");
+            } catch {
+                return;
+            }
+        } else if (fs.existsSync(path.join(ompHome, "settings.json"))) {
+            // JSON base: settings.json is omp's one-time migration source
+            // (renamed away on first bare run) — creating a config.yml beside
+            // it would reshape the user's home, so skip.
+            return;
+        }
+        let oText: string;
+        try {
+            oText = fs.readFileSync(overlayCfg, "utf8");
+        } catch {
+            return;
+        }
+        // The generator normalizes CRLF to LF, so compare and write in a
+        // canonical form and restore the real file's own line-ending style —
+        // otherwise a CRLF config would churn on every launch.
+        const norm = (t: string): string => t.replace(/\r\n/g, "\n");
+        const stripped = norm(stripOmpCompactionInjection(oText, realText));
+        if (target) {
+            if (realText !== undefined && stripped === norm(realText)) return;
+            let rSt: fs.Stats;
+            try {
+                rSt = fs.lstatSync(target);
+            } catch {
+                return;
+            }
+            if (rSt.mtimeMs >= oSt.mtimeMs) {
+                if (!holderActive) {
+                    try {
+                        fs.renameSync(overlayCfg, freeConflictName(target));
+                    } catch {}
+                }
+                return;
+            }
+            const crlf = realText !== undefined && realText.includes("\r\n");
+            atomicWriteTextFile(target, crlf ? stripped.replace(/\n/g, "\r\n") : stripped);
+            return;
+        }
+        if (stripped.trim() === "") return;
+        atomicWriteTextFile(path.join(ompHome, "config.yml"), stripped);
+    } catch (err) {
+        console.error(`bili: could not merge the overlay config.yml back into ${ompHome}: ${(err as Error).message}`);
+    }
+}
+
 function writeOmpCompactionDisabledConfig(ompHome: string, overlay: string): void {
     // omp reads config.yml at runtime (settings.json is only a one-time migration
     // source, renamed to .bak). Merge compaction.enabled=false over the real
@@ -1305,6 +1463,10 @@ export function prepareOmpHttpRewrite(
     // compression); models.yml is generated only when present, so both stay
     // out of the real-home symlink set.
     const generated: string[] = ["config.yml"];
+    // #531: read the holder BEFORE refreshOverlayHome overwrites the marker
+    // with our own pid — decides whether regenerating the shared overlay's
+    // config.yml would clobber a still-running session's saved settings.
+    const holder = livePidHoldsOverlay(overlay);
     const modelsPath = path.join(ompHome, "models.yml");
     const unpacked = unpackDeadProxyUrlsInFile(modelsPath, liveProxyPorts());
     if (unpacked > 0) {
@@ -1316,6 +1478,7 @@ export function prepareOmpHttpRewrite(
         generated.push("models.yml");
     } catch {}
     if (!refreshOverlayHome(ompHome, overlay, generated)) return undefined;
+    mergeBackOmpOverlayConfig(ompHome, overlay, holder !== undefined);
     if (modelsText !== undefined) {
         const httpMap = new Map(httpRewrites.map((r) => [r.key, wrapUpstream(origin, r.realUpstream)]));
         const httpsMap = new Map(httpsRewrites.map((r) => [r.key, r.realUpstream]));
@@ -1352,7 +1515,14 @@ export function prepareOmpHttpRewrite(
         }
         writeOverlayFileAtomic(overlay, "models.yml", lines.join("\n"));
     }
-    writeOmpCompactionDisabledConfig(ompHome, overlay);
+    if (holder !== undefined) {
+        console.error(
+            `bili: another bili omp (pid ${holder}) is still running — skipping the config.yml regeneration so ` +
+                `the shared overlay keeps its saved settings (this session inherits them; its proxy port still wins in models.yml).`,
+        );
+    } else {
+        writeOmpCompactionDisabledConfig(ompHome, overlay);
+    }
     return overlay;
 }
 

--- a/tests/launcher.test.ts
+++ b/tests/launcher.test.ts
@@ -1,5 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
 import fs from "node:fs";
 import type { PathLike } from "node:fs";
 type SymlinkKind = "dir" | "file" | "junction";
@@ -1326,6 +1327,186 @@ test("prepareOmpHttpRewrite: file-vs-dir type clash preserves both sides", () =>
 
 test("prepareOmpHttpRewrite: returns undefined when no rewrites", () => {
     assert.equal(prepareOmpHttpRewrite("/whatever", "http://127.0.0.1:8787", [], []), undefined);
+});
+
+test("prepareOmpHttpRewrite: in-session config.yml edit merges back into real home on next launch (#531)", () => {
+    const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "bili-omphome-")));
+    fs.writeFileSync(path.join(home, "config.yml"), "theme: dark\nmodelRoles:\n  default: claude-opus-5\n");
+    const overlay = `${home}-bili`;
+    try {
+        prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", [], []);
+        fs.writeFileSync(
+            path.join(overlay, "config.yml"),
+            "theme: dark\nmodelRoles:\n  default: qwen3.8-max-0902:xhigh\ncompaction:\n  enabled: false\n",
+        );
+        const now = Date.now();
+        fs.utimesSync(path.join(overlay, "config.yml"), new Date(now), new Date(now));
+        fs.utimesSync(path.join(home, "config.yml"), new Date(now - 4000), new Date(now - 4000));
+        prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", [], []);
+        const real = fs.readFileSync(path.join(home, "config.yml"), "utf8");
+        assert.ok(real.includes("default: qwen3.8-max-0902:xhigh"), "new default merged into real home");
+        assert.ok(!real.includes("compaction:"), "injected compaction block not baked into real home");
+        const cfg = fs.readFileSync(path.join(overlay, "config.yml"), "utf8");
+        assert.ok(cfg.includes("default: qwen3.8-max-0902:xhigh"), "regenerated overlay keeps the new default");
+        assert.ok(cfg.includes("enabled: false"), "regenerated overlay disables native compaction");
+        const fossils = [...fs.readdirSync(home), ...fs.readdirSync(overlay)].filter((f) => f.includes(".bili-conflict"));
+        assert.deepEqual(fossils, [], "main flow produces no .bili-conflict fossils");
+    } finally {
+        fs.rmSync(home, { recursive: true, force: true });
+        fs.rmSync(overlay, { recursive: true, force: true });
+    }
+});
+
+test("prepareOmpHttpRewrite: untouched config.yml → real home byte-identical, no churn or fossils (#531)", () => {
+    const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "bili-omphome-")));
+    fs.writeFileSync(path.join(home, "config.yml"), "theme: dark\nmodelRoles:\n  default: claude-opus-5\n");
+    const overlay = `${home}-bili`;
+    try {
+        prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", [], []);
+        const before = fs.readFileSync(path.join(home, "config.yml"), "utf8");
+        const mtimeBefore = fs.lstatSync(path.join(home, "config.yml")).mtimeMs;
+        prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", [], []);
+        assert.equal(fs.readFileSync(path.join(home, "config.yml"), "utf8"), before, "real file byte-identical");
+        assert.equal(fs.lstatSync(path.join(home, "config.yml")).mtimeMs, mtimeBefore, "no rewrite churn");
+        const fossils = [...fs.readdirSync(home), ...fs.readdirSync(overlay)].filter((f) => f.includes(".bili-conflict"));
+        assert.deepEqual(fossils, [], "idempotent relaunch leaves no fossils");
+    } finally {
+        fs.rmSync(home, { recursive: true, force: true });
+        fs.rmSync(overlay, { recursive: true, force: true });
+    }
+});
+
+test("prepareOmpHttpRewrite: CRLF config.yml untouched by relaunch (no EOL churn) (#531)", () => {
+    const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "bili-omphome-")));
+    fs.writeFileSync(path.join(home, "config.yml"), "theme: dark\r\nmodelRoles:\r\n  default: claude-opus-5\r\n");
+    const overlay = `${home}-bili`;
+    try {
+        prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", [], []);
+        const before = fs.readFileSync(path.join(home, "config.yml"));
+        prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", [], []);
+        assert.ok(before.equals(fs.readFileSync(path.join(home, "config.yml"))), "CRLF real file byte-identical after relaunch");
+    } finally {
+        fs.rmSync(home, { recursive: true, force: true });
+        fs.rmSync(overlay, { recursive: true, force: true });
+    }
+});
+
+test("prepareOmpHttpRewrite: concurrent edit — newer real home wins, overlay version kept as fossil (#531)", () => {
+    const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "bili-omphome-")));
+    fs.writeFileSync(path.join(home, "config.yml"), "theme: dark\nmodelRoles:\n  default: old\n");
+    const overlay = `${home}-bili`;
+    try {
+        prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", [], []);
+        fs.writeFileSync(
+            path.join(overlay, "config.yml"),
+            "theme: dark\nmodelRoles:\n  default: session-edit\ncompaction:\n  enabled: false\n",
+        );
+        fs.writeFileSync(path.join(home, "config.yml"), "theme: dark\nmodelRoles:\n  default: bare-edit\n");
+        const now = Date.now();
+        fs.utimesSync(path.join(overlay, "config.yml"), new Date(now - 2000), new Date(now - 2000));
+        fs.utimesSync(path.join(home, "config.yml"), new Date(now), new Date(now));
+        prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", [], []);
+        const real = fs.readFileSync(path.join(home, "config.yml"), "utf8");
+        assert.ok(real.includes("default: bare-edit"), "newer real-home edit wins");
+        assert.ok(!real.includes("session-edit"), "stale overlay value not merged over newer real");
+        assert.ok(
+            fs.readFileSync(path.join(home, "config.yml.bili-conflict"), "utf8").includes("default: session-edit"),
+            "divergent overlay version preserved as fossil",
+        );
+        const cfg = fs.readFileSync(path.join(overlay, "config.yml"), "utf8");
+        assert.ok(cfg.includes("default: bare-edit"), "overlay regenerated from the winning real content");
+        assert.ok(cfg.includes("enabled: false"), "injection reapplied after regeneration");
+        assert.ok(!cfg.includes("session-edit"), "lost overlay value gone from regenerated overlay");
+    } finally {
+        fs.rmSync(home, { recursive: true, force: true });
+        fs.rmSync(overlay, { recursive: true, force: true });
+    }
+});
+
+test("prepareOmpHttpRewrite: concurrent bili omp holding overlay → regeneration skipped with warn, edits preserved (#531)", async () => {
+    const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "bili-omphome-")));
+    fs.writeFileSync(path.join(home, "config.yml"), "theme: dark\nmodelRoles:\n  default: old\n");
+    const overlay = `${home}-bili`;
+    const child = spawn(process.execPath, ["-e", "setTimeout(() => {}, 60000)"], { stdio: "ignore" });
+    const errors: string[] = [];
+    const origError = console.error;
+    console.error = (...args: unknown[]) => {
+        errors.push(args.map(String).join(" "));
+    };
+    let savedBytes = "";
+    try {
+        await new Promise((r) => setTimeout(r, 100));
+        prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", [], []);
+        savedBytes = "theme: dark\nmodelRoles:\n  default: session-a\ncompaction:\n  enabled: false\n";
+        fs.writeFileSync(path.join(overlay, "config.yml"), savedBytes);
+        const now = Date.now();
+        fs.utimesSync(path.join(overlay, "config.yml"), new Date(now), new Date(now));
+        fs.utimesSync(path.join(home, "config.yml"), new Date(now - 4000), new Date(now - 4000));
+        fs.writeFileSync(path.join(overlay, ".bili-launch.pid"), `${child.pid}\n`);
+        prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", [], []);
+        assert.equal(fs.readFileSync(path.join(overlay, "config.yml"), "utf8"), savedBytes, "overlay NOT regenerated while holder alive");
+        assert.ok(
+            fs.readFileSync(path.join(home, "config.yml"), "utf8").includes("default: session-a"),
+            "merge-back still persisted the running session's edit into real home",
+        );
+        assert.ok(errors.some((e) => e.includes("skipping the config.yml regeneration")), "explicit concurrent-launch warning emitted");
+    } finally {
+        console.error = origError;
+        child.kill();
+        fs.rmSync(home, { recursive: true, force: true });
+        fs.rmSync(overlay, { recursive: true, force: true });
+    }
+});
+
+test("prepareOmpHttpRewrite: real home's own compaction.enabled restored on merge-back (#531)", () => {
+    const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "bili-omphome-")));
+    fs.writeFileSync(path.join(home, "config.yml"), "theme: dark\ncompaction:\n  enabled: true\n  reserveTokens: 8000\n");
+    const overlay = `${home}-bili`;
+    try {
+        prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", [], []);
+        fs.writeFileSync(
+            path.join(overlay, "config.yml"),
+            "theme: light\ncompaction:\n  enabled: false\n  reserveTokens: 8000\n",
+        );
+        const now = Date.now();
+        fs.utimesSync(path.join(overlay, "config.yml"), new Date(now), new Date(now));
+        fs.utimesSync(path.join(home, "config.yml"), new Date(now - 4000), new Date(now - 4000));
+        prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", [], []);
+        const real = fs.readFileSync(path.join(home, "config.yml"), "utf8");
+        assert.ok(real.includes("enabled: true"), "user's own enabled: true restored verbatim");
+        assert.ok(real.includes("reserveTokens: 8000"), "other compaction keys preserved");
+        assert.ok(real.includes("theme: light"), "unrelated user edit merged in");
+        assert.ok(!real.includes("enabled: false"), "injected false not baked into real home");
+        const fossils = fs.readdirSync(home).filter((f) => f.includes(".bili-conflict"));
+        assert.deepEqual(fossils, [], "no fossils in the non-concurrent flow");
+    } finally {
+        fs.rmSync(home, { recursive: true, force: true });
+        fs.rmSync(overlay, { recursive: true, force: true });
+    }
+});
+
+test("prepareOmpHttpRewrite: no config in real home → user edit creates it without injection (#531)", () => {
+    const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "bili-omphome-")));
+    fs.writeFileSync(path.join(home, "models.yml"), "providers:\n  a:\n    baseUrl: https://keep.example.com\n");
+    const overlay = `${home}-bili`;
+    try {
+        prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", [], []);
+        fs.writeFileSync(
+            path.join(overlay, "config.yml"),
+            "modelRoles:\n  default: qwen3.8-max-0902:xhigh\ncompaction:\n  enabled: false\n",
+        );
+        const now = Date.now();
+        fs.utimesSync(path.join(overlay, "config.yml"), new Date(now), new Date(now));
+        prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", [], []);
+        const real = fs.readFileSync(path.join(home, "config.yml"), "utf8");
+        assert.ok(real.includes("default: qwen3.8-max-0902:xhigh"), "real config.yml created from the user edit");
+        assert.ok(!real.includes("compaction:"), "created file carries no injected block");
+        const cfg = fs.readFileSync(path.join(overlay, "config.yml"), "utf8");
+        assert.ok(cfg.includes("default: qwen3.8-max-0902:xhigh") && cfg.includes("enabled: false"), "overlay regenerated with injection");
+    } finally {
+        fs.rmSync(home, { recursive: true, force: true });
+        fs.rmSync(overlay, { recursive: true, force: true });
+    }
 });
 
 test("prepareOmpHttpRewrite: models.yml missing → overlay still built (config.yml generated), no models.yml", () => {


### PR DESCRIPTION
## What

`bili omp` settings saved inside a session (default model, thinking level, anything omp persists to global `config.yml`) evaporated on the next launch — the overlay copy was regenerated from the real home unconditionally, and the overlay→real merge-back never ran for it.

## Root cause (verified line-by-line on v0.1.83)

- #449 put `config.yml` in the generated set (`src/launcher.ts:1307`), so `refreshOverlayHome` skips its merge-back (`:873`) and never symlinks it;
- every launch then rewrites the overlay's `config.yml` from the real home only (`writeOmpCompactionDisabledConfig` → `writeOverlayFileAtomic`, `:1355`);
- pre-#449 this file went through the normal mtime-newer-wins merge-back with `.bili-conflict` fossil preservation — that safety net is what regressed away.

## Fix (scoped to omp's generated `config.yml`)

- **Injection-aware merge-back** before regeneration: `stripOmpCompactionInjection` undoes bili's `compaction.enabled: false` injection (inverse of `mergeOmpCompactionDisabledYaml`). The real file's own `enabled:` line is copied back verbatim when present, so a user's own `enabled: false` survives; an emptied block collapses away. With no user edits the stripped content is byte-identical to the real file → clean no-op (no write, no mtime churn, no fossil).
- **Adjudication mirrors existing overlay semantics**: overlay newer → becomes the real file (main flow stays fossil-free, per acceptance criteria); real newer → real wins and the divergent overlay version is preserved as `config.yml.bili-conflict` (restores the pre-#449 safety net for concurrent bare-omp/manual edits).
- **Concurrent-launch guard**: the pid-holder snapshot is taken BEFORE `refreshOverlayHome` overwrites the marker; while another `bili omp` is alive, the `config.yml` regeneration is skipped with an explicit warn so the running session's saved settings are not clobbered (merge-back still runs, persisting its edits into the real home).
- **EOL-safe**: the generator normalizes CRLF→LF, so comparison/write happen in canonical form and restore the real file's own line-ending style (a CRLF config does not churn on relaunch).
- Safe w.r.t. #410: `config.yml` carries no per-launch proxy content (that's `models.yml`), so merging it back cannot bake proxy URLs into the real home. pi/hermes/dsh generated files are intentionally untouched.

Known residual edge (documented in code): if the real config is concurrently edited AND loses the mtime adjudication AND omp's serializer drops unknown keys, those keys would be lost without a fossil — triple-conjunction, extremely unlikely; the common concurrent case is covered by the fossil.

## Tests (7 new, all in tests/launcher.test.ts)

1. in-session edit merges into real home, no fossils, overlay regenerated with injection + new value (acceptance ① + ③a)
2. untouched config → real file byte-identical, no churn/fossils
3. CRLF config → byte-identical across relaunch (no EOL churn)
4. concurrent edits both sides: newer real wins, overlay version kept as `.bili-conflict` (③b)
5. live holder → regeneration skipped with explicit warn, overlay preserved, merge-back still persists
6. real home's own `compaction.enabled: true` restored verbatim on merge-back
7. no config in real home → user edit creates `config.yml` without the injected block

## Pre-flight

- `npm run typecheck` ✅
- `npm test`: 1038/1039 pass — the single failure (`resolveClientCommand: codex/claude resolve to themselves`) fails identically on pristine master in this sandbox (it has `/usr/bin/codex` installed); unrelated to this change
- `npm run build` ✅
