### PR TITLE
fix: status panel counts outbound system prompt + tool schema (#532)

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -409,15 +409,24 @@ export function handlePluginStatus(conversationId: string, res: import("node:htt
     }
     let panel: string | undefined;
     try {
+        // #532: the kernel breakdown classifies messages only; bili measured
+        // the outbound system+tools overhead at prepare time (same source as
+        // estimateInputTokens) and stored it on the session. Feeding it in is
+        // what makes Sent/SysPrompt reflect reality instead of undercounting
+        // by the full system+tools size every turn. unprunedTokens gets the
+        // same addition so the Session-only derivation (unpruned − sent) still
+        // isolates pruned originals on one scale.
+        const sysTokRaw = session.metadata.systemPromptTokens;
+        const systemPromptTokens = typeof sysTokRaw === "number" && Number.isFinite(sysTokRaw) && sysTokRaw > 0 ? sysTokRaw : 0;
         panel = buildStatusPanel({
             version: `billion-context@${PROXY_VERSION}`,
             tokenCount: session.hostContextTokens ?? session.stats.lastInputTokens,
-            systemPromptTokens: 0,
+            systemPromptTokens,
             state: session.state,
             nudge,
             modelContextLimit,
             unprunedTokens: mem && mem.original.length > 0
-                ? mem.original.reduce((sum, m) => sum + defaultCountTokens(m.text ?? ""), 0)
+                ? mem.original.reduce((sum, m) => sum + defaultCountTokens(m.text ?? ""), 0) + systemPromptTokens
                 : undefined,
         });
     } catch {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1834,6 +1834,10 @@ function prepareAnthropic(
         log("warn", `[${sessionId}] kernel transform failed, forwarding unchanged: ${String(err)}`);
         processedMessages = [];
     }
+    // #532: measure the outbound system+tools overhead for the status panel's
+    // SysPrompt row — the kernel breakdown classifies messages only, and on
+    // this wire the system rides the top-level `system` field outside the fold.
+    session.metadata.systemPromptTokens = countSystemAndToolsTokens(extractSystem(systemOut), toolsOut);
     snapshotMessages(session, originalMessages);
     markDirty(session);
 
@@ -1872,14 +1876,21 @@ const OUTPUT_CLAMP_FLOOR = 1024;
 // host-side: renderNudgeText does not depend on shouldInject.
 const EMERGENCY_NUDGE_ESCALATION_PCT = 0.7;
 
+/** chars/4 measure of the per-request overhead that lives OUTSIDE the kernel's
+ *  fold space: the outbound system prompt (client text plus bili-injected parts)
+ *  and the tool schemas. The kernel's contextBreakdown classifies messages only,
+ *  so this is what the status panel's SysPrompt row must add back (#532). Same
+ *  counting method as estimateInputTokens below. */
+export function countSystemAndToolsTokens(systemText: string | undefined, tools: unknown): number {
+    return defaultCountTokens(systemText ?? "") + defaultCountTokens(JSON.stringify(tools ?? []));
+}
+
 /** Conservative outbound-input estimate: the larger of the upstream-reported
  *  previous-turn input (real tokenizer count, already includes system+tools) and
  *  a fresh count of the rebuilt conversation text + system + tool definitions
  *  (needed on turn 1 / right after a shrink, when lastInputTokens lags). */
 export function estimateInputTokens(processedMessages: CoreMessage[], systemText: string | undefined, tools: unknown, lastInputTokens: number): number {
-    const est = estimateCoreMessages(processedMessages)
-        + defaultCountTokens(systemText ?? "")
-        + defaultCountTokens(JSON.stringify(tools ?? []));
+    const est = estimateCoreMessages(processedMessages) + countSystemAndToolsTokens(systemText, tools);
     return Math.max(lastInputTokens > 0 ? lastInputTokens : 0, est);
 }
 
@@ -1973,6 +1984,7 @@ function prepareOpenai(
     ++session.stats.requests;
     session.hostCreditTokens = 0;
     let openaiSystemText = "";
+    let openaiOutboundSystem: string | undefined;
     let processedMessages: CoreMessage[] = [];
     let originalMessages: CoreMessage[] = [];
     let nudge: NudgeDecision | undefined;
@@ -2040,6 +2052,11 @@ function prepareOpenai(
         if (systemText) sysParts.push(systemText);
         if (shouldInject) sysParts.push(buildCompressSystemPrompt(prompts));
         rebuiltMessages = injectOpenaiSystem(rebuiltMessages, sysParts);
+        // #532: capture what bili injects outside the fold space (client system
+        // + compress prompt). A head system message already in the rebuilt view
+        // is classified by the kernel breakdown — counting only these parts
+        // avoids double-counting it.
+        openaiOutboundSystem = sysParts.join("\n\n");
         if (injectTools) {
             toolsOut = injectOpenaiTool(parsed.tools);
         }
@@ -2092,6 +2109,11 @@ function prepareOpenai(
     if (session.hostCreditTokens > 0) {
         log("info", `[${sessionId}] host usage backfill armed: +${session.hostCreditTokens} tok (forwarded view is folded); host usage will report the uncompressed baseline`);
     }
+    // #532: title-gen side requests carry their own tiny system and would
+    // clobber the conversation's measured overhead — skip them.
+    if (!isTitleGen && openaiOutboundSystem !== undefined) {
+        session.metadata.systemPromptTokens = countSystemAndToolsTokens(openaiOutboundSystem, toolsOut);
+    }
     snapshotMessages(session, originalMessages);
     markDirty(session);
     return { body: JSON.stringify(rebuilt), session, processedMessages, originalMessages, protocol: "openai", stream, compressInjected: injectTools, pluginMode, nudge, prompts, openaiSystemText, renderTags: "text-only" } as Prepared;
@@ -2141,6 +2163,7 @@ function prepareResponses(
     let rebuiltInput: ResponseInputItem[] | string = parsed.input;
     let toolsOut = parsed.tools;
     let transformOk = false;
+    let responsesDevContent: string | undefined;
 
     // #242: over-long input item ids (poisoned rollouts) 400 upstream on every
     // request; rewrite them to short deterministic ids before anything reads
@@ -2219,6 +2242,7 @@ function prepareResponses(
         if (shouldInject && !isCompactionTrigger && !process.env.ACP_NO_COMPRESS_PROMPT) {
             const prompt = responsesTextProtocol ? buildCompressHybridSystemPrompt(prompts) : buildCompressSystemPrompt(prompts);
             const devContent = [...projection.systemParts, ...forgedSummaries, prompt].join("\n\n---\n\n");
+            responsesDevContent = devContent;
             rebuiltInput = injectResponsesDeveloperMessage(rebuiltInput, devContent);
             if (!process.env.ACP_NO_INJECT_TOOL && injectTools) {
                 toolsOut = responsesTextProtocol
@@ -2227,6 +2251,7 @@ function prepareResponses(
             }
         } else if (projection.systemParts.length > 0 || forgedSummaries.length > 0) {
             const devContent = [...projection.systemParts, ...forgedSummaries].join("\n\n---\n\n");
+            responsesDevContent = devContent;
             rebuiltInput = injectResponsesDeveloperMessage(rebuiltInput, devContent);
         }
         // A nudge appended after a trailing `compaction_trigger` would break
@@ -2337,6 +2362,13 @@ function prepareResponses(
         : 0;
     if (session.hostCreditTokens > 0) {
         log("info", `[${sessionId}] host usage backfill armed: +${session.hostCreditTokens} tok (forwarded view is folded); host usage will report the uncompressed baseline`);
+    }
+    // #532: measure the outbound developer(system)+tools overhead for the panel.
+    // On this wire the system rides the injected developer message outside the
+    // fold space, so counting devContent + tools does not double-count the
+    // mid-history items the kernel already classifies.
+    if (transformOk) {
+        session.metadata.systemPromptTokens = countSystemAndToolsTokens(responsesDevContent ?? "", toolsOut);
     }
     snapshotMessages(session, originalMessages);
     markDirty(session);

--- a/tests/issue532-panel-system-tokens.test.ts
+++ b/tests/issue532-panel-system-tokens.test.ts
@@ -1,0 +1,269 @@
+import assert from "node:assert";
+import http from "node:http";
+import { once } from "node:events";
+import test from "node:test";
+
+process.env.NODE_ENV = "test";
+
+import { createInitialState, defaultConfig, defaultCountTokens, type NudgeDecision } from "acp-kernel";
+import { buildStatusPanel } from "acp-kernel/panel";
+import { startServer, countSystemAndToolsTokens, type ProxyOptions } from "../src/server.ts";
+import { SessionStore, _setStoreForTest } from "../src/persist.ts";
+import { _setForTest as setRegistryForTest } from "../src/registry.ts";
+import { _resetPluginStateForTest } from "../src/plugin.ts";
+
+// #532: the status panel's "Sent to LLM" / Token Breakdown must include the
+// outbound system prompt + tool schema, which the kernel breakdown cannot see
+// (it rides outside the fold space on every wire).
+
+function makeNudge(bd: { system: number; tool: number; summaries: number; code: number; text: number }): NudgeDecision {
+    const total = bd.system + bd.tool + bd.summaries + bd.code + bd.text;
+    return {
+        shouldInject: false,
+        reason: "below threshold",
+        compressibleRanges: [],
+        contextUsage: 0.5,
+        tier: null,
+        breakdown: {
+            usage: 0.5, growth: 0, growthReference: 0, effectiveThreshold: 0,
+            nudgeGrowthTokens: 0, growthFloor: 0, hasPendingNudge: false,
+            overLimit: false, emergencyOverride: false, pendingT1: 0, pendingT2: 0, pendingT3: 0,
+        },
+        contextBreakdown: { ...bd, total, growth: 0 },
+    };
+}
+
+// formatCompactTokens rounding is at most ±500 for values below 1e6.
+const COMPACT_TOL = 502;
+
+function decodeCompact(s: string): number {
+    if (/^\d+$/.test(s)) return Number(s);
+    const m = s.match(/^(\d+(?:\.\d+)?)([kM])$/);
+    assert.ok(m, `unparseable token value: ${s}`);
+    return m![2] === "k" ? Math.round(Number(m![1]) * 1_000) : Math.round(Number(m![1]) * 1_000_000);
+}
+
+function parseSentTotal(panel: string): number {
+    const m = panel.match(/^Sent to LLM \(after compression, est\.\): ([\d.]+[kM]?)(?: \(\d+% of limit\))?$/m);
+    assert.ok(m, `sent line missing:\n${panel}`);
+    return decodeCompact(m![1]!);
+}
+
+function parseRows(panel: string): Map<string, number> {
+    const rows = new Map<string, number>();
+    for (const m of panel.matchAll(/^ {2}(\w+)\s+[█░]+\s+\d+%\s{2}([\d.]+[kM]?)\s*$/gm)) {
+        rows.set(m[1]!, decodeCompact(m[2]!));
+    }
+    return rows;
+}
+
+test("#532 countSystemAndToolsTokens sums system text and JSON tool schema", () => {
+    // No content: only the "[]" serialization counts (1 token) — identical
+    // arithmetic to estimateInputTokens' pre-refactor body.
+    assert.equal(countSystemAndToolsTokens("", []), 1);
+    assert.equal(countSystemAndToolsTokens(undefined, undefined), 1);
+    const sys = "a".repeat(4000);
+    const sysTok = defaultCountTokens(sys);
+    const tools = [{ name: "t1", description: "d".repeat(8000) }];
+    const toolTok = defaultCountTokens(JSON.stringify(tools));
+    assert.equal(countSystemAndToolsTokens(sys, tools), sysTok + toolTok);
+    assert.ok(Math.abs((sysTok + toolTok) - defaultCountTokens(sys + JSON.stringify(tools))) <= 1, "per-part counting stays within ceil noise of a single count");
+});
+
+test("#532 panel sentTotal includes systemPromptTokens and stays self-consistent", () => {
+    const state = createInitialState();
+    const nudge = makeNudge({ system: 0, tool: 3_000, summaries: 1_500, code: 700, text: 900 });
+    const SYS = 20_000;
+
+    const withSys = buildStatusPanel({
+        tokenCount: 60_000,
+        systemPromptTokens: SYS,
+        state,
+        nudge,
+        modelContextLimit: 200_000,
+        unprunedTokens: 40_000,
+        fmtTokens: (n: number) => String(n),
+    });
+    assert.equal(parseSentTotal(withSys), 6_100 + SYS);
+    const rows = parseRows(withSys);
+    assert.equal(rows.get("SysPrompt"), SYS, "SysPrompt row must render");
+    assert.equal(rows.get("Tool"), 3_000);
+    assert.equal(rows.get("Text"), 900);
+    assert.equal(rows.get("Code"), 700);
+    assert.equal(rows.get("Summaries"), 1_500);
+    const sum = [...rows.values()].reduce((a, b) => a + b, 0);
+    assert.equal(sum, parseSentTotal(withSys), "breakdown rows must sum to Sent total");
+    assert.match(withSys, /Session-only \(compressed originals, est\.\): 13900 /);
+
+    const zero = buildStatusPanel({
+        tokenCount: 60_000,
+        systemPromptTokens: 0,
+        state,
+        nudge,
+        modelContextLimit: 200_000,
+        fmtTokens: (n: number) => String(n),
+    });
+    assert.equal(parseSentTotal(zero), 6_100);
+    assert.equal(parseRows(zero).get("SysPrompt"), undefined, "zero SysPrompt row must be skipped");
+});
+
+interface Harness {
+    proxyPort: number;
+    upstreamPort: number;
+    close(): Promise<void>;
+}
+
+function anthropicSse(event: string, data: unknown): string {
+    return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+async function startHarness(): Promise<Harness> {
+    const upstream = http.createServer((req, res) => {
+        req.resume();
+        req.on("end", () => {
+            if (req.url?.includes("/v1/chat/completions")) {
+                res.writeHead(200, { "content-type": "text/event-stream" });
+                res.write(`data: {"id":"chatcmpl-532","object":"chat.completion.chunk","created":1,"model":"gpt-test","choices":[{"index":0,"delta":{"role":"assistant","content":"ok"},"finish_reason":null}]}\n\n`);
+                res.write(`data: {"id":"chatcmpl-532","object":"chat.completion.chunk","created":1,"model":"gpt-test","choices":[],"usage":{"prompt_tokens":55,"completion_tokens":3,"total_tokens":58}}\n\n`);
+                res.write(`data: [DONE]\n\n`);
+                res.end();
+                return;
+            }
+            res.writeHead(200, { "content-type": "text/event-stream" });
+            res.write(anthropicSse("message_start", { type: "message_start", message: { id: "msg_532", role: "assistant", usage: { input_tokens: 55 } } }));
+            res.write(anthropicSse("content_block_start", { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } }));
+            res.write(anthropicSse("content_block_delta", { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "ok" } }));
+            res.write(anthropicSse("content_block_stop", { type: "content_block_stop", index: 0 }));
+            res.write(anthropicSse("message_delta", { type: "message_delta", delta: { stop_reason: "end_turn", stop_sequence: null }, usage: { output_tokens: 3 } }));
+            res.write(anthropicSse("message_stop", { type: "message_stop" }));
+            res.end();
+        });
+    });
+    upstream.listen(0, "127.0.0.1");
+    await once(upstream, "listening");
+    const upstreamPort = upstream.address().port;
+
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    setRegistryForTest({});
+    _resetPluginStateForTest();
+    const proxy = await startServer({
+        port: 0,
+        host: "127.0.0.1",
+        upstream: "http://127.0.0.1",
+        routes: { [`http://127.0.0.1:${upstreamPort}`]: { models: { "claude-test": { context: 400_000 }, "gpt-test": { context: 400_000 } } } },
+        modelContextLimit: 400_000,
+        kernelConfig: defaultConfig(400_000),
+        compress: { injectTool: true, injectNudge: true },
+        promptCache: { routing: "auto" },
+        sessionHeader: "x-acp-session",
+        log: false,
+        debug: false,
+        passthrough: false,
+        autoUpdate: false,
+        mitm: { enabled: false, domains: [] },
+    } as ProxyOptions);
+    await once(proxy, "listening");
+    const proxyPort = proxy.address().port;
+
+    return {
+        proxyPort,
+        upstreamPort,
+        close: async () => {
+            proxy.close();
+            await once(proxy, "close");
+            upstream.close();
+            await once(upstream, "close");
+        },
+    };
+}
+
+async function fetchPanel(h: Harness, conversationId: string): Promise<string> {
+    const resp = await fetch(`http://127.0.0.1:${h.proxyPort}/__bili/plugin/status?conversationId=${conversationId}`);
+    assert.equal(resp.status, 200);
+    const status = (await resp.json()) as { ok: boolean; panel?: string };
+    assert.equal(status.ok, true);
+    assert.ok(typeof status.panel === "string" && status.panel.length > 0, "panel rendered");
+    return status.panel!;
+}
+
+test("#532 anthropic plugin session: panel counts outbound system+tools (SysPrompt row)", async () => {
+    const h = await startHarness();
+    try {
+        const conv = "issue532-anthropic";
+        const clientSystem = "S".repeat(80_000);
+        const tools = [{ name: "big_tool", description: "D".repeat(40_000), input_schema: { type: "object" } }];
+        const resp = await fetch(`http://127.0.0.1:${h.proxyPort}/bili/http://127.0.0.1:${h.upstreamPort}/v1/messages`, {
+            method: "POST",
+            headers: {
+                "content-type": "application/json",
+                "x-bili-plugin": "pi-plugin/0.0.1",
+                "x-bili-plugin-conversation": conv,
+            },
+            body: JSON.stringify({
+                model: "claude-test",
+                max_tokens: 1024,
+                stream: true,
+                system: clientSystem,
+                messages: [{ role: "user", content: "hello" }],
+                tools,
+            }),
+        });
+        assert.equal(resp.status, 200);
+        for await (const _chunk of resp.body) { /* drain */ }
+
+        const panel = await fetchPanel(h, conv);
+        const rows = parseRows(panel);
+        const vSys = rows.get("SysPrompt");
+        assert.notEqual(vSys, undefined, `SysPrompt row must render:\n${panel}`);
+        // Floor = client system + tools schema (what the issue calls the ~20k+10k miss);
+        // ceiling adds the injected compress prompt (bounded, a few k tokens max).
+        const lower = defaultCountTokens(clientSystem) + defaultCountTokens(JSON.stringify(tools));
+        assert.ok(vSys! >= lower - COMPACT_TOL, `SysPrompt ${vSys} below floor ${lower} (client system + tools schema)`);
+        assert.ok(vSys! <= lower + COMPACT_TOL + 4_000, `SysPrompt ${vSys} far above floor ${lower} (injected compress prompt should stay small)`);
+        const sent = parseSentTotal(panel);
+        assert.ok(sent >= lower - COMPACT_TOL && sent >= vSys! - 2 * COMPACT_TOL, `Sent ${sent} must cover system+tools (${lower}) plus message text`);
+    } finally {
+        await h.close();
+    }
+});
+
+test("#532 openai plugin session: panel counts injected system+tools (SysPrompt row)", async () => {
+    const h = await startHarness();
+    try {
+        const conv = "issue532-openai";
+        const clientSystem = "O".repeat(80_000);
+        const tools = [{ type: "function", function: { name: "big_tool", description: "E".repeat(40_000), parameters: { type: "object" } } }];
+        const resp = await fetch(`http://127.0.0.1:${h.proxyPort}/bili/http://127.0.0.1:${h.upstreamPort}/v1/chat/completions`, {
+            method: "POST",
+            headers: {
+                "content-type": "application/json",
+                "x-bili-plugin": "pi-plugin/0.0.1",
+                "x-bili-plugin-conversation": conv,
+            },
+            body: JSON.stringify({
+                model: "gpt-test",
+                max_tokens: 1024,
+                stream: true,
+                messages: [
+                    { role: "system", content: clientSystem },
+                    { role: "user", content: "hello" },
+                ],
+                tools,
+            }),
+        });
+        assert.equal(resp.status, 200);
+        for await (const _chunk of resp.body) { /* drain */ }
+
+        const panel = await fetchPanel(h, conv);
+        const rows = parseRows(panel);
+        const vSys = rows.get("SysPrompt");
+        assert.notEqual(vSys, undefined, `SysPrompt row must render:\n${panel}`);
+        const lower = defaultCountTokens(clientSystem) + defaultCountTokens(JSON.stringify(tools));
+        assert.ok(vSys! >= lower - COMPACT_TOL, `SysPrompt ${vSys} below floor ${lower} (client system + tools schema)`);
+        assert.ok(vSys! <= lower + COMPACT_TOL + 4_000, `SysPrompt ${vSys} far above floor ${lower} (injected compress prompt should stay small)`);
+        const sent = parseSentTotal(panel);
+        assert.ok(sent >= lower - COMPACT_TOL && sent >= vSys! - 2 * COMPACT_TOL, `Sent ${sent} must cover system+tools (${lower}) plus message text`);
+    } finally {
+        await h.close();
+    }
+});


### PR DESCRIPTION
## Problem

The ACP Context Analysis panel's `Sent to LLM (after compression, est.)` total and `Token Breakdown (sent view)` systematically undercounted the host system prompt and tool schemas: `handlePluginStatus` passed a hardcoded `systemPromptTokens: 0` into `buildStatusPanel`, while the kernel panel computes `sentTotal = classified + systemPromptTokens` and skips rows with value <= 0 — so the `SysPrompt` row never rendered and large system+tools payloads were invisible (a 62k/35k session showed Sent=181/219).

The quantity was already measured elsewhere in bili (`estimateInputTokens` in `src/server.ts`) but never handed to the panel.

## Fix

- `src/server.ts`: new exported `countSystemAndToolsTokens(systemText, tools)` — same counting as `estimateInputTokens`, which now reuses it (behavior unchanged, existing backstop tests still pass). Each prepare path stores the measured **outbound** system+tools tokens on `session.metadata.systemPromptTokens`:
  - **anthropic**: the final `injectSystem` result (includes the compress prompt when injected)
  - **openai**: the hoisted client system + compress system prompt (`sysParts`), skipped for title-gen side requests (their tiny own system must not clobber the main session value)
  - **responses**: the developer message content, only when the transform succeeded
- `src/plugin.ts`: passes that value into `buildStatusPanel` instead of `0` (with a numeric guard), and adds the same amount to `unprunedTokens` so the `Session-only (compressed originals)` derivation stays on one scale.

### Why this shape

- The adapters hoist the head system out of the message projection (`openaiToCore` → `{msgs, systemText}`, Responses → `systemParts`), so the kernel breakdown's `bd.system` ≈ 0 by design — feeding the stored value as `systemPromptTokens` (the kernel's explicit "host-measured system" slot) does NOT double-count anything the breakdown already sees. Self-consistency follows automatically: the five breakdown rows sum exactly to the Sent total.
- Measuring the **outbound** text (what actually reaches the LLM) rather than the raw client input keeps the number truthful when bili injects its compress system prompt.
- Known residual: Responses-API `preamble` items (`additional_tools` / `mcp_list_tools`) are not counted — consistent with the existing `estimateInputTokens` / #453 clamp convention, which also ignores them. Small relative to real tool schemas; can be added later if it matters.

## Tests (`tests/issue532-panel-system-tokens.test.ts`, new)

1. Counter unit test: empty-safety and additivity vs per-part counting.
2. Panel math (acceptance #2): with non-zero `systemPromptTokens`, `Sent == classified + sysPrompt`, the `SysPrompt` row renders, and **sum of all breakdown rows == Sent total**; zero case keeps the row hidden.
3. Anthropic plugin-mode integration (acceptance #1): ~80k-char system (~20k tokens) + ~40k-char tool description (~10k tokens) through a real proxy → `SysPrompt` row renders within [client system + tools, +compress-prompt bound] and `Sent >= client system + tools`. Pre-fix this session showed Sent≈219.
4. Same integration via the OpenAI chat path.

## Pre-flight

- `npm run typecheck` — clean
- `npm test` — 1035/1036; the single failure (`launcher.test.ts` "codex/claude resolve to themselves") reproduces identically on pristine master in any environment where `codex` is installed at an absolute PATH location (resolver returns `/usr/bin/codex`, test expects bare `codex`) — pre-existing/environmental, unrelated to this change
- `npm run build` — success