### PR TITLE
fix(#541): hoist TextDecoder out of SSE read loops in all three adapters

### DIFF
--- a/src/loop/adapter-anthropic.ts
+++ b/src/loop/adapter-anthropic.ts
@@ -18,6 +18,7 @@ interface ToolUseBuffer {
 
 async function* iterSseEvents(stream: ReadableStream<Uint8Array>): AsyncGenerator<string> {
     const reader = stream.getReader();
+    const decoder = new TextDecoder();
     let buf = "";
     try {
         while (true) {
@@ -29,7 +30,7 @@ async function* iterSseEvents(stream: ReadableStream<Uint8Array>): AsyncGenerato
                 break;
             }
             if (done) break;
-            buf += new TextDecoder().decode(value, { stream: true });
+            buf += decoder.decode(value, { stream: true });
             buf = buf.replace(/\r\n|\r/g, "\n");
             let idx: number;
             while ((idx = buf.indexOf("\n\n")) >= 0) {

--- a/src/loop/adapter-openai.ts
+++ b/src/loop/adapter-openai.ts
@@ -59,6 +59,7 @@ interface ToolCallBuffer {
 
 async function* iterSseChunks(stream: ReadableStream<Uint8Array>): AsyncGenerator<string> {
     const reader = stream.getReader();
+    const decoder = new TextDecoder();
     let buf = "";
     try {
         while (true) {
@@ -70,7 +71,7 @@ async function* iterSseChunks(stream: ReadableStream<Uint8Array>): AsyncGenerato
                 break;
             }
             if (done) break;
-            buf += new TextDecoder().decode(value, { stream: true });
+            buf += decoder.decode(value, { stream: true });
             buf = buf.replace(/\r\n|\r/g, "\n");
             let idx: number;
             while ((idx = buf.indexOf("\n\n")) >= 0) {

--- a/src/loop/adapter-responses.ts
+++ b/src/loop/adapter-responses.ts
@@ -143,6 +143,7 @@ function rebuildResponsesEvent(type: string, obj: Record<string, unknown>): Buff
 
 async function* iterSseEvents(stream: ReadableStream<Uint8Array>): AsyncGenerator<string> {
     const reader = stream.getReader();
+    const decoder = new TextDecoder();
     let buf = "";
     try {
         while (true) {
@@ -154,7 +155,7 @@ async function* iterSseEvents(stream: ReadableStream<Uint8Array>): AsyncGenerato
                 break;
             }
             if (done) break;
-            buf += new TextDecoder().decode(value, { stream: true });
+            buf += decoder.decode(value, { stream: true });
             buf = buf.replace(/\r\n|\r/g, "\n");
             let idx: number;
             while ((idx = buf.indexOf("\n\n")) >= 0) {

--- a/tests/loop-adapters.test.ts
+++ b/tests/loop-adapters.test.ts
@@ -579,6 +579,70 @@ test("F7: anthropic buildRequest preserves client system + cache_control + merge
     assert.ok(hasCc, "cache_control marker preserved on system block (Anthropic prefix-cache anchor)");
 });
 
+function byteStream(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
+    return new ReadableStream<Uint8Array>({
+        start(controller) {
+            for (const c of chunks) controller.enqueue(c);
+            controller.close();
+        },
+    });
+}
+
+function splitAfterLeadByte(full: Uint8Array, ch: string): [Uint8Array, Uint8Array] {
+    const needle = new TextEncoder().encode(ch);
+    let off = -1;
+    for (let i = 0; i + needle.length <= full.length && off < 0; i++) {
+        let match = true;
+        for (let j = 0; j < needle.length; j++) {
+            if (full[i + j] !== needle[j]) { match = false; break; }
+        }
+        if (match) off = i;
+    }
+    assert.ok(off >= 0, `bytes of ${ch} found in payload`);
+    return [full.slice(0, off + 1), full.slice(off + 1)];
+}
+
+async function cjkChunkSplitRoundTrip(
+    name: string,
+    adapter: ReturnType<typeof createResponsesAdapter> | ReturnType<typeof createOpenaiAdapter> | ReturnType<typeof createAnthropicAdapter>,
+    payload: string,
+): Promise<void> {
+    const [c1, c2] = splitAfterLeadByte(new TextEncoder().encode(payload), "留");
+    const events = await collectParseEvents(adapter, byteStream([c1, c2]), 1);
+    let text = "";
+    for (const ev of events) {
+        if (ev.kind === "text") text += ev.delta;
+    }
+    assert.equal(text, "残留", `${name}: multi-byte CJK split across chunk boundary round-trips intact`);
+    assert.ok(!text.includes("\uFFFD"), `${name}: no U+FFFD replacement characters`);
+}
+
+test("F8 (#541): responses adapter — CJK char split across SSE chunk boundary decodes intact (no U+FFFD)", async () => {
+    const payload = sseLf("response.output_text.delta", {
+        type: "response.output_text.delta",
+        item_id: "m1",
+        output_index: 0,
+        delta: "残留",
+    });
+    await cjkChunkSplitRoundTrip("responses", createResponsesAdapter(), payload);
+});
+
+test("F8 (#541): openai adapter — CJK char split across SSE chunk boundary decodes intact (no U+FFFD)", async () => {
+    const payload =
+        `data: ${JSON.stringify({ id: "c1", object: "chat.completion.chunk", created: 1, model: "gpt", choices: [{ index: 0, delta: { content: "残留" }, finish_reason: null }] })}\n\n` +
+        `data: [DONE]\n\n`;
+    await cjkChunkSplitRoundTrip("openai", createOpenaiAdapter({ model: "gpt" }), payload);
+});
+
+test("F8 (#541): anthropic adapter — CJK char split across SSE chunk boundary decodes intact (no U+FFFD)", async () => {
+    const payload = sseLf("content_block_delta", {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text: "残留" },
+    });
+    await cjkChunkSplitRoundTrip("anthropic", createAnthropicAdapter({ model: "claude" }), payload);
+});
+
 test("openai emitCompletion: usage with absent token counts still serializes complete numeric fields (#dsh)", () => {
     const adapter = createOpenaiAdapter({ model: "deepseek-v4-flash" });
     const out = adapter.emitCompletion({ finishReason: "stop", usage: { inputTokens: undefined, outputTokens: undefined } }).toString("utf8");


### PR DESCRIPTION
## What

`iterSseChunks` (openai), `iterSseEvents` (anthropic) and `iterSseEvents` (responses) each created a **new `TextDecoder` inside their read loop**. With `{ stream: true }`, an incomplete multi-byte UTF-8 sequence is held in the decoder instance's internal buffer — which was discarded every iteration. The next chunk's orphan continuation bytes (0x80–0xBF) then decoded as U+FFFD, corrupting exactly one CJK character per boundary split (issue #541: random 1–2 U+FFFD mid-character in compressed long sessions).

Fix: hoist `const decoder = new TextDecoder()` out of the loop in all three adapters — same pattern already used by `observeSseTerminalState` (`src/stream-terminal.ts:40`) and both SSE loops in `src/plugin.ts`. One line net effect per site.

## Sites

- `src/loop/adapter-openai.ts` — `iterSseChunks`
- `src/loop/adapter-anthropic.ts` — `iterSseEvents`
- `src/loop/adapter-responses.ts` — `iterSseEvents`

A repo-wide scan confirmed these are the only in-loop decoders (`stream-terminal.ts` and `plugin.ts` were already correct).

## Regression tests

New F8 tests in `tests/loop-adapters.test.ts`: for each adapter, build a real SSE payload containing CJK text (`残留`), encode to bytes, split the stream into two chunks right after the lead byte of the second character (worst case: two orphan continuation bytes), run through `parseStream`, and assert the text round-trips exactly with no U+FFFD.

Verified the guard bites: with the fix stashed, all three F8 tests fail (`残留` → `残\uFFFD\uFFFD`); with the fix, they pass.

## Pre-flight

- `npm run typecheck` — pass
- `npm test` — 1034/1035 pass; the single failure (`launcher.test.ts` "resolveClientCommand: codex/claude resolve to themselves") is pre-existing in this environment (sandbox has `/usr/bin/codex`, test expects bare `codex`) — reproduced identically on pristine master without this change
- `npm run build` — pass
- E2E (`tests/e2e/e2e-codex.test.ts`): preflight (`E2E_CHECK=1`) passes; full run blocked here because the default local sglang upstream (127.0.0.1:8199) is not running in this sandbox — `ECONNREFUSED` on forward, reproduced identically on pristine master (A/B verified). Needs the manual-dispatch CI or a machine with the local upstream up.