### PR TITLE
feat(#535): zero-file injection phases 2+3 — absolute-form forward proxy, hermes/dsh env routing

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -538,8 +538,8 @@ How each client is pointed at the proxy (set automatically in the child env):
 | codex | `HTTPS_PROXY` + `-c key=value` overrides | `SSL_CERT_FILE` → `combined-ca.pem` |
 | claude | `ANTHROPIC_BASE_URL` = `/bili/` URL | none needed |
 | opencode | `HTTPS_PROXY` + isolated `OPENCODE_CONFIG` | `NODE_EXTRA_CA_CERTS` |
-| hermes | isolated `HERMES_HOME`; **all** upstreams `/bili/` | none (certifi ignores `SSL_CERT_FILE`) |
-| dsh | isolated `DSH_HOME` + `DEEPSEEK_BASE_URL`; **all** upstreams `/bili/` | none (plain fetch, no proxy/CA knobs) |
+| hermes | `HTTPS_PROXY` (+`HTTP_PROXY` when plaintext-http upstreams exist); inherited `NO_PROXY` loopback-sanitized | `HERMES_CA_BUNDLE` → `combined-ca.pem` |
+| dsh | `HTTPS_PROXY` (+`HTTP_PROXY` for non-loopback plaintext); **loopback** upstreams → `settings.yaml` overlay `DSH_HOME`; inherited `NO_PROXY` loopback-sanitized | `NODE_EXTRA_CA_CERTS` |
 
 `NODE_EXTRA_CA_CERTS` *appends* to the built-in trust store, so it points at the MITM root alone (`root-ca.pem`). `SSL_CERT_FILE` *replaces* the default CA bundle, so for codex it points at `combined-ca.pem` — a bundle containing the MITM root **plus** the system/Node public roots — keeping pip/git/curl style TLS (blind-tunnelled, real certificates) working inside the child env (#152).
 
@@ -555,7 +555,7 @@ Where upstreams are discovered from (read-only):
 | Claude Code | `ANTHROPIC_BASE_URL` env var, else hardcoded `api.anthropic.com` |
 | OpenCode | `~/.config/opencode/opencode.json` — each provider's `baseURL` |
 | hermes | `~/.hermes/config.yaml` — each provider's endpoint lines |
-| dsh | `~/.dsh/settings.yaml` — every `baseURL`/`baseUrl`/`base_url` value; plus the built-in `deepseek-official` route via `$DEEPSEEK_BASE_URL` |
+| dsh | `~/.dsh/settings.yaml` — every `baseURL`/`baseUrl`/`base_url` value; plus the built-in `deepseek-official` host `api.deepseek.com` (MITM-whitelisted) |
 
 ### Isolated temp config (what gets written)
 
@@ -563,8 +563,8 @@ The `/bili/` rewrite modes write a **temp copy** — the real config is never ed
 
 - **pi / omp** — an isolated `PI_CODING_AGENT_DIR` (under `/tmp`) containing only a rewritten `models.json` / `models.yml` with the `/bili/`-wrapped plaintext baseUrls. Everything else (`settings.json`, `sessions/`, `auth.json`, extensions…) is **symlinked** to the real pi/omp home, so sessions and logins are shared: a conversation started under the launcher continues seamlessly in a bare client, and vice versa.
 - **opencode** — a temp `opencode.json` pointed at by `OPENCODE_CONFIG`, with `/bili/`-rewritten baseURLs **plus the thin `/acp` plugin appended** (native tools out of the box; the standalone `opencode-acp` plugin self-disables via `BILLION_CONTEXT_PROXY`).
-- **hermes** — an isolated `HERMES_HOME` with a rewritten `config.yaml` routing **every** upstream (HTTP and HTTPS) through `/bili/` (httpx builds its own CA bundle and ignores `SSL_CERT_FILE`, so cert MITM is impossible). `skills/`, `memories/`, `sessions/` are symlinked through. If no providers are configured — or `config.yaml` can't be rewritten — the launcher prints a warning and hermes runs **unproxied** (compression off).
-- **dsh** — an isolated `DSH_HOME` (persistent overlay `~/.dsh-bili`) with a rewritten `settings.yaml` routing every configured upstream through `/bili/` (plain `fetch`, no proxy/CA knobs, so cert MITM is impossible). `profiles/`, credentials and sessions are symlinked through. The built-in `deepseek-official` route is captured separately via `$DEEPSEEK_BASE_URL` (dsh resolves `settings llm-deepseek.baseURL` ?? env ?? default, so a rewritten user setting wins and the env is the zero-config fallback) — with no custom providers the deepseek route is still proxied out of the box.
+- **hermes** — zero file writes (#535): https upstream hosts are MITM-whitelisted and reached via `HTTPS_PROXY`, with `HERMES_CA_BUNDLE` pointing at `combined-ca.pem` (httpx builds its own bundle from that env, so the combined bundle keeps system roots working for blind-tunnelled hosts); plaintext-http upstreams ride `HTTP_PROXY` as absolute-form requests. Inherited `NO_PROXY` is sanitized of loopback entries so local upstreams still reach bili. The session-identity plugin (#286) is installed idempotently into the REAL `~/.hermes/plugins/model-providers/bili-session-identity/` — bili-owned files that coexist with user plugins; nothing else is written. If no providers are configured, the launcher warns and LLM traffic bypasses the proxy (compression off).
+- **dsh** — split by destination (#535): non-loopback https hosts are MITM-whitelisted (`HTTPS_PROXY` + `NODE_EXTRA_CA_CERTS`), non-loopback plaintext-http rides `HTTP_PROXY`, and the built-in `deepseek-official` route is captured by whitelisting `api.deepseek.com` (no more `$DEEPSEEK_BASE_URL` clobbering of a user-set value). **Loopback destinations are the documented exception**: dsh unconditionally bypasses proxies for localhost/127.0.0.1/::1 (`LOOPBACK_NO_PROXY`, "the bypass is not optional"), so loopback upstreams keep the legacy `settings.yaml` rewrite in an isolated `DSH_HOME` overlay (`~/.dsh-bili`) with everything else symlinked through. Inherited `NO_PROXY` is sanitized of loopback entries.
 
 ### Native tools in the launcher
 

--- a/CONFIGURATION.zh-CN.md
+++ b/CONFIGURATION.zh-CN.md
@@ -535,8 +535,8 @@ MITM 只对一份**白名单**中的模型域名生效（`open.bigmodel.cn`、`a
 | codex | `HTTPS_PROXY` + `-c key=value` 覆盖 | `SSL_CERT_FILE` → `combined-ca.pem` |
 | claude | `ANTHROPIC_BASE_URL` = `/bili/` URL | 无需 |
 | opencode | `HTTPS_PROXY` + 隔离 `OPENCODE_CONFIG` | `NODE_EXTRA_CA_CERTS` |
-| hermes | 隔离 `HERMES_HOME`；**全部**上游走 `/bili/` | 无（certifi 忽略 `SSL_CERT_FILE`） |
-| dsh | 隔离 `DSH_HOME` + `DEEPSEEK_BASE_URL`；**全部**上游走 `/bili/` | 无（纯 fetch，无代理/CA 接口） |
+| hermes | `HTTPS_PROXY`（存在明文 http 上游时加 `HTTP_PROXY`）；继承的 `NO_PROXY` 做回环清洗 | `HERMES_CA_BUNDLE` → `combined-ca.pem` |
+| dsh | `HTTPS_PROXY`（非回环明文上游加 `HTTP_PROXY`）；**回环**上游 → `settings.yaml` overlay `DSH_HOME`；继承的 `NO_PROXY` 做回环清洗 | `NODE_EXTRA_CA_CERTS` |
 
 `NODE_EXTRA_CA_CERTS` 是**追加**到内置信任库，所以只指向 MITM 根证书（`root-ca.pem`）即可。`SSL_CERT_FILE` 会**替换**默认 CA bundle，所以 codex 指向 `combined-ca.pem` —— 包含 MITM 根证书**加上**系统/Node 公共根 —— 保证子进程环境里 pip/git/curl 类 TLS（盲转发、真证书）不受影响（#152）。
 
@@ -552,7 +552,7 @@ Claude Code 的 undici fetch 忽略 `HTTPS_PROXY`，所以证书 MITM 拦不到�
 | Claude Code | `ANTHROPIC_BASE_URL` 环境变量，否则硬编码 `api.anthropic.com` |
 | OpenCode | `~/.config/opencode/opencode.json` —— 各 provider 的 `baseURL` |
 | hermes | `~/.hermes/config.yaml` —— 各 provider 的端点行 |
-| dsh | `~/.dsh/settings.yaml` —— 每个 `baseURL`/`baseUrl`/`base_url` 值；内置 `deepseek-official` 路由另经 `$DEEPSEEK_BASE_URL` 接管 |
+| dsh | `~/.dsh/settings.yaml` —— 每个 `baseURL`/`baseUrl`/`base_url` 值；内置 `deepseek-official` 主机 `api.deepseek.com`（纳入 MITM 白名单） |
 
 ### 隔离临时配置（写了什么）
 
@@ -560,8 +560,8 @@ Claude Code 的 undici fetch 忽略 `HTTPS_PROXY`，所以证书 MITM 拦不到�
 
 - **pi / omp** —— 隔离的 `PI_CODING_AGENT_DIR`（在 `/tmp` 下），里面只有一份重写后的 `models.json` / `models.yml`（明文 baseUrl 包上 `/bili/`）。其余一切（`settings.json`、`sessions/`、`auth.json`、扩展……）都**符号链接**到真实 pi/omp 主目录，所以会话与登录互通：launcher 里开的会话在裸客户端里无缝继续，反之亦然。
 - **opencode** —— 临时 `opencode.json`（由 `OPENCODE_CONFIG` 指向），`baseURL` 重写为 `/bili/` 形式，**并追加了薄 `/acp` 插件**（开箱即原生工具；独立的 `opencode-acp` 插件检测到 `BILLION_CONTEXT_PROXY` 后自禁用）。
-- **hermes** —— 隔离的 `HERMES_HOME`，重写后的 `config.yaml` 让**所有**上游（HTTP 和 HTTPS）都走 `/bili/`（httpx 自建 CA bundle 且忽略 `SSL_CERT_FILE`，证书 MITM 不可行）。`skills/`、`memories/`、`sessions/` 符号链接共享。若没配置任何 provider —— 或 `config.yaml` 无法重写 —— 启动器打印警告，hermes 将**不经代理**运行（无压缩）。
-- **dsh** —— 隔离的 `DSH_HOME`（持久 overlay `~/.dsh-bili`），重写后的 `settings.yaml` 让所有已配置上游都走 `/bili/`（纯 `fetch`，无代理/CA 接口，证书 MITM 不可行）。`profiles/`、凭据、会话符号链接共享。内置 `deepseek-official` 路由另行经 `$DEEPSEEK_BASE_URL` 接管（dsh 解析顺序为 settings `llm-deepseek.baseURL` ?? 环境变量 ?? 默认值，重写过的用户配置优先，环境变量作零配置兜底）—— 即便没有任何自定义 provider，内置 deepseek 路由也照样走代理。
+- **hermes** —— 零文件写入（#535）：https 上游主机纳入 MITM 白名单，经 `HTTPS_PROXY` 到达；`HERMES_CA_BUNDLE` 指向 `combined-ca.pem`（httpx 用该 env 自建 CA bundle，合并 bundle 保留系统根证书，盲转发的主机不受影响）；明文 http 上游经 `HTTP_PROXY` 以 absolute-form 请求到达。继承的 `NO_PROXY` 会被清洗掉回环条目，本地上游仍能到 bili。会话身份插件（#286）**幂等装入真实** `~/.hermes/plugins/model-providers/bili-session-identity/`——bili 自有文件，与用户插件共存；其余什么都不写。若没配置任何 provider，启动器打印警告，LLM 流量将绕过代理（无压缩）。
+- **dsh** —— 按目标分流（#535）：非回环 https 主机纳入 MITM 白名单（`HTTPS_PROXY` + `NODE_EXTRA_CA_CERTS`），非回环明文 http 走 `HTTP_PROXY`，内置 `deepseek-official` 路由通过白名单 `api.deepseek.com` 接管（不再覆写用户可能设置的 `$DEEPSEEK_BASE_URL`）。**回环目标是文档化例外**：dsh 对 localhost/127.0.0.1/::1 无条件绕过代理（`LOOPBACK_NO_PROXY`，“bypass is not optional”），所以回环上游保留旧的 `settings.yaml` 重写（隔离 `DSH_HOME` overlay `~/.dsh-bili`，其余符号链接共享）。继承的 `NO_PROXY` 会被清洗掉回环条目。
 
 ### 启动器里的原生工具
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,18 @@ turn is a semantic mismatch the model tolerates (it is clearly marked
   summaries (their tool call isn't in the agent's history and the agent's view
   skips `acp_summary`) — but that needs the id match above, which doesn't occur.
 
+### Injection priority — no files unless unavoidable
+
+How the launcher points a client at the proxy follows a strict priority
+(#535): **env vars** (`HTTPS_PROXY` cert-MITM for discovered upstream hosts,
+`HTTP_PROXY` absolute-form requests for plaintext-http upstreams, plus the
+per-client CA trust variable) > **client-native CLI flags / extension APIs**
+> **generated config files** (last resort — today omp's overlay and dsh's
+loopback exception). No real config file is ever edited, and bili never owns
+user data: clients run against their real home directory, and pre-existing
+overlay dirs from older versions (e.g. `~/.hermes-bili`) are left in place,
+unmigrated.
+
 ## Which do I need?
 
 Pick by your client:
@@ -157,8 +169,8 @@ bili codex                            # launch codex through the proxy
 bili claude                           # launch claude through the proxy
 bili omp                              # pi-style: MITM env + persistent overlay home (~/.omp/agent-bili, real config untouched)
 bili opencode                         # MITM for HTTPS + temp opencode.json (/bili/ for HTTP) + thin /acp plugin
-bili hermes                           # no MITM possible (certifi CA) — persistent overlay home (~/.hermes-bili), all traffic /bili/
-bili dsh                              # deepseek-harness: built-in deepseek route via DEEPSEEK_BASE_URL + overlay DSH_HOME (~/.dsh-bili), all traffic /bili/, native /acp command injected via --patch
+bili hermes                           # HTTPS_PROXY cert-MITM (HERMES_CA_BUNDLE) + HTTP_PROXY for plaintext upstreams; identity plugin in real ~/.hermes
+bili dsh                              # deepseek-harness: MITM env incl. built-in deepseek route + HTTP_PROXY for non-loopback plaintext; loopback keeps settings.yaml overlay (~/.dsh-bili); native /acp via --patch
 bili pi --mitm-domain api.foo.com     # add a domain to the MITM whitelist
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -88,8 +88,8 @@ bili codex                            # 拉起 codex
 bili claude                           # 拉起 claude
 bili omp                              # pi 同款 MITM 环境变量 + 隔离临时 models.yml
 bili opencode                         # HTTPS 走 MITM + 临时 opencode.json(HTTP 走 /bili/)+ 轻量 /acp 插件
-bili hermes                           # 无法 MITM(certifi CA)—— 隔离 HERMES_HOME,全部流量 /bili/
-bili dsh                              # deepseek-harness:内置 deepseek 路由走 DEEPSEEK_BASE_URL + 隔离 DSH_HOME(~/.dsh-bili),全部流量 /bili/,经 --patch 注入原生 /acp 命令
+bili hermes                           # HTTPS_PROXY 证书 MITM(HERMES_CA_BUNDLE)+ HTTP_PROXY 走明文上游;身份插件装入真实 ~/.hermes
+bili dsh                              # deepseek-harness:MITM 环境变量(含内置 deepseek 路由)+ HTTP_PROXY 走非回环明文上游;回环上游保留 settings.yaml overlay(~/.dsh-bili);经 --patch 注入原生 /acp 命令
 bili pi --mitm-domain api.foo.com     # 向 MITM 白名单追加域名
 ```
 

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -179,6 +179,26 @@ export interface DiscoveredRoutes {
     httpsDomains: string[];
     httpRewrites: HttpRewrite[];
     httpsRewrites: HttpRewrite[];
+    /** #535: plaintext-http upstreams routed purely through HTTP_PROXY as
+     *  standard absolute-form forward-proxy requests (no client-side URL
+     *  rewrite). hermes: every http upstream; dsh: non-loopback only — its
+     *  loopback no-proxy bypass is unconditional, those keep the settings.yaml
+     *  /bili/ form in httpRewrites below. */
+    httpEnvRoutes: string[];
+    /** #535: discovered provider names whose traffic rides the proxy. hermes
+     *  feeds these to the session-identity plugin, which must register a
+     *  profile for every named provider it fronts. */
+    providerKeys: string[];
+}
+
+/** Loopback destinations a client's own no-proxy list would normally exclude —
+ *  bili's proxy itself lives on the loopback, so inherited NO_PROXY entries
+ *  for these hosts would shadow the routing (see stripLoopbackNoProxy). */
+export function isLoopbackHost(host: string): boolean {
+    const h = host.toLowerCase();
+    if (h === "localhost" || h === "::1" || h === "[::1]") return true;
+    const m = /^(\d+)\.(\d+)\.(\d+)\.(\d+)$/.exec(h);
+    return m !== null && m[1] === "127";
 }
 
 export function resolveCaCertPath(env: NodeJS.ProcessEnv): string {
@@ -215,6 +235,8 @@ export function discoverRoutes(client: ClientName, config: ClientConfig): Discov
     const httpsDomains: string[] = [];
     const httpRewrites: HttpRewrite[] = [];
     const httpsRewrites: HttpRewrite[] = [];
+    const httpEnvRoutes: string[] = [];
+    const providerKeys: string[] = [];
     const httpsSeen = new Set<string>();
     const rewriteKeys = new Set<string>();
     const httpsRewriteKeys = new Set<string>();
@@ -276,43 +298,73 @@ export function discoverRoutes(client: ClientName, config: ClientConfig): Discov
             classify(prov.baseURL, name);
         }
     } else if (client === "hermes") {
-        // hermes rides /bili/ for EVERY upstream (http AND https): its httpx
-        // client builds its own CA bundle from certifi, so cert-MITM would
-        // need extra trust config. Wrapping the URL form needs no cert at all.
+        // #535 file-free routing: hermes's httpx stack honors the standard
+        // proxy env vars (run_agent.py _get_proxy_for_base_url), so NO
+        // config.yaml rewrite happens anymore — https upstreams ride
+        // HTTPS_PROXY + cert-MITM (host whitelisted here; the CA bundle is
+        // trusted via HERMES_CA_BUNDLE in runLaunch), plaintext http upstreams
+        // ride HTTP_PROXY as absolute-form forward-proxy requests. providerKeys
+        // feeds the session-identity plugin (prompt_cache_key, #286).
         const hermesSeen = new Set<string>();
         for (const [name, prov] of Object.entries(config.hermes?.providers ?? {})) {
             if (!nonEmpty(prov.api)) continue;
             const real = unwrapUpstream(prov.api!);
+            let url: URL;
             try {
-                const url = new URL(real);
-                if (url.protocol !== "http:" && url.protocol !== "https:") continue;
-                if (hermesSeen.has(name)) continue;
-                hermesSeen.add(name);
-                rewriteKeys.add(name);
-                httpRewrites.push({ key: name, realUpstream: real });
+                url = new URL(real);
             } catch {
-                // Unparseable endpoint: skip.
+                continue;
+            }
+            if (url.protocol !== "http:" && url.protocol !== "https:") continue;
+            if (hermesSeen.has(name)) continue;
+            hermesSeen.add(name);
+            rewriteKeys.add(name);
+            providerKeys.push(name);
+            if (url.protocol === "https:") {
+                const host = url.hostname;
+                if (host && !httpsSeen.has(host.toLowerCase())) {
+                    httpsSeen.add(host.toLowerCase());
+                    httpsDomains.push(host);
+                }
+            } else {
+                httpEnvRoutes.push(real);
             }
         }
     } else if (client === "dsh") {
-        // dsh (deepseek-harness) has no proxy/CA knobs in its fetch stack:
-        // every configured upstream rides the /bili/ URL form. The built-in
-        // deepseek-official route is captured via $DEEPSEEK_BASE_URL in
-        // runLaunch; user-configured settings.yaml endpoints here.
+        // #535: dsh's undici dispatcher honors the standard proxy env vars,
+        // BUT its loopback no-proxy list (localhost/127.0.0.1/::1) is
+        // unconditional ("the bypass is not optional") — env routing can never
+        // reach a loopback upstream. Loopback destinations therefore keep the
+        // settings.yaml /bili/ rewrite (documented exception); everything else
+        // rides env — https via HTTPS_PROXY + cert-MITM (domain whitelisted
+        // here), plaintext http via HTTP_PROXY. The built-in deepseek-official
+        // route is MITM-whitelisted in runLaunch instead of wrapping
+        // $DEEPSEEK_BASE_URL.
         const dshSeen = new Set<string>();
         let anon = 0;
         for (const raw of config.dsh?.baseUrls ?? []) {
             const real = unwrapUpstream(raw);
+            let url: URL;
             try {
-                const url = new URL(real);
-                if (url.protocol !== "http:" && url.protocol !== "https:") continue;
-                if (dshSeen.has(real)) continue;
-                dshSeen.add(real);
+                url = new URL(real);
+            } catch {
+                continue;
+            }
+            if (url.protocol !== "http:" && url.protocol !== "https:") continue;
+            if (dshSeen.has(real)) continue;
+            dshSeen.add(real);
+            if (isLoopbackHost(url.hostname)) {
                 anon += 1;
                 rewriteKeys.add(`dsh-${anon}`);
                 httpRewrites.push({ key: `dsh-${anon}`, realUpstream: real });
-            } catch {
-                // Unparseable endpoint: skip.
+            } else if (url.protocol === "https:") {
+                const host = url.hostname;
+                if (!httpsSeen.has(host.toLowerCase())) {
+                    httpsSeen.add(host.toLowerCase());
+                    httpsDomains.push(host);
+                }
+            } else {
+                httpEnvRoutes.push(real);
             }
         }
     } else {
@@ -322,7 +374,7 @@ export function discoverRoutes(client: ClientName, config: ClientConfig): Discov
         classify(config.codex?.openaiBaseUrl, "openai_base_url");
     }
 
-    return { httpsDomains, httpRewrites, httpsRewrites };
+    return { httpsDomains, httpRewrites, httpsRewrites, httpEnvRoutes, providerKeys };
 }
 
 export function discoverDomains(client: ClientName, config: ClientConfig): string[] {
@@ -1355,51 +1407,7 @@ export function prepareOmpHttpRewrite(
     return overlay;
 }
 
-/**
- * hermes counterpart of prepareOmpHttpRewrite: a persistent `<hermesHome>-bili`
- * overlay (every ~/.hermes sibling symlinked so skills/memories/sessions stay
- * shared) holding a rewritten copy of config.yaml. Every provider endpoint
- * line (api: / base_url: / url:) is rewrapped as origin + "/bili/" + raw
- * upstream — http AND https alike, since hermes's httpx stack can't consume
- * the MITM CA without extra trust config. The real ~/.hermes is never
- * touched. Returns the overlay dir (undefined when nothing is rewritable).
- */
-export function prepareHermesHome(
-    hermesHome: string,
-    origin: string,
-    rewrites: HttpRewrite[],
-): string | undefined {
-    if (rewrites.length === 0) return undefined;
-    const cfgPath = path.join(hermesHome, "config.yaml");
-    let txt: string;
-    try {
-        txt = fs.readFileSync(cfgPath, "utf8");
-    } catch {
-        return undefined;
-    }
-    const wrapSet = new Set(rewrites.map((r) => r.realUpstream));
-    const eol = txt.includes("\r\n") ? "\r\n" : "\n";
-    const lines = txt.split(/\r?\n/);
-    let changed = false;
-    for (let i = 0; i < lines.length; i++) {
-        const rawLine = lines[i];
-        const m = /^(\s*(?:api|base_url|url):\s*)(\S+)(\s+#.*)?$/.exec(rawLine);
-        if (!m) continue;
-        const rawUrl = m[2].replace(/^["']|["']$/g, "");
-        if (!/^https?:\/\//i.test(rawUrl)) continue;
-        const real = unwrapUpstream(rawUrl);
-        if (!wrapSet.has(real)) continue;
-        lines[i] = `${m[1]}${wrapUpstream(origin, real)}${m[3] ?? ""}`;
-        changed = true;
-    }
-    if (!changed) return undefined;
-    const overlay = `${hermesHome}-bili`;
-    if (!refreshOverlayHome(hermesHome, overlay, "config.yaml")) return undefined;
-    writeOverlayFileAtomic(overlay, "config.yaml", lines.join(eol));
-    return overlay;
-}
-
-/** Write the hermes session-identity plugin into the bili overlay home.
+/** Write the hermes session-identity plugin into the user's REAL home.
  *  Hermes sends NO conversation identity on the wire by default: its native
  *  `prompt_cache_key` support (transports/chat_completions.py) is gated on
  *  `supports_prompt_cache_key`, which no bundled provider profile enables —
@@ -1412,43 +1420,34 @@ export function prepareHermesHome(
  *  the bundled "custom" profile and stamps prompt_cache_key = session_id,
  *  giving the proxy the same stable per-conversation id omp/pi provide.
  *  Registered names: "custom" (model.base_url / provider: custom) plus
- *  "custom:<name>" for every provider key bili rewrites (named providers
+ *  "custom:<name>" for every provider key bili fronts (named providers
  *  resolve to that shape — agent_init only maps "custom"/"custom:<key>"
  *  to custom endpoints, and a bare "custom:<key>" lookup otherwise misses
  *  the profile registry and falls to the legacy no-pck path).
- *  Skipped (returns false) when the REAL ~/.hermes already has a plugins/
- *  dir — refreshOverlayHome symlinks it into the overlay, and writing
- *  through the symlink would mutate the user's real home. The proxy then
- *  400s anonymous requests with the fix-it message. */
-export function writeHermesIdentityPlugin(hermesHome: string, overlay: string, rewrites: HttpRewrite[]): boolean {
+ *  #535 file-free routing: installed under <hermesHome>/plugins/model-
+ *  providers/bili-session-identity/ — a bili-owned subdir in the real home
+ *  that coexists with the user's own plugins (unique dir name, no
+ *  collision) and is overwritten idempotently on every launch. Safe to
+ *  delete (stock behavior returns: anonymous requests, proxy 400 fix-it
+ *  message). */
+export function writeHermesIdentityPlugin(hermesHome: string, providerKeys: string[]): boolean {
+    const dir = path.join(hermesHome, "plugins", "model-providers", "bili-session-identity");
     try {
-        if (fs.existsSync(path.join(hermesHome, "plugins"))) return false;
-    } catch {
-        return false;
-    }
-    const dir = path.join("plugins", "model-providers", "bili-session-identity");
-    try {
-        fs.mkdirSync(path.join(overlay, dir), { recursive: true });
-    } catch {
-        return false;
-    }
-    const keys = rewrites.map((r) => r.key);
-    const pluginDir = path.join(overlay, dir);
-    try {
-        fs.writeFileSync(path.join(pluginDir, "__init__.py"), hermesIdentityPluginSource(keys));
-        fs.writeFileSync(path.join(pluginDir, "plugin.yaml"), [
-        "name: bili-session-identity",
-        "kind: model-provider",
-        "version: 1.0.0",
-        "description: billion-context session identity (installed by `bili hermes` — safe to delete)",
-        "author: billion-context",
-        "",
-    ].join("\n"));
+        fs.mkdirSync(dir, { recursive: true });
+        fs.writeFileSync(path.join(dir, "__init__.py"), hermesIdentityPluginSource(providerKeys));
+        fs.writeFileSync(path.join(dir, "plugin.yaml"), [
+            "name: bili-session-identity",
+            "kind: model-provider",
+            "version: 1.0.0",
+            "description: billion-context session identity (installed by `bili hermes` — safe to delete)",
+            "author: billion-context",
+            "",
+        ].join("\n"));
     } catch {
         return false;
     }
     try {
-        return fs.existsSync(path.join(overlay, dir, "__init__.py"));
+        return fs.existsSync(path.join(dir, "__init__.py"));
     } catch {
         return false;
     }
@@ -1506,13 +1505,16 @@ function hermesIdentityPluginSource(providerKeys: string[]): string {
     ].join("\n");
 }
 
-/** dsh counterpart of prepareHermesHome: a persistent `<dshHome>-bili` overlay
+/** dsh loopback exception (#535): a persistent `<dshHome>-bili` overlay
  *  (every ~/.dsh sibling symlinked so credentials/profiles/sessions stay
- *  shared) holding a rewritten copy of settings.yaml. Every baseURL/baseUrl/
- *  base_url value is rewrapped as origin + "/bili/" + raw upstream — http AND
- *  https alike, since dsh's fetch stack exposes no proxy/CA trust knobs. The
- *  real ~/.dsh is never touched. Returns the overlay dir (undefined when the
- *  settings file is unreadable or nothing is rewritable). */
+ *  shared) holding a rewritten copy of settings.yaml. Only LOOPBACK upstreams
+ *  land here — dsh's unconditional loopback no-proxy bypass makes env routing
+ *  impossible for them, so they keep the /bili/ URL form; every other
+ *  destination rides the proxy env vars instead (see discoverRoutes). Every
+ *  baseURL/baseUrl/base_url value matching a loopback rewrite is rewrapped as
+ *  origin + "/bili/" + raw upstream. The real ~/.dsh is never touched.
+ *  Returns the overlay dir (undefined when the settings file is unreadable or
+ *  nothing is rewritable). */
 export function prepareDshHome(
     dshHome: string,
     origin: string,
@@ -1755,6 +1757,24 @@ export function stripInheritedProxy(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
     return cleaned;
 }
 
+// Clients that route their LLM traffic through bili via the standard proxy
+// env vars (hermes httpx, dsh undici dispatcher) also honor NO_PROXY — and a
+// user's inherited NO_PROXY almost always excludes localhost, which would
+// silently shadow bili's own loopback origin for every local upstream
+// (sglang & co). Strip loopback entries from the child env only; the user's
+// own shell is untouched.
+export function stripLoopbackNoProxy(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+    const out: NodeJS.ProcessEnv = { ...env };
+    for (const key of ["NO_PROXY", "no_proxy"]) {
+        const value = out[key];
+        if (typeof value !== "string" || value.length === 0) continue;
+        const kept = value.split(",").map((s) => s.trim()).filter((s) => s.length > 0 && !isLoopbackHost(s));
+        if (kept.length > 0) out[key] = kept.join(",");
+        else delete out[key];
+    }
+    return out;
+}
+
 function proxyStartArgs(opts: LaunchOptions): string[] {
     const args = ["start", "--host", opts.host, "--port", String(opts.port)];
     if (opts.passthrough) args.push("--passthrough");
@@ -1963,12 +1983,19 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
     // bili's own route graph (same sources the spawned proxy child reads —
     // used to resolve the budget-alignment window, #321).
     const biliRoutes = loadRoutes(process.env);
-    const domains = dedupeInOrder([...routes.httpsDomains, ...(params.mitmDomains ?? [])]);
+    // #535: dsh's built-in deepseek-official route (default
+    // https://api.deepseek.com; user settings/env may point elsewhere) is
+    // captured by MITM-whitelisting the official host instead of wrapping
+    // $DEEPSEEK_BASE_URL — the whitelist entry is inert unless traffic to it
+    // actually flows.
+    const builtinDomains = base === "dsh" ? ["api.deepseek.com"] : [];
+    const domains = dedupeInOrder([...routes.httpsDomains, ...builtinDomains, ...(params.mitmDomains ?? [])]);
     const handle = await ensureProxyRunning({ host, port, passthrough, debug, mitmDomains: domains, modelWindows: collectModelWindows(config, base) }, deps);
     console.error(
         `bili: started proxy at ${handle.origin} (MITM domains: ${domains.length ? domains.join(", ") : "defaults"})` +
             (routes.httpRewrites.length > 0 ? ` (HTTP /bili/ rewrites: ${routes.httpRewrites.length})` : "") +
             (routes.httpsRewrites.length > 0 ? ` (HTTPS cert rewrites: ${routes.httpsRewrites.length})` : "") +
+            (routes.httpEnvRoutes.length > 0 ? ` (HTTP proxy-env routes: ${routes.httpEnvRoutes.length})` : "") +
             (params.client === "pi-test" ? " (no extensions)" : ""),
     );
     if (handle.logPath) {
@@ -1981,7 +2008,6 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
     let piOverlayHome: string | undefined;
     let ompOverlayHome: string | undefined;
     let opencodeTmpFile: string | undefined;
-    let hermesOverlayHome: string | undefined;
     let dshOverlayHome: string | undefined;
     const tmpFiles: string[] = [];
     const directUrl = launcherDirectUrl(process.env);
@@ -2049,44 +2075,56 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
         opencodeTmpFile = prepareOpencodeHttpRewrite(resolveOpencodeConfigFile(process.env), origin, routes.httpRewrites, routes.httpsRewrites, opencodePluginPath);
         if (opencodeTmpFile) env.OPENCODE_CONFIG = opencodeTmpFile;
     } else if (base === "hermes") {
-        // hermes: no plugin, no MITM cert trust (httpx builds its own CA
-        // bundle) — every upstream rides the /bili/ URL form via a persistent
-        // overlay HERMES_HOME (~/.hermes-bili) whose config.yaml is rewritten.
-        // skills/memories/sessions stay shared through symlinks; the real
-        // ~/.hermes is never touched.
-        env = { ...process.env };
-        hermesOverlayHome = prepareHermesHome(resolveHermesHome(process.env), origin, routes.httpRewrites);
-        if (hermesOverlayHome) {
-            env.HERMES_HOME = hermesOverlayHome;
+        // #535 file-free routing: NOTHING in ~/.hermes is rewritten anymore —
+        // hermes keeps writing its own config.yaml however it likes and bili
+        // never owns it. https upstreams ride HTTPS_PROXY + cert-MITM
+        // (whitelisted hosts; HERMES_CA_BUNDLE points at the COMBINED bundle
+        // because hermes replaces its trust store wholesale, so blind-
+        // tunneled hosts still need the system roots inside it); plaintext
+        // http upstreams ride HTTP_PROXY as absolute-form forward-proxy
+        // requests. Inherited NO_PROXY loses its loopback entries so a user's
+        // localhost exclusion can't shadow bili's own loopback origin.
+        env = stripLoopbackNoProxy({
+            ...process.env,
+            HTTPS_PROXY: origin,
+            HERMES_CA_BUNDLE: resolveCombinedCaPath(process.env),
+            ...(routes.httpEnvRoutes.length > 0 ? { HTTP_PROXY: origin } : {}),
+        });
+        if (routes.providerKeys.length > 0) {
             // Session identity for the proxied custom providers: hermes sends
             // no conversation id on the wire, so the proxy 400s anonymous
             // requests (#286). The plugin stamps the real hermes session id as
-            // prompt_cache_key. Skipped (identity stays anonymous) when the
-            // real ~/.hermes already has a plugins/ dir — writing through the
-            // overlay symlink would mutate the user's home.
-            if (!writeHermesIdentityPlugin(resolveHermesHome(process.env), hermesOverlayHome, routes.httpRewrites)) {
+            // prompt_cache_key.
+            if (!writeHermesIdentityPlugin(resolveHermesHome(process.env), routes.providerKeys)) {
                 console.error(
-                    "bili: ~/.hermes has its own plugins/ — skipping the session-identity plugin; hermes requests will be rejected by the proxy without an identity (see #286).",
+                    "bili: could not install the session-identity plugin into ~/.hermes/plugins — hermes requests will be rejected by the proxy without an identity (see #286).",
                 );
             }
         } else {
             console.error(
-                routes.httpRewrites.length === 0
-                    ? "bili: no hermes providers found in ~/.hermes/config.yaml — traffic will NOT go through the proxy (configure a provider first)."
-                    : "bili: hermes config.yaml could not be rewritten (unreadable or no matching provider endpoints) — traffic will NOT go through the proxy.",
+                "bili: no hermes providers found in ~/.hermes/config.yaml — LLM traffic will NOT go through the proxy (configure a provider first).",
             );
         }
     } else if (base === "dsh") {
-        // dsh (deepseek-harness): no plugin surface, no MITM cert trust (plain
-        // fetch) — the built-in deepseek-official route is captured through
-        // $DEEPSEEK_BASE_URL (its resolution order is settings baseURL ?? env
-        // ?? https://api.deepseek.com, so a rewritten user setting wins and
-        // this env is the no-settings fallback). Custom providers in
-        // ~/.dsh/settings.yaml ride a persistent overlay DSH_HOME
-        // (~/.dsh-bili); credentials/profiles/sessions stay shared through
-        // symlinks and the real ~/.dsh is never touched.
-        env = { ...process.env, BILLION_CONTEXT_PROXY: origin };
-        env.DEEPSEEK_BASE_URL = wrapUpstream(origin, "https://api.deepseek.com");
+        // #535: dsh's fetch stack honors the standard proxy env vars —
+        // EXCEPT its loopback no-proxy list is unconditional, so only LOOPBACK
+        // custom providers keep the settings.yaml /bili/ rewrite via a
+        // persistent overlay DSH_HOME (~/.dsh-bili; credentials/profiles/
+        // sessions shared through symlinks, real ~/.dsh untouched). Every
+        // other destination rides env: https via HTTPS_PROXY + cert-MITM
+        // (NODE_EXTRA_CA_CERTS), plaintext http via HTTP_PROXY as absolute-
+        // form forward-proxy requests. The built-in deepseek-official route
+        // is captured by MITM-whitelisting api.deepseek.com (see domains
+        // above) instead of wrapping $DEEPSEEK_BASE_URL — which also stops us
+        // clobbering a user-set DEEPSEEK_BASE_URL. Inherited NO_PROXY loses
+        // its loopback entries for the same reason as hermes above.
+        env = stripLoopbackNoProxy({
+            ...process.env,
+            BILLION_CONTEXT_PROXY: origin,
+            HTTPS_PROXY: origin,
+            NODE_EXTRA_CA_CERTS: ca,
+            ...(routes.httpEnvRoutes.length > 0 ? { HTTP_PROXY: origin } : {}),
+        });
         // Session identity for the proxy: dsh's pi-ai stack keys its
         // `prompt_cache_key` body field (the dsh session id) off
         // cacheRetention — every non-api.openai.com base URL defaults to
@@ -2100,17 +2138,15 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
         // overrides the env fallback).
         env.PI_CACHE_RETENTION = "long";
         const dshHomeDir = resolveDshHome(process.env);
-        dshOverlayHome = prepareDshHome(dshHomeDir, origin, routes.httpRewrites);
-        if (dshOverlayHome) {
-            env.DSH_HOME = dshOverlayHome;
-        } else if (routes.httpRewrites.length > 0) {
-            console.error(
-                "bili: dsh settings.yaml could not be rewritten (unreadable or no matching endpoints) — custom providers will NOT go through the proxy; the built-in deepseek route still does.",
-            );
-        } else {
-            console.error(
-                "bili: no custom providers found in ~/.dsh/settings.yaml — proxying the built-in deepseek route via DEEPSEEK_BASE_URL only.",
-            );
+        if (routes.httpRewrites.length > 0) {
+            dshOverlayHome = prepareDshHome(dshHomeDir, origin, routes.httpRewrites);
+            if (dshOverlayHome) {
+                env.DSH_HOME = dshOverlayHome;
+            } else {
+                console.error(
+                    "bili: dsh settings.yaml could not be rewritten (unreadable or no matching loopback endpoints) — loopback custom providers will NOT go through the proxy.",
+                );
+            }
         }
         // Native /acp command rides a --patch overlay (independent of the
         // settings rewrite above), so it exists on every profile dsh boots.

--- a/src/server.ts
+++ b/src/server.ts
@@ -262,6 +262,19 @@ export function resolveUpstream(_opts: ProxyOptions, reqUrl: string, req?: http.
         const mitmKey = mitmUpstream.replace(/^https:\/\//, "mitm://");
         return { upstream: mitmUpstream, rewrittenUrl: mitmKey + (reqUrl ?? "") };
     }
+    // Forward-proxy mode (#535): a standard absolute-form request line
+    // (`POST http://host/path`) arrives from clients that route their traffic
+    // through us via HTTP_PROXY (hermes's httpx stack). Same routing semantics
+    // as the /bili/ path form below — full pipeline plus #409 destination
+    // admission (tunnel: true), which also rejects self/link-local targets.
+    if (/^https?:\/\//i.test(reqUrl)) {
+        try {
+            const u = new URL(reqUrl);
+            return { upstream: `${u.protocol}//${u.host}`, rewrittenUrl: reqUrl, tunnel: true };
+        } catch {
+            // malformed absolute URL — fall through to no-route passthrough
+        }
+    }
     // Zero-config mode: a request like `/bili/https://open.bigmodel.cn/api/anthropic`
     // embeds the full upstream URL after the `/bili/` prefix. Strip the prefix,
     // take the rest verbatim as the upstream. This is the ONLY routing mode —

--- a/tests/forward-absolute-url.test.ts
+++ b/tests/forward-absolute-url.test.ts
@@ -23,12 +23,14 @@ test("forward: absolute-URL proxy-mode request reaches the correct upstream (no 
 
     let capturedUrl = "";
     let capturedHost = "";
+    let capturedTunnel = "";
     const upstream = http.createServer((req, res) => {
         const chunks: Buffer[] = [];
         req.on("data", (c: Buffer) => chunks.push(c));
         req.on("end", () => {
             capturedUrl = req.url ?? "";
             capturedHost = String(req.headers["host"] ?? "");
+            capturedTunnel = String(req.headers["x-bili-tunnel"] ?? "");
             res.writeHead(200, { "content-type": "application/json" });
             res.end(JSON.stringify({ ok: true }));
         });
@@ -99,8 +101,65 @@ test("forward: absolute-URL proxy-mode request reaches the correct upstream (no 
             upstreamHost,
             `upstream Host header must be the real upstream host, not the default; got "${capturedHost}"`,
         );
+        // #409: absolute-form forwards ride the same destination admission as
+        // /bili/ tunnels, so the management-plane marker must be stamped.
+        assert.equal(capturedTunnel, "1", "tunneled forward must carry the x-bili-tunnel marker");
     } finally {
         await close(proxy);
         await close(upstream);
+    }
+});
+
+test("forward: absolute-form request targeting the proxy itself is denied (#409 admission)", async () => {
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    setRegistryForTest({});
+
+    const opts: ProxyOptions = {
+        port: 0,
+        host: "127.0.0.1",
+        upstream: "https://api.anthropic.com",
+        routes: {},
+        modelContextLimit: 400_000,
+        kernelConfig: defaultConfig(400_000),
+        compress: { injectTool: true, injectNudge: true },
+        promptCache: { routing: "auto" },
+        sessionHeader: "x-acp-session",
+        log: false,
+        debug: false,
+        passthrough: false,
+        autoUpdate: false,
+        mitm: { enabled: false, domains: [] },
+    };
+    const proxy = await startServer(opts);
+    await listen(proxy);
+    const proxyPort = (proxy.address() as { port: number }).port;
+
+    try {
+        const status = await new Promise<number>((resolve, reject) => {
+            const req = http.request(
+                {
+                    host: "127.0.0.1",
+                    port: proxyPort,
+                    method: "POST",
+                    path: `http://127.0.0.1:${proxyPort}/v1/chat/completions`,
+                    headers: {
+                        "content-type": "application/json",
+                        host: `127.0.0.1:${proxyPort}`,
+                        "x-acp-session": "forward-absolute-self-test",
+                        "content-length": "2",
+                    },
+                },
+                (res) => {
+                    res.on("data", () => {});
+                    res.on("end", () => resolve(res.statusCode ?? 0));
+                },
+            );
+            req.on("error", reject);
+            req.write("{}");
+            req.end();
+        });
+        assert.equal(status, 403, "self-destination must be denied by #409 tunnel admission");
+    } finally {
+        await close(proxy);
     }
 });

--- a/tests/launcher.test.ts
+++ b/tests/launcher.test.ts
@@ -16,6 +16,7 @@ import {
     healthUrl,
     wrapUpstream,
     unwrapUpstream,
+    isLoopbackHost,
     buildPiEnv,
     buildCodexEnv,
     buildClaudeEnv,
@@ -24,6 +25,7 @@ import {
     prepareOmpHttpRewrite,
     prepareOpencodeHttpRewrite,
     stripInheritedProxy,
+    stripLoopbackNoProxy,
     resolvePiHome,
     resolveOmpHome,
     extractDomains,
@@ -38,7 +40,6 @@ import {
     parseHermesYaml,
     readHermesConfig,
     resolveHermesHome,
-    prepareHermesHome,
     writeHermesIdentityPlugin,
     parseDshSettingsYaml,
     readDshConfig,
@@ -878,9 +879,10 @@ test("discoverRoutes: pi with one http provider → rewrite keyed by provider na
     ]);
 });
 
-test("discoverRoutes: empty config → {httpsDomains:[], httpRewrites:[]}", () => {
-    assert.deepEqual(discoverRoutes("pi", {}), { httpsDomains: [], httpRewrites: [], httpsRewrites: [] });
-    assert.deepEqual(discoverRoutes("codex", {}), { httpsDomains: [], httpRewrites: [], httpsRewrites: [] });
+test("discoverRoutes: empty config → all route lists empty", () => {
+    const empty = { httpsDomains: [], httpRewrites: [], httpsRewrites: [], httpEnvRoutes: [], providerKeys: [] };
+    assert.deepEqual(discoverRoutes("pi", {}), empty);
+    assert.deepEqual(discoverRoutes("codex", {}), empty);
 });
 
 test("discoverRoutes: codex /bili/-wrapped HTTPS provider → httpsRewrites to raw upstream", () => {
@@ -1768,7 +1770,7 @@ test("readHermesConfig + resolveHermesHome", () => {
     }
 });
 
-test("discoverRoutes: hermes wraps http AND https via /bili/ (no MITM domains)", () => {
+test("discoverRoutes: hermes splits https→MITM domains, http→proxy-env routes, keys every provider (#535)", () => {
     const config: ClientConfig = {};
     (config as Record<string, unknown>).hermes = {
         providers: {
@@ -1779,143 +1781,60 @@ test("discoverRoutes: hermes wraps http AND https via /bili/ (no MITM domains)",
         },
     };
     const routes = discoverRoutes("hermes", config);
-    assert.deepEqual(routes.httpsDomains, []);
-    assert.deepEqual(routes.httpRewrites.map((r) => r.key).sort(), ["glm", "sglang", "wrapped"]);
-    const glm = routes.httpRewrites.find((r) => r.key === "glm");
-    assert.equal(glm?.realUpstream, "https://open.bigmodel.cn/api/paas/v4");
-    const wrapped = routes.httpRewrites.find((r) => r.key === "wrapped");
-    assert.equal(wrapped?.realUpstream, "https://api.foo.io/v1");
+    // https upstreams ride HTTPS_PROXY cert-MITM (host whitelisted), legacy
+    // /bili/ wraps self-heal back to their raw upstream.
+    assert.deepEqual(routes.httpsDomains, ["open.bigmodel.cn", "api.foo.io"]);
+    // plaintext http upstreams ride HTTP_PROXY absolute-form — no rewrite at all.
+    assert.deepEqual(routes.httpEnvRoutes, ["http://127.0.0.1:8199/v1"]);
+    // identity plugin must register a profile per named provider it fronts.
+    assert.deepEqual(routes.providerKeys, ["sglang", "glm", "wrapped"]);
+    assert.deepEqual(routes.httpRewrites, []);
 });
 
-test("prepareHermesHome: rewrites api lines, shares siblings, never touches the real home", () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "hermes-home-"));
-    try {
-        fs.writeFileSync(path.join(dir, "config.yaml"), [
-            "model:",
-            "  default: qwen3.8-27b",
-            "providers:",
-            "  bili:",
-            "    api: http://127.0.0.1:8199/v1  # local sglang",
-            "  glm:",
-            "    api: https://open.bigmodel.cn/api/paas/v4",
-            "custom_providers:",
-            "  - name: legacy",
-            "    base_url: http://10.0.0.5:1234/v1",
-        ].join("\n"));
-        fs.writeFileSync(path.join(dir, "SOUL.md"), "soul");
-        fs.mkdirSync(path.join(dir, "skills"));
-        const original = fs.readFileSync(path.join(dir, "config.yaml"), "utf8");
-
-        const rewrites: HttpRewrite[] = [
-            { key: "bili", realUpstream: "http://127.0.0.1:8199/v1" },
-            { key: "glm", realUpstream: "https://open.bigmodel.cn/api/paas/v4" },
-            { key: "legacy", realUpstream: "http://10.0.0.5:1234/v1" },
-        ];
-        const tmp = prepareHermesHome(dir, "http://127.0.0.1:8787", rewrites);
-        assert.ok(tmp);
-        const txt = fs.readFileSync(path.join(tmp, "config.yaml"), "utf8");
-        assert.ok(txt.includes("api: http://127.0.0.1:8787/bili/http://127.0.0.1:8199/v1  # local sglang"));
-        assert.ok(txt.includes("api: http://127.0.0.1:8787/bili/https://open.bigmodel.cn/api/paas/v4"));
-        assert.ok(txt.includes("base_url: http://127.0.0.1:8787/bili/http://10.0.0.5:1234/v1"));
-        assert.equal(fs.readFileSync(path.join(dir, "config.yaml"), "utf8"), original);
-        assert.equal(fs.readFileSync(path.join(tmp, "SOUL.md"), "utf8"), "soul");
-        assert.ok(fs.lstatSync(path.join(tmp, "skills")).isSymbolicLink());
-        fs.rmSync(tmp, { recursive: true, force: true });
-
-        assert.equal(prepareHermesHome(dir, "http://127.0.0.1:8787", []), undefined);
-    } finally {
-        fs.rmSync(dir, { recursive: true, force: true });
+test("isLoopbackHost: recognizes loopback forms, rejects everything else", () => {
+    for (const h of ["localhost", "LOCALHOST", "::1", "[::1]", "127.0.0.1", "127.5.6.7"]) {
+        assert.equal(isLoopbackHost(h), true, h);
+    }
+    for (const h of ["1270.0.0.1", "10.0.0.1", "192.168.1.1", "open.bigmodel.cn", ""]) {
+        assert.equal(isLoopbackHost(h), false, h);
     }
 });
 
-test("prepareHermesHome: preserves CRLF line endings when rewriting", () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "hermes-home-"));
-    try {
-        fs.writeFileSync(
-            path.join(dir, "config.yaml"),
-            ["model:", "  default: qwen3.8-27b", "providers:", "  bili:", "    api: http://127.0.0.1:8199/v1"].join("\r\n") + "\r\n",
-        );
-        const rewrites: HttpRewrite[] = [{ key: "bili", realUpstream: "http://127.0.0.1:8199/v1" }];
-        const tmp = prepareHermesHome(dir, "http://127.0.0.1:8787", rewrites);
-        assert.ok(tmp);
-        const txt = fs.readFileSync(path.join(tmp, "config.yaml"), "utf8");
-        assert.ok(txt.includes("\r\n"), "CRLF preserved");
-        assert.ok(!/\r\n\r\n/.test(txt), "no doubled newlines");
-        assert.ok(txt.includes("api: http://127.0.0.1:8787/bili/http://127.0.0.1:8199/v1\r"));
-        fs.rmSync(tmp, { recursive: true, force: true });
-    } finally {
-        fs.rmSync(dir, { recursive: true, force: true });
-    }
+test("stripLoopbackNoProxy: drops loopback entries only, deletes emptied vars, leaves user shell untouched", () => {
+    // The launcher strips loopback entries from the CHILD env so an inherited
+    // NO_PROXY=localhost can't shadow bili's own loopback origin (#535).
+    let env = stripLoopbackNoProxy({ NO_PROXY: "localhost, .internal, 127.0.0.1,example.com" } as NodeJS.ProcessEnv);
+    assert.equal(env.NO_PROXY, ".internal,example.com");
+    env = stripLoopbackNoProxy({ no_proxy: "::1,[::1],foo" } as NodeJS.ProcessEnv);
+    assert.equal(env.no_proxy, "foo");
+    env = stripLoopbackNoProxy({ NO_PROXY: "localhost,127.0.0.1" } as NodeJS.ProcessEnv);
+    assert.equal(env.NO_PROXY, undefined);
+    assert.deepEqual(stripLoopbackNoProxy({} as NodeJS.ProcessEnv), {});
+    const input = { NO_PROXY: "localhost" } as NodeJS.ProcessEnv;
+    stripLoopbackNoProxy(input);
+    assert.equal(input.NO_PROXY, "localhost", "input env object is not mutated");
 });
 
-test("prepareHermesHome: returns undefined for unreadable config even with rewrites pending", () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "hermes-home-"));
-    try {
-        const rewrites: HttpRewrite[] = [{ key: "bili", realUpstream: "http://127.0.0.1:8199/v1" }];
-        assert.equal(prepareHermesHome(dir, "http://127.0.0.1:8787", rewrites), undefined);
-    } finally {
-        fs.rmSync(dir, { recursive: true, force: true });
-    }
-});
-
-test("prepareHermesHome: rewrites quoted YAML api values (quotes stripped before match)", () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "hermes-home-"));
-    try {
-        fs.writeFileSync(path.join(dir, "config.yaml"), [
-            "providers:",
-            "  bili:",
-            '    api: "https://api.example.com/v1"',
-            "  glm:",
-            "    api: 'http://10.0.0.5:1234/v1'",
-        ].join("\n"));
-        const rewrites: HttpRewrite[] = [
-            { key: "bili", realUpstream: "https://api.example.com/v1" },
-            { key: "glm", realUpstream: "http://10.0.0.5:1234/v1" },
-        ];
-        const tmp = prepareHermesHome(dir, "http://127.0.0.1:8787", rewrites);
-        assert.ok(tmp, "quoted values must still be rewritten");
-        const txt = fs.readFileSync(path.join(tmp!, "config.yaml"), "utf8");
-        assert.ok(txt.includes("api: http://127.0.0.1:8787/bili/https://api.example.com/v1"));
-        assert.ok(txt.includes("api: http://127.0.0.1:8787/bili/http://10.0.0.5:1234/v1"));
-        fs.rmSync(tmp!, { recursive: true, force: true });
-    } finally {
-        fs.rmSync(dir, { recursive: true, force: true });
-    }
-});
-
-test("writeHermesIdentityPlugin: drops the identity plugin into the overlay, keyed by provider names", () => {
+test("writeHermesIdentityPlugin: installs into the REAL home (#535 zero-file), keyed by provider names", () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "hermes-home-"));
     try {
         fs.writeFileSync(path.join(dir, "config.yaml"), "providers:\n  bili:\n    api: https://api.example.com/v1\n");
-        const rewrites: HttpRewrite[] = [{ key: "bili", realUpstream: "https://api.example.com/v1" }];
-        const overlay = prepareHermesHome(dir, "http://127.0.0.1:8787", rewrites);
-        assert.ok(overlay);
-        assert.equal(writeHermesIdentityPlugin(dir, overlay!, rewrites), true);
-        const init = fs.readFileSync(path.join(overlay!, "plugins/model-providers/bili-session-identity/__init__.py"), "utf8");
+        assert.equal(writeHermesIdentityPlugin(dir, ["bili"]), true);
+        const init = fs.readFileSync(path.join(dir, "plugins/model-providers/bili-session-identity/__init__.py"), "utf8");
         assert.ok(init.includes('_PROVIDER_KEYS = ["bili"]'));
         assert.ok(init.includes('_register("custom", _custom, True)'));
         assert.ok(init.includes('_register("custom:" + _key, _custom, False)'));
         assert.ok(init.includes('top_level.setdefault("prompt_cache_key", sid[:64])'));
-        assert.ok(fs.existsSync(path.join(overlay!, "plugins/model-providers/bili-session-identity/plugin.yaml")));
+        assert.ok(fs.existsSync(path.join(dir, "plugins/model-providers/bili-session-identity/plugin.yaml")));
         // Idempotent rewrite on the next launch.
-        assert.equal(writeHermesIdentityPlugin(dir, overlay!, rewrites), true);
-        fs.rmSync(overlay!, { recursive: true, force: true });
-    } finally {
-        fs.rmSync(dir, { recursive: true, force: true });
-    }
-});
-
-test("writeHermesIdentityPlugin: skipped when the real home has its own plugins dir", () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "hermes-home-"));
-    try {
-        fs.writeFileSync(path.join(dir, "config.yaml"), "providers:\n  bili:\n    api: https://api.example.com/v1\n");
-        fs.mkdirSync(path.join(dir, "plugins"), { recursive: true });
-        const rewrites: HttpRewrite[] = [{ key: "bili", realUpstream: "https://api.example.com/v1" }];
-        const overlay = prepareHermesHome(dir, "http://127.0.0.1:8787", rewrites);
-        assert.ok(overlay);
-        assert.equal(writeHermesIdentityPlugin(dir, overlay!, rewrites), false);
-        assert.ok(!fs.existsSync(path.join(overlay!, "plugins", "model-providers")));
-        fs.rmSync(overlay!, { recursive: true, force: true });
+        assert.equal(writeHermesIdentityPlugin(dir, ["bili"]), true);
+        // Coexists with user plugins elsewhere in the same plugins/ tree and
+        // picks up newly discovered provider keys on re-install.
+        fs.mkdirSync(path.join(dir, "plugins/my-custom"), { recursive: true });
+        assert.equal(writeHermesIdentityPlugin(dir, ["bili", "other"]), true);
+        const init2 = fs.readFileSync(path.join(dir, "plugins/model-providers/bili-session-identity/__init__.py"), "utf8");
+        assert.ok(init2.includes('_PROVIDER_KEYS = ["bili","other"]'));
+        assert.ok(fs.existsSync(path.join(dir, "plugins/my-custom")));
     } finally {
         fs.rmSync(dir, { recursive: true, force: true });
     }
@@ -1957,24 +1876,25 @@ test("readDshConfig + resolveDshHome + parseDshSettingsYaml", () => {
     }
 });
 
-test("discoverRoutes: dsh wraps every settings.yaml endpoint via /bili/", () => {
+test("discoverRoutes: dsh splits loopback→settings rewrite, https→MITM, http→proxy-env (#535)", () => {
     const config: ClientConfig = {};
     (config as Record<string, unknown>).dsh = {
         baseUrls: [
             "http://127.0.0.1:8199/v1",
             "https://open.bigmodel.cn/api/paas/v4",
+            "http://10.0.0.5:1234/v1",
             "http://127.0.0.1:8787/bili/https://api.foo.io/v1",
             "http://127.0.0.1:8199/v1",
             "::::",
         ],
     };
     const routes = discoverRoutes("dsh", config);
-    assert.deepEqual(routes.httpsDomains, []);
-    assert.deepEqual(routes.httpRewrites.map((r) => r.realUpstream).sort(), [
-        "http://127.0.0.1:8199/v1",
-        "https://api.foo.io/v1",
-        "https://open.bigmodel.cn/api/paas/v4",
-    ]);
+    // Loopback keeps the settings.yaml /bili/ rewrite — dsh's loopback
+    // no-proxy bypass is unconditional, env routing can't reach it.
+    assert.deepEqual(routes.httpRewrites.map((r) => r.realUpstream), ["http://127.0.0.1:8199/v1"]);
+    // Everything else rides env vars; legacy /bili/ wraps self-heal to raw.
+    assert.deepEqual(routes.httpsDomains, ["open.bigmodel.cn", "api.foo.io"]);
+    assert.deepEqual(routes.httpEnvRoutes, ["http://10.0.0.5:1234/v1"]);
 });
 
 test("prepareDshHome: rewrites baseURL lines, shares siblings, never touches the real home", () => {
@@ -2075,7 +1995,7 @@ test("prepareDshHome: returns undefined for unreadable settings even with rewrit
     }
 });
 
-test("runLaunch dsh: DSH_HOME overlay + DEEPSEEK_BASE_URL env, real home untouched", async () => {
+test("runLaunch dsh: loopback-only settings overlay + proxy envs, real home untouched (#535)", async () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "bili-dsh-launch-"));
     const prevBin = process.env.BILI_CLIENT_BIN;
     const prevDshHome = process.env.DSH_HOME;
@@ -2088,6 +2008,8 @@ test("runLaunch dsh: DSH_HOME overlay + DEEPSEEK_BASE_URL env, real home untouch
             "  providers:",
             "    anthropic:",
             "      baseURL: https://api.anthropic.com",
+            "    sglang:",
+            "      baseURL: http://127.0.0.1:8199/v1",
         ].join("\n"),
     );
     fs.mkdirSync(path.join(dshHome, "profiles"));
@@ -2099,6 +2021,7 @@ test("runLaunch dsh: DSH_HOME overlay + DEEPSEEK_BASE_URL env, real home untouch
 
     const envSeen: NodeJS.ProcessEnv[] = [];
     const argsSeen: string[][] = [];
+    const proxyEnvs: (NodeJS.ProcessEnv | undefined)[] = [];
     const spawnImpl: SpawnFn = (cmd, args, options) => {
         if (cmd === fakeDsh) {
             if (options?.env) envSeen.push(options.env);
@@ -2112,6 +2035,7 @@ test("runLaunch dsh: DSH_HOME overlay + DEEPSEEK_BASE_URL env, real home untouch
             };
             return child;
         }
+        proxyEnvs.push((options as { env?: NodeJS.ProcessEnv } | undefined)?.env);
         return makeFakeChild(42423);
     };
 
@@ -2133,7 +2057,16 @@ test("runLaunch dsh: DSH_HOME overlay + DEEPSEEK_BASE_URL env, real home untouch
         const seenEnv = envSeen[0];
         const origin = seenEnv.BILLION_CONTEXT_PROXY;
         assert.ok(/^http:\/\/127\.0\.0\.1:\d+$/.test(String(origin)));
-        assert.equal(seenEnv.DEEPSEEK_BASE_URL, `${origin}/bili/https://api.deepseek.com`);
+        // #535: no more $DEEPSEEK_BASE_URL wrap — the built-in deepseek route
+        // is MITM-whitelisted instead (asserted below via proxyEnvs), and all
+        // other traffic rides the standard proxy env vars.
+        assert.equal(seenEnv.DEEPSEEK_BASE_URL, undefined);
+        assert.equal(seenEnv.HTTPS_PROXY, origin);
+        assert.ok(String(seenEnv.NODE_EXTRA_CA_CERTS).endsWith(path.join("billion-context", "ca", "root-ca.pem")));
+        assert.equal(seenEnv.HTTP_PROXY, undefined, "no plaintext-http upstreams in this fixture");
+        const mitmDomains = String(proxyEnvs.find((e) => e)?.BILI_MITM_DOMAINS ?? "");
+        assert.ok(mitmDomains.split(",").includes("api.anthropic.com"), mitmDomains);
+        assert.ok(mitmDomains.split(",").includes("api.deepseek.com"), mitmDomains);
         // Session identity for the proxy: forces dsh's pi-ai stack to stamp
         // prompt_cache_key (the dsh session id) on every request.
         assert.equal(seenEnv.PI_CACHE_RETENTION, "long");
@@ -2143,7 +2076,10 @@ test("runLaunch dsh: DSH_HOME overlay + DEEPSEEK_BASE_URL env, real home untouch
         const overlay = `${dshHome}-bili`;
         assert.ok(fs.existsSync(path.join(overlay, "settings.yaml")));
         const overlayTxt = fs.readFileSync(path.join(overlay, "settings.yaml"), "utf8");
-        assert.ok(overlayTxt.includes(`baseURL: ${origin}/bili/https://api.anthropic.com`));
+        // Only the loopback upstream gets the /bili/ rewrite (documented #535
+        // exception); the remote https host stays raw — it rides HTTPS_PROXY MITM.
+        assert.ok(overlayTxt.includes(`baseURL: ${origin}/bili/http://127.0.0.1:8199/v1`));
+        assert.ok(overlayTxt.includes("baseURL: https://api.anthropic.com"));
         assert.ok(fs.lstatSync(path.join(overlay, "profiles")).isSymbolicLink());
         // /acp command injection: --patch flag spliced before user args, and
         // the patch overlay file exists pointing at our bundled cordis plugin.
@@ -2160,6 +2096,89 @@ test("runLaunch dsh: DSH_HOME overlay + DEEPSEEK_BASE_URL env, real home untouch
         else process.env.BILI_CLIENT_BIN = prevBin;
         if (prevDshHome === undefined) delete process.env.DSH_HOME;
         else process.env.DSH_HOME = prevDshHome;
+        fs.rmSync(home, { recursive: true, force: true });
+    }
+});
+
+test("runLaunch hermes: proxy envs + real-home identity plugin, no HERMES_HOME overlay (#535)", async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "bili-hermes-launch-"));
+    const prevBin = process.env.BILI_CLIENT_BIN;
+    const prevHermesHome = process.env.HERMES_HOME;
+    const prevNoProxy = process.env.NO_PROXY;
+    const hermesHome = path.join(home, ".hermes");
+    fs.mkdirSync(hermesHome);
+    fs.writeFileSync(
+        path.join(hermesHome, "config.yaml"),
+        [
+            "providers:",
+            "  glm:",
+            "    api: https://open.bigmodel.cn/api/paas/v4",
+            "  sglang:",
+            "    api: http://127.0.0.1:8199/v1",
+        ].join("\n"),
+    );
+    const original = fs.readFileSync(path.join(hermesHome, "config.yaml"), "utf8");
+    const fakeHermes = path.join(home, "fake-hermes");
+    fs.writeFileSync(fakeHermes, "");
+    process.env.BILI_CLIENT_BIN = fakeHermes;
+    process.env.HERMES_HOME = hermesHome;
+    // Inherited NO_PROXY with a loopback entry must not survive into the child
+    // env or it would shadow bili's own loopback origin for sglang.
+    process.env.NO_PROXY = "localhost,.corp";
+
+    const envSeen: NodeJS.ProcessEnv[] = [];
+    const spawnImpl: SpawnFn = (cmd, args, options) => {
+        if (cmd === fakeHermes) {
+            if (options?.env) envSeen.push(options.env);
+            const child = makeFakeChild(0);
+            const orig = child.on.bind(child);
+            (child as { on: SpawnChild["on"] }).on = (event, listener) => {
+                orig(event, listener);
+                if (event === "exit") setTimeout(() => listener(0, null), 0);
+                return child;
+            };
+            return child;
+        }
+        return makeFakeChild(42424);
+    };
+
+    const prevExit = process.exit;
+    const exitCalls: number[] = [];
+    process.exit = ((code?: number) => {
+        exitCalls.push(code ?? 0);
+        return undefined as never;
+    }) as typeof process.exit;
+
+    try {
+        await runLaunch(
+            { client: "hermes", clientArgs: [], overrides: {} },
+            // hermetic: never attach to / handshake against a real proxy
+            // whose instance file happens to live on this machine
+            { fetchImpl: async () => ({ ok: true }), spawnImpl, sleep: () => Promise.resolve(), readInstanceFile: () => undefined },
+        );
+        assert.equal(envSeen.length, 1);
+        const seenEnv = envSeen[0];
+        const origin = String(seenEnv.HTTPS_PROXY);
+        assert.ok(/^http:\/\/127\.0\.0\.1:\d+$/.test(origin));
+        assert.equal(seenEnv.HTTP_PROXY, origin, "plaintext-http upstream present → HTTP_PROXY set");
+        assert.ok(String(seenEnv.HERMES_CA_BUNDLE).endsWith(path.join("billion-context", "ca", "combined-ca.pem")));
+        assert.equal(seenEnv.NO_PROXY, ".corp", "loopback entries stripped from child NO_PROXY");
+        // Zero-file: no overlay home, config.yaml byte-identical in place.
+        assert.equal(seenEnv.HERMES_HOME, hermesHome);
+        assert.ok(!fs.existsSync(`${hermesHome}-bili`));
+        assert.equal(fs.readFileSync(path.join(hermesHome, "config.yaml"), "utf8"), original);
+        // Session identity installed into the REAL home for every provider.
+        const init = fs.readFileSync(path.join(hermesHome, "plugins/model-providers/bili-session-identity/__init__.py"), "utf8");
+        assert.ok(init.includes('_PROVIDER_KEYS = ["glm","sglang"]'));
+        assert.deepEqual(exitCalls, [0]);
+    } finally {
+        process.exit = prevExit;
+        if (prevBin === undefined) delete process.env.BILI_CLIENT_BIN;
+        else process.env.BILI_CLIENT_BIN = prevBin;
+        if (prevHermesHome === undefined) delete process.env.HERMES_HOME;
+        else process.env.HERMES_HOME = prevHermesHome;
+        if (prevNoProxy === undefined) delete process.env.NO_PROXY;
+        else process.env.NO_PROXY = prevNoProxy;
         fs.rmSync(home, { recursive: true, force: true });
     }
 });


### PR DESCRIPTION
## What

Continues #535 (注入零文件化) after PR #536 (phase 1, pi). Three commits:

1. **`feat: absolute-form http forward-proxy requests ride the full pipeline`** (src/server.ts)
   `resolveUpstream` now recognizes standard forward-proxy request lines (`POST http://host/path`) and routes them exactly like the `/bili/` absolute-URL form: full compression pipeline + `tunnel: true`, so #409 destination admission applies (self/link-local denied, private per client locality). Malformed URLs fall through to passthrough. This is what lets hermes's httpx stack route plaintext-http upstreams through bili via `HTTP_PROXY`.

2. **`feat: hermes/dsh zero-file injection`** (src/launcher.ts + tests)
   - **hermes**: `prepareHermesHome` / `HERMES_HOME` overlay deleted. https upstream hosts are MITM-whitelisted (`HTTPS_PROXY` + `HERMES_CA_BUNDLE` → `combined-ca.pem`, since httpx builds its own bundle from that env — combined keeps system roots for blind-tunnelled hosts); plaintext-http upstreams ride `HTTP_PROXY` (absolute-form). Inherited `NO_PROXY` is loopback-sanitized in the child env so local sglang still reaches bili. The session-identity plugin (#286) is installed **idempotently into the real** `~/.hermes/plugins/model-providers/bili-session-identity/` (bili-owned subdir, coexists with user plugins; old skip-on-user-plugins guard removed).
   - **dsh**: split by destination. Non-loopback https → MITM whitelist; non-loopback plaintext-http → `HTTP_PROXY`; built-in deepseek route captured by whitelisting `api.deepseek.com` instead of clobbering `$DEEPSEEK_BASE_URL`. **Loopback destinations keep the legacy `settings.yaml` overlay rewrite** — documented exception: dsh bypasses proxies for localhost/127.0.0.1/::1 unconditionally (`LOOPBACK_NO_PROXY`, "the bypass is not optional"), so no env route exists there.
   - New exported helpers: `isLoopbackHost`, `stripLoopbackNoProxy`. `DiscoveredRoutes` += `httpEnvRoutes` / `providerKeys`.
   - Tests: hermes/dsh discoverRoutes split coverage, helper unit tests, real-home identity-plugin test, runLaunch env assertions for both clients (incl. NO_PROXY sanitize + MITM domain lists), forward-absolute-url test extended with `x-bili-tunnel` marker assertion + self-destination 403 case.

3. **`docs:`** EN+ZH launcher one-liners, redirect table, discovery table, temp-config bullets; injection-priority note (env > CLI/extension API > generated files) next to "Two compression modes".

## Deliberately NOT in this PR

- **omp** stays on its current mechanism — blocked on the omp upstream PR adding `reason`/`willRetry` to `SessionBeforeCompactEvent` (per issue; #533 also still open and touches that region).
- **pi doc lines** in CONFIGURATION.md/README left as-is on master — PR #536 owns them.
- **refreshOverlayHome is not deleted** — still used by omp + dsh-loopback. Full abolition lands when those two exceptions resolve.

## Ordering note

Best merged **after #536** (doc hunks are adjacent but disjoint; code hunks don't overlap). Based on master fadfcdd.

## Pre-flight

- `npm run typecheck` clean
- `npm test`: 1036/1037 — sole failure is the pre-existing sandbox-only `resolveClientCommand: codex/claude resolve to themselves` (sandbox has /usr/bin/codex), present on pristine master
- `npm run build` OK