### PR TITLE
hermes/omp file-free routing (#535 phases 2+3) — re-target to master

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,9 +155,9 @@ and blind-tunnel everything else.
 bili pi                               # launch pi through the proxy — file-free (#535): env + extension registerProvider, real ~/.pi untouched
 bili codex                            # launch codex through the proxy
 bili claude                           # launch claude through the proxy
-bili omp                              # pi-style: MITM env + persistent overlay home (~/.omp/agent-bili, real config untouched)
+bili omp                              # pi-style, file-free (#535): env + extension registerProvider + compaction cancel, real ~/.omp untouched
 bili opencode                         # MITM for HTTPS + temp opencode.json (/bili/ for HTTP) + thin /acp plugin
-bili hermes                           # no MITM possible (certifi CA) — persistent overlay home (~/.hermes-bili), all traffic /bili/
+bili hermes                           # file-free (#535): hermes proxy env (HTTPS_PROXY + HERMES_CA_BUNDLE) — https via CONNECT MITM, http via absolute-form forward proxy; real ~/.hermes untouched
 bili dsh                              # deepseek-harness: built-in deepseek route via DEEPSEEK_BASE_URL + overlay DSH_HOME (~/.dsh-bili), all traffic /bili/, native /acp command injected via --patch
 bili pi --mitm-domain api.foo.com     # add a domain to the MITM whitelist
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -86,9 +86,9 @@ npm install -g billion-context
 bili pi                               # 拉起 pi,走代理 —— file-free(#535):环境变量 + 扩展 registerProvider,真实 ~/.pi 不动
 bili codex                            # 拉起 codex
 bili claude                           # 拉起 claude
-bili omp                              # pi 同款 MITM 环境变量 + 隔离临时 models.yml
+bili omp                              # pi 同款,file-free(#535):环境变量 + 扩展 registerProvider + 压缩取消,真实 ~/.omp 不动
 bili opencode                         # HTTPS 走 MITM + 临时 opencode.json(HTTP 走 /bili/)+ 轻量 /acp 插件
-bili hermes                           # 无法 MITM(certifi CA)—— 隔离 HERMES_HOME,全部流量 /bili/
+bili hermes                           # file-free(#535):hermes 代理环境变量(HTTPS_PROXY + HERMES_CA_BUNDLE)—— https 走 CONNECT MITM,http 走绝对形式转发;真实 ~/.hermes 不动
 bili dsh                              # deepseek-harness:内置 deepseek 路由走 DEEPSEEK_BASE_URL + 隔离 DSH_HOME(~/.dsh-bili),全部流量 /bili/,经 --patch 注入原生 /acp 命令
 bili pi --mitm-domain api.foo.com     # 向 MITM 白名单追加域名
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -83,7 +83,7 @@ npm install -g billion-context
 启动器把客户端包进一条命令:在独立端口拉起一个代理(总是全新实例,绝不复用端口),再按客户端支持的机制把它指向代理 —— 能吃代理/CA 环境变量的走**证书 MITM**,不吃的走隔离的**`/bili/` 配置重写**。真实配置文件从不被修改;客户端自己的配置只被**读取**,用来发现它实际连接的 HTTPS 上游主机,把这些主机加入 MITM 白名单 —— 代理只 TLS 终结它们,其余流量盲透传。
 
 ```bash
-bili pi                               # 拉起 pi,走代理
+bili pi                               # 拉起 pi,走代理 —— file-free(#535):环境变量 + 扩展 registerProvider,真实 ~/.pi 不动
 bili codex                            # 拉起 codex
 bili claude                           # 拉起 claude
 bili omp                              # pi 同款 MITM 环境变量 + 隔离临时 models.yml

--- a/src/agent/pi.ts
+++ b/src/agent/pi.ts
@@ -9,7 +9,7 @@ import { detectProxyBase, fetchManifest, forwardTool, fetchStatus, fetchProxyVer
 
 type Ctx = {
     sessionManager?: { getSessionId?: () => string } | undefined;
-    model?: { contextWindow?: number; baseUrl?: string } | undefined;
+    model?: { contextWindow?: number; baseUrl?: string; provider?: string; id?: string; [key: string]: unknown } | undefined;
     cwd?: string;
 };
 
@@ -42,6 +42,12 @@ type ExtensionAPI = {
     // overrides each provider's baseUrl at load (file-free routing — no
     // models.json overlay). Optional because older hosts may lack it.
     registerProvider?: (name: string, config: { baseUrl: string }) => void;
+    // #535 omp-only: omp pins the session's Model object from the static
+    // catalog BEFORE extensions load, and its registerProvider — unlike
+    // pi's _refreshCurrentModelFromRegistry — never re-resolves the live
+    // session model, so the extension must re-pin it via setModel (see the
+    // session_start handler below). Optional because pi hosts lack it.
+    setModel?: (model: Record<string, unknown> & { baseUrl?: string }) => Promise<boolean | void> | boolean | void;
 };
 
 function agentName(override: string | undefined): string {
@@ -259,20 +265,57 @@ export function createBiliPlugin(agentOverride?: string, opts?: { retryIntervalM
                 }
             }
         }
-        // #535: cancel pi's NATIVE auto-compaction (threshold + overflow) so
-        // its summarizer never fires alongside bili's ACP compression — the
-        // in-extension replacement for the old settings.json compaction-off
-        // injection. `reason` gates to the auto paths only: manual /compact
-        // stays user-owned. omp's session_before_compact event has no reason
-        // field yet (upstream PR pending), so omp keeps its config.yml
-        // compaction-off entry until then. Only armed under `bili` launch:
-        // plain `pi` with the plugin installed must behave fully native.
-        if (agent === "pi" && process.env.BILLION_CONTEXT_PROXY !== undefined) {
+        // #535: cancel the host's NATIVE compaction so its summarizer never
+        // fires alongside bili's ACP compression — the in-extension
+        // replacement for the old compaction-off config injection. pi's event
+        // carries `reason`: cancel only threshold + overflow so manual
+        // /compact stays user-owned. omp's event has no reason field, so omp
+        // cancels ALL compaction — under bili, manual native /compact is
+        // equally harmful (the native summarizer would destroy the
+        // ACP-tagged context), the host shows "Compaction cancelled", and
+        // the user should reach for /acp instead. Only armed under `bili`
+        // launch: plain pi/omp with the plugin installed stays fully native.
+        if ((agent === "pi" || agent === "omp") && process.env.BILLION_CONTEXT_PROXY !== undefined) {
             pi.on("session_before_compact", (event) => {
-                const reason = (event as unknown as { reason?: unknown }).reason;
-                if (reason === "threshold" || reason === "overflow") return { cancel: true };
-                return undefined;
+                if (agent === "pi") {
+                    const reason = (event as unknown as { reason?: unknown }).reason;
+                    if (reason === "threshold" || reason === "overflow") return { cancel: true };
+                    return undefined;
+                }
+                return { cancel: true };
             });
+        }
+        // #535 omp-only: omp resolves modelRoles.default into options.model
+        // from the PRE-extension static catalog (main.ts: "scope is resolved
+        // before extensions register their providers"), and omp's fork lacks
+        // pi's registerProvider → _refreshCurrentModelFromRegistry hop — the
+        // registry gets the rewritten baseUrl but the live session keeps the
+        // direct one, so every request bypasses the proxy (fetch trace →
+        // http://127.0.0.1:8197/v1/responses with zero proxy forwards). Re-pin
+        // the session model at load + on every session switch: spread the
+        // current model with the rewritten baseUrl through the host setModel
+        // (keyed-provider-gated; local providers carry dummy keys). Mid-session
+        // /model picks resolve from the already-overridden registry, so only
+        // session start/restore need this.
+        if (agent === "omp" && rewrites !== undefined && typeof pi.setModel === "function") {
+            const repin = async (ctx: Ctx): Promise<void> => {
+                const model = ctx?.model;
+                if (model === null || typeof model !== "object") return;
+                const provider = model.provider;
+                if (typeof provider !== "string" || provider === "") return;
+                const rewritten = rewrites[provider];
+                if (rewritten === undefined || model.baseUrl === rewritten) return;
+                try {
+                    const switched = await pi.setModel?.({ ...model, baseUrl: rewritten });
+                    if (switched === false) {
+                        console.error(`bili-plugin: omp setModel(${provider}/${String(model.id)}) rejected (no API key) — traffic for this provider goes direct`);
+                    }
+                } catch (err) {
+                    console.error(`bili-plugin: omp setModel failed: ${err instanceof Error ? err.message : String(err)} — traffic goes direct`);
+                }
+            };
+            pi.on("session_start", (_event, ctx) => repin(ctx));
+            pi.on("session_switch", (_event, ctx) => repin(ctx));
         }
         if (typeof pi.registerCommand === "function") {
             pi.registerCommand("acp", {

--- a/src/ca.ts
+++ b/src/ca.ts
@@ -94,7 +94,7 @@ function generateRootCA(): { cert: string; key: string } {
     cert.setSubject(attrs);
     cert.setIssuer(attrs);
     cert.setExtensions([
-        { name: "basicConstraints", cA: true },
+        { name: "basicConstraints", cA: true, critical: true },
         { name: "keyUsage", keyCertSign: true, cRLSign: true, digitalSignature: true },
         { name: "subjectKeyIdentifier" },
     ]);
@@ -135,6 +135,43 @@ export function ensureRootCA(): void {
     writeCombinedBundle();
 }
 
+/** Mint a leaf certificate for `host` signed by the root CA (with the
+ *  strict-OpenSSL-3 extension set Python/httpx requires: SKI + AKI matching
+ *  the root's SKI — see getSecureContext). */
+export function mintHostCert(host: string): { certPem: string; keyPem: string } {
+    if (!rootCertPem || !rootKeyPem || !rootCert || !rootKey) {
+        throw new Error("CA not initialized — call ensureRootCA() first");
+    }
+    const keys = forge.pki.rsa.generateKeyPair({ bits: 2048 });
+    const cert = forge.pki.createCertificate();
+    cert.publicKey = keys.publicKey;
+    cert.serialNumber = Date.now().toString() + Math.floor(Math.random() * 1e6).toString();
+    cert.validity.notBefore = new Date();
+    cert.validity.notAfter = new Date();
+    cert.validity.notAfter.setFullYear(cert.validity.notBefore.getFullYear() + 2);
+    cert.setSubject([{ name: "commonName", value: host }]);
+    cert.setIssuer(rootCert.subject.attributes);
+    // AKI must point at the ROOT's key (explicit bytes — forge's `true` form
+    // would stamp the leaf's own SKI here since options.cert is the leaf).
+    // Python's OpenSSL 3 chain verification rejects leaves without AKI
+    // ("certificate verify failed: Missing Authority Key Identifier") even
+    // though curl tolerates them — hermes/httpx is the client that hit it.
+    const rootSki = rootCert.generateSubjectKeyIdentifier().getBytes();
+    cert.setExtensions([
+        { name: "basicConstraints", cA: false },
+        { name: "keyUsage", digitalSignature: true, keyEncipherment: true },
+        { name: "extKeyUsage", serverAuth: true },
+        { name: "subjectAltName", altNames: [{ type: 2, value: host }] },
+        { name: "subjectKeyIdentifier" },
+        { name: "authorityKeyIdentifier", keyIdentifier: rootSki },
+    ]);
+    cert.sign(rootKey as forge.pki.rsa.PrivateKey, forge.md.sha256.create());
+    return {
+        certPem: forge.pki.certificateToPem(cert),
+        keyPem: forge.pki.privateKeyToPem(keys.privateKey),
+    };
+}
+
 /** Return a tls.SecureContext that presents a certificate for `host`, signed
  *  by our root CA. Cached per host — RSA keygen (~100ms) only happens once
  *  per unique hostname, then the cached context is reused for the lifetime of
@@ -150,26 +187,11 @@ export function getSecureContext(host: string): tls.SecureContext {
         return cached;
     }
 
-    const keys = forge.pki.rsa.generateKeyPair({ bits: 2048 });
-    const cert = forge.pki.createCertificate();
-    cert.publicKey = keys.publicKey;
-    cert.serialNumber = Date.now().toString() + Math.floor(Math.random() * 1e6).toString();
-    cert.validity.notBefore = new Date();
-    cert.validity.notAfter = new Date();
-    cert.validity.notAfter.setFullYear(cert.validity.notBefore.getFullYear() + 2);
-    cert.setSubject([{ name: "commonName", value: host }]);
-    cert.setIssuer(rootCert.subject.attributes);
-    cert.setExtensions([
-        { name: "basicConstraints", cA: false },
-        { name: "keyUsage", digitalSignature: true, keyEncipherment: true },
-        { name: "extKeyUsage", serverAuth: true },
-        { name: "subjectAltName", altNames: [{ type: 2, value: host }] },
-    ]);
-    cert.sign(rootKey as forge.pki.rsa.PrivateKey, forge.md.sha256.create());
+    const { certPem, keyPem } = mintHostCert(host);
 
     const ctx = tls.createSecureContext({
-        cert: forge.pki.certificateToPem(cert),
-        key: forge.pki.privateKeyToPem(keys.privateKey),
+        cert: certPem,
+        key: keyPem,
         ca: rootCertPem,
     });
     secureContextCache.set(host, ctx);

--- a/src/client-config.ts
+++ b/src/client-config.ts
@@ -387,6 +387,7 @@ export function readOmpConfig(ompHome: string): OmpConfig {
  *  launcher route discovery. */
 export function parseHermesYaml(text: string): HermesConfig {
     const result: HermesConfig = { providers: {} };
+    const candidates = new Map<string, string>();
     type Mode = "none" | "dict" | "list";
     let mode: Mode = "none";
     let sectionIndent = -1;
@@ -433,8 +434,10 @@ export function parseHermesYaml(text: string): HermesConfig {
                 current = m ? m[1] : null;
                 if (current && !result.providers[current]) result.providers[current] = {};
             } else if (indent > entryIndent && current) {
-                const apiMatch = /^api:\s*(\S+)/.exec(trimmed);
-                if (apiMatch) result.providers[current].api = apiMatch[1];
+                // hermes accepts base_url / url / api (priority order) — collect
+                // all and resolve after the scan.
+                const apiMatch = /^(base_url|url|api):\s*(\S+)/.exec(trimmed);
+                if (apiMatch) candidates.set(`${current}\u0000${apiMatch[1]}`, apiMatch[2]);
             }
         } else {
             // Legacy list: "- name: x" opens an entry; nested base_url/api/url lines.
@@ -451,6 +454,10 @@ export function parseHermesYaml(text: string): HermesConfig {
                 if (urlMatch) result.providers[current].api = urlMatch[1];
             }
         }
+    }
+    for (const name of Object.keys(result.providers)) {
+        const pick = candidates.get(`${name}\u0000base_url`) ?? candidates.get(`${name}\u0000url`) ?? candidates.get(`${name}\u0000api`);
+        if (pick !== undefined) result.providers[name].api = pick;
     }
     return result;
 }

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -43,7 +43,7 @@ import { selfPackageRoot, isBiliPiEntry, ompPluginLoadedFrom } from "./plugin-in
 function selfDistFile(name: string): string {
     return path.join(selfPackageRoot(), "dist", name);
 }
-import { nonEmpty, resolvePiHome, resolveOmpHome, resolveHermesHome, resolveDshHome, loadClientConfig, collectModelWindows, type ClientConfig, type CodexConfig, resolveOpencodeConfigFile, type OpencodeConfig, type OpencodeProvider, type HermesConfig, type HermesProvider } from "./client-config.js";
+import { nonEmpty, resolvePiHome, resolveOmpHome, resolveDshHome, loadClientConfig, collectModelWindows, type ClientConfig, type CodexConfig, resolveOpencodeConfigFile, type OpencodeConfig, type OpencodeProvider, type HermesConfig, type HermesProvider } from "./client-config.js";
 import { loadRoutes, resolveConfiguredContextLimit, lookupContextLimit, type ProviderRoutes } from "./config.js";
 import { contextFromRegistry } from "./registry.js";
 
@@ -276,9 +276,12 @@ export function discoverRoutes(client: ClientName, config: ClientConfig): Discov
             classify(prov.baseURL, name);
         }
     } else if (client === "hermes") {
-        // hermes rides /bili/ for EVERY upstream (http AND https): its httpx
-        // client builds its own CA bundle from certifi, so cert-MITM would
-        // need extra trust config. Wrapping the URL form needs no cert at all.
+        // #535 phase 2: hermes rides its httpx proxy env for every upstream —
+        // https via CONNECT + cert MITM (host whitelisted for the CA),
+        // plain-http via absolute-form forward-proxy requests the server
+        // understands. No URL rewriting anywhere, so the real config.yaml is
+        // never touched. httpRewrites is inventory-only here: it feeds the
+        // banner and the no-provider warning; the child never consumes it.
         const hermesSeen = new Set<string>();
         for (const [name, prov] of Object.entries(config.hermes?.providers ?? {})) {
             if (!nonEmpty(prov.api)) continue;
@@ -288,8 +291,16 @@ export function discoverRoutes(client: ClientName, config: ClientConfig): Discov
                 if (url.protocol !== "http:" && url.protocol !== "https:") continue;
                 if (hermesSeen.has(name)) continue;
                 hermesSeen.add(name);
-                rewriteKeys.add(name);
-                httpRewrites.push({ key: name, realUpstream: real });
+                if (url.protocol === "https:") {
+                    const host = url.hostname.toLowerCase();
+                    if (host && !httpsSeen.has(host)) {
+                        httpsSeen.add(host);
+                        httpsDomains.push(host);
+                    }
+                } else if (!rewriteKeys.has(name)) {
+                    rewriteKeys.add(name);
+                    httpRewrites.push({ key: name, realUpstream: real });
+                }
             } catch {
                 // Unparseable endpoint: skip.
             }
@@ -632,10 +643,11 @@ export function buildCodexMcpArgs(origin: string, conversationId: string): strin
 }
 
 /**
- * Shared persistent-overlay machinery for home-dir-based launchers (pi / omp /
- * hermes). The overlay (`<realHome>-bili`) symlinks every real-home entry
- * except the launcher-generated file (models.json / models.yml / config.yaml),
- * which is rewritten in place atomically.
+ * Shared persistent-overlay machinery for the remaining home-dir launcher
+ * (dsh; pi/omp/hermes went file-free in #535 — env routing + extension, no
+ * overlay). The overlay (`<realHome>-bili`) symlinks every real-home entry
+ * except the launcher-generated file (settings.yaml), which is rewritten in
+ * place atomically.
  *
  * The overlay is PERSISTENT and never deleted: these agents record absolute
  * paths derived from their home override into shared state (resume pointers
@@ -1104,10 +1116,9 @@ function writeOverlayFileAtomic(overlay: string, fileName: string, contents: str
 }
 
 /**
- * omp models.yml rewrite (line-based, indentation-tracked): HTTP → /bili/ wrap, wrapped-HTTPS → raw https for cert
- * MITM, riding the persistent `<ompHome>-bili` overlay from
- * refreshOverlayHome — comments, ordering and formatting are preserved
- * verbatim, and the real models.yml is never touched.
+ * Atomic text write via rename (draft + rename, never a torn file) — used for
+ * the generated overlay files (e.g. dsh's rewritten settings.yaml) and the
+ * dead-proxy-URL unpacker below.
  */
 function atomicWriteTextFile(filePath: string, contents: string): void {
     const draft = `${filePath}.${process.pid}.bili-tmp`;
@@ -1160,311 +1171,6 @@ export function unpackDeadProxyUrlsInFile(filePath: string, livePorts: Set<numbe
         return 0;
     }
     return changed;
-}
-
-function mergeOmpCompactionDisabledYaml(text: string): string {
-    const lines = text.split(/\r?\n/);
-    let compactionLine = -1;
-    for (let i = 0; i < lines.length; i++) {
-        const rawLine = lines[i];
-        const trimmed = rawLine.trim();
-        if (!trimmed || trimmed.startsWith("#")) continue;
-        const indent = rawLine.length - rawLine.trimStart().length;
-        if (indent === 0 && /^compaction:\s*(#.*)?$/.test(trimmed)) {
-            compactionLine = i;
-            break;
-        }
-    }
-    if (compactionLine === -1) {
-        const base = text === "" || text.endsWith("\n") ? text : `${text}\n`;
-        return `${base}compaction:\n  enabled: false\n`;
-    }
-    for (let i = compactionLine + 1; i < lines.length; i++) {
-        const rawLine = lines[i];
-        const trimmed = rawLine.trim();
-        if (!trimmed || trimmed.startsWith("#")) continue;
-        const indent = rawLine.length - rawLine.trimStart().length;
-        if (indent === 0) break;
-        if (/^enabled:/.test(trimmed)) {
-            const leading = rawLine.slice(0, rawLine.length - rawLine.trimStart().length);
-            const commentMatch = /\s+#.*$/.exec(rawLine);
-            const comment = commentMatch ? commentMatch[0] : "";
-            lines[i] = `${leading}enabled: false${comment}`;
-            return lines.join("\n");
-        }
-    }
-    let childIndent = 2;
-    for (let i = compactionLine + 1; i < lines.length; i++) {
-        const rawLine = lines[i];
-        const trimmed = rawLine.trim();
-        if (!trimmed || trimmed.startsWith("#")) continue;
-        const indent = rawLine.length - rawLine.trimStart().length;
-        if (indent === 0) break;
-        childIndent = indent;
-        break;
-    }
-    lines.splice(compactionLine + 1, 0, `${" ".repeat(childIndent)}enabled: false`);
-    return lines.join("\n");
-}
-
-function writeOmpCompactionDisabledConfig(ompHome: string, overlay: string): void {
-    // omp reads config.yml at runtime (settings.json is only a one-time migration
-    // source, renamed to .bak). Merge compaction.enabled=false over the real
-    // config.yml / config.yaml / settings.json so the native auto-compaction
-    // never fires alongside bili's ACP compression. JSON is a valid YAML subset,
-    // so the settings.json fallback is written as JSON and parsed by omp fine.
-    let base: string | undefined;
-    let baseIsJson = false;
-    for (const name of ["config.yml", "config.yaml"]) {
-        try {
-            base = fs.readFileSync(path.join(ompHome, name), "utf8");
-            break;
-        } catch {}
-    }
-    if (base === undefined) {
-        try {
-            base = fs.readFileSync(path.join(ompHome, "settings.json"), "utf8");
-            baseIsJson = true;
-        } catch {}
-    }
-    let merged: string;
-    if (base === undefined) {
-        merged = "compaction:\n  enabled: false\n";
-    } else if (baseIsJson) {
-        let settings: Record<string, unknown> = {};
-        try {
-            const parsed: unknown = JSON.parse(base);
-            if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-                settings = parsed as Record<string, unknown>;
-            }
-        } catch {}
-        const compactionRaw = settings.compaction;
-        const compaction =
-            compactionRaw && typeof compactionRaw === "object" && !Array.isArray(compactionRaw)
-                ? { ...(compactionRaw as Record<string, unknown>) }
-                : {};
-        compaction.enabled = false;
-        settings.compaction = compaction;
-        merged = JSON.stringify(settings, null, 2);
-    } else {
-        merged = mergeOmpCompactionDisabledYaml(base);
-    }
-    writeOverlayFileAtomic(overlay, "config.yml", merged);
-}
-
-export function prepareOmpHttpRewrite(
-    ompHome: string,
-    origin: string,
-    httpRewrites: HttpRewrite[],
-    httpsRewrites: HttpRewrite[],
-): string | undefined {
-    if (!fs.existsSync(ompHome)) return undefined;
-    const overlay = `${ompHome}-bili`;
-    // #449: the overlay always carries a config.yml disabling omp's native
-    // auto-compaction (its summarizer must never fire alongside bili's ACP
-    // compression); models.yml is generated only when present, so both stay
-    // out of the real-home symlink set.
-    const generated: string[] = ["config.yml"];
-    const modelsPath = path.join(ompHome, "models.yml");
-    const unpacked = unpackDeadProxyUrlsInFile(modelsPath, liveProxyPorts());
-    if (unpacked > 0) {
-        console.error(`bili: unpacked ${unpacked} dead proxy URL(s) from the real ${modelsPath}`);
-    }
-    let modelsText: string | undefined;
-    try {
-        modelsText = fs.readFileSync(modelsPath, "utf8");
-        generated.push("models.yml");
-    } catch {}
-    if (!refreshOverlayHome(ompHome, overlay, generated)) return undefined;
-    if (modelsText !== undefined) {
-        const httpMap = new Map(httpRewrites.map((r) => [r.key, wrapUpstream(origin, r.realUpstream)]));
-        const httpsMap = new Map(httpsRewrites.map((r) => [r.key, r.realUpstream]));
-        const lines = modelsText.split(/\r?\n/);
-        let providersIndent = -1;
-        let providerIndent = -1;
-        let currentProvider: string | null = null;
-        for (let i = 0; i < lines.length; i++) {
-            const rawLine = lines[i];
-            const trimmed = rawLine.trim();
-            if (!trimmed || trimmed.startsWith("#")) continue;
-            const indent = rawLine.length - rawLine.trimStart().length;
-            if (providersIndent === -1) {
-                if (/^providers:\s*(#.*)?$/.test(trimmed)) providersIndent = indent;
-                continue;
-            }
-            if (indent <= providersIndent) break;
-            if (providerIndent === -1) providerIndent = indent;
-            if (indent === providerIndent) {
-                const m = /^([A-Za-z0-9_.-]+):/.exec(trimmed);
-                currentProvider = m ? m[1] : null;
-            } else if (indent > providerIndent && currentProvider) {
-                const baseMatch = /^(baseUrl:\s*)(\S+)/.exec(trimmed);
-                if (baseMatch) {
-                    const target = httpMap.get(currentProvider) ?? httpsMap.get(currentProvider);
-                    if (target) {
-                        const leading = rawLine.slice(0, rawLine.length - rawLine.trimStart().length);
-                        const commentMatch = /\s+#.*$/.exec(rawLine);
-                        const comment = commentMatch ? commentMatch[0] : "";
-                        lines[i] = `${leading}baseUrl: ${target}${comment}`;
-                    }
-                }
-            }
-        }
-        writeOverlayFileAtomic(overlay, "models.yml", lines.join("\n"));
-    }
-    writeOmpCompactionDisabledConfig(ompHome, overlay);
-    return overlay;
-}
-
-/**
- * hermes counterpart of prepareOmpHttpRewrite: a persistent `<hermesHome>-bili`
- * overlay (every ~/.hermes sibling symlinked so skills/memories/sessions stay
- * shared) holding a rewritten copy of config.yaml. Every provider endpoint
- * line (api: / base_url: / url:) is rewrapped as origin + "/bili/" + raw
- * upstream — http AND https alike, since hermes's httpx stack can't consume
- * the MITM CA without extra trust config. The real ~/.hermes is never
- * touched. Returns the overlay dir (undefined when nothing is rewritable).
- */
-export function prepareHermesHome(
-    hermesHome: string,
-    origin: string,
-    rewrites: HttpRewrite[],
-): string | undefined {
-    if (rewrites.length === 0) return undefined;
-    const cfgPath = path.join(hermesHome, "config.yaml");
-    let txt: string;
-    try {
-        txt = fs.readFileSync(cfgPath, "utf8");
-    } catch {
-        return undefined;
-    }
-    const wrapSet = new Set(rewrites.map((r) => r.realUpstream));
-    const eol = txt.includes("\r\n") ? "\r\n" : "\n";
-    const lines = txt.split(/\r?\n/);
-    let changed = false;
-    for (let i = 0; i < lines.length; i++) {
-        const rawLine = lines[i];
-        const m = /^(\s*(?:api|base_url|url):\s*)(\S+)(\s+#.*)?$/.exec(rawLine);
-        if (!m) continue;
-        const rawUrl = m[2].replace(/^["']|["']$/g, "");
-        if (!/^https?:\/\//i.test(rawUrl)) continue;
-        const real = unwrapUpstream(rawUrl);
-        if (!wrapSet.has(real)) continue;
-        lines[i] = `${m[1]}${wrapUpstream(origin, real)}${m[3] ?? ""}`;
-        changed = true;
-    }
-    if (!changed) return undefined;
-    const overlay = `${hermesHome}-bili`;
-    if (!refreshOverlayHome(hermesHome, overlay, "config.yaml")) return undefined;
-    writeOverlayFileAtomic(overlay, "config.yaml", lines.join(eol));
-    return overlay;
-}
-
-/** Write the hermes session-identity plugin into the bili overlay home.
- *  Hermes sends NO conversation identity on the wire by default: its native
- *  `prompt_cache_key` support (transports/chat_completions.py) is gated on
- *  `supports_prompt_cache_key`, which no bundled provider profile enables —
- *  so every custom-provider request reaches the proxy anonymous and gets a
- *  400 (#286). User plugins under $HERMES_HOME/plugins/model-providers/<name>/
- *  override bundled profiles (discovery order bundled → user, last-writer-
- *  wins), and the profile hook `build_api_kwargs_extras(session_id=...)`
- *  receives the REAL hermes session id — its top_level return value is
- *  merged straight into the request body. The generated plugin subclasses
- *  the bundled "custom" profile and stamps prompt_cache_key = session_id,
- *  giving the proxy the same stable per-conversation id omp/pi provide.
- *  Registered names: "custom" (model.base_url / provider: custom) plus
- *  "custom:<name>" for every provider key bili rewrites (named providers
- *  resolve to that shape — agent_init only maps "custom"/"custom:<key>"
- *  to custom endpoints, and a bare "custom:<key>" lookup otherwise misses
- *  the profile registry and falls to the legacy no-pck path).
- *  Skipped (returns false) when the REAL ~/.hermes already has a plugins/
- *  dir — refreshOverlayHome symlinks it into the overlay, and writing
- *  through the symlink would mutate the user's real home. The proxy then
- *  400s anonymous requests with the fix-it message. */
-export function writeHermesIdentityPlugin(hermesHome: string, overlay: string, rewrites: HttpRewrite[]): boolean {
-    try {
-        if (fs.existsSync(path.join(hermesHome, "plugins"))) return false;
-    } catch {
-        return false;
-    }
-    const dir = path.join("plugins", "model-providers", "bili-session-identity");
-    try {
-        fs.mkdirSync(path.join(overlay, dir), { recursive: true });
-    } catch {
-        return false;
-    }
-    const keys = rewrites.map((r) => r.key);
-    const pluginDir = path.join(overlay, dir);
-    try {
-        fs.writeFileSync(path.join(pluginDir, "__init__.py"), hermesIdentityPluginSource(keys));
-        fs.writeFileSync(path.join(pluginDir, "plugin.yaml"), [
-        "name: bili-session-identity",
-        "kind: model-provider",
-        "version: 1.0.0",
-        "description: billion-context session identity (installed by `bili hermes` — safe to delete)",
-        "author: billion-context",
-        "",
-    ].join("\n"));
-    } catch {
-        return false;
-    }
-    try {
-        return fs.existsSync(path.join(overlay, dir, "__init__.py"));
-    } catch {
-        return false;
-    }
-}
-
-function hermesIdentityPluginSource(providerKeys: string[]): string {
-    return [
-        '"""Installed by `bili hermes` (billion-context) — safe to delete.',
-        "",
-        "Re-registers hermes's `custom` provider profile (plus a `custom:<name>`",
-        "profile for every provider the proxy fronts) with one addition: the",
-        "REAL hermes session id is sent as `prompt_cache_key` on every request,",
-        "which the billion-context proxy uses as the stable conversation",
-        'identity for its compression sessions. Removing this file restores',
-        'stock behavior (no prompt_cache_key)."""',
-        "from providers import get_provider_profile, register_provider",
-        "from providers.base import ProviderProfile",
-        "",
-        `_PROVIDER_KEYS = ${JSON.stringify(providerKeys)}`,
-        "",
-        '_custom = get_provider_profile("custom")',
-        "_BASE = type(_custom) if _custom is not None else ProviderProfile",
-        "",
-        "",
-        "class _BiliSessionIdentity(_BASE):",
-        "    def build_api_kwargs_extras(self, *, session_id=None, **ctx):",
-        "        extra_body, top_level = _BASE.build_api_kwargs_extras(",
-        "            self, session_id=session_id, **ctx",
-        "        )",
-        '        sid = str(session_id or "").strip()',
-        "        if sid:",
-        '            top_level.setdefault("prompt_cache_key", sid[:64])',
-        "        return extra_body, top_level",
-        "",
-        "",
-        "def _register(name, template, with_aliases):",
-        "    fields = {}",
-        "    if template is not None:",
-        "        # Aliases are copied ONLY for the canonical custom",
-        "        # re-registration: copying them onto custom:<name> entries",
-        "        # would steal the aliases (register_provider re-points each",
-        "        # alias at the registering name).",
-        '        for attr in ((\"aliases\",) if with_aliases else ()) + (\"env_vars\", \"base_url\", \"default_max_tokens\"):',
-        "            value = getattr(template, attr, None)",
-        "            if value:",
-        "                fields[attr] = value",
-        "    register_provider(_BiliSessionIdentity(name=name, **fields))",
-        "",
-        "",
-        "if _custom is not None:",
-        '    _register("custom", _custom, True)',
-        "for _key in _PROVIDER_KEYS:",
-        '    _register("custom:" + _key, _custom, False)',
-        "",
-    ].join("\n");
 }
 
 /** dsh counterpart of prepareHermesHome: a persistent `<dshHome>-bili` overlay
@@ -1708,7 +1414,16 @@ export function pickEphemeralPort(host = LAUNCHER_DEFAULT_HOST): Promise<number>
     });
 }
 
-const INHERITED_PROXY_VARS = ["http_proxy", "https_proxy", "all_proxy", "HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY"];
+const INHERITED_PROXY_VARS = [
+    "http_proxy",
+    "https_proxy",
+    "all_proxy",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "ALL_PROXY",
+    "no_proxy",
+    "NO_PROXY",
+];
 
 export function stripInheritedProxy(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
     const cleaned: NodeJS.ProcessEnv = { ...env };
@@ -1919,10 +1634,11 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
     const debug = params.overrides.ACP_DEBUG === "1";
 
     const base = baseClientName(params.client);
-    // #535: for pi, discovery must read the REAL home — a stale inherited
-    // PI_CODING_AGENT_DIR (legacy overlay launch) would discover routes from
-    // an old overlay's rewritten models.json.
-    const discoveryEnv = base === "pi" ? { ...process.env, PI_CODING_AGENT_DIR: undefined } : process.env;
+    // #535: for pi and omp, discovery must read the REAL home — a stale
+    // inherited PI_CODING_AGENT_DIR (legacy overlay launch) would discover
+    // routes from an old overlay's rewritten models.json/models.yml.
+    const discoveryEnv =
+        base === "pi" || base === "omp" ? { ...process.env, PI_CODING_AGENT_DIR: undefined } : process.env;
     const config = loadClientConfig(discoveryEnv, process.cwd());
     const routes = discoverRoutes(base, config);
     // #535: pi's REAL home — resolvePiHome honors a possibly-stale inherited
@@ -1930,8 +1646,11 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
     // a legacy bili overlay launch exported it into); the new file-free
     // design must never let that redirect pi at an old overlay dir.
     const piRealHome = resolvePiHome({ ...process.env, PI_CODING_AGENT_DIR: undefined });
-    // #535: validate pi's extension availability BEFORE spawning the proxy —
-    // a refusal after ensureProxyRunning would leak a detached proxy child.
+    // #535 phase 3: omp's REAL home, resolved with the same stale-inheritance
+    // strip as pi (resolveOmpHome honors PI_CODING_AGENT_DIR too).
+    const ompRealHome = resolveOmpHome({ ...process.env, PI_CODING_AGENT_DIR: undefined });
+    // #535: validate extension availability BEFORE spawning the proxy — a
+    // refusal after ensureProxyRunning would leak a detached proxy child.
     if (base === "pi" && (routes.httpRewrites.length > 0 || routes.httpsRewrites.length > 0)) {
         const piExt = selfDistFile("agent/pi.js");
         const extAvailable = (piExt !== undefined && fs.existsSync(piExt)) || piPluginInstalled(piRealHome);
@@ -1940,6 +1659,17 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
                 "bili: pi needs provider URL rewrites but the bili extension cannot load " +
                     "(dist/agent/pi.js missing and the plugin is not installed in ~/.pi/agent/settings.json) — " +
                     "reinstall billion-context or run `bili plugin install pi`",
+            );
+        }
+    }
+    if (base === "omp" && routes.httpRewrites.length > 0) {
+        const ompExt = selfDistFile("agent/omp.js");
+        const extAvailable = (ompExt !== undefined && fs.existsSync(ompExt)) || ompPluginLoadedFrom(ompRealHome);
+        if (!extAvailable) {
+            throw new Error(
+                "bili: omp needs provider URL rewrites but the bili extension cannot load " +
+                    "(dist/agent/omp.js missing and the plugin is not installed in ~/.omp/agent/config.yml) — " +
+                    "reinstall billion-context or run `bili plugin install omp`",
             );
         }
     }
@@ -1961,9 +1691,7 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
     const ca = resolveCaCertPath(process.env);
     let env: NodeJS.ProcessEnv;
     let clientArgs = params.clientArgs;
-    let ompOverlayHome: string | undefined;
     let opencodeTmpFile: string | undefined;
-    let hermesOverlayHome: string | undefined;
     let dshOverlayHome: string | undefined;
     const tmpFiles: string[] = [];
     const directUrl = launcherDirectUrl(process.env);
@@ -2011,20 +1739,18 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
             clientArgs = ["-e", piExt, ...clientArgs];
         }
     } else if (base === "omp") {
-        // omp is pi-based: same env as pi (HTTPS_PROXY + CA + BILLION_CONTEXT_PROXY);
-        // the /bili/ rewrite rides a persistent overlay PI_CODING_AGENT_DIR
-        // (~/.omp/agent-bili; real models.yml untouched, session paths stay resolvable).
-        env = buildPiEnv(origin, ca, process.env);
-        ompOverlayHome = prepareOmpHttpRewrite(resolveOmpHome(process.env), origin, routes.httpRewrites, routes.httpsRewrites);
-        if (ompOverlayHome) env.PI_CODING_AGENT_DIR = ompOverlayHome;
-        // Native tooling out of the box (same rationale as pi): omp does NOT
-        // ship the bili plugin — when the config carries no loadable entry,
-        // ride omp's `-e <file>` (loads for this run only, writes nothing)
-        // instead of dropping to wire-mode fallback. A loadable entry (the
-        // overlay's generated config.yml preserves the real home's entries)
-        // already provides the plugin; adding `-e` too would double-register.
+        // #535 phase 3: file-free — omp is pi-based and runs on its REAL home
+        // (no overlay, no PI_CODING_AGENT_DIR redirect). Provider baseUrls are
+        // overridden at extension load from the env manifest (omp's fork keeps
+        // pi's registerProvider), and native compaction — auto AND manual — is
+        // cancelled by the extension's session_before_compact handler (omp's
+        // event carries no reason field, so under bili every compaction is
+        // cancelled; the native summarizer would destroy the ACP-tagged
+        // context). https upstreams ride cert-MITM like pi.
+        env = buildPiEnv(origin, ca, process.env, routes.httpRewrites);
+        delete env.PI_CODING_AGENT_DIR;
         const ompExt = selfDistFile("agent/omp.js");
-        if (ompExt && fs.existsSync(ompExt) && !ompPluginLoadedFrom(resolveOmpHome(process.env))) {
+        if (ompExt && fs.existsSync(ompExt) && !ompPluginLoadedFrom(ompRealHome)) {
             clientArgs = ["-e", ompExt, ...clientArgs];
         }
     } else if (base === "opencode") {
@@ -2038,31 +1764,21 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
         opencodeTmpFile = prepareOpencodeHttpRewrite(resolveOpencodeConfigFile(process.env), origin, routes.httpRewrites, routes.httpsRewrites, opencodePluginPath);
         if (opencodeTmpFile) env.OPENCODE_CONFIG = opencodeTmpFile;
     } else if (base === "hermes") {
-        // hermes: no plugin, no MITM cert trust (httpx builds its own CA
-        // bundle) — every upstream rides the /bili/ URL form via a persistent
-        // overlay HERMES_HOME (~/.hermes-bili) whose config.yaml is rewritten.
-        // skills/memories/sessions stay shared through symlinks; the real
-        // ~/.hermes is never touched.
-        env = { ...process.env };
-        hermesOverlayHome = prepareHermesHome(resolveHermesHome(process.env), origin, routes.httpRewrites);
-        if (hermesOverlayHome) {
-            env.HERMES_HOME = hermesOverlayHome;
-            // Session identity for the proxied custom providers: hermes sends
-            // no conversation id on the wire, so the proxy 400s anonymous
-            // requests (#286). The plugin stamps the real hermes session id as
-            // prompt_cache_key. Skipped (identity stays anonymous) when the
-            // real ~/.hermes already has a plugins/ dir — writing through the
-            // overlay symlink would mutate the user's home.
-            if (!writeHermesIdentityPlugin(resolveHermesHome(process.env), hermesOverlayHome, routes.httpRewrites)) {
-                console.error(
-                    "bili: ~/.hermes has its own plugins/ — skipping the session-identity plugin; hermes requests will be rejected by the proxy without an identity (see #286).",
-                );
-            }
-        } else {
+        // #535 phase 2: file-free — no overlay HERMES_HOME, no config.yaml
+        // runs on its REAL home — including a user-set HERMES_HOME (discovery
+        // resolved the same path, so the MITM whitelist matches). Its httpx
+        // stack resolves ONE proxy env var (HTTPS_PROXY first) for both
+        // schemes and trusts custom CAs via HERMES_CA_BUNDLE: https upstreams
+        // ride CONNECT + cert MITM, plain-http upstreams ride absolute-form
+        // forward-proxy requests the server understands. Sessions bind by
+        // persisted content-prefix affinity when no identity carrier is
+        // present (anonymous requests are accepted, #286).
+        env = stripInheritedProxy(process.env);
+        env.HTTPS_PROXY = origin;
+        env.HERMES_CA_BUNDLE = ca;
+        if (routes.httpRewrites.length === 0 && routes.httpsDomains.length === 0) {
             console.error(
-                routes.httpRewrites.length === 0
-                    ? "bili: no hermes providers found in ~/.hermes/config.yaml — traffic will NOT go through the proxy (configure a provider first)."
-                    : "bili: hermes config.yaml could not be rewritten (unreadable or no matching provider endpoints) — traffic will NOT go through the proxy.",
+                "bili: no hermes providers found in ~/.hermes/config.yaml — traffic will NOT go through the proxy (configure a provider first).",
             );
         }
     } else if (base === "dsh") {

--- a/src/server.ts
+++ b/src/server.ts
@@ -290,6 +290,25 @@ export function resolveUpstream(_opts: ProxyOptions, reqUrl: string, req?: http.
             }
         }
     }
+    // Forward-proxy mode (#535 phase 2): a client honoring an http_proxy env
+    // sent this request in absolute form (`GET http://host/path HTTP/1.1`) —
+    // exactly what httpx emits for plain-http base URLs through a proxy. Route
+    // it like the /bili/ embedded form: the absolute URL IS the upstream, same
+    // tunnel semantics. A target equal to this request's own Host header means
+    // the client is asking the proxy to fetch ITSELF — forwarding that would
+    // loop the request straight back into handle(), so fall through (own-API
+    // routing) instead.
+    if (reqUrl.startsWith("http://") || reqUrl.startsWith("https://")) {
+        try {
+            const u = new URL(reqUrl);
+            const ownHost = (req?.headers.host ?? "").toLowerCase();
+            if (u.host.toLowerCase() !== ownHost) {
+                return { upstream: `${u.protocol}//${u.host}`, rewrittenUrl: reqUrl, tunnel: true };
+            }
+        } catch {
+            // malformed absolute URL
+        }
+    }
     return undefined;
 }
 

