### PR TITLE
feat: pi file-free injection (#535 phase 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ hosts are whitelisted for MITM so the proxy can TLS-terminate exactly them
 and blind-tunnel everything else.
 
 ```bash
-bili pi                               # launch pi through the proxy
+bili pi                               # launch pi through the proxy — file-free (#535): env + extension registerProvider, real ~/.pi untouched
 bili codex                            # launch codex through the proxy
 bili claude                           # launch claude through the proxy
 bili omp                              # pi-style: MITM env + persistent overlay home (~/.omp/agent-bili, real config untouched)

--- a/src/agent/pi.ts
+++ b/src/agent/pi.ts
@@ -38,6 +38,10 @@ type ExtensionAPI = {
     on: (event: string, handler: (event: never, ctx: Ctx) => unknown) => void;
     registerTool: (tool: ToolDefinition) => void;
     registerCommand?: (name: string, options: { description?: string; handler: (args: string, ctx: CommandCtx) => void | Promise<void> }) => void;
+    // #535: launcher passes provider URL rewrites via env; the extension
+    // overrides each provider's baseUrl at load (file-free routing — no
+    // models.json overlay). Optional because older hosts may lack it.
+    registerProvider?: (name: string, config: { baseUrl: string }) => void;
 };
 
 function agentName(override: string | undefined): string {
@@ -134,6 +138,25 @@ function manifestToTool(proxyBase: string, tool: ManifestTool, agent: string): T
     };
 }
 
+function parseProviderRewrites(env: NodeJS.ProcessEnv): Record<string, string> | undefined {
+    const raw = env.BILI_PROVIDER_REWRITES;
+    if (raw === undefined || raw.trim().length === 0) return undefined;
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(raw);
+    } catch {
+        console.error("bili-plugin: BILI_PROVIDER_REWRITES is not valid JSON — provider URLs left untouched");
+        return undefined;
+    }
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return undefined;
+    const out: Record<string, string> = {};
+    for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+        if (typeof value !== "string" || !/^https?:\/\//i.test(value)) continue;
+        out[key] = value;
+    }
+    return Object.keys(out).length > 0 ? out : undefined;
+}
+
 const RETRY_INTERVAL_MS = 10000;
 
 type RegisterState = { sid?: string; toolsFor?: string; toolsReady?: boolean; pending?: Promise<void>; retryAt?: number; identityAt?: string; retryIntervalMs: number };
@@ -216,6 +239,35 @@ export function createBiliPlugin(agentOverride?: string, opts?: { retryIntervalM
     return function biliPlugin(pi: ExtensionAPI): void {
         const agent = agentName(agentOverride);
         const state: RegisterState = { retryIntervalMs: opts?.retryIntervalMs ?? RETRY_INTERVAL_MS };
+        // #535: file-free routing — override provider baseUrls at load from
+        // the launcher-passed manifest (see buildPiEnv). registerProvider is
+        // queued during initial extension load and applied before any model
+        // traffic, so every request (including round 1) rides the proxy.
+        const rewrites = parseProviderRewrites(process.env);
+        if (rewrites !== undefined && typeof pi.registerProvider === "function") {
+            for (const [key, url] of Object.entries(rewrites)) {
+                try {
+                    pi.registerProvider(key, { baseUrl: url });
+                } catch (err) {
+                    console.error(`bili-plugin: registerProvider(${key}) failed: ${err instanceof Error ? err.message : String(err)} — traffic for this provider goes direct`);
+                }
+            }
+        }
+        // #535: cancel pi's NATIVE auto-compaction (threshold + overflow) so
+        // its summarizer never fires alongside bili's ACP compression — the
+        // in-extension replacement for the old settings.json compaction-off
+        // injection. `reason` gates to the auto paths only: manual /compact
+        // stays user-owned. omp's session_before_compact event has no reason
+        // field yet (upstream PR pending), so omp keeps its config.yml
+        // compaction-off entry until then. Only armed under `bili` launch:
+        // plain `pi` with the plugin installed must behave fully native.
+        if (agent === "pi" && process.env.BILLION_CONTEXT_PROXY !== undefined) {
+            pi.on("session_before_compact", (event) => {
+                const reason = (event as unknown as { reason?: unknown }).reason;
+                if (reason === "threshold" || reason === "overflow") return { cancel: true };
+                return undefined;
+            });
+        }
         if (typeof pi.registerCommand === "function") {
             pi.registerCommand("acp", {
                 description: "Show ACP context-compression status for this session",

--- a/src/agent/pi.ts
+++ b/src/agent/pi.ts
@@ -244,6 +244,12 @@ export function createBiliPlugin(agentOverride?: string, opts?: { retryIntervalM
         // queued during initial extension load and applied before any model
         // traffic, so every request (including round 1) rides the proxy.
         const rewrites = parseProviderRewrites(process.env);
+        if (rewrites !== undefined && typeof pi.registerProvider !== "function") {
+            console.error(
+                "bili-plugin: BILI_PROVIDER_REWRITES is set but this pi build has no registerProvider API — " +
+                    "provider traffic goes DIRECT (uncompressed). Update pi, or reinstall the bili plugin: `bili plugin install pi`.",
+            );
+        }
         if (rewrites !== undefined && typeof pi.registerProvider === "function") {
             for (const [key, url] of Object.entries(rewrites)) {
                 try {

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -329,16 +329,28 @@ export function discoverDomains(client: ClientName, config: ClientConfig): strin
     return discoverRoutes(client, config).httpsDomains;
 }
 
-export function buildPiEnv(origin: string, caPath: string, baseEnv: NodeJS.ProcessEnv, httpRewrites: HttpRewrite[] = []): NodeJS.ProcessEnv {
+export function buildPiEnv(
+    origin: string,
+    caPath: string,
+    baseEnv: NodeJS.ProcessEnv,
+    httpRewrites: HttpRewrite[] = [],
+    httpsRewrites: HttpRewrite[] = [],
+): NodeJS.ProcessEnv {
     // #535: provider URL rewrites ride env, not a generated models.json —
     // the bili extension (agent/pi.js) consumes this manifest at load and
     // overrides each provider's baseUrl via registerProvider before any
-    // model traffic. https upstreams need no entry: their real baseUrls
-    // stay untouched and ride HTTPS_PROXY cert-MITM.
+    // model traffic. https upstreams whose models.json baseUrl was already
+    // hand-wrapped to `<origin>/bili/https://...` (README Option 2) ALSO
+    // need an entry — with the RAW https value, which repoints them off the
+    // stale embedded origin onto the cert-MITM path (HTTPS_PROXY + CA).
     const manifest: Record<string, string> = {};
     for (const r of httpRewrites) {
         if (r.key.length === 0 || r.realUpstream.length === 0) continue;
         manifest[r.key] = wrapUpstream(origin, r.realUpstream);
+    }
+    for (const r of httpsRewrites) {
+        if (r.key.length === 0 || r.realUpstream.length === 0) continue;
+        manifest[r.key] = r.realUpstream;
     }
     return {
         ...baseEnv,
@@ -1093,7 +1105,7 @@ function writeOverlayFileAtomic(overlay: string, fileName: string, contents: str
 
 /**
  * omp models.yml rewrite (line-based, indentation-tracked): HTTP → /bili/ wrap, wrapped-HTTPS → raw https for cert
- * MITM) riding the persistent `<ompHome>-bili` overlay from
+ * MITM, riding the persistent `<ompHome>-bili` overlay from
  * refreshOverlayHome — comments, ordering and formatting are preserved
  * verbatim, and the real models.yml is never touched.
  */
@@ -1920,7 +1932,7 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
     const piRealHome = resolvePiHome({ ...process.env, PI_CODING_AGENT_DIR: undefined });
     // #535: validate pi's extension availability BEFORE spawning the proxy —
     // a refusal after ensureProxyRunning would leak a detached proxy child.
-    if (base === "pi" && routes.httpRewrites.length > 0) {
+    if (base === "pi" && (routes.httpRewrites.length > 0 || routes.httpsRewrites.length > 0)) {
         const piExt = selfDistFile("agent/pi.js");
         const extAvailable = (piExt !== undefined && fs.existsSync(piExt)) || piPluginInstalled(piRealHome);
         if (!extAvailable) {
@@ -1984,7 +1996,7 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
         // at extension load from the env manifest (registerProvider; see
         // buildPiEnv), and the old settings.json compaction-off generation is
         // replaced by the extension's session_before_compact cancel.
-        env = buildPiEnv(origin, ca, process.env, routes.httpRewrites);
+        env = buildPiEnv(origin, ca, process.env, routes.httpRewrites, routes.httpsRewrites);
         // #535: never let a stale inherited overlay redirect (from a legacy
         // launch or a shell exported inside one) leak into the child — pi
         // always runs on its REAL home now.

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -6,8 +6,8 @@
  *     discovered hosts whitelisted for TLS interception).
  *   - HTTP upstreams → `/bili/` baseURL rewrite (cert MITM can't intercept
  *     plaintext), applied via the client's own mechanism: codex `-c key=value`,
- *     claude `ANTHROPIC_BASE_URL` env, pi via an isolated `PI_CODING_AGENT_DIR`
- *     pointing at a temp copy of the pi home with a rewritten `models.json`.
+ *     claude `ANTHROPIC_BASE_URL` env, pi via `registerProvider` in the bili
+ *     extension (#535 — manifest passed through BILI_PROVIDER_REWRITES).
  *
  *   bili pi     [-- client args...]   HTTPS_PROXY + NODE_EXTRA_CA_CERTS
  *   bili codex  [-- client args...]   HTTPS_PROXY + SSL_CERT_FILE
@@ -329,8 +329,24 @@ export function discoverDomains(client: ClientName, config: ClientConfig): strin
     return discoverRoutes(client, config).httpsDomains;
 }
 
-export function buildPiEnv(origin: string, caPath: string, baseEnv: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
-    return { ...baseEnv, HTTPS_PROXY: origin, NODE_EXTRA_CA_CERTS: caPath, BILLION_CONTEXT_PROXY: origin };
+export function buildPiEnv(origin: string, caPath: string, baseEnv: NodeJS.ProcessEnv, httpRewrites: HttpRewrite[] = []): NodeJS.ProcessEnv {
+    // #535: provider URL rewrites ride env, not a generated models.json —
+    // the bili extension (agent/pi.js) consumes this manifest at load and
+    // overrides each provider's baseUrl via registerProvider before any
+    // model traffic. https upstreams need no entry: their real baseUrls
+    // stay untouched and ride HTTPS_PROXY cert-MITM.
+    const manifest: Record<string, string> = {};
+    for (const r of httpRewrites) {
+        if (r.key.length === 0 || r.realUpstream.length === 0) continue;
+        manifest[r.key] = wrapUpstream(origin, r.realUpstream);
+    }
+    return {
+        ...baseEnv,
+        HTTPS_PROXY: origin,
+        NODE_EXTRA_CA_CERTS: caPath,
+        BILLION_CONTEXT_PROXY: origin,
+        ...(Object.keys(manifest).length > 0 ? { BILI_PROVIDER_REWRITES: JSON.stringify(manifest) } : {}),
+    };
 }
 
 export function buildCodexEnv(origin: string, caPath: string, baseEnv: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
@@ -1075,75 +1091,8 @@ function writeOverlayFileAtomic(overlay: string, fileName: string, contents: str
     }
 }
 
-function writePiCompactionDisabledSettings(piHome: string, overlay: string): void {
-    let settings: Record<string, unknown> = {};
-    try {
-        const parsed: unknown = JSON.parse(fs.readFileSync(path.join(piHome, "settings.json"), "utf8"));
-        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-            settings = parsed as Record<string, unknown>;
-        }
-    } catch {}
-    const compactionRaw = settings.compaction;
-    const compaction =
-        compactionRaw && typeof compactionRaw === "object" && !Array.isArray(compactionRaw)
-            ? { ...(compactionRaw as Record<string, unknown>) }
-            : {};
-    compaction.enabled = false;
-    settings.compaction = compaction;
-    writeOverlayFileAtomic(overlay, "settings.json", JSON.stringify(settings, null, 2));
-}
-
-export function preparePiHttpRewrite(
-    piHome: string,
-    origin: string,
-    httpRewrites: HttpRewrite[],
-    httpsRewrites: HttpRewrite[],
-): string | undefined {
-    if (!fs.existsSync(piHome)) return undefined;
-    const overlay = `${piHome}-bili`;
-    // #447: the overlay always carries a settings.json disabling pi's native
-    // auto-compaction (its summarizer must never fire alongside bili's ACP
-    // compression); models.json is generated only when present, so both stay
-    // out of the real-home symlink set.
-    const generated: string[] = ["settings.json"];
-    let modelsRoot: Record<string, unknown> | undefined;
-    try {
-        const parsed: unknown = JSON.parse(fs.readFileSync(path.join(piHome, "models.json"), "utf8"));
-        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-            modelsRoot = parsed as Record<string, unknown>;
-            generated.push("models.json");
-        }
-    } catch {}
-    if (!refreshOverlayHome(piHome, overlay, generated)) return undefined;
-    if (modelsRoot) {
-        const providersVal = modelsRoot.providers;
-        if (providersVal && typeof providersVal === "object" && !Array.isArray(providersVal)) {
-            const providers = providersVal as Record<string, unknown>;
-            for (const r of httpRewrites) {
-                const prov = providers[r.key];
-                if (prov && typeof prov === "object" && !Array.isArray(prov)) {
-                    const p = prov as { baseUrl?: unknown };
-                    const existing = typeof p.baseUrl === "string" ? p.baseUrl : r.realUpstream;
-                    p.baseUrl = wrapUpstream(origin, unwrapUpstream(existing));
-                }
-            }
-            for (const r of httpsRewrites) {
-                const prov = providers[r.key];
-                if (prov && typeof prov === "object" && !Array.isArray(prov)) {
-                    const p = prov as { baseUrl?: unknown };
-                    p.baseUrl = r.realUpstream;
-                }
-            }
-        }
-        writeOverlayFileAtomic(overlay, "models.json", JSON.stringify(modelsRoot));
-    }
-    writePiCompactionDisabledSettings(piHome, overlay);
-    return overlay;
-}
-
 /**
- * omp counterpart of preparePiHttpRewrite: line-based (indentation-tracked)
- * models.yml rewrite (HTTP → /bili/ wrap, wrapped-HTTPS → raw https for cert
+ * omp models.yml rewrite (line-based, indentation-tracked): HTTP → /bili/ wrap, wrapped-HTTPS → raw https for cert
  * MITM) riding the persistent `<ompHome>-bili` overlay from
  * refreshOverlayHome — comments, ordering and formatting are preserved
  * verbatim, and the real models.yml is never touched.
@@ -1957,9 +1906,31 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
     const passthrough = params.overrides.ACP_PASSTHROUGH === "1";
     const debug = params.overrides.ACP_DEBUG === "1";
 
-    const config = loadClientConfig(process.env, process.cwd());
     const base = baseClientName(params.client);
+    // #535: for pi, discovery must read the REAL home — a stale inherited
+    // PI_CODING_AGENT_DIR (legacy overlay launch) would discover routes from
+    // an old overlay's rewritten models.json.
+    const discoveryEnv = base === "pi" ? { ...process.env, PI_CODING_AGENT_DIR: undefined } : process.env;
+    const config = loadClientConfig(discoveryEnv, process.cwd());
     const routes = discoverRoutes(base, config);
+    // #535: pi's REAL home — resolvePiHome honors a possibly-stale inherited
+    // PI_CODING_AGENT_DIR (e.g. launching `bili pi` from inside a shell that
+    // a legacy bili overlay launch exported it into); the new file-free
+    // design must never let that redirect pi at an old overlay dir.
+    const piRealHome = resolvePiHome({ ...process.env, PI_CODING_AGENT_DIR: undefined });
+    // #535: validate pi's extension availability BEFORE spawning the proxy —
+    // a refusal after ensureProxyRunning would leak a detached proxy child.
+    if (base === "pi" && routes.httpRewrites.length > 0) {
+        const piExt = selfDistFile("agent/pi.js");
+        const extAvailable = (piExt !== undefined && fs.existsSync(piExt)) || piPluginInstalled(piRealHome);
+        if (!extAvailable) {
+            throw new Error(
+                "bili: pi needs provider URL rewrites but the bili extension cannot load " +
+                    "(dist/agent/pi.js missing and the plugin is not installed in ~/.pi/agent/settings.json) — " +
+                    "reinstall billion-context or run `bili plugin install pi`",
+            );
+        }
+    }
     // bili's own route graph (same sources the spawned proxy child reads —
     // used to resolve the budget-alignment window, #321).
     const biliRoutes = loadRoutes(process.env);
@@ -1978,7 +1949,6 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
     const ca = resolveCaCertPath(process.env);
     let env: NodeJS.ProcessEnv;
     let clientArgs = params.clientArgs;
-    let piOverlayHome: string | undefined;
     let ompOverlayHome: string | undefined;
     let opencodeTmpFile: string | undefined;
     let hermesOverlayHome: string | undefined;
@@ -2009,16 +1979,23 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
     }
     const origin = handle.origin;
     if (base === "pi") {
-        env = buildPiEnv(origin, ca, process.env);
-        piOverlayHome = preparePiHttpRewrite(resolvePiHome(process.env), origin, routes.httpRewrites, routes.httpsRewrites);
-        if (piOverlayHome) env.PI_CODING_AGENT_DIR = piOverlayHome;
+        // #535: file-free injection — no overlay, no PI_CODING_AGENT_DIR
+        // redirect. pi runs on its REAL home: provider baseUrls are overridden
+        // at extension load from the env manifest (registerProvider; see
+        // buildPiEnv), and the old settings.json compaction-off generation is
+        // replaced by the extension's session_before_compact cancel.
+        env = buildPiEnv(origin, ca, process.env, routes.httpRewrites);
+        // #535: never let a stale inherited overlay redirect (from a legacy
+        // launch or a shell exported inside one) leak into the child — pi
+        // always runs on its REAL home now.
+        delete env.PI_CODING_AGENT_DIR;
         // Native tooling out of the box: when the user has NOT installed the
         // plugin, ride pi's `-e <file>` (loads for this run only, writes
         // nothing) instead of leaving them on wire-mode fallback. When they
-        // HAVE installed it, settings.json (merged into the overlay home)
-        // already loads it — adding `-e` too would double-register.
+        // HAVE installed it, settings.json already loads it — adding `-e` too
+        // would double-register.
         const piExt = selfDistFile("agent/pi.js");
-        if (piExt && fs.existsSync(piExt) && !piPluginInstalled(resolvePiHome(process.env))) {
+        if (piExt && fs.existsSync(piExt) && !piPluginInstalled(piRealHome)) {
             clientArgs = ["-e", piExt, ...clientArgs];
         }
     } else if (base === "omp") {

--- a/tests/launcher.test.ts
+++ b/tests/launcher.test.ts
@@ -20,7 +20,6 @@ import {
     buildCodexEnv,
     buildClaudeEnv,
     buildCodexArgs,
-    preparePiHttpRewrite,
     prepareOmpHttpRewrite,
     prepareOpencodeHttpRewrite,
     stripInheritedProxy,
@@ -382,6 +381,84 @@ test("runLaunch pi: native -e plugin injected only when not installed", async ()
         if (prevPiDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
         else process.env.PI_CODING_AGENT_DIR = prevPiDir;
         if (stubbed) fs.rmSync(distAgent, { force: true });
+        fs.rmSync(home, { recursive: true, force: true });
+    }
+});
+
+test("runLaunch pi #535: refuses launch when http rewrites needed and extension cannot load; no overlay files written", async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "bili-pirefuse-"));
+    const prevHome = process.env.HOME;
+    const prevUserProfile = process.env.USERPROFILE;
+    const prevPiDir = process.env.PI_CODING_AGENT_DIR;
+    process.env.HOME = home;
+    if (prevUserProfile !== undefined) process.env.USERPROFILE = home;
+    delete process.env.PI_CODING_AGENT_DIR;
+    const piHome = path.join(home, ".pi/agent");
+    fs.mkdirSync(piHome, { recursive: true });
+    fs.writeFileSync(path.join(piHome, "models.json"), JSON.stringify({ providers: { glm: { baseUrl: "http://127.0.0.1:8199/v1" } } }));
+
+    const root = selfPackageRoot();
+    const distAgent = path.join(root, "dist", "agent", "pi.js");
+    const distBackup = `${distAgent}.bak-test`;
+    const distExisted = fs.existsSync(distAgent);
+    if (distExisted) fs.renameSync(distAgent, distBackup);
+
+    const fakePi = path.join(home, "fake-pi");
+    fs.writeFileSync(fakePi, "");
+    const prevPiBin = process.env.PI_BIN;
+    process.env.PI_BIN = fakePi;
+    const prevExit = process.exit;
+    const exitCalls: number[] = [];
+    process.exit = ((code?: number) => {
+        exitCalls.push(code ?? 0);
+        return undefined as never;
+    }) as typeof process.exit;
+    const clientArgsSeen: string[][] = [];
+    const spawnImpl: SpawnFn = (cmd, args) => {
+        if (cmd === fakePi) {
+            clientArgsSeen.push([...args]);
+            const child = makeFakeChild(0);
+            const orig = child.on.bind(child);
+            (child as { on: SpawnChild["on"] }).on = (event, listener) => {
+                orig(event, listener);
+                if (event === "exit") setTimeout(() => listener(0, null), 0);
+                return child;
+            };
+            return child;
+        }
+        return makeFakeChild(42422);
+    };
+    try {
+        // no dist file, no installed plugin entry → refuse, and refuse BEFORE
+        // spawning anything (no proxy child, no client)
+        await assert.rejects(
+            runLaunch({ client: "pi", clientArgs: [], overrides: {} }, { fetchImpl: async () => ({ ok: true }), spawnImpl, sleep: () => Promise.resolve() }),
+            /needs provider URL rewrites but the bili extension cannot load/,
+        );
+        assert.equal(clientArgsSeen.length, 0);
+        // no overlay dir was created for pi anymore (#535)
+        assert.equal(fs.existsSync(`${piHome}-bili`), false, "no pi overlay dir");
+
+        // plugin installed in settings.json → extension loadable → launch proceeds
+        fs.writeFileSync(path.join(piHome, "settings.json"), JSON.stringify({ packages: [root] }));
+        await runLaunch(
+            { client: "pi", clientArgs: [], overrides: {} },
+            { fetchImpl: async () => ({ ok: true }), spawnImpl, sleep: () => Promise.resolve() },
+        );
+        assert.equal(clientArgsSeen.length, 1);
+        assert.ok(!clientArgsSeen[0].includes("-e"), "installed entry loads the plugin — no -e double load");
+        assert.equal(fs.existsSync(`${piHome}-bili`), false, "still no overlay dir");
+        assert.deepEqual(exitCalls, [0]);
+    } finally {
+        process.exit = prevExit;
+        if (prevPiBin === undefined) delete process.env.PI_BIN;
+        else process.env.PI_BIN = prevPiBin;
+        process.env.HOME = prevHome;
+        if (prevUserProfile === undefined) delete process.env.USERPROFILE;
+        else process.env.USERPROFILE = prevUserProfile;
+        if (prevPiDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+        else process.env.PI_CODING_AGENT_DIR = prevPiDir;
+        if (distExisted) fs.renameSync(distBackup, distAgent);
         fs.rmSync(home, { recursive: true, force: true });
     }
 });
@@ -950,76 +1027,31 @@ test("buildClaudeEnv: no ANTHROPIC_BASE_URL rewrite → env.ANTHROPIC_BASE_URL u
     assert.equal(env.HTTPS_PROXY, "http://127.0.0.1:8787");
 });
 
-test("preparePiHttpRewrite: rewrites matching provider, leaves others, symlinks siblings", () => {
-    // realpath: on macOS os.tmpdir() is /var/folders (a symlink to /private/var);
-    // the realpathSync asserts below compare canonical forms on both sides.
-    const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "bili-pihome-")));
-    fs.writeFileSync(
-        path.join(home, "models.json"),
-        JSON.stringify({
-            providers: {
-                a: { baseUrl: "http://example.com/v1" },
-                b: { baseUrl: "https://secure.example.com" },
-            },
-        }),
-    );
-    fs.writeFileSync(path.join(home, "auth.json"), '{"key":"x"}');
-    const tmp = preparePiHttpRewrite(home, "http://127.0.0.1:8787", [
+test("buildPiEnv: http rewrites → BILI_PROVIDER_REWRITES manifest (#535 file-free routing)", () => {
+    const env = buildPiEnv("http://127.0.0.1:8787", "/tmp/ca.pem", { PATH: "/usr/bin" }, [
         { key: "a", realUpstream: "http://example.com/v1" },
-    ], []);
-    try {
-        assert.ok(typeof tmp === "string" && tmp.length > 0);
-        const out = JSON.parse(fs.readFileSync(path.join(tmp!, "models.json"), "utf8"));
-        assert.equal(out.providers.a.baseUrl, "http://127.0.0.1:8787/bili/http://example.com/v1");
-        assert.equal(out.providers.b.baseUrl, "https://secure.example.com");
-        assert.equal(fs.lstatSync(path.join(tmp!, "auth.json")).isSymbolicLink(), true);
-        assert.equal(fs.realpathSync(path.join(tmp!, "auth.json")), path.join(home, "auth.json"));
-        const settings = JSON.parse(fs.readFileSync(path.join(tmp!, "settings.json"), "utf8"));
-        assert.equal(settings.compaction.enabled, false, "pi native compaction disabled");
-    } finally {
-        if (tmp) fs.rmSync(tmp, { recursive: true, force: true });
-        fs.rmSync(home, { recursive: true, force: true });
-    }
+        { key: "b", realUpstream: "http://other.example.com" },
+    ]);
+    assert.equal(env.HTTPS_PROXY, "http://127.0.0.1:8787");
+    assert.equal(env.BILLION_CONTEXT_PROXY, "http://127.0.0.1:8787");
+    const manifest = JSON.parse(env.BILI_PROVIDER_REWRITES ?? "null");
+    assert.deepEqual(manifest, {
+        a: "http://127.0.0.1:8787/bili/http://example.com/v1",
+        b: "http://127.0.0.1:8787/bili/http://other.example.com",
+    });
 });
 
-test("preparePiHttpRewrite: non-existent home → undefined", () => {
-    assert.equal(preparePiHttpRewrite("/nonexistent-bili-pi-home-xyz", "http://127.0.0.1:8787", [], []), undefined);
+test("buildPiEnv: no rewrites → no manifest env", () => {
+    const env = buildPiEnv("http://127.0.0.1:8787", "/tmp/ca.pem", { PATH: "/usr/bin" }, []);
+    assert.equal(env.BILI_PROVIDER_REWRITES, undefined);
 });
 
-test("preparePiHttpRewrite: no rewrites → overlay built, pi native compaction disabled, models.json copied verbatim", () => {
-    const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "bili-pihome-")));
-    fs.writeFileSync(path.join(home, "models.json"), JSON.stringify({ providers: { a: { baseUrl: "https://keep.example.com" } } }));
-    try {
-        const overlay = preparePiHttpRewrite(home, "http://127.0.0.1:8787", [], []);
-        assert.ok(typeof overlay === "string" && overlay.length > 0);
-        const settings = JSON.parse(fs.readFileSync(path.join(overlay!, "settings.json"), "utf8"));
-        assert.equal(settings.compaction.enabled, false, "pi native compaction disabled");
-        const out = JSON.parse(fs.readFileSync(path.join(overlay!, "models.json"), "utf8"));
-        assert.equal(out.providers.a.baseUrl, "https://keep.example.com", "no rewrite → baseUrl untouched");
-    } finally {
-        fs.rmSync(home, { recursive: true, force: true });
-        fs.rmSync(`${home}-bili`, { recursive: true, force: true });
-    }
-});
-
-test("preparePiHttpRewrite: preserves other settings.json keys, disables only compaction", () => {
-    const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "bili-pihome-")));
-    fs.writeFileSync(
-        path.join(home, "settings.json"),
-        JSON.stringify({ packages: ["/opt/pi-plugin"], theme: "dark", compaction: { reserveTokens: 9999 } }),
-    );
-    try {
-        const overlay = preparePiHttpRewrite(home, "http://127.0.0.1:8787", [], []);
-        assert.ok(typeof overlay === "string");
-        const settings = JSON.parse(fs.readFileSync(path.join(overlay!, "settings.json"), "utf8"));
-        assert.equal(settings.compaction.enabled, false, "compaction disabled");
-        assert.equal(settings.compaction.reserveTokens, 9999, "other compaction keys preserved");
-        assert.deepEqual(settings.packages, ["/opt/pi-plugin"], "packages preserved");
-        assert.equal(settings.theme, "dark", "theme preserved");
-    } finally {
-        fs.rmSync(home, { recursive: true, force: true });
-        fs.rmSync(`${home}-bili`, { recursive: true, force: true });
-    }
+test("buildPiEnv: empty-key/empty-upstream entries skipped", () => {
+    const env = buildPiEnv("http://127.0.0.1:8787", "/tmp/ca.pem", { PATH: "/usr/bin" }, [
+        { key: "", realUpstream: "http://example.com/v1" },
+        { key: "b", realUpstream: "" },
+    ]);
+    assert.equal(env.BILI_PROVIDER_REWRITES, undefined);
 });
 
 test("stripInheritedProxy: removes generic proxy redirector vars, keeps the rest", () => {

--- a/tests/launcher.test.ts
+++ b/tests/launcher.test.ts
@@ -463,6 +463,46 @@ test("runLaunch pi #535: refuses launch when http rewrites needed and extension 
     }
 });
 
+test("runLaunch pi #535: refuses launch when ONLY https (hand-wrapped) rewrites needed and extension cannot load", async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "bili-pirefuse2-"));
+    const prevHome = process.env.HOME;
+    const prevUserProfile = process.env.USERPROFILE;
+    const prevPiDir = process.env.PI_CODING_AGENT_DIR;
+    process.env.HOME = home;
+    if (prevUserProfile !== undefined) process.env.USERPROFILE = home;
+    delete process.env.PI_CODING_AGENT_DIR;
+    const piHome = path.join(home, ".pi/agent");
+    fs.mkdirSync(piHome, { recursive: true });
+    // README Option 2: baseUrl already hand-wrapped to a stale origin — without
+    // the manifest repin it would point at a dead embedded proxy origin.
+    fs.writeFileSync(
+        path.join(piHome, "models.json"),
+        JSON.stringify({ providers: { openai: { baseUrl: "http://127.0.0.1:8787/bili/https://api.openai.com/v1" } } }),
+    );
+
+    const root = selfPackageRoot();
+    const distAgent = path.join(root, "dist", "agent", "pi.js");
+    const distBackup = `${distAgent}.bak-test`;
+    const distExisted = fs.existsSync(distAgent);
+    if (distExisted) fs.renameSync(distAgent, distBackup);
+
+    const spawnImpl: SpawnFn = () => makeFakeChild(42422);
+    try {
+        await assert.rejects(
+            runLaunch({ client: "pi", clientArgs: [], overrides: {} }, { fetchImpl: async () => ({ ok: true }), spawnImpl, sleep: () => Promise.resolve() }),
+            /needs provider URL rewrites but the bili extension cannot load/,
+        );
+    } finally {
+        process.env.HOME = prevHome;
+        if (prevUserProfile === undefined) delete process.env.USERPROFILE;
+        else process.env.USERPROFILE = prevUserProfile;
+        if (prevPiDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+        else process.env.PI_CODING_AGENT_DIR = prevPiDir;
+        if (distExisted) fs.renameSync(distBackup, distAgent);
+        fs.rmSync(home, { recursive: true, force: true });
+    }
+});
+
 test("runLaunch omp: native -e plugin injected only when no loadable config entry", async () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "bili-ompe-"));
     const prevHome = process.env.HOME;
@@ -1044,6 +1084,21 @@ test("buildPiEnv: http rewrites → BILI_PROVIDER_REWRITES manifest (#535 file-f
 test("buildPiEnv: no rewrites → no manifest env", () => {
     const env = buildPiEnv("http://127.0.0.1:8787", "/tmp/ca.pem", { PATH: "/usr/bin" }, []);
     assert.equal(env.BILI_PROVIDER_REWRITES, undefined);
+});
+
+test("buildPiEnv: https rewrites merge RAW values (hand-wrapped baseUrl repointed onto cert-MITM)", () => {
+    const env = buildPiEnv(
+        "http://127.0.0.1:8787",
+        "/tmp/ca.pem",
+        { PATH: "/usr/bin" },
+        [{ key: "httpProv", realUpstream: "http://example.com/v1" }],
+        [{ key: "httpsProv", realUpstream: "https://api.openai.com/v1" }],
+    );
+    const manifest = JSON.parse(env.BILI_PROVIDER_REWRITES ?? "null");
+    assert.deepEqual(manifest, {
+        httpProv: "http://127.0.0.1:8787/bili/http://example.com/v1",
+        httpsProv: "https://api.openai.com/v1",
+    });
 });
 
 test("buildPiEnv: empty-key/empty-upstream entries skipped", () => {

--- a/tests/plugin-agent.test.ts
+++ b/tests/plugin-agent.test.ts
@@ -154,21 +154,25 @@ type FakePi = {
     events: Map<string, (event: unknown, ctx: unknown) => unknown>;
     tools: RecordedTool[];
     commands: Map<string, RecordedCommand>;
+    providers: Map<string, string>;
     readonly registerCalls: number;
     on: (event: string, handler: (event: never, ctx: never) => unknown) => void;
     registerTool: (tool: RecordedTool) => void;
     registerCommand: (name: string, options: RecordedCommand) => void;
+    registerProvider?: (name: string, config: { baseUrl: string }) => void;
 };
 
 function makeFakePi(): FakePi {
     const events = new Map<string, (event: unknown, ctx: unknown) => unknown>();
     const tools: RecordedTool[] = [];
     const commands = new Map<string, RecordedCommand>();
+    const providers = new Map<string, string>();
     let registerCallCount = 0;
     return {
         events,
         tools,
         commands,
+        providers,
         get registerCalls() { return registerCallCount; },
         on: (event, handler) => events.set(event, handler as (event: never, ctx: never) => unknown),
         registerTool: (tool) => {
@@ -179,6 +183,9 @@ function makeFakePi(): FakePi {
         },
         registerCommand: (name, options) => {
             commands.set(name, options);
+        },
+        registerProvider: (name, config) => {
+            providers.set(name, config.baseUrl);
         },
     };
 }
@@ -204,6 +211,87 @@ async function waitForTools(pi: FakePi, count: number, timeoutMs = 15000): Promi
         await new Promise((r) => setTimeout(r, 25));
     }
 }
+
+test("#535: provider URL rewrites from env manifest applied at load", () => {
+    const prevRewrites = process.env.BILI_PROVIDER_REWRITES;
+    process.env.BILI_PROVIDER_REWRITES = JSON.stringify({
+        glm: "http://127.0.0.1:8787/bili/http://127.0.0.1:8199/v1",
+        other: "http://127.0.0.1:8787/bili/http://example.com",
+    });
+    try {
+        const pi = makeFakePi();
+        createBiliPlugin()(pi as never);
+        assert.deepEqual(Object.fromEntries(pi.providers), {
+            glm: "http://127.0.0.1:8787/bili/http://127.0.0.1:8199/v1",
+            other: "http://127.0.0.1:8787/bili/http://example.com",
+        });
+    } finally {
+        if (prevRewrites === undefined) delete process.env.BILI_PROVIDER_REWRITES;
+        else process.env.BILI_PROVIDER_REWRITES = prevRewrites;
+    }
+});
+
+test("#535: invalid BILI_PROVIDER_REWRITES JSON → no rewrites applied", () => {
+    const prevRewrites = process.env.BILI_PROVIDER_REWRITES;
+    process.env.BILI_PROVIDER_REWRITES = "{not json";
+    try {
+        const pi = makeFakePi();
+        createBiliPlugin()(pi as never);
+        assert.equal(pi.providers.size, 0);
+    } finally {
+        if (prevRewrites === undefined) delete process.env.BILI_PROVIDER_REWRITES;
+        else process.env.BILI_PROVIDER_REWRITES = prevRewrites;
+    }
+});
+
+test("#535: non-http(s) manifest entries are dropped", () => {
+    const prevRewrites = process.env.BILI_PROVIDER_REWRITES;
+    process.env.BILI_PROVIDER_REWRITES = JSON.stringify({ good: "http://x.example/v1", bad: "ftp://x.example", bad2: "not-a-url" });
+    try {
+        const pi = makeFakePi();
+        createBiliPlugin()(pi as never);
+        assert.deepEqual(Object.fromEntries(pi.providers), { good: "http://x.example/v1" });
+    } finally {
+        if (prevRewrites === undefined) delete process.env.BILI_PROVIDER_REWRITES;
+        else process.env.BILI_PROVIDER_REWRITES = prevRewrites;
+    }
+});
+
+test("#535: session_before_compact cancels only pi auto compaction under bili launch", () => {
+    const prevProxy = process.env.BILLION_CONTEXT_PROXY;
+    process.env.BILLION_CONTEXT_PROXY = "http://127.0.0.1:8787";
+    try {
+        const pi = makeFakePi();
+        createBiliPlugin("pi")(pi as never);
+        const handler = pi.events.get("session_before_compact");
+        assert.ok(handler, "pi under bili launch: handler registered");
+        assert.deepEqual(handler({ reason: "threshold" }, undefined), { cancel: true });
+        assert.deepEqual(handler({ reason: "overflow" }, undefined), { cancel: true });
+        assert.equal(handler({ reason: "manual" }, undefined), undefined, "manual /compact stays user-owned");
+        assert.equal(handler({ reason: "startup" }, undefined), undefined, "unknown reason → not cancelled");
+
+        // omp: no reason field upstream yet → handler must NOT be registered
+        const omp = makeFakePi();
+        createBiliPlugin("omp")(omp as never);
+        assert.equal(omp.events.get("session_before_compact"), undefined, "omp: no cancel handler until upstream reason PR");
+    } finally {
+        if (prevProxy === undefined) delete process.env.BILLION_CONTEXT_PROXY;
+        else process.env.BILLION_CONTEXT_PROXY = prevProxy;
+    }
+});
+
+test("#535: plain pi (no BILLION_CONTEXT_PROXY) → no compaction cancel handler", () => {
+    const prevProxy = process.env.BILLION_CONTEXT_PROXY;
+    delete process.env.BILLION_CONTEXT_PROXY;
+    try {
+        const pi = makeFakePi();
+        createBiliPlugin("pi")(pi as never);
+        assert.equal(pi.events.get("session_before_compact"), undefined, "native run stays fully native");
+    } finally {
+        if (prevProxy === undefined) delete process.env.BILLION_CONTEXT_PROXY;
+        else process.env.BILLION_CONTEXT_PROXY = prevProxy;
+    }
+});
 
 test("pi extension registers manifest tools and stamps headers when proxied", async () => {
     const proxy = await startFakeProxy();


### PR DESCRIPTION
#535 phase 1 (pi). Closes nothing yet — the issue tracks all four phases.

## What changes

`bili pi` no longer creates the `~/.pi/agent-bili` overlay and no longer sets `PI_CODING_AGENT_DIR`. pi always runs on its **real** home; every in-session write (settings edits, `models-store.json`, `run-history.jsonl`, `auth.json`, `sessions/`) lands in the real home, so nothing is ever silently lost (#531 root fix for pi).

Injection becomes file-free:

- **Provider URL rewrites** — the launcher passes `BILI_PROVIDER_REWRITES` (JSON `{providerKey: wrapUpstream(...)}` for http upstreams) through the child env; the bili pi extension consumes it at load and calls `pi.registerProvider(key, { baseUrl })` (queued at extension load, applied before any model traffic). HTTPS upstreams keep their real baseUrls and ride `HTTPS_PROXY` cert-MITM as before.
- **Native compaction off** — replaced the generated `settings.json` (`compaction.enabled=false`) with an in-extension `session_before_compact` handler returning `{cancel:true}` **only** for `reason==="threshold"||"overflow"` (manual `/compact` stays user-owned — exact parity with the old setting). Armed only when `BILLION_CONTEXT_PROXY` is present, so a plain `pi` with the plugin installed stays fully native. omp is untouched: its event has no `reason` field yet (upstream PR pending).

## Safety

- Refuses to launch (before spawning anything) when http rewrites are needed but the extension cannot load (`dist/agent/pi.js` missing **and** plugin not installed) — without this the rewrites would silently vanish and traffic would go direct.
- A stale inherited `PI_CODING_AGENT_DIR` (e.g. launching from inside a legacy overlay shell) is stripped from the child env and ignored for discovery + plugin detection.
- Old overlays are left in place untouched — no merge-back, no deletion (per #535).

## Verification

- `npm run typecheck` clean; `npm test` 1041/1043 (the 2 known env-dependent fails in plugin-agent.test.ts, fail only when the runner itself sits behind a live `BILLION_CONTEXT_PROXY`); `npm run build` ok.
- New tests: `buildPiEnv` manifest (3), plugin `registerProvider` from env (3), `session_before_compact` cancel semantics (2), launcher refusal + no-overlay-dir (1).
- E2E on this machine: `node dist/index.js pi -- --model vllm/glm-5.3 -p '...'` → proxy log shows `forward POST → …:8199/v1/chat/completions` through the `/bili/` route; `~/.pi/agent-bili` and real home untouched (mtime check); child env carries the manifest and no `PI_CODING_AGENT_DIR`.