--- a/tests/instance-governance.test.ts
+++ b/tests/instance-governance.test.ts
@@ -16,7 +16,7 @@ import {
 } from "../src/instance.ts";
 import { resolveProxyOrigin } from "../src/mcp.ts";
 import { loadConversations, recordPluginSession, flushConversations } from "../src/plugin.ts";
-import { unpackDeadProxyUrlsInFile, liveProxyPorts, prepareOmpHttpRewrite } from "../src/launcher.ts";
+import { unpackDeadProxyUrlsInFile, liveProxyPorts, prepareDshHome } from "../src/launcher.ts";
 import { pluginInstall } from "../src/plugin-install.ts";
 import { setLogCapture } from "../src/logger.ts";
 
@@ -207,20 +207,20 @@ test("unpackDeadProxyUrlsInFile: dead-origin wraps unpacked, live-origin wraps k
     }
 });
 
-test("omp overlay: nested generated models.yml is never promoted into the real home (#410)", () => {
-    const home = fs.mkdtempSync(path.join(os.tmpdir(), "bili-omp-nest-"));
+test("dsh overlay: nested generated settings.yaml is never promoted into the real home (#410)", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "bili-dsh-nest-"));
     const overlay = `${home}-bili`;
-    fs.writeFileSync(path.join(home, "models.yml"), ["providers:", "  a:", "    baseUrl: http://example.com/v1"].join("\n"));
+    fs.writeFileSync(path.join(home, "settings.yaml"), ["llm-pi-ai:", "  providers:", "    a:", "      baseURL: http://example.com/v1"].join("\n"));
     fs.mkdirSync(path.join(home, "sessions"), { recursive: true });
     fs.mkdirSync(path.join(overlay, "sessions"), { recursive: true });
-    fs.writeFileSync(path.join(overlay, "sessions", "models.yml"), "providers:\n  poisoned:\n    baseUrl: http://127.0.0.1:8787/bili/http://evil.example.com/v1\n");
+    fs.writeFileSync(path.join(overlay, "sessions", "settings.yaml"), "llm-pi-ai:\n  providers:\n    poisoned:\n      baseURL: http://127.0.0.1:8787/bili/http://evil.example.com/v1\n");
     let tmp: string | undefined;
     try {
-        tmp = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", [{ key: "a", realUpstream: "http://example.com/v1" }], []);
+        tmp = prepareDshHome(home, "http://127.0.0.1:8787", [{ key: "dsh-1", realUpstream: "http://example.com/v1" }]);
         assert.ok(tmp);
-        assert.equal(fs.existsSync(path.join(home, "sessions", "models.yml")), false, "nested generated file NOT promoted");
-        const real = fs.readFileSync(path.join(home, "models.yml"), "utf8");
-        assert.ok(!real.includes("poisoned"), "real models.yml clean");
+        assert.equal(fs.existsSync(path.join(home, "sessions", "settings.yaml")), false, "nested generated file NOT promoted");
+        const real = fs.readFileSync(path.join(home, "settings.yaml"), "utf8");
+        assert.ok(!real.includes("poisoned"), "real settings.yaml clean");
     } finally {
         if (tmp) fs.rmSync(tmp, { recursive: true, force: true });
         fs.rmSync(home, { recursive: true, force: true });

--- a/tests/launcher.test.ts
+++ b/tests/launcher.test.ts
@@ -20,7 +20,6 @@ import {
     buildCodexEnv,
     buildClaudeEnv,
     buildCodexArgs,
-    prepareOmpHttpRewrite,
     prepareOpencodeHttpRewrite,
     stripInheritedProxy,
     resolvePiHome,
@@ -37,8 +36,6 @@ import {
     parseHermesYaml,
     readHermesConfig,
     resolveHermesHome,
-    prepareHermesHome,
-    writeHermesIdentityPlugin,
     parseDshSettingsYaml,
     readDshConfig,
     resolveDshHome,
@@ -463,6 +460,157 @@ test("runLaunch pi #535: refuses launch when http rewrites needed and extension 
     }
 });
 
+test("runLaunch omp #535: refuses launch when http rewrites needed and extension cannot load; no overlay files written", async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "bili-omprefuse-"));
+    const prevHome = process.env.HOME;
+    const prevUserProfile = process.env.USERPROFILE;
+    const prevClientBin = process.env.BILI_CLIENT_BIN;
+    const prevOmpDir = process.env.PI_CODING_AGENT_DIR;
+    process.env.HOME = home;
+    if (prevUserProfile !== undefined) process.env.USERPROFILE = home;
+    delete process.env.PI_CODING_AGENT_DIR;
+    process.env.BILI_CLIENT_BIN = path.join(home, "fake-omp");
+    fs.writeFileSync(process.env.BILI_CLIENT_BIN, "");
+    const ompHome = path.join(home, ".omp", "agent");
+    fs.mkdirSync(ompHome, { recursive: true });
+    fs.writeFileSync(path.join(ompHome, "models.yml"), "providers:\n  glm:\n    baseUrl: http://127.0.0.1:8199/v1\n");
+
+    const root = selfPackageRoot();
+    const distAgent = path.join(root, "dist", "agent", "omp.js");
+    const distBackup = `${distAgent}.bak-test`;
+    const distExisted = fs.existsSync(distAgent);
+    if (distExisted) fs.renameSync(distAgent, distBackup);
+
+    const clientArgsSeen: string[][] = [];
+    const spawnImpl: SpawnFn = (cmd, args) => {
+        if (cmd === process.env.BILI_CLIENT_BIN) {
+            clientArgsSeen.push([...args]);
+            const child = makeFakeChild(0);
+            const orig = child.on.bind(child);
+            (child as { on: SpawnChild["on"] }).on = (event, listener) => {
+                orig(event, listener);
+                if (event === "exit") setTimeout(() => listener(0, null), 0);
+                return child;
+            };
+            return child;
+        }
+        return makeFakeChild(42422);
+    };
+    const prevExit = process.exit;
+    const exitCalls: number[] = [];
+    process.exit = ((code?: number) => {
+        exitCalls.push(code ?? 0);
+        return undefined as never;
+    }) as typeof process.exit;
+    try {
+        // no dist file, no installed config.yml entry → refuse BEFORE spawning
+        // anything (no proxy child, no client)
+        await assert.rejects(
+            runLaunch({ client: "omp", clientArgs: [], overrides: {} }, { fetchImpl: async () => ({ ok: true }), spawnImpl, sleep: () => Promise.resolve() }),
+            /omp needs provider URL rewrites but the bili extension cannot load/,
+        );
+        assert.equal(clientArgsSeen.length, 0);
+        assert.equal(fs.existsSync(`${ompHome}-bili`), false, "no omp overlay dir");
+
+        // plugin entry in config.yml (existing file) → extension loadable → launch proceeds
+        const otherInstall = path.join(home, "other-install", "dist", "agent", "omp.js");
+        fs.mkdirSync(path.dirname(otherInstall), { recursive: true });
+        fs.writeFileSync(otherInstall, "");
+        fs.writeFileSync(path.join(ompHome, "config.yml"), `extensions:\n  - ${otherInstall}\n`);
+        await runLaunch(
+            { client: "omp", clientArgs: [], overrides: {} },
+            { fetchImpl: async () => ({ ok: true }), spawnImpl, sleep: () => Promise.resolve() },
+        );
+        assert.equal(clientArgsSeen.length, 1);
+        assert.ok(!clientArgsSeen[0].includes("-e"), "installed entry loads the plugin — no -e double load");
+        assert.equal(fs.existsSync(`${ompHome}-bili`), false, "still no overlay dir");
+        assert.deepEqual(exitCalls, [0]);
+    } finally {
+        process.exit = prevExit;
+        if (prevClientBin === undefined) delete process.env.BILI_CLIENT_BIN;
+        else process.env.BILI_CLIENT_BIN = prevClientBin;
+        process.env.HOME = prevHome;
+        if (prevUserProfile === undefined) delete process.env.USERPROFILE;
+        else process.env.USERPROFILE = prevUserProfile;
+        if (prevOmpDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+        else process.env.PI_CODING_AGENT_DIR = prevOmpDir;
+        if (distExisted) fs.renameSync(distBackup, distAgent);
+        fs.rmSync(home, { recursive: true, force: true });
+    }
+});
+
+test("runLaunch hermes #535: proxy env routing, no HERMES_HOME overlay, real config untouched", async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "bili-hermesenv-"));
+    const prevHome = process.env.HOME;
+    const prevUserProfile = process.env.USERPROFILE;
+    const prevHermesHome = process.env.HERMES_HOME;
+    const prevHttpsProxy = process.env.HTTPS_PROXY;
+    const prevClientBin = process.env.BILI_CLIENT_BIN;
+    process.env.HOME = home;
+    if (prevUserProfile !== undefined) process.env.USERPROFILE = home;
+    delete process.env.HTTPS_PROXY;
+    const fakeHermes = path.join(home, "fake-hermes");
+    fs.writeFileSync(fakeHermes, "");
+    process.env.BILI_CLIENT_BIN = fakeHermes;
+    const hermesHome = path.join(home, ".hermes");
+    fs.mkdirSync(hermesHome, { recursive: true });
+    fs.writeFileSync(
+        path.join(hermesHome, "config.yaml"),
+        "providers:\n  sglang:\n    api: http://127.0.0.1:8199/v1\n",
+    );
+    // Custom real home: a user-set HERMES_HOME points at their actual hermes
+    // install (discovery resolved the same path) and must survive to the child.
+    process.env.HERMES_HOME = hermesHome;
+    const configStat = fs.statSync(path.join(hermesHome, "config.yaml"));
+
+    let childEnv: NodeJS.ProcessEnv | undefined;
+    const spawnImpl: SpawnFn = (cmd, _args, options) => {
+        if (cmd === fakeHermes) {
+            childEnv = options.env;
+            const child = makeFakeChild(0);
+            const orig = child.on.bind(child);
+            (child as { on: SpawnChild["on"] }).on = (event, listener) => {
+                orig(event, listener);
+                if (event === "exit") setTimeout(() => listener(0, null), 0);
+                return child;
+            };
+            return child;
+        }
+        return makeFakeChild(42422);
+    };
+    const prevExit = process.exit;
+    const exitCalls: number[] = [];
+    process.exit = ((code?: number) => {
+        exitCalls.push(code ?? 0);
+        return undefined as never;
+    }) as typeof process.exit;
+    try {
+        await runLaunch(
+            { client: "hermes", clientArgs: [], overrides: {} },
+            { fetchImpl: async () => ({ ok: true }), spawnImpl, sleep: () => Promise.resolve() },
+        );
+        assert.deepEqual(exitCalls, [0]);
+        assert.ok(childEnv, "client spawned");
+        assert.match(childEnv!.HTTPS_PROXY ?? "", /^http:\/\/127\.0\.0\.1:\d+$/);
+        assert.ok(childEnv!.HERMES_CA_BUNDLE, "CA bundle exported");
+        assert.equal(childEnv!.HERMES_HOME, hermesHome, "user-set real home survives to the child");
+        assert.equal(fs.existsSync(`${hermesHome}-bili`), false, "no hermes overlay dir");
+        const after = fs.statSync(path.join(hermesHome, "config.yaml"));
+        assert.equal(after.mtimeMs, configStat.mtimeMs, "real config.yaml untouched");
+    } finally {
+        process.exit = prevExit;
+        if (prevClientBin === undefined) delete process.env.BILI_CLIENT_BIN;
+        else process.env.BILI_CLIENT_BIN = prevClientBin;
+        if (prevHermesHome === undefined) delete process.env.HERMES_HOME;
+        else process.env.HERMES_HOME = prevHermesHome;
+        if (prevHttpsProxy === undefined) delete process.env.HTTPS_PROXY;
+        else process.env.HTTPS_PROXY = prevHttpsProxy;
+        process.env.HOME = prevHome;
+        if (prevUserProfile === undefined) delete process.env.USERPROFILE;
+        else process.env.USERPROFILE = prevUserProfile;
+        fs.rmSync(home, { recursive: true, force: true });
+    }
+});
 test("runLaunch pi #535: refuses launch when ONLY https (hand-wrapped) rewrites needed and extension cannot load", async () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "bili-pirefuse2-"));
     const prevHome = process.env.HOME;
@@ -1086,21 +1234,6 @@ test("buildPiEnv: no rewrites → no manifest env", () => {
     assert.equal(env.BILI_PROVIDER_REWRITES, undefined);
 });
 
-test("buildPiEnv: https rewrites merge RAW values (hand-wrapped baseUrl repointed onto cert-MITM)", () => {
-    const env = buildPiEnv(
-        "http://127.0.0.1:8787",
-        "/tmp/ca.pem",
-        { PATH: "/usr/bin" },
-        [{ key: "httpProv", realUpstream: "http://example.com/v1" }],
-        [{ key: "httpsProv", realUpstream: "https://api.openai.com/v1" }],
-    );
-    const manifest = JSON.parse(env.BILI_PROVIDER_REWRITES ?? "null");
-    assert.deepEqual(manifest, {
-        httpProv: "http://127.0.0.1:8787/bili/http://example.com/v1",
-        httpsProv: "https://api.openai.com/v1",
-    });
-});
-
 test("buildPiEnv: empty-key/empty-upstream entries skipped", () => {
     const env = buildPiEnv("http://127.0.0.1:8787", "/tmp/ca.pem", { PATH: "/usr/bin" }, [
         { key: "", realUpstream: "http://example.com/v1" },
@@ -1123,10 +1256,12 @@ test("stripInheritedProxy: removes generic proxy redirector vars, keeps the rest
         PATH: "/usr/bin",
         HOME: "/home/dog",
     });
-    for (const k of ["http_proxy", "https_proxy", "all_proxy", "HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY"]) {
+    for (const k of ["http_proxy", "https_proxy", "all_proxy", "HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "no_proxy", "NO_PROXY"]) {
         assert.equal(cleaned[k], undefined, `${k} should be stripped`);
     }
-    assert.equal(cleaned.no_proxy, "127.0.0.1", "no_proxy kept");
+    // #535: no_proxy/NO_PROXY are stripped too — an inherited exclusion list
+    // could punch holes in the proxy routing we inject (hermes/httpx honors
+    // no_proxy per-URL).
     assert.equal(cleaned.BILI_UPSTREAM_PROXY, "http://relay:9999", "BILI_UPSTREAM_PROXY kept (explicit chaining)");
     assert.equal(cleaned.PATH, "/usr/bin", "PATH kept");
     assert.equal(cleaned.HOME, "/home/dog", "HOME kept");
@@ -1198,539 +1333,6 @@ test("discoverRoutes: omp http + https providers → splits httpsDomains + httpR
     assert.deepEqual(routes.httpRewrites, [
         { key: "sglang", realUpstream: "http://127.0.0.1:8199/v1" },
     ]);
-});
-
-test("prepareOmpHttpRewrite: rewrites matching provider, leaves others, symlinks siblings", () => {
-    // realpath: on macOS os.tmpdir() is /var/folders (a symlink to /private/var);
-    // the realpathSync asserts below compare canonical forms on both sides.
-    const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "bili-omphome-")));
-    fs.writeFileSync(
-        path.join(home, "models.yml"),
-        [
-            "providers:",
-            "  a:",
-            "    baseUrl: http://example.com/v1",
-            "  b:",
-            "    baseUrl: https://secure.example.com",
-        ].join("\n"),
-    );
-    fs.writeFileSync(path.join(home, "config.yml"), "extensions:\n  - /x/omp.js\n");
-    fs.writeFileSync(path.join(home, "auth.json"), '{"key":"x"}');
-    const tmp = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", [
-        { key: "a", realUpstream: "http://example.com/v1" },
-    ], []);
-    try {
-        assert.equal(tmp, `${home}-bili`);
-        const out = fs.readFileSync(path.join(tmp!, "models.yml"), "utf8");
-        assert.ok(out.includes("baseUrl: http://127.0.0.1:8787/bili/http://example.com/v1"), "a rewritten");
-        assert.ok(out.includes("baseUrl: https://secure.example.com"), "b unchanged");
-        assert.equal(fs.lstatSync(path.join(tmp!, "auth.json")).isSymbolicLink(), true, "sibling symlinked");
-        assert.equal(fs.realpathSync(path.join(tmp!, "auth.json")), path.join(home, "auth.json"));
-        assert.equal(fs.lstatSync(path.join(tmp!, "config.yml")).isSymbolicLink(), false, "config.yml generated, not symlinked");
-        const cfg = fs.readFileSync(path.join(tmp!, "config.yml"), "utf8");
-        assert.ok(cfg.includes("extensions:"), "config.yml preserves other keys");
-        assert.ok(cfg.includes("compaction:"), "config.yml has compaction block");
-        assert.ok(cfg.includes("enabled: false"), "omp native compaction disabled");
-    } finally {
-        if (tmp) fs.rmSync(tmp, { recursive: true, force: true });
-        fs.rmSync(home, { recursive: true, force: true });
-    }
-});
-
-test("prepareOmpHttpRewrite: non-existent home → undefined", () => {
-    assert.equal(prepareOmpHttpRewrite("/nonexistent-bili-omp-home-xyz", "http://127.0.0.1:8787", [], []), undefined);
-});
-
-test("prepareOmpHttpRewrite: no rewrites → overlay built, omp native compaction disabled, models.yml copied verbatim", () => {
-    const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "bili-omphome-")));
-    fs.writeFileSync(path.join(home, "models.yml"), "providers:\n  a:\n    baseUrl: https://keep.example.com\n");
-    try {
-        const overlay = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", [], []);
-        assert.ok(typeof overlay === "string" && overlay.length > 0);
-        const cfg = fs.readFileSync(path.join(overlay!, "config.yml"), "utf8");
-        assert.ok(cfg.includes("enabled: false"), "omp native compaction disabled");
-        const out = fs.readFileSync(path.join(overlay!, "models.yml"), "utf8");
-        assert.ok(out.includes("baseUrl: https://keep.example.com"), "no rewrite → baseUrl untouched");
-    } finally {
-        fs.rmSync(home, { recursive: true, force: true });
-        fs.rmSync(`${home}-bili`, { recursive: true, force: true });
-    }
-});
-
-test("prepareOmpHttpRewrite: preserves other config.yml keys, disables only compaction", () => {
-    const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "bili-omphome-")));
-    fs.writeFileSync(path.join(home, "config.yml"), "theme: dark\nmodel: omp/large\nextensions:\n  - /x/omp.js\n");
-    try {
-        const overlay = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", [], []);
-        assert.ok(typeof overlay === "string");
-        const cfg = fs.readFileSync(path.join(overlay!, "config.yml"), "utf8");
-        assert.ok(cfg.includes("theme: dark"), "theme preserved");
-        assert.ok(cfg.includes("model: omp/large"), "model preserved");
-        assert.ok(cfg.includes("extensions:"), "extensions preserved");
-        assert.ok(cfg.includes("compaction:"), "compaction block added");
-        assert.ok(cfg.includes("enabled: false"), "compaction disabled");
-    } finally {
-        fs.rmSync(home, { recursive: true, force: true });
-        fs.rmSync(`${home}-bili`, { recursive: true, force: true });
-    }
-});
-
-test("prepareOmpHttpRewrite: existing compaction block → enabled overridden to false, other compaction keys preserved", () => {
-    const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "bili-omphome-")));
-    fs.writeFileSync(path.join(home, "config.yml"), "theme: dark\ncompaction:\n  enabled: true\n  reserveTokens: 8000\n");
-    try {
-        const overlay = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", [], []);
-        assert.ok(typeof overlay === "string");
-        const cfg = fs.readFileSync(path.join(overlay!, "config.yml"), "utf8");
-        assert.ok(cfg.includes("theme: dark"), "theme preserved");
-        assert.ok(cfg.includes("enabled: false"), "enabled overridden to false");
-        assert.ok(!cfg.includes("enabled: true"), "old enabled: true gone");
-        assert.ok(cfg.includes("reserveTokens: 8000"), "other compaction keys preserved");
-    } finally {
-        fs.rmSync(home, { recursive: true, force: true });
-        fs.rmSync(`${home}-bili`, { recursive: true, force: true });
-    }
-});
-
-test("prepareOmpHttpRewrite: legacy settings.json (no config.yml) → config.yml generated from it, compaction disabled", () => {
-    const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "bili-omphome-")));
-    fs.writeFileSync(path.join(home, "settings.json"), JSON.stringify({ theme: "dark", compaction: { reserveTokens: 1234 } }));
-    try {
-        const overlay = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", [], []);
-        assert.ok(typeof overlay === "string");
-        const cfg = fs.readFileSync(path.join(overlay!, "config.yml"), "utf8");
-        const parsed = JSON.parse(cfg);
-        assert.equal(parsed.compaction.enabled, false, "compaction disabled");
-        assert.equal(parsed.compaction.reserveTokens, 1234, "other compaction keys preserved");
-        assert.equal(parsed.theme, "dark", "theme preserved");
-    } finally {
-        fs.rmSync(home, { recursive: true, force: true });
-        fs.rmSync(`${home}-bili`, { recursive: true, force: true });
-    }
-});
-
-test("prepareOmpHttpRewrite: overlay is stable, refreshes symlinks, keeps bili-created entries", () => {
-    const home = fs.mkdtempSync(path.join(os.tmpdir(), "bili-omphome-"));
-    const modelsYml = ["providers:", "  a:", "    baseUrl: http://example.com/v1"].join("\n");
-    fs.writeFileSync(path.join(home, "models.yml"), modelsYml);
-    fs.mkdirSync(path.join(home, "sessions"));
-    const rw = [{ key: "a", realUpstream: "http://example.com/v1" }];
-    let tmp: string | undefined;
-    try {
-        tmp = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", rw, []);
-        assert.equal(tmp, `${home}-bili`);
-        assert.equal(fs.lstatSync(path.join(tmp!, "sessions")).isSymbolicLink(), true);
-        fs.writeFileSync(path.join(tmp!, "agent.db"), "state-created-inside-overlay");
-        const tmp2 = prepareOmpHttpRewrite(home, "http://127.0.0.1:9999", rw, []);
-        assert.equal(tmp2, tmp);
-        assert.equal(fs.readFileSync(path.join(tmp!, "agent.db"), "utf8"), "state-created-inside-overlay");
-        const rewritten = fs.readFileSync(path.join(tmp!, "models.yml"), "utf8");
-        assert.ok(rewritten.includes("baseUrl: http://127.0.0.1:9999/bili/http://example.com/v1"), "port updated");
-        fs.mkdirSync(path.join(home, "memories"));
-        const tmp3 = prepareOmpHttpRewrite(home, "http://127.0.0.1:9999", rw, []);
-        assert.equal(tmp3, tmp);
-        assert.equal(fs.lstatSync(path.join(tmp!, "memories")).isSymbolicLink(), true);
-        const leftovers = fs.readdirSync(tmp!).filter((f) => /^\.models\.yml\.\d+\.tmp$/.test(f));
-        assert.deepEqual(leftovers, [], "no leftover models.yml tmp files");
-    } finally {
-        if (tmp) fs.rmSync(tmp, { recursive: true, force: true });
-        fs.rmSync(home, { recursive: true, force: true });
-    }
-});
-
-test("prepareOmpHttpRewrite: drops dead symlinks and merges shadowed dirs into real home", () => {
-    const home = fs.mkdtempSync(path.join(os.tmpdir(), "bili-omphome-"));
-    const modelsYml = ["providers:", "  a:", "    baseUrl: http://example.com/v1"].join("\n");
-    fs.writeFileSync(path.join(home, "models.yml"), modelsYml);
-    fs.mkdirSync(path.join(home, "sessions"));
-    const rw = [{ key: "a", realUpstream: "http://example.com/v1" }];
-    const overlay = `${home}-bili`;
-    let tmp: string | undefined;
-    try {
-        tmp = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", rw, []);
-        fs.symlinkSync(path.join(home, "gone-entry"), path.join(overlay, "gone-entry"));
-        fs.rmSync(path.join(overlay, "sessions"));
-        fs.mkdirSync(path.join(overlay, "sessions"));
-        fs.writeFileSync(path.join(overlay, "sessions", "orphaned.jsonl"), "session-created-under-bili");
-        tmp = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", rw, []);
-        assert.equal(fs.existsSync(path.join(overlay, "gone-entry")), false, "dead symlink dropped");
-        assert.equal(fs.lstatSync(path.join(overlay, "sessions")).isSymbolicLink(), true, "shadow dir re-linked");
-        assert.equal(
-            fs.readFileSync(path.join(home, "sessions", "orphaned.jsonl"), "utf8"),
-            "session-created-under-bili",
-            "shadow dir merged into real home",
-        );
-    } finally {
-        if (tmp) fs.rmSync(tmp, { recursive: true, force: true });
-        fs.rmSync(home, { recursive: true, force: true });
-    }
-});
-
-test("prepareOmpHttpRewrite: shadow FILE merged newer-wins, loser kept as .bili-conflict", () => {
-    const home = fs.mkdtempSync(path.join(os.tmpdir(), "bili-omphome-"));
-    const modelsYml = ["providers:", "  a:", "    baseUrl: http://example.com/v1"].join("\n");
-    fs.writeFileSync(path.join(home, "models.yml"), modelsYml);
-    fs.writeFileSync(path.join(home, "settings.json"), "stale-from-real-home");
-    fs.writeFileSync(path.join(home, "older.json"), "real-newer");
-    const rw = [{ key: "a", realUpstream: "http://example.com/v1" }];
-    const overlay = `${home}-bili`;
-    let tmp: string | undefined;
-    try {
-        tmp = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", rw, []);
-        assert.equal(fs.readFileSync(path.join(overlay, ".bili-launch.pid"), "utf8").trim(), `${process.pid}`, "launch pid marker written");
-        fs.rmSync(path.join(overlay, "settings.json"));
-        fs.writeFileSync(path.join(overlay, "settings.json"), "client-newer-write");
-        const now = Date.now();
-        fs.utimesSync(path.join(home, "settings.json"), new Date(now - 4000), new Date(now - 4000));
-        fs.rmSync(path.join(overlay, "older.json"));
-        fs.writeFileSync(path.join(overlay, "older.json"), "overlay-stale");
-        fs.utimesSync(path.join(overlay, "older.json"), new Date(now - 4000), new Date(now - 4000));
-        tmp = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", rw, []);
-        assert.equal(fs.readFileSync(path.join(home, "settings.json"), "utf8"), "client-newer-write", "newer overlay file wins");
-        assert.equal(fs.readFileSync(path.join(home, "settings.json.bili-conflict"), "utf8"), "stale-from-real-home", "loser preserved as conflict copy");
-        assert.equal(fs.lstatSync(path.join(overlay, "settings.json")).isSymbolicLink(), true, "shadow file re-linked");
-        assert.equal(fs.readFileSync(path.join(home, "older.json"), "utf8"), "real-newer", "newer real-home file wins");
-        assert.equal(fs.readFileSync(path.join(home, "older.json.bili-conflict"), "utf8"), "overlay-stale", "stale overlay copy preserved as conflict");
-        assert.equal(fs.lstatSync(path.join(overlay, "older.json")).isSymbolicLink(), true, "re-linked after merge");
-    } finally {
-        if (tmp) fs.rmSync(tmp, { recursive: true, force: true });
-        fs.rmSync(home, { recursive: true, force: true });
-    }
-});
-
-test("prepareOmpHttpRewrite: recursive dir merge keeps deep new files when both sides share a subdir", () => {
-    const home = fs.mkdtempSync(path.join(os.tmpdir(), "bili-omphome-"));
-    const modelsYml = ["providers:", "  a:", "    baseUrl: http://example.com/v1"].join("\n");
-    fs.writeFileSync(path.join(home, "models.yml"), modelsYml);
-    fs.mkdirSync(path.join(home, "sessions", "sub"), { recursive: true });
-    fs.writeFileSync(path.join(home, "sessions", "sub", "old.jsonl"), "old");
-    const rw = [{ key: "a", realUpstream: "http://example.com/v1" }];
-    const overlay = `${home}-bili`;
-    let tmp: string | undefined;
-    try {
-        tmp = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", rw, []);
-        fs.rmSync(path.join(overlay, "sessions"));
-        fs.mkdirSync(path.join(overlay, "sessions", "sub"), { recursive: true });
-        fs.writeFileSync(path.join(overlay, "sessions", "sub", "new.jsonl"), "deep-new-session");
-        tmp = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", rw, []);
-        assert.equal(fs.readFileSync(path.join(home, "sessions", "sub", "old.jsonl"), "utf8"), "old", "existing deep file untouched");
-        assert.equal(fs.readFileSync(path.join(home, "sessions", "sub", "new.jsonl"), "utf8"), "deep-new-session", "deep new file merged, not destroyed");
-        assert.equal(fs.lstatSync(path.join(overlay, "sessions")).isSymbolicLink(), true, "shadow dir re-linked");
-    } finally {
-        if (tmp) fs.rmSync(tmp, { recursive: true, force: true });
-        fs.rmSync(home, { recursive: true, force: true });
-    }
-});
-
-test("prepareOmpHttpRewrite: file-vs-dir type clash preserves both sides", () => {
-    const home = fs.mkdtempSync(path.join(os.tmpdir(), "bili-omphome-"));
-    const modelsYml = ["providers:", "  a:", "    baseUrl: http://example.com/v1"].join("\n");
-    fs.writeFileSync(path.join(home, "models.yml"), modelsYml);
-    fs.writeFileSync(path.join(home, "state.bin"), "v1-file");
-    const rw = [{ key: "a", realUpstream: "http://example.com/v1" }];
-    const overlay = `${home}-bili`;
-    let tmp: string | undefined;
-    try {
-        tmp = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", rw, []);
-        fs.rmSync(path.join(overlay, "state.bin"));
-        fs.mkdirSync(path.join(overlay, "state.bin", "x"), { recursive: true });
-        fs.writeFileSync(path.join(overlay, "state.bin", "x", "precious.txt"), "precious");
-        tmp = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", rw, []);
-        assert.equal(fs.statSync(path.join(home, "state.bin")).isDirectory(), true, "merged dir took the canonical name");
-        assert.equal(fs.readFileSync(path.join(home, "state.bin", "x", "precious.txt"), "utf8"), "precious", "overlay subtree preserved, not destroyed");
-        assert.equal(fs.readFileSync(path.join(home, "state.bin.bili-conflict"), "utf8"), "v1-file", "displaced real-home file preserved as conflict copy");
-        assert.equal(fs.lstatSync(path.join(overlay, "state.bin")).isSymbolicLink(), true, "re-linked after merge");
-    } finally {
-        if (tmp) fs.rmSync(tmp, { recursive: true, force: true });
-        fs.rmSync(home, { recursive: true, force: true });
-    }
-});
-
-test("prepareOmpHttpRewrite: returns undefined when no rewrites", () => {
-    assert.equal(prepareOmpHttpRewrite("/whatever", "http://127.0.0.1:8787", [], []), undefined);
-});
-
-test("prepareOmpHttpRewrite: models.yml missing → overlay still built (config.yml generated), no models.yml", () => {
-    const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "bili-omphome-")));
-    try {
-        const rw = [{ key: "a", realUpstream: "http://example.com/v1" }];
-        const overlay = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", rw, []);
-        assert.equal(overlay, `${home}-bili`);
-        assert.equal(fs.existsSync(path.join(overlay!, "config.yml")), true, "config.yml generated");
-        assert.ok(fs.readFileSync(path.join(overlay!, "config.yml"), "utf8").includes("enabled: false"), "omp native compaction disabled");
-        assert.equal(fs.existsSync(path.join(overlay!, "models.yml")), false, "no models.yml copied");
-    } finally {
-        fs.rmSync(home, { recursive: true, force: true });
-        fs.rmSync(`${home}-bili`, { recursive: true, force: true });
-    }
-});
-
-// #381: Windows overlay symlink EPERM fallback. Unprivileged Windows
-// processes lack SeCreateSymbolicLinkPrivilege, so plain symlinkSync throws
-// EPERM and the overlay would be silently hollowed (fresh, unconfigured
-// client every launch). Simulated on Linux by denying fs.symlinkSync for
-// non-junction links (junctions stay allowed).
-function denyErr(code: string): NodeJS.ErrnoException {
-    const err = new Error(`${code}: operation not permitted`) as NodeJS.ErrnoException;
-    err.code = code;
-    return err;
-}
-
-test("prepareOmpHttpRewrite: EPERM fallback links dir→junction, file→hardlink, overlay not hollow (#381)", () => {
-    const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "bili-omphome-")));
-    fs.writeFileSync(path.join(home, "models.yml"), ["providers:", "  a:", "    baseUrl: http://example.com/v1"].join("\n"));
-    fs.mkdirSync(path.join(home, "sessions"));
-    fs.writeFileSync(path.join(home, "settings.json"), "real-settings");
-    const rw = [{ key: "a", realUpstream: "http://example.com/v1" }];
-    const realSymlinkSync = fs.symlinkSync;
-    fs.symlinkSync = ((target: PathLike, link: PathLike, type?: SymlinkKind) => {
-        if (type === "junction") return realSymlinkSync(target, link, "junction");
-        throw denyErr("EPERM");
-    }) as typeof fs.symlinkSync;
-    let tmp: string | undefined;
-    try {
-        tmp = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", rw, []);
-        assert.equal(tmp, `${home}-bili`, "overlay returned, not hollow");
-        const overlay = tmp!;
-        assert.equal(fs.lstatSync(path.join(overlay, "sessions")).isSymbolicLink(), true, "dir linked via junction");
-        assert.equal(fs.realpathSync(path.join(overlay, "sessions")), path.join(home, "sessions"), "junction points at real dir");
-        const st = fs.lstatSync(path.join(overlay, "settings.json"));
-        const realSt = fs.lstatSync(path.join(home, "settings.json"));
-        assert.equal(st.isSymbolicLink(), false, "file is a hardlink, not a symlink");
-        assert.equal(st.nlink, 2, "hardlink has nlink 2");
-        assert.ok(st.dev === realSt.dev && st.ino === realSt.ino, "hardlink shares inode with real file");
-    } finally {
-        fs.symlinkSync = realSymlinkSync;
-        if (tmp) fs.rmSync(tmp, { recursive: true, force: true });
-        fs.rmSync(home, { recursive: true, force: true });
-    }
-});
-
-test("prepareOmpHttpRewrite: EPERM fallback copies file when hardlink also denied (#381)", () => {
-    const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "bili-omphome-")));
-    fs.writeFileSync(path.join(home, "models.yml"), ["providers:", "  a:", "    baseUrl: http://example.com/v1"].join("\n"));
-    fs.writeFileSync(path.join(home, "settings.json"), "real-settings");
-    const rw = [{ key: "a", realUpstream: "http://example.com/v1" }];
-    const realSymlinkSync = fs.symlinkSync;
-    const realLinkSync = fs.linkSync;
-    fs.symlinkSync = ((target: PathLike, link: PathLike, type?: SymlinkKind) => {
-        if (type === "junction") return realSymlinkSync(target, link, "junction");
-        throw denyErr("EPERM");
-    }) as typeof fs.symlinkSync;
-    fs.linkSync = (() => { throw denyErr("EPERM"); }) as typeof fs.linkSync;
-    let tmp: string | undefined;
-    try {
-        tmp = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", rw, []);
-        assert.equal(tmp, `${home}-bili`);
-        const st = fs.lstatSync(path.join(tmp!, "settings.json"));
-        assert.equal(st.isSymbolicLink(), false, "file is a copy, not a symlink");
-        assert.equal(st.nlink, 1, "copy has nlink 1 (not a hardlink)");
-        assert.equal(fs.readFileSync(path.join(tmp!, "settings.json"), "utf8"), "real-settings", "copy content matches");
-    } finally {
-        fs.symlinkSync = realSymlinkSync;
-        fs.linkSync = realLinkSync;
-        if (tmp) fs.rmSync(tmp, { recursive: true, force: true });
-        fs.rmSync(home, { recursive: true, force: true });
-    }
-});
-
-test("prepareOmpHttpRewrite: all link fallbacks fail → hollow overlay → returns undefined (#381)", () => {
-    const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "bili-omphome-")));
-    fs.writeFileSync(path.join(home, "models.yml"), ["providers:", "  a:", "    baseUrl: http://example.com/v1"].join("\n"));
-    fs.mkdirSync(path.join(home, "sessions"));
-    fs.writeFileSync(path.join(home, "settings.json"), "real-settings");
-    const rw = [{ key: "a", realUpstream: "http://example.com/v1" }];
-    const realSymlinkSync = fs.symlinkSync;
-    const realLinkSync = fs.linkSync;
-    const realCopyFileSync = fs.copyFileSync;
-    fs.symlinkSync = (() => { throw denyErr("EPERM"); }) as typeof fs.symlinkSync;
-    fs.linkSync = (() => { throw denyErr("EPERM"); }) as typeof fs.linkSync;
-    fs.copyFileSync = (() => { throw denyErr("EPERM"); }) as typeof fs.copyFileSync;
-    try {
-        const tmp = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", rw, []);
-        assert.equal(tmp, undefined, "hollow overlay → undefined (fail loudly, not silent)");
-    } finally {
-        fs.symlinkSync = realSymlinkSync;
-        fs.linkSync = realLinkSync;
-        fs.copyFileSync = realCopyFileSync;
-        fs.rmSync(`${home}-bili`, { recursive: true, force: true });
-        fs.rmSync(home, { recursive: true, force: true });
-    }
-});
-
-test("prepareOmpHttpRewrite: SQLite three-piece set (.db/.db-wal/.db-shm) moves as a unit (#381)", () => {
-    const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "bili-omphome-")));
-    fs.writeFileSync(path.join(home, "models.yml"), ["providers:", "  a:", "    baseUrl: http://example.com/v1"].join("\n"));
-    const rw = [{ key: "a", realUpstream: "http://example.com/v1" }];
-    const overlay = `${home}-bili`;
-    let tmp: string | undefined;
-    try {
-        tmp = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", rw, []);
-        assert.equal(tmp, overlay);
-        fs.writeFileSync(path.join(overlay, "agent.db"), "db-content");
-        fs.writeFileSync(path.join(overlay, "agent.db-wal"), "wal-content");
-        fs.writeFileSync(path.join(overlay, "agent.db-shm"), "shm-content");
-        tmp = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", rw, []);
-        assert.equal(fs.readFileSync(path.join(home, "agent.db"), "utf8"), "db-content", "db moved to real home");
-        assert.equal(fs.readFileSync(path.join(home, "agent.db-wal"), "utf8"), "wal-content", "wal moved with the db");
-        assert.equal(fs.readFileSync(path.join(home, "agent.db-shm"), "utf8"), "shm-content", "shm moved with the db");
-        assert.equal(fs.existsSync(path.join(overlay, "agent.db")), false, "db left the overlay");
-        assert.equal(fs.existsSync(path.join(overlay, "agent.db-wal")), false, "wal left the overlay");
-        assert.equal(fs.existsSync(path.join(overlay, "agent.db-shm")), false, "shm left the overlay");
-    } finally {
-        if (tmp) fs.rmSync(tmp, { recursive: true, force: true });
-        fs.rmSync(home, { recursive: true, force: true });
-    }
-});
-
-test("prepareOmpHttpRewrite: SQLite set merge failure rolls back, keeps set in overlay (#381)", () => {
-    const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "bili-omphome-")));
-    fs.writeFileSync(path.join(home, "models.yml"), ["providers:", "  a:", "    baseUrl: http://example.com/v1"].join("\n"));
-    fs.writeFileSync(path.join(home, "agent.db"), "real-original-db");
-    const old = new Date(Date.now() - 60000);
-    fs.utimesSync(path.join(home, "agent.db"), old, old);
-    const rw = [{ key: "a", realUpstream: "http://example.com/v1" }];
-    const overlay = `${home}-bili`;
-    let tmp: string | undefined;
-    const realRenameSync = fs.renameSync;
-    try {
-        tmp = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", rw, []);
-        assert.equal(tmp, overlay);
-        fs.rmSync(path.join(overlay, "agent.db"));
-        fs.writeFileSync(path.join(overlay, "agent.db"), "overlay-db");
-        fs.writeFileSync(path.join(overlay, "agent.db-wal"), "overlay-wal");
-        fs.writeFileSync(path.join(overlay, "agent.db-shm"), "overlay-shm");
-        fs.renameSync = ((src: PathLike, dst: PathLike) => {
-            if (String(src).endsWith("agent.db-shm")) throw denyErr("EPERM");
-            return realRenameSync(src, dst);
-        }) as typeof fs.renameSync;
-        tmp = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", rw, []);
-        assert.equal(fs.readFileSync(path.join(home, "agent.db"), "utf8"), "real-original-db", "real db restored after rollback");
-        assert.equal(fs.existsSync(path.join(home, "agent.db-wal")), false, "wal rolled back to overlay");
-        assert.equal(fs.existsSync(path.join(home, "agent.db-shm")), false, "shm rolled back to overlay");
-        assert.equal(fs.readFileSync(path.join(overlay, "agent.db"), "utf8"), "overlay-db", "db stays in overlay");
-        assert.equal(fs.readFileSync(path.join(overlay, "agent.db-wal"), "utf8"), "overlay-wal", "wal stays in overlay");
-        assert.equal(fs.readFileSync(path.join(overlay, "agent.db-shm"), "utf8"), "overlay-shm", "shm stays in overlay");
-    } finally {
-        fs.renameSync = realRenameSync;
-        if (tmp) fs.rmSync(tmp, { recursive: true, force: true });
-        fs.rmSync(home, { recursive: true, force: true });
-    }
-});
-
-test("prepareOmpHttpRewrite: write-through hardlink is re-pointed, never merged back (#381)", () => {
-    const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "bili-omphome-")));
-    fs.writeFileSync(path.join(home, "models.yml"), ["providers:", "  a:", "    baseUrl: http://example.com/v1"].join("\n"));
-    fs.writeFileSync(path.join(home, "settings.json"), "real-settings");
-    const rw = [{ key: "a", realUpstream: "http://example.com/v1" }];
-    const overlay = `${home}-bili`;
-    const realSymlinkSync = fs.symlinkSync;
-    fs.symlinkSync = ((target: PathLike, link: PathLike, type?: SymlinkKind) => {
-        if (type === "junction") return realSymlinkSync(target, link, "junction");
-        throw denyErr("EPERM");
-    }) as typeof fs.symlinkSync;
-    let tmp: string | undefined;
-    try {
-        tmp = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", rw, []);
-        assert.equal(tmp, overlay);
-        assert.equal(fs.lstatSync(path.join(overlay, "settings.json")).nlink, 2, "file linked as a hardlink");
-        fs.appendFileSync(path.join(overlay, "settings.json"), "-appended");
-        tmp = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", rw, []);
-        assert.equal(fs.readFileSync(path.join(home, "settings.json"), "utf8"), "real-settings-appended", "write-through reached the real file");
-        const st = fs.lstatSync(path.join(overlay, "settings.json"));
-        assert.equal(st.isSymbolicLink(), false, "re-pointed as a hardlink, not a symlink");
-        assert.equal(st.nlink, 2, "still a hardlink after re-point");
-        assert.equal(fs.existsSync(path.join(home, "settings.json.bili-conflict")), false, "not merged (no .bili-conflict)");
-    } finally {
-        fs.symlinkSync = realSymlinkSync;
-        if (tmp) fs.rmSync(tmp, { recursive: true, force: true });
-        fs.rmSync(home, { recursive: true, force: true });
-    }
-});
-
-test("prepareOmpHttpRewrite: SQLite set adjudicated by main db — no cross-side WAL splice (#381)", () => {
-    const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "bili-omphome-")));
-    fs.writeFileSync(path.join(home, "models.yml"), ["providers:", "  a:", "    baseUrl: http://example.com/v1"].join("\n"));
-    const now = Date.now();
-    fs.writeFileSync(path.join(home, "agent.db"), "real-db");
-    fs.writeFileSync(path.join(home, "agent.db-wal"), "real-wal");
-    const overlay = `${home}-bili`;
-    fs.mkdirSync(overlay);
-    fs.writeFileSync(path.join(overlay, "agent.db"), "overlay-db");
-    fs.writeFileSync(path.join(overlay, "agent.db-wal"), "overlay-wal");
-    // main db: real newer than overlay; wal: overlay newer than real — the
-    // cross-generational splice per-member mtime adjudication would produce.
-    fs.utimesSync(path.join(home, "agent.db"), new Date(now - 10000), new Date(now - 10000));
-    fs.utimesSync(path.join(home, "agent.db-wal"), new Date(now - 50000), new Date(now - 50000));
-    fs.utimesSync(path.join(overlay, "agent.db"), new Date(now - 60000), new Date(now - 60000));
-    fs.utimesSync(path.join(overlay, "agent.db-wal"), new Date(now - 5000), new Date(now - 5000));
-    const rw = [{ key: "a", realUpstream: "http://example.com/v1" }];
-    let tmp: string | undefined;
-    try {
-        tmp = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", rw, []);
-        assert.equal(tmp, overlay);
-        assert.equal(fs.readFileSync(path.join(home, "agent.db"), "utf8"), "real-db", "real main db (newer) wins");
-        assert.equal(fs.readFileSync(path.join(home, "agent.db-wal"), "utf8"), "real-wal", "wal comes from the SAME side as the db (no splice)");
-        assert.equal(fs.readFileSync(path.join(home, "agent.db.bili-conflict"), "utf8"), "overlay-db", "losing overlay db preserved");
-        assert.equal(fs.readFileSync(path.join(home, "agent.db-wal.bili-conflict"), "utf8"), "overlay-wal", "losing overlay wal preserved");
-    } finally {
-        if (tmp) fs.rmSync(tmp, { recursive: true, force: true });
-        fs.rmSync(home, { recursive: true, force: true });
-    }
-});
-
-test("prepareOmpHttpRewrite: SQLite -journal sidecar moves with the set, not separately (#381)", () => {
-    const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "bili-omphome-")));
-    fs.writeFileSync(path.join(home, "models.yml"), ["providers:", "  a:", "    baseUrl: http://example.com/v1"].join("\n"));
-    const now = Date.now();
-    fs.writeFileSync(path.join(home, "agent.db"), "real-db");
-    const overlay = `${home}-bili`;
-    fs.mkdirSync(overlay);
-    fs.writeFileSync(path.join(overlay, "agent.db"), "overlay-db");
-    fs.writeFileSync(path.join(overlay, "agent.db-journal"), "overlay-journal");
-    // real main db newer than overlay's; the overlay journal must NOT be
-    // spliced in as an active file against the real (newer) db.
-    fs.utimesSync(path.join(home, "agent.db"), new Date(now - 10000), new Date(now - 10000));
-    fs.utimesSync(path.join(overlay, "agent.db"), new Date(now - 60000), new Date(now - 60000));
-    fs.utimesSync(path.join(overlay, "agent.db-journal"), new Date(now - 5000), new Date(now - 5000));
-    const rw = [{ key: "a", realUpstream: "http://example.com/v1" }];
-    let tmp: string | undefined;
-    try {
-        tmp = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", rw, []);
-        assert.equal(tmp, overlay);
-        assert.equal(fs.readFileSync(path.join(home, "agent.db"), "utf8"), "real-db", "real main db (newer) wins");
-        assert.equal(fs.existsSync(path.join(home, "agent.db-journal")), false, "journal NOT spliced in as an active file");
-        assert.equal(fs.readFileSync(path.join(home, "agent.db-journal.bili-conflict"), "utf8"), "overlay-journal", "journal preserved as a conflict (same side as the losing db)");
-    } finally {
-        if (tmp) fs.rmSync(tmp, { recursive: true, force: true });
-        fs.rmSync(home, { recursive: true, force: true });
-    }
-});
-
-test("prepareOmpHttpRewrite: conflict rename never clobbers a previous round's loser (#381)", () => {
-    const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "bili-omphome-")));
-    fs.writeFileSync(path.join(home, "models.yml"), ["providers:", "  a:", "    baseUrl: http://example.com/v1"].join("\n"));
-    const now = Date.now();
-    fs.writeFileSync(path.join(home, "agent.db"), "real-db");
-    fs.writeFileSync(path.join(home, "agent.db.bili-conflict"), "previous-loser");
-    const overlay = `${home}-bili`;
-    fs.mkdirSync(overlay);
-    fs.writeFileSync(path.join(overlay, "agent.db"), "overlay-db-v1");
-    fs.writeFileSync(path.join(overlay, "agent.db-wal"), "overlay-wal-v1");
-    fs.utimesSync(path.join(home, "agent.db"), new Date(now - 10000), new Date(now - 10000));
-    fs.utimesSync(path.join(overlay, "agent.db"), new Date(now - 60000), new Date(now - 60000));
-    const rw = [{ key: "a", realUpstream: "http://example.com/v1" }];
-    let tmp: string | undefined;
-    try {
-        tmp = prepareOmpHttpRewrite(home, "http://127.0.0.1:8787", rw, []);
-        assert.equal(tmp, overlay);
-        assert.equal(fs.readFileSync(path.join(home, "agent.db"), "utf8"), "real-db", "real main db (newer) wins");
-        assert.equal(fs.readFileSync(path.join(home, "agent.db.bili-conflict"), "utf8"), "previous-loser", "previous round's loser NOT overwritten");
-        assert.equal(fs.readFileSync(path.join(home, "agent.db.bili-conflict.1"), "utf8"), "overlay-db-v1", "this round's loser gets a suffixed name");
-    } finally {
-        if (tmp) fs.rmSync(tmp, { recursive: true, force: true });
-        fs.rmSync(home, { recursive: true, force: true });
-    }
 });
 
 test("readOpencodeConfig: reads provider baseURLs from opencode.json", () => {
@@ -1841,6 +1443,28 @@ test("parseHermesYaml: v12 providers dict + legacy custom_providers list", () =>
     assert.equal(legacy.providers["custom-1"]?.api, "http://other:1/v1");
 });
 
+test("parseHermesYaml: v12 dict base_url/url forms + base_url wins over api", () => {
+    const canonical = parseHermesYaml([
+        "providers:",
+        "  bili:",
+        "    name: bili",
+        "    base_url: http://127.0.0.1:8199/v1",
+        "    transport: openai_chat",
+    ].join("\n"));
+    assert.equal(canonical.providers.bili?.api, "http://127.0.0.1:8199/v1", "base_url is hermes' canonical form");
+
+    const urlForm = parseHermesYaml("providers:\n  u:\n    url: http://u:1/v1\n");
+    assert.equal(urlForm.providers.u?.api, "http://u:1/v1");
+
+    const priority = parseHermesYaml([
+        "providers:",
+        "  p:",
+        "    api: http://stale:1/v1",
+        "    base_url: http://fresh:1/v1",
+    ].join("\n"));
+    assert.equal(priority.providers.p?.api, "http://fresh:1/v1", "base_url beats api (hermes priority)");
+});
+
 test("readHermesConfig + resolveHermesHome", () => {
     assert.equal(resolveHermesHome({ HERMES_HOME: "/tmp/hh" }), "/tmp/hh");
     assert.ok(resolveHermesHome({}).endsWith(path.join(".hermes")));
@@ -1855,7 +1479,7 @@ test("readHermesConfig + resolveHermesHome", () => {
     }
 });
 
-test("discoverRoutes: hermes wraps http AND https via /bili/ (no MITM domains)", () => {
+test("discoverRoutes: hermes splits https → MITM domains, http → forward-proxy inventory (#535)", () => {
     const config: ClientConfig = {};
     (config as Record<string, unknown>).hermes = {
         providers: {
@@ -1866,146 +1490,12 @@ test("discoverRoutes: hermes wraps http AND https via /bili/ (no MITM domains)",
         },
     };
     const routes = discoverRoutes("hermes", config);
-    assert.deepEqual(routes.httpsDomains, []);
-    assert.deepEqual(routes.httpRewrites.map((r) => r.key).sort(), ["glm", "sglang", "wrapped"]);
-    const glm = routes.httpRewrites.find((r) => r.key === "glm");
-    assert.equal(glm?.realUpstream, "https://open.bigmodel.cn/api/paas/v4");
-    const wrapped = routes.httpRewrites.find((r) => r.key === "wrapped");
-    assert.equal(wrapped?.realUpstream, "https://api.foo.io/v1");
-});
-
-test("prepareHermesHome: rewrites api lines, shares siblings, never touches the real home", () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "hermes-home-"));
-    try {
-        fs.writeFileSync(path.join(dir, "config.yaml"), [
-            "model:",
-            "  default: qwen3.8-27b",
-            "providers:",
-            "  bili:",
-            "    api: http://127.0.0.1:8199/v1  # local sglang",
-            "  glm:",
-            "    api: https://open.bigmodel.cn/api/paas/v4",
-            "custom_providers:",
-            "  - name: legacy",
-            "    base_url: http://10.0.0.5:1234/v1",
-        ].join("\n"));
-        fs.writeFileSync(path.join(dir, "SOUL.md"), "soul");
-        fs.mkdirSync(path.join(dir, "skills"));
-        const original = fs.readFileSync(path.join(dir, "config.yaml"), "utf8");
-
-        const rewrites: HttpRewrite[] = [
-            { key: "bili", realUpstream: "http://127.0.0.1:8199/v1" },
-            { key: "glm", realUpstream: "https://open.bigmodel.cn/api/paas/v4" },
-            { key: "legacy", realUpstream: "http://10.0.0.5:1234/v1" },
-        ];
-        const tmp = prepareHermesHome(dir, "http://127.0.0.1:8787", rewrites);
-        assert.ok(tmp);
-        const txt = fs.readFileSync(path.join(tmp, "config.yaml"), "utf8");
-        assert.ok(txt.includes("api: http://127.0.0.1:8787/bili/http://127.0.0.1:8199/v1  # local sglang"));
-        assert.ok(txt.includes("api: http://127.0.0.1:8787/bili/https://open.bigmodel.cn/api/paas/v4"));
-        assert.ok(txt.includes("base_url: http://127.0.0.1:8787/bili/http://10.0.0.5:1234/v1"));
-        assert.equal(fs.readFileSync(path.join(dir, "config.yaml"), "utf8"), original);
-        assert.equal(fs.readFileSync(path.join(tmp, "SOUL.md"), "utf8"), "soul");
-        assert.ok(fs.lstatSync(path.join(tmp, "skills")).isSymbolicLink());
-        fs.rmSync(tmp, { recursive: true, force: true });
-
-        assert.equal(prepareHermesHome(dir, "http://127.0.0.1:8787", []), undefined);
-    } finally {
-        fs.rmSync(dir, { recursive: true, force: true });
-    }
-});
-
-test("prepareHermesHome: preserves CRLF line endings when rewriting", () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "hermes-home-"));
-    try {
-        fs.writeFileSync(
-            path.join(dir, "config.yaml"),
-            ["model:", "  default: qwen3.8-27b", "providers:", "  bili:", "    api: http://127.0.0.1:8199/v1"].join("\r\n") + "\r\n",
-        );
-        const rewrites: HttpRewrite[] = [{ key: "bili", realUpstream: "http://127.0.0.1:8199/v1" }];
-        const tmp = prepareHermesHome(dir, "http://127.0.0.1:8787", rewrites);
-        assert.ok(tmp);
-        const txt = fs.readFileSync(path.join(tmp, "config.yaml"), "utf8");
-        assert.ok(txt.includes("\r\n"), "CRLF preserved");
-        assert.ok(!/\r\n\r\n/.test(txt), "no doubled newlines");
-        assert.ok(txt.includes("api: http://127.0.0.1:8787/bili/http://127.0.0.1:8199/v1\r"));
-        fs.rmSync(tmp, { recursive: true, force: true });
-    } finally {
-        fs.rmSync(dir, { recursive: true, force: true });
-    }
-});
-
-test("prepareHermesHome: returns undefined for unreadable config even with rewrites pending", () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "hermes-home-"));
-    try {
-        const rewrites: HttpRewrite[] = [{ key: "bili", realUpstream: "http://127.0.0.1:8199/v1" }];
-        assert.equal(prepareHermesHome(dir, "http://127.0.0.1:8787", rewrites), undefined);
-    } finally {
-        fs.rmSync(dir, { recursive: true, force: true });
-    }
-});
-
-test("prepareHermesHome: rewrites quoted YAML api values (quotes stripped before match)", () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "hermes-home-"));
-    try {
-        fs.writeFileSync(path.join(dir, "config.yaml"), [
-            "providers:",
-            "  bili:",
-            '    api: "https://api.example.com/v1"',
-            "  glm:",
-            "    api: 'http://10.0.0.5:1234/v1'",
-        ].join("\n"));
-        const rewrites: HttpRewrite[] = [
-            { key: "bili", realUpstream: "https://api.example.com/v1" },
-            { key: "glm", realUpstream: "http://10.0.0.5:1234/v1" },
-        ];
-        const tmp = prepareHermesHome(dir, "http://127.0.0.1:8787", rewrites);
-        assert.ok(tmp, "quoted values must still be rewritten");
-        const txt = fs.readFileSync(path.join(tmp!, "config.yaml"), "utf8");
-        assert.ok(txt.includes("api: http://127.0.0.1:8787/bili/https://api.example.com/v1"));
-        assert.ok(txt.includes("api: http://127.0.0.1:8787/bili/http://10.0.0.5:1234/v1"));
-        fs.rmSync(tmp!, { recursive: true, force: true });
-    } finally {
-        fs.rmSync(dir, { recursive: true, force: true });
-    }
-});
-
-test("writeHermesIdentityPlugin: drops the identity plugin into the overlay, keyed by provider names", () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "hermes-home-"));
-    try {
-        fs.writeFileSync(path.join(dir, "config.yaml"), "providers:\n  bili:\n    api: https://api.example.com/v1\n");
-        const rewrites: HttpRewrite[] = [{ key: "bili", realUpstream: "https://api.example.com/v1" }];
-        const overlay = prepareHermesHome(dir, "http://127.0.0.1:8787", rewrites);
-        assert.ok(overlay);
-        assert.equal(writeHermesIdentityPlugin(dir, overlay!, rewrites), true);
-        const init = fs.readFileSync(path.join(overlay!, "plugins/model-providers/bili-session-identity/__init__.py"), "utf8");
-        assert.ok(init.includes('_PROVIDER_KEYS = ["bili"]'));
-        assert.ok(init.includes('_register("custom", _custom, True)'));
-        assert.ok(init.includes('_register("custom:" + _key, _custom, False)'));
-        assert.ok(init.includes('top_level.setdefault("prompt_cache_key", sid[:64])'));
-        assert.ok(fs.existsSync(path.join(overlay!, "plugins/model-providers/bili-session-identity/plugin.yaml")));
-        // Idempotent rewrite on the next launch.
-        assert.equal(writeHermesIdentityPlugin(dir, overlay!, rewrites), true);
-        fs.rmSync(overlay!, { recursive: true, force: true });
-    } finally {
-        fs.rmSync(dir, { recursive: true, force: true });
-    }
-});
-
-test("writeHermesIdentityPlugin: skipped when the real home has its own plugins dir", () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "hermes-home-"));
-    try {
-        fs.writeFileSync(path.join(dir, "config.yaml"), "providers:\n  bili:\n    api: https://api.example.com/v1\n");
-        fs.mkdirSync(path.join(dir, "plugins"), { recursive: true });
-        const rewrites: HttpRewrite[] = [{ key: "bili", realUpstream: "https://api.example.com/v1" }];
-        const overlay = prepareHermesHome(dir, "http://127.0.0.1:8787", rewrites);
-        assert.ok(overlay);
-        assert.equal(writeHermesIdentityPlugin(dir, overlay!, rewrites), false);
-        assert.ok(!fs.existsSync(path.join(overlay!, "plugins", "model-providers")));
-        fs.rmSync(overlay!, { recursive: true, force: true });
-    } finally {
-        fs.rmSync(dir, { recursive: true, force: true });
-    }
+    assert.deepEqual(routes.httpsDomains, ["open.bigmodel.cn", "api.foo.io"]);
+    // httpRewrites is inventory-only for hermes (banner + no-provider
+    // warning); nothing is rewritten and the real config.yaml is untouched.
+    assert.deepEqual(routes.httpRewrites.map((r) => r.key).sort(), ["sglang"]);
+    const sglang = routes.httpRewrites.find((r) => r.key === "sglang");
+    assert.equal(sglang?.realUpstream, "http://127.0.0.1:8199/v1");
 });
 
 test("readDshConfig + resolveDshHome + parseDshSettingsYaml", () => {

--- a/tests/launcher.test.ts
+++ b/tests/launcher.test.ts
@@ -1768,6 +1768,13 @@ test("runLaunch omp: launcher hands per-model windows to the spawned proxy", asy
             "        contextWindow: 4096",
         ].join("\n"),
     );
+    // A loadable config.yml entry makes the extension available regardless
+    // of whether dist/ is built — CI runs the tests without a prior build, so
+    // the #535 omp refusal must not fire here (models.yml has rewrites).
+    const otherInstall = path.join(home, "other-install", "dist", "agent", "omp.js");
+    fs.mkdirSync(path.dirname(otherInstall), { recursive: true });
+    fs.writeFileSync(otherInstall, "");
+    fs.writeFileSync(path.join(ompHome, "config.yml"), `extensions:\n  - ${otherInstall}\n`);
 
     const proxyEnvs: (NodeJS.ProcessEnv | undefined)[] = [];
     const spawnImpl: SpawnFn = (cmd, args, opts) => {

--- a/tests/mitm.test.ts
+++ b/tests/mitm.test.ts
@@ -8,7 +8,7 @@ import net from "node:net";
 import { once } from "node:events";
 import http from "node:http";
 import { isMitmHost, readMitmUpstream, MITM_UPSTREAM_KEY, setupMitm, noteMitmTlsError, _resetCertRejectionWarningForTest } from "../src/mitm.js";
-import { ensureRootCA, rootCaPath, getSecureContext, _resetForTest } from "../src/ca.js";
+import { ensureRootCA, rootCaPath, getSecureContext, mintHostCert, _resetForTest } from "../src/ca.js";
 import { _resetDiscoveryCacheForTest } from "../src/discover.js";
 
 // isMitmHost now calls discoverMitmDomains(), which reads real client config
@@ -135,6 +135,26 @@ await test("getSecureContext: returns a usable SecureContext", async () => {
         ensureRootCA();
         const ctx = getSecureContext("open.bigmodel.cn");
         assert.ok(ctx, "should return a SecureContext");
+    });
+});
+
+await test("#535: MITM certs satisfy strict OpenSSL 3 chain verification (Python/hermes)", async () => {
+    await withTmpCa(async () => {
+        ensureRootCA();
+        const forge = (await import("node-forge")).default;
+        const root = forge.pki.certificateFromPem(fs.readFileSync(rootCaPath(), "utf8"));
+        const rootBc = root.getExtension("basicConstraints");
+        assert.ok(rootBc, "root has basicConstraints");
+        assert.equal(rootBc.critical, true, "CA basicConstraints must be critical (python OpenSSL 3 rejects otherwise)");
+        const rootSkiHex = root.generateSubjectKeyIdentifier().toHex();
+        assert.match(rootSkiHex, /^[0-9a-f]{40}$/i, "root SKI is a sha1 key id");
+        const leaf = forge.pki.certificateFromPem(mintHostCert("api.openai.com").certPem);
+        const aki = leaf.getExtension("authorityKeyIdentifier");
+        assert.ok(aki, "leaf has authorityKeyIdentifier (python OpenSSL 3 rejects without)");
+        assert.ok(aki.value.includes(forge.util.hexToBytes(rootSkiHex)), "leaf AKI carries the root SKI (forge keeps parsed AKI as raw DER)");
+        assert.ok(leaf.getExtension("subjectKeyIdentifier"), "leaf has subjectKeyIdentifier");
+        const verified = root.verify(leaf);
+        assert.ok(verified, "leaf is really signed by the root");
     });
 });
 

--- a/tests/plugin-agent.test.ts
+++ b/tests/plugin-agent.test.ts
@@ -270,10 +270,17 @@ test("#535: session_before_compact cancels only pi auto compaction under bili la
         assert.equal(handler({ reason: "manual" }, undefined), undefined, "manual /compact stays user-owned");
         assert.equal(handler({ reason: "startup" }, undefined), undefined, "unknown reason → not cancelled");
 
-        // omp: no reason field upstream yet → handler must NOT be registered
+        // omp: the event carries no reason field, so under bili ALL compaction
+        // is cancelled (manual native /compact would destroy the ACP-tagged
+        // context just like the auto path; the host shows "Compaction
+        // cancelled" and the user should reach for /acp instead).
         const omp = makeFakePi();
         createBiliPlugin("omp")(omp as never);
-        assert.equal(omp.events.get("session_before_compact"), undefined, "omp: no cancel handler until upstream reason PR");
+        const ompHandler = omp.events.get("session_before_compact");
+        assert.ok(ompHandler, "omp under bili launch: cancel-all handler registered");
+        assert.deepEqual(ompHandler({}, undefined), { cancel: true });
+        assert.deepEqual(ompHandler({ reason: "manual" }, undefined), { cancel: true });
+        assert.deepEqual(ompHandler({ reason: "threshold" }, undefined), { cancel: true });
     } finally {
         if (prevProxy === undefined) delete process.env.BILLION_CONTEXT_PROXY;
         else process.env.BILLION_CONTEXT_PROXY = prevProxy;

--- a/tests/upstream-proxy-routing.test.ts
+++ b/tests/upstream-proxy-routing.test.ts
@@ -57,6 +57,30 @@ test("/bili/ resolves upstream host and full path from embedded URL", () => {
     assert.equal(resolveUpstream(opts, "/bili-not-owned/responses"), undefined);
 });
 
+test("#535: absolute-form request URLs route as forward-proxy targets (self-host guard)", () => {
+    const opts = loadOptions({ ACP_PORT: "8787" });
+    // httpx through an http_proxy emits absolute form for plain-http base URLs
+    assert.deepEqual(resolveUpstream(opts, "http://127.0.0.1:8199/v1/chat/completions", { headers: { host: "127.0.0.1:8787" } } as never), {
+        upstream: "http://127.0.0.1:8199",
+        rewrittenUrl: "http://127.0.0.1:8199/v1/chat/completions",
+        tunnel: true,
+    });
+    assert.deepEqual(resolveUpstream(opts, "https://relay.example/v1/responses?x=1", { headers: { host: "127.0.0.1:8787" } } as never), {
+        upstream: "https://relay.example",
+        rewrittenUrl: "https://relay.example/v1/responses?x=1",
+        tunnel: true,
+    });
+    // a target equal to the request's own Host header is the proxy itself —
+    // forwarding would loop the request back into handle(); fall through.
+    assert.equal(
+        resolveUpstream(opts, "http://127.0.0.1:8787/v1/chat/completions", { headers: { host: "127.0.0.1:8787" } } as never),
+        undefined,
+        "self-target falls through to own-API routing",
+    );
+    assert.equal(resolveUpstream(opts, "http://127.0.0.1:8787:bad/v1"), undefined, "malformed absolute URL falls through");
+    assert.equal(resolveUpstream(opts, "/v1/chat/completions", { headers: { host: "127.0.0.1:8787" } } as never), undefined, "origin-form stays own-API");
+});
+
 test("/bili/ integration preserves query, subscription, account and thread headers", async () => {
     _setStoreForTest(new SessionStore({ enabled: false }));
     setRegistryForTest({});


### PR DESCRIPTION
#538 was merged while its base was still the #536 branch (the branch was not deleted on merge, so GitHub did not retarget it) — its content landed on `2026-09-04_535-pi-file-free` instead of master. This PR carries that exact merge (555bb3b) to master; the diff vs master is precisely the #538 content (12 files, +454/−1106).

Content (unchanged from #538, already reviewed + locally smoke-tested):
- omp: file-free (env manifest BILI_PROVIDER_REWRITES + extension setModel repin fixing the stale-session-model bypass + compaction cancel-all); overlay machinery removed
- hermes: file-free env routing (HTTPS_PROXY + HERMES_CA_BUNDLE cert-MITM; http via absolute-form forward proxy); no HERMES_HOME overlay; custom HERMES_HOME respected
- MITM cert strictness fix (src/ca.ts): root BC critical, leaf minted with SKI+AKI (mintHostCert) — satisfies OpenSSL 3 chain verification
- parseHermesYaml: dict-form base_url/url/api collection
- zh-CN README launcher table synced

Pre-flight: typecheck clean; 1021/1021 tests (live-proxy env unset); build OK. Local install smoke via `npm install -g .`: pi/omp/hermes all forward through the proxy, real homes untouched.