### PR TITLE
feat(#535): dsh phase 4 — split by destination (last overlay shrinks to loopback)

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -387,7 +387,7 @@ Full command surface (`bili --help` prints an abridged version). Precedence ever
 | `bili omp [opts --] [args]` | Proxy + **omp** (pi-based) |
 | `bili opencode [opts --] [args]` | Proxy + **opencode** |
 | `bili hermes [opts --] [args]` | Proxy + **hermes-agent** (`/bili/` rewrite) |
-| `bili dsh [opts --] [args]` | Proxy + **deepseek-harness** (`/bili/` rewrite; args like `--profile web "task"` pass through) |
+| `bili dsh [opts --] [args]` | Proxy + **deepseek-harness** (non-loopback upstreams via proxy envs, loopback via `/bili/` rewrite — #535; args like `--profile web "task"` pass through) |
 | `bili test pi` | Non-polluting end-to-end smoke test of the pi path |
 | `bili export [session] [--full] [--output FILE]` | List persisted sessions / export one as a Markdown handoff — see [Sessions & Migration](#sessions--migration) |
 | `bili update` | Check for & install a newer version now (bypasses the 3-minute throttle) |
@@ -533,13 +533,13 @@ How each client is pointed at the proxy (set automatically in the child env):
 
 | Client | Redirect | CA trust |
 |---|---|---|
-| pi | `HTTPS_PROXY` + isolated `PI_CODING_AGENT_DIR` | `NODE_EXTRA_CA_CERTS` |
-| omp | `HTTPS_PROXY` + isolated `PI_CODING_AGENT_DIR` | `NODE_EXTRA_CA_CERTS` |
+| pi | `HTTPS_PROXY` + `BILI_PROVIDER_REWRITES` env manifest (extension `registerProvider`) | `NODE_EXTRA_CA_CERTS` |
+| omp | `HTTPS_PROXY` + `BILI_PROVIDER_REWRITES` env manifest (extension `registerProvider`) | `NODE_EXTRA_CA_CERTS` |
 | codex | `HTTPS_PROXY` + `-c key=value` overrides | `SSL_CERT_FILE` → `combined-ca.pem` |
 | claude | `ANTHROPIC_BASE_URL` = `/bili/` URL | none needed |
 | opencode | `HTTPS_PROXY` + isolated `OPENCODE_CONFIG` | `NODE_EXTRA_CA_CERTS` |
-| hermes | isolated `HERMES_HOME`; **all** upstreams `/bili/` | none (certifi ignores `SSL_CERT_FILE`) |
-| dsh | isolated `DSH_HOME` + `DEEPSEEK_BASE_URL`; **all** upstreams `/bili/` | none (plain fetch, no proxy/CA knobs) |
+| hermes | `HTTPS_PROXY` (plain-http rides absolute-form forward-proxy requests) | `HERMES_CA_BUNDLE` → `root-ca.pem` |
+| dsh | `HTTPS_PROXY` (+ `HTTP_PROXY` for plain-http) + `DEEPSEEK_BASE_URL`; **loopback-only** isolated `DSH_HOME` | `SSL_CERT_FILE` → `combined-ca.pem` |
 
 `NODE_EXTRA_CA_CERTS` *appends* to the built-in trust store, so it points at the MITM root alone (`root-ca.pem`). `SSL_CERT_FILE` *replaces* the default CA bundle, so for codex it points at `combined-ca.pem` — a bundle containing the MITM root **plus** the system/Node public roots — keeping pip/git/curl style TLS (blind-tunnelled, real certificates) working inside the child env (#152).
 
@@ -555,16 +555,16 @@ Where upstreams are discovered from (read-only):
 | Claude Code | `ANTHROPIC_BASE_URL` env var, else hardcoded `api.anthropic.com` |
 | OpenCode | `~/.config/opencode/opencode.json` — each provider's `baseURL` |
 | hermes | `~/.hermes/config.yaml` — each provider's endpoint lines |
-| dsh | `~/.dsh/settings.yaml` — every `baseURL`/`baseUrl`/`base_url` value; plus the built-in `deepseek-official` route via `$DEEPSEEK_BASE_URL` |
+| dsh | `~/.dsh/settings.yaml` — every `baseURL`/`baseUrl`/`base_url` value, split by destination (loopback → `/bili/` rewrite; non-loopback https → MITM whitelist; non-loopback http → `HTTP_PROXY`); plus the built-in `deepseek-official` route via `$DEEPSEEK_BASE_URL` |
 
-### Isolated temp config (what gets written)
+### Generated files (what gets written — last resort only, #535)
 
-The `/bili/` rewrite modes write a **temp copy** — the real config is never edited — and the temp dir is removed when the client exits:
+The launcher prefers file-free injection (env vars > CLI flags/extension APIs > generated files; see README, “Injection priority” section). Where a file is unavoidable it is a **copy** — the real config is never edited:
 
-- **pi / omp** — an isolated `PI_CODING_AGENT_DIR` (under `/tmp`) containing only a rewritten `models.json` / `models.yml` with the `/bili/`-wrapped plaintext baseUrls. Everything else (`settings.json`, `sessions/`, `auth.json`, extensions…) is **symlinked** to the real pi/omp home, so sessions and logins are shared: a conversation started under the launcher continues seamlessly in a bare client, and vice versa.
-- **opencode** — a temp `opencode.json` pointed at by `OPENCODE_CONFIG`, with `/bili/`-rewritten baseURLs **plus the thin `/acp` plugin appended** (native tools out of the box; the standalone `opencode-acp` plugin self-disables via `BILLION_CONTEXT_PROXY`).
-- **hermes** — an isolated `HERMES_HOME` with a rewritten `config.yaml` routing **every** upstream (HTTP and HTTPS) through `/bili/` (httpx builds its own CA bundle and ignores `SSL_CERT_FILE`, so cert MITM is impossible). `skills/`, `memories/`, `sessions/` are symlinked through. If no providers are configured — or `config.yaml` can't be rewritten — the launcher prints a warning and hermes runs **unproxied** (compression off).
-- **dsh** — an isolated `DSH_HOME` (persistent overlay `~/.dsh-bili`) with a rewritten `settings.yaml` routing every configured upstream through `/bili/` (plain `fetch`, no proxy/CA knobs, so cert MITM is impossible). `profiles/`, credentials and sessions are symlinked through. The built-in `deepseek-official` route is captured separately via `$DEEPSEEK_BASE_URL` (dsh resolves `settings llm-deepseek.baseURL` ?? env ?? default, so a rewritten user setting wins and the env is the zero-config fallback) — with no custom providers the deepseek route is still proxied out of the box.
+- **pi / omp** — nothing is written (#535): provider baseUrls ride the `BILI_PROVIDER_REWRITES` env manifest consumed by the bili extension at load (`registerProvider`), and native compaction is cancelled in-extension (`session_before_compact`). The real `~/.pi` / `~/.omp` homes are untouched.
+- **opencode** — a temp `opencode.json` pointed at by `OPENCODE_CONFIG` (removed when the client exits), with `/bili/`-rewritten plaintext baseURLs **plus the thin `/acp` plugin appended** (native tools out of the box; the standalone `opencode-acp` plugin self-disables via `BILLION_CONTEXT_PROXY`).
+- **hermes** — nothing is written (#535): its httpx stack rides `HTTPS_PROXY` (+ `HERMES_CA_BUNDLE`) — https via CONNECT cert-MITM, plain-http via absolute-form forward-proxy requests. If no providers are configured, the launcher prints a warning and hermes runs **unproxied** (compression off).
+- **dsh** — split by destination (#535): dsh's fetch stack honors proxy envs except for an unconditional loopback bypass, so **non-loopback** upstreams ride `HTTPS_PROXY` (cert MITM) / `HTTP_PROXY` (absolute-form forward-proxy requests) with `SSL_CERT_FILE` → `combined-ca.pem`; only **loopback** upstreams keep the persistent overlay `DSH_HOME` (`~/.dsh-bili`) with a rewritten `settings.yaml` routing them through `/bili/`. `profiles/`, credentials and sessions are symlinked through; the real `~/.dsh` is never touched. The built-in `deepseek-official` route is captured separately via `$DEEPSEEK_BASE_URL` (dsh resolves `settings llm-deepseek.baseURL` ?? env ?? default, so a user setting wins and the env is the zero-config fallback) — with no custom providers the deepseek route is still proxied out of the box.
 
 ### Native tools in the launcher
 

--- a/CONFIGURATION.zh-CN.md
+++ b/CONFIGURATION.zh-CN.md
@@ -530,13 +530,13 @@ MITM 只对一份**白名单**中的模型域名生效（`open.bigmodel.cn`、`a
 
 | 客户端 | 重定向方式 | CA 信任 |
 |---|---|---|
-| pi | `HTTPS_PROXY` + 隔离 `PI_CODING_AGENT_DIR` | `NODE_EXTRA_CA_CERTS` |
-| omp | `HTTPS_PROXY` + 隔离 `PI_CODING_AGENT_DIR` | `NODE_EXTRA_CA_CERTS` |
+| pi | `HTTPS_PROXY` + `BILI_PROVIDER_REWRITES` env 清单（扩展 `registerProvider`） | `NODE_EXTRA_CA_CERTS` |
+| omp | `HTTPS_PROXY` + `BILI_PROVIDER_REWRITES` env 清单（扩展 `registerProvider`） | `NODE_EXTRA_CA_CERTS` |
 | codex | `HTTPS_PROXY` + `-c key=value` 覆盖 | `SSL_CERT_FILE` → `combined-ca.pem` |
 | claude | `ANTHROPIC_BASE_URL` = `/bili/` URL | 无需 |
 | opencode | `HTTPS_PROXY` + 隔离 `OPENCODE_CONFIG` | `NODE_EXTRA_CA_CERTS` |
-| hermes | 隔离 `HERMES_HOME`；**全部**上游走 `/bili/` | 无（certifi 忽略 `SSL_CERT_FILE`） |
-| dsh | 隔离 `DSH_HOME` + `DEEPSEEK_BASE_URL`；**全部**上游走 `/bili/` | 无（纯 fetch，无代理/CA 接口） |
+| hermes | `HTTPS_PROXY`（明文 http 走 absolute-form 正向代理请求） | `HERMES_CA_BUNDLE` → `root-ca.pem` |
+| dsh | `HTTPS_PROXY`（明文 http 另加 `HTTP_PROXY`）+ `DEEPSEEK_BASE_URL`；**仅回环**隔离 `DSH_HOME` | `SSL_CERT_FILE` → `combined-ca.pem` |
 
 `NODE_EXTRA_CA_CERTS` 是**追加**到内置信任库，所以只指向 MITM 根证书（`root-ca.pem`）即可。`SSL_CERT_FILE` 会**替换**默认 CA bundle，所以 codex 指向 `combined-ca.pem` —— 包含 MITM 根证书**加上**系统/Node 公共根 —— 保证子进程环境里 pip/git/curl 类 TLS（盲转发、真证书）不受影响（#152）。
 
@@ -552,16 +552,16 @@ Claude Code 的 undici fetch 忽略 `HTTPS_PROXY`，所以证书 MITM 拦不到�
 | Claude Code | `ANTHROPIC_BASE_URL` 环境变量，否则硬编码 `api.anthropic.com` |
 | OpenCode | `~/.config/opencode/opencode.json` —— 各 provider 的 `baseURL` |
 | hermes | `~/.hermes/config.yaml` —— 各 provider 的端点行 |
-| dsh | `~/.dsh/settings.yaml` —— 每个 `baseURL`/`baseUrl`/`base_url` 值；内置 `deepseek-official` 路由另经 `$DEEPSEEK_BASE_URL` 接管 |
+| dsh | `~/.dsh/settings.yaml` —— 每个 `baseURL`/`baseUrl`/`base_url` 值，按目的地分流（回环 → `/bili/` 重写；非回环 https → MITM 白名单；非回环 http → `HTTP_PROXY`）；内置 `deepseek-official` 路由另经 `$DEEPSEEK_BASE_URL` 接管 |
 
-### 隔离临时配置（写了什么）
+### 生成文件（写了什么 —— 最后手段，#535）
 
-`/bili/` 重写模式写的是**临时副本** —— 真实配置绝不编辑 —— 客户端退出时临时目录一并删除：
+启动器优先零文件注入（env > CLI 参数/扩展 API > 生成文件；见 [README —— 注入优先级](README.zh-CN.md)）。确实绕不开文件时写的都是**副本** —— 真实配置绝不编辑：
 
-- **pi / omp** —— 隔离的 `PI_CODING_AGENT_DIR`（在 `/tmp` 下），里面只有一份重写后的 `models.json` / `models.yml`（明文 baseUrl 包上 `/bili/`）。其余一切（`settings.json`、`sessions/`、`auth.json`、扩展……）都**符号链接**到真实 pi/omp 主目录，所以会话与登录互通：launcher 里开的会话在裸客户端里无缝继续，反之亦然。
-- **opencode** —— 临时 `opencode.json`（由 `OPENCODE_CONFIG` 指向），`baseURL` 重写为 `/bili/` 形式，**并追加了薄 `/acp` 插件**（开箱即原生工具；独立的 `opencode-acp` 插件检测到 `BILLION_CONTEXT_PROXY` 后自禁用）。
-- **hermes** —— 隔离的 `HERMES_HOME`，重写后的 `config.yaml` 让**所有**上游（HTTP 和 HTTPS）都走 `/bili/`（httpx 自建 CA bundle 且忽略 `SSL_CERT_FILE`，证书 MITM 不可行）。`skills/`、`memories/`、`sessions/` 符号链接共享。若没配置任何 provider —— 或 `config.yaml` 无法重写 —— 启动器打印警告，hermes 将**不经代理**运行（无压缩）。
-- **dsh** —— 隔离的 `DSH_HOME`（持久 overlay `~/.dsh-bili`），重写后的 `settings.yaml` 让所有已配置上游都走 `/bili/`（纯 `fetch`，无代理/CA 接口，证书 MITM 不可行）。`profiles/`、凭据、会话符号链接共享。内置 `deepseek-official` 路由另行经 `$DEEPSEEK_BASE_URL` 接管（dsh 解析顺序为 settings `llm-deepseek.baseURL` ?? 环境变量 ?? 默认值，重写过的用户配置优先，环境变量作零配置兜底）—— 即便没有任何自定义 provider，内置 deepseek 路由也照样走代理。
+- **pi / omp** —— 不写任何文件（#535）：provider baseUrl 走 `BILI_PROVIDER_REWRITES` env 清单，由 bili 扩展加载时消费（`registerProvider`）；原生压缩改由扩展内取消（`session_before_compact`）。真实 `~/.pi` / `~/.omp` 主目录原样不动。
+- **opencode** —— 临时 `opencode.json`（由 `OPENCODE_CONFIG` 指向，客户端退出时删除），明文 `baseURL` 重写为 `/bili/` 形式，**并追加了薄 `/acp` 插件**（开箱即原生工具；独立的 `opencode-acp` 插件检测到 `BILLION_CONTEXT_PROXY` 后自禁用）。
+- **hermes** —— 不写任何文件（#535）：其 httpx 栈走 `HTTPS_PROXY`（+ `HERMES_CA_BUNDLE`）—— https 经 CONNECT 证书 MITM，明文 http 经 absolute-form 正向代理请求。若没配置任何 provider，启动器打印警告，hermes 将**不经代理**运行（无压缩）。
+- **dsh** —— 按目的地分流（#535）：dsh 的 fetch 栈尊重代理 env，但对回环目标无条件绕过，所以**非回环**上游走 `HTTPS_PROXY`（证书 MITM）/ `HTTP_PROXY`（absolute-form 正向代理请求），`SSL_CERT_FILE` → `combined-ca.pem`；仅**回环**上游保留持久 overlay `DSH_HOME`（`~/.dsh-bili`），重写后的 `settings.yaml` 让它们走 `/bili/`。`profiles/`、凭据、会话符号链接共享；真实 `~/.dsh` 绝不触碰。内置 `deepseek-official` 路由另行经 `$DEEPSEEK_BASE_URL` 接管（dsh 解析顺序为 settings `llm-deepseek.baseURL` ?? 环境变量 ?? 默认值，用户配置优先，环境变量作零配置兜底）—— 即便没有任何自定义 provider，内置 deepseek 路由也照样走代理。
 
 ### 启动器里的原生工具
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,21 @@ Two ways to use it — pick one:
 - **URL change (persistent):** prefix your client's baseURL with the proxy
   origin + `/bili/`.
 
+### Injection priority — no files unless unavoidable (#535)
+
+bili never owns user data: every launched client runs on its **real home**, so
+runtime writes land where the user expects them. When pointing a client at the
+proxy, the launcher picks by priority — **env vars first** (proxy/CA envs for
+hermes/dsh/codex; the `BILI_PROVIDER_REWRITES` URL manifest for pi/omp,
+consumed by their extension's `registerProvider` at load), then **CLI flags or
+extension APIs** (codex `-c key=value`, opencode plugin), and **generated files
+last** — today only opencode's temp `opencode.json` (deleted on exit) and dsh's
+loopback exception: dsh's fetch stack bypasses proxy envs for loopback targets
+unconditionally, so local upstreams keep the persistent `~/.dsh-bili` overlay
+rewrite until dsh gains a settings-path env or an upstream loopback opt-out.
+Overlay dirs created by older versions are left in place and never merged back
+into the real home.
+
 ### Option 1 — Launcher (`bili pi` / `bili codex` / `bili claude` / `bili omp` / `bili opencode` / `bili hermes` / `bili dsh`)
 
 The launcher wraps a client in one command: it starts a proxy on an
@@ -158,7 +173,7 @@ bili claude                           # launch claude through the proxy
 bili omp                              # pi-style, file-free (#535): env + extension registerProvider + compaction cancel, real ~/.omp untouched
 bili opencode                         # MITM for HTTPS + temp opencode.json (/bili/ for HTTP) + thin /acp plugin
 bili hermes                           # file-free (#535): hermes proxy env (HTTPS_PROXY + HERMES_CA_BUNDLE) — https via CONNECT MITM, http via absolute-form forward proxy; real ~/.hermes untouched
-bili dsh                              # deepseek-harness: built-in deepseek route via DEEPSEEK_BASE_URL + overlay DSH_HOME (~/.dsh-bili), all traffic /bili/, native /acp command injected via --patch
+bili dsh                              # deepseek-harness: non-loopback upstreams ride proxy envs (https MITM, http absolute-form), loopback keeps the overlay DSH_HOME (~/.dsh-bili) rewrite (#535), built-in deepseek route via DEEPSEEK_BASE_URL, native /acp command injected via --patch
 bili pi --mitm-domain api.foo.com     # add a domain to the MITM whitelist
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -78,6 +78,10 @@ npm install -g billion-context
 
 
 
+### 注入优先级 —— 能不写文件就不写(#535)
+
+bili 永不拥有用户数据:每个被启动的客户端都跑在**真实 home** 上,运行期写入落在用户预期的位置。把客户端指向代理时,启动器按优先级选择——**优先 env 变量**(hermes/dsh/codex 的代理/CA env;pi/omp 的 `BILI_PROVIDER_REWRITES` URL 清单,由扩展加载时经 `registerProvider` 消费),其次 **CLI 参数或扩展 API**(codex `-c key=value`、opencode 插件),最后才是**生成文件**——目前仅剩 opencode 的临时 `opencode.json`(退出即删)和 dsh 的回环例外:dsh 的 fetch 栈对回环目标无条件绕过代理 env,所以本地上游保留持久 `~/.dsh-bili` overlay 改写,直到 dsh 提供 settings-path env 或上游支持回环 opt-out。旧版本创建的 overlay 目录原地保留,绝不合并回真实 home。
+
 ### 方式 1 —— 启动器(`bili pi` / `bili codex` / `bili claude` / `bili omp` / `bili opencode` / `bili hermes` / `bili dsh`)
 
 启动器把客户端包进一条命令:在独立端口拉起一个代理(总是全新实例,绝不复用端口),再按客户端支持的机制把它指向代理 —— 能吃代理/CA 环境变量的走**证书 MITM**,不吃的走隔离的**`/bili/` 配置重写**。真实配置文件从不被修改;客户端自己的配置只被**读取**,用来发现它实际连接的 HTTPS 上游主机,把这些主机加入 MITM 白名单 —— 代理只 TLS 终结它们,其余流量盲透传。
@@ -89,7 +93,7 @@ bili claude                           # 拉起 claude
 bili omp                              # pi 同款,file-free(#535):环境变量 + 扩展 registerProvider + 压缩取消,真实 ~/.omp 不动
 bili opencode                         # HTTPS 走 MITM + 临时 opencode.json(HTTP 走 /bili/)+ 轻量 /acp 插件
 bili hermes                           # file-free(#535):hermes 代理环境变量(HTTPS_PROXY + HERMES_CA_BUNDLE)—— https 走 CONNECT MITM,http 走绝对形式转发;真实 ~/.hermes 不动
-bili dsh                              # deepseek-harness:内置 deepseek 路由走 DEEPSEEK_BASE_URL + 隔离 DSH_HOME(~/.dsh-bili),全部流量 /bili/,经 --patch 注入原生 /acp 命令
+bili dsh                              # deepseek-harness:非回环上游走代理 env(https MITM、http absolute-form),回环上游保留 overlay DSH_HOME(~/.dsh-bili)改写(#535),内置 deepseek 路由走 DEEPSEEK_BASE_URL,经 --patch 注入原生 /acp 命令
 bili pi --mitm-domain api.foo.com     # 向 MITM 白名单追加域名
 ```
 

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -170,6 +170,15 @@ export function unwrapUpstream(url: string): string {
     return idx >= 0 ? url.slice(idx + "/bili/".length) : url;
 }
 
+/** Loopback destinations (localhost / ::1 / 127.x). dsh's fetch stack bypasses
+ *  proxy envs for these unconditionally (LOOPBACK_NO_PROXY), so they are the
+ *  only upstreams that need the /bili/ URL rewrite (#535 phase 4). */
+export function isLoopbackHost(host: string): boolean {
+    const h = host.toLowerCase();
+    if (h === "localhost" || h === "::1" || h === "[::1]") return true;
+    return h.split(".")[0] === "127";
+}
+
 export interface HttpRewrite {
     key: string;
     realUpstream: string;
@@ -179,6 +188,11 @@ export interface DiscoveredRoutes {
     httpsDomains: string[];
     httpRewrites: HttpRewrite[];
     httpsRewrites: HttpRewrite[];
+    // Plaintext-http upstreams routed purely via HTTP_PROXY absolute-form
+    // forward-proxy requests (no URL rewriting). dsh-only today, and never
+    // loopback — dsh bypasses proxy envs for loopback targets unconditionally,
+    // so those ride httpRewrites instead (#535 phase 4).
+    httpEnvRoutes: string[];
 }
 
 export function resolveCaCertPath(env: NodeJS.ProcessEnv): string {
@@ -215,6 +229,7 @@ export function discoverRoutes(client: ClientName, config: ClientConfig): Discov
     const httpsDomains: string[] = [];
     const httpRewrites: HttpRewrite[] = [];
     const httpsRewrites: HttpRewrite[] = [];
+    const httpEnvRoutes: string[] = [];
     const httpsSeen = new Set<string>();
     const rewriteKeys = new Set<string>();
     const httpsRewriteKeys = new Set<string>();
@@ -306,10 +321,15 @@ export function discoverRoutes(client: ClientName, config: ClientConfig): Discov
             }
         }
     } else if (client === "dsh") {
-        // dsh (deepseek-harness) has no proxy/CA knobs in its fetch stack:
-        // every configured upstream rides the /bili/ URL form. The built-in
-        // deepseek-official route is captured via $DEEPSEEK_BASE_URL in
-        // runLaunch; user-configured settings.yaml endpoints here.
+        // #535 phase 4: split by destination. dsh's fetch stack honors proxy
+        // envs EXCEPT for an unconditional loopback bypass (LOOPBACK_NO_PROXY —
+        // "the bypass is not optional"), so only non-loopback upstreams can
+        // ride the proxy: https → cert MITM (host whitelisted below), plain
+        // http → absolute-form forward-proxy requests (httpEnvRoutes).
+        // Loopback destinations (http OR https) still need the /bili/ URL
+        // rewrite in settings.yaml — the documented file exception. The
+        // built-in deepseek-official route is captured via $DEEPSEEK_BASE_URL
+        // in runLaunch.
         const dshSeen = new Set<string>();
         let anon = 0;
         for (const raw of config.dsh?.baseUrls ?? []) {
@@ -320,8 +340,18 @@ export function discoverRoutes(client: ClientName, config: ClientConfig): Discov
                 if (dshSeen.has(real)) continue;
                 dshSeen.add(real);
                 anon += 1;
-                rewriteKeys.add(`dsh-${anon}`);
-                httpRewrites.push({ key: `dsh-${anon}`, realUpstream: real });
+                if (isLoopbackHost(url.hostname)) {
+                    rewriteKeys.add(`dsh-${anon}`);
+                    httpRewrites.push({ key: `dsh-${anon}`, realUpstream: real });
+                } else if (url.protocol === "https:") {
+                    const host = url.hostname.toLowerCase();
+                    if (host && !httpsSeen.has(host)) {
+                        httpsSeen.add(host);
+                        httpsDomains.push(host);
+                    }
+                } else if (!httpEnvRoutes.includes(real)) {
+                    httpEnvRoutes.push(real);
+                }
             } catch {
                 // Unparseable endpoint: skip.
             }
@@ -333,7 +363,7 @@ export function discoverRoutes(client: ClientName, config: ClientConfig): Discov
         classify(config.codex?.openaiBaseUrl, "openai_base_url");
     }
 
-    return { httpsDomains, httpRewrites, httpsRewrites };
+    return { httpsDomains, httpRewrites, httpsRewrites, httpEnvRoutes };
 }
 
 export function discoverDomains(client: ClientName, config: ClientConfig): string[] {
@@ -1173,13 +1203,14 @@ export function unpackDeadProxyUrlsInFile(filePath: string, livePorts: Set<numbe
     return changed;
 }
 
-/** dsh counterpart of prepareHermesHome: a persistent `<dshHome>-bili` overlay
- *  (every ~/.dsh sibling symlinked so credentials/profiles/sessions stay
- *  shared) holding a rewritten copy of settings.yaml. Every baseURL/baseUrl/
- *  base_url value is rewrapped as origin + "/bili/" + raw upstream — http AND
- *  https alike, since dsh's fetch stack exposes no proxy/CA trust knobs. The
- *  real ~/.dsh is never touched. Returns the overlay dir (undefined when the
- *  settings file is unreadable or nothing is rewritable). */
+/** dsh loopback exception (#535 phase 4): dsh's fetch stack bypasses proxy
+ *  envs for loopback targets unconditionally, so ONLY loopback upstreams need
+ *  the /bili/ URL rewrite. A persistent `<dshHome>-bili` overlay (every
+ *  ~/.dsh sibling symlinked so credentials/profiles/sessions stay shared)
+ *  holds a rewritten copy of settings.yaml; matching baseURL/baseUrl/base_url
+ *  values are rewrapped as origin + "/bili/" + raw upstream. The real ~/.dsh
+ *  is never touched. Returns the overlay dir (undefined when the settings
+ *  file is unreadable or nothing is rewritable). */
 export function prepareDshHome(
     dshHome: string,
     origin: string,
@@ -1682,6 +1713,7 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
         `bili: started proxy at ${handle.origin} (MITM domains: ${domains.length ? domains.join(", ") : "defaults"})` +
             (routes.httpRewrites.length > 0 ? ` (HTTP /bili/ rewrites: ${routes.httpRewrites.length})` : "") +
             (routes.httpsRewrites.length > 0 ? ` (HTTPS cert rewrites: ${routes.httpsRewrites.length})` : "") +
+            (routes.httpEnvRoutes.length > 0 ? ` (HTTP proxy-env routes: ${routes.httpEnvRoutes.length})` : "") +
             (params.client === "pi-test" ? " (no extensions)" : ""),
     );
     if (handle.logPath) {
@@ -1782,16 +1814,29 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
             );
         }
     } else if (base === "dsh") {
-        // dsh (deepseek-harness): no plugin surface, no MITM cert trust (plain
-        // fetch) — the built-in deepseek-official route is captured through
-        // $DEEPSEEK_BASE_URL (its resolution order is settings baseURL ?? env
-        // ?? https://api.deepseek.com, so a rewritten user setting wins and
-        // this env is the no-settings fallback). Custom providers in
-        // ~/.dsh/settings.yaml ride a persistent overlay DSH_HOME
-        // (~/.dsh-bili); credentials/profiles/sessions stay shared through
-        // symlinks and the real ~/.dsh is never touched.
-        env = { ...process.env, BILLION_CONTEXT_PROXY: origin };
+        // #535 phase 4: split by destination (see discoverRoutes). Non-loopback
+        // upstreams ride the proxy envs — https via CONNECT + cert MITM
+        // (HTTPS_PROXY + SSL_CERT_FILE), plain-http via absolute-form forward-
+        // proxy requests (HTTP_PROXY). SSL_CERT_FILE gets the COMBINED bundle
+        // because it REPLACES dsh's trust store — system roots must survive for
+        // blind-tunneled hosts (same pattern as codex). The built-in
+        // deepseek-official route stays captured through $DEEPSEEK_BASE_URL
+        // (resolution order: settings baseURL ?? env ?? default, so a user
+        // setting wins and this env is the no-settings fallback). ONLY loopback
+        // destinations take the settings.yaml /bili/ rewrite below (persistent
+        // overlay DSH_HOME ~/.dsh-bili; real ~/.dsh never touched) — dsh
+        // bypasses proxy envs for loopback unconditionally. Proxy envs are set
+        // only when something actually routes through them, so a launch with
+        // no non-loopback custom providers behaves exactly as before.
+        const usesProxyEnv = routes.httpsDomains.length > 0 || routes.httpEnvRoutes.length > 0;
+        env = usesProxyEnv ? stripInheritedProxy(process.env) : { ...process.env };
+        env.BILLION_CONTEXT_PROXY = origin;
         env.DEEPSEEK_BASE_URL = wrapUpstream(origin, "https://api.deepseek.com");
+        if (usesProxyEnv) {
+            env.HTTPS_PROXY = origin;
+            env.SSL_CERT_FILE = resolveCombinedCaPath(process.env);
+        }
+        if (routes.httpEnvRoutes.length > 0) env.HTTP_PROXY = origin;
         // Session identity for the proxy: dsh's pi-ai stack keys its
         // `prompt_cache_key` body field (the dsh session id) off
         // cacheRetention — every non-api.openai.com base URL defaults to
@@ -1805,14 +1850,14 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
         // overrides the env fallback).
         env.PI_CACHE_RETENTION = "long";
         const dshHomeDir = resolveDshHome(process.env);
-        dshOverlayHome = prepareDshHome(dshHomeDir, origin, routes.httpRewrites);
+        dshOverlayHome = routes.httpRewrites.length > 0 ? prepareDshHome(dshHomeDir, origin, routes.httpRewrites) : undefined;
         if (dshOverlayHome) {
             env.DSH_HOME = dshOverlayHome;
         } else if (routes.httpRewrites.length > 0) {
             console.error(
-                "bili: dsh settings.yaml could not be rewritten (unreadable or no matching endpoints) — custom providers will NOT go through the proxy; the built-in deepseek route still does.",
+                "bili: dsh settings.yaml could not be rewritten (unreadable or no matching endpoints) — loopback custom providers will NOT go through the proxy; other routes still do.",
             );
-        } else {
+        } else if (!usesProxyEnv) {
             console.error(
                 "bili: no custom providers found in ~/.dsh/settings.yaml — proxying the built-in deepseek route via DEEPSEEK_BASE_URL only.",
             );

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -176,7 +176,9 @@ export function unwrapUpstream(url: string): string {
 export function isLoopbackHost(host: string): boolean {
     const h = host.toLowerCase();
     if (h === "localhost" || h === "::1" || h === "[::1]") return true;
-    return h.split(".")[0] === "127";
+    // Dotted-quad 127/8 only — not "first label starts with 127" (that would
+    // misclassify hostnames like 127.evil.com, #544 review nit).
+    return /^127\.\d+\.\d+\.\d+$/.test(h);
 }
 
 export interface HttpRewrite {

--- a/tests/launcher.test.ts
+++ b/tests/launcher.test.ts
@@ -16,6 +16,7 @@ import {
     healthUrl,
     wrapUpstream,
     unwrapUpstream,
+    isLoopbackHost,
     buildPiEnv,
     buildCodexEnv,
     buildClaudeEnv,
@@ -1144,8 +1145,8 @@ test("discoverRoutes: pi with one http provider → rewrite keyed by provider na
 });
 
 test("discoverRoutes: empty config → {httpsDomains:[], httpRewrites:[]}", () => {
-    assert.deepEqual(discoverRoutes("pi", {}), { httpsDomains: [], httpRewrites: [], httpsRewrites: [] });
-    assert.deepEqual(discoverRoutes("codex", {}), { httpsDomains: [], httpRewrites: [], httpsRewrites: [] });
+    assert.deepEqual(discoverRoutes("pi", {}), { httpsDomains: [], httpRewrites: [], httpsRewrites: [], httpEnvRoutes: [] });
+    assert.deepEqual(discoverRoutes("codex", {}), { httpsDomains: [], httpRewrites: [], httpsRewrites: [], httpEnvRoutes: [] });
 });
 
 test("discoverRoutes: codex /bili/-wrapped HTTPS provider → httpsRewrites to raw upstream", () => {
@@ -1534,24 +1535,38 @@ test("readDshConfig + resolveDshHome + parseDshSettingsYaml", () => {
     }
 });
 
-test("discoverRoutes: dsh wraps every settings.yaml endpoint via /bili/", () => {
+test("discoverRoutes: dsh splits by destination — loopback rewrote, rest proxied (#535 phase 4)", () => {
     const config: ClientConfig = {};
     (config as Record<string, unknown>).dsh = {
         baseUrls: [
             "http://127.0.0.1:8199/v1",
+            "https://localhost:8443/v1",
             "https://open.bigmodel.cn/api/paas/v4",
             "http://127.0.0.1:8787/bili/https://api.foo.io/v1",
+            "http://10.0.0.5:1234/v1",
             "http://127.0.0.1:8199/v1",
             "::::",
         ],
     };
     const routes = discoverRoutes("dsh", config);
-    assert.deepEqual(routes.httpsDomains, []);
-    assert.deepEqual(routes.httpRewrites.map((r) => r.realUpstream).sort(), [
-        "http://127.0.0.1:8199/v1",
-        "https://api.foo.io/v1",
-        "https://open.bigmodel.cn/api/paas/v4",
-    ]);
+    // loopback (http OR https) → settings.yaml /bili/ rewrite; non-loopback
+    // https → cert-MITM whitelist; wrapped values unwrap first (legacy
+    // self-heal); non-loopback plain-http → HTTP_PROXY absolute-form routing.
+    assert.deepEqual(
+        routes.httpRewrites.map((r) => r.realUpstream).sort(),
+        ["http://127.0.0.1:8199/v1", "https://localhost:8443/v1"],
+    );
+    assert.deepEqual(routes.httpsDomains, ["open.bigmodel.cn", "api.foo.io"]);
+    assert.deepEqual(routes.httpEnvRoutes, ["http://10.0.0.5:1234/v1"]);
+});
+
+test("isLoopbackHost: localhost / ::1 / 127.x only", () => {
+    for (const h of ["localhost", "LOCALHOST", "::1", "[::1]", "127.0.0.1", "127.5.6.7"]) {
+        assert.equal(isLoopbackHost(h), true, h);
+    }
+    for (const h of ["1270.0.0.1", "10.0.0.1", "192.168.1.1", "open.bigmodel.cn", ""]) {
+        assert.equal(isLoopbackHost(h), false, h);
+    }
 });
 
 test("prepareDshHome: rewrites baseURL lines, shares siblings, never touches the real home", () => {
@@ -1652,10 +1667,11 @@ test("prepareDshHome: returns undefined for unreadable settings even with rewrit
     }
 });
 
-test("runLaunch dsh: DSH_HOME overlay + DEEPSEEK_BASE_URL env, real home untouched", async () => {
+test("runLaunch dsh: non-loopback upstreams ride proxy envs, loopback keeps the overlay (#535 phase 4)", async () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "bili-dsh-launch-"));
     const prevBin = process.env.BILI_CLIENT_BIN;
     const prevDshHome = process.env.DSH_HOME;
+    const prevNoProxy = process.env.NO_PROXY;
     const dshHome = path.join(home, ".dsh");
     fs.mkdirSync(dshHome);
     fs.writeFileSync(
@@ -1665,6 +1681,8 @@ test("runLaunch dsh: DSH_HOME overlay + DEEPSEEK_BASE_URL env, real home untouch
             "  providers:",
             "    anthropic:",
             "      baseURL: https://api.anthropic.com",
+            "    sglang:",
+            "      baseURL: http://127.0.0.1:8199/v1",
         ].join("\n"),
     );
     fs.mkdirSync(path.join(dshHome, "profiles"));
@@ -1673,9 +1691,11 @@ test("runLaunch dsh: DSH_HOME overlay + DEEPSEEK_BASE_URL env, real home untouch
     fs.writeFileSync(fakeDsh, "");
     process.env.BILI_CLIENT_BIN = fakeDsh;
     process.env.DSH_HOME = dshHome;
+    process.env.NO_PROXY = "localhost,.corp";
 
     const envSeen: NodeJS.ProcessEnv[] = [];
     const argsSeen: string[][] = [];
+    const proxyEnvs: NodeJS.ProcessEnv[] = [];
     const spawnImpl: SpawnFn = (cmd, args, options) => {
         if (cmd === fakeDsh) {
             if (options?.env) envSeen.push(options.env);
@@ -1689,6 +1709,7 @@ test("runLaunch dsh: DSH_HOME overlay + DEEPSEEK_BASE_URL env, real home untouch
             };
             return child;
         }
+        if (options?.env) proxyEnvs.push(options.env);
         return makeFakeChild(42423);
     };
 
@@ -1714,14 +1735,27 @@ test("runLaunch dsh: DSH_HOME overlay + DEEPSEEK_BASE_URL env, real home untouch
         // Session identity for the proxy: forces dsh's pi-ai stack to stamp
         // prompt_cache_key (the dsh session id) on every request.
         assert.equal(seenEnv.PI_CACHE_RETENTION, "long");
+        // Non-loopback upstreams ride the proxy envs; the combined bundle is
+        // mandatory because SSL_CERT_FILE replaces dsh's trust store. Proxy
+        // vars are fully stripped (same contract as hermes): dsh's loopback
+        // exclusion comes from its built-in policy, not from NO_PROXY.
+        assert.equal(seenEnv.HTTPS_PROXY, origin);
+        assert.ok(String(seenEnv.SSL_CERT_FILE).endsWith(path.join("billion-context", "ca", "combined-ca.pem")));
+        assert.equal(seenEnv.HTTP_PROXY, undefined);
+        assert.equal(seenEnv.NO_PROXY, undefined);
+        // Loopback sglang stays on the /bili/ rewrite path via the persistent
+        // overlay — and ONLY the loopback endpoint gets rewritten there.
         assert.equal(seenEnv.DSH_HOME, `${dshHome}-bili`);
         assert.deepEqual(exitCalls, [0]);
         assert.equal(fs.readFileSync(path.join(dshHome, "settings.yaml"), "utf8"), original);
         const overlay = `${dshHome}-bili`;
-        assert.ok(fs.existsSync(path.join(overlay, "settings.yaml")));
         const overlayTxt = fs.readFileSync(path.join(overlay, "settings.yaml"), "utf8");
-        assert.ok(overlayTxt.includes(`baseURL: ${origin}/bili/https://api.anthropic.com`));
+        assert.ok(overlayTxt.includes(`baseURL: ${origin}/bili/http://127.0.0.1:8199/v1`));
+        assert.ok(overlayTxt.includes("baseURL: https://api.anthropic.com"));
         assert.ok(fs.lstatSync(path.join(overlay, "profiles")).isSymbolicLink());
+        // The MITM whitelist carries the non-loopback https host.
+        assert.ok(proxyEnvs.length > 0);
+        assert.ok(String(proxyEnvs[0].BILI_MITM_DOMAINS).split(",").includes("api.anthropic.com"));
         // /acp command injection: --patch flag spliced before user args, and
         // the patch overlay file exists pointing at our bundled cordis plugin.
         const patchFile = path.join(overlay, ".bili-acp.patch.yml");
@@ -1731,6 +1765,77 @@ test("runLaunch dsh: DSH_HOME overlay + DEEPSEEK_BASE_URL env, real home untouch
         assert.ok(/- name: file:\/\/\/.*dsh-acp\.js\n/.test(patchTxt));
         assert.deepEqual(argsSeen[0], ["--patch", patchFile, "--profile", "headless", "task"]);
         fs.rmSync(overlay, { recursive: true, force: true });
+    } finally {
+        process.exit = prevExit;
+        if (prevBin === undefined) delete process.env.BILI_CLIENT_BIN;
+        else process.env.BILI_CLIENT_BIN = prevBin;
+        if (prevDshHome === undefined) delete process.env.DSH_HOME;
+        else process.env.DSH_HOME = prevDshHome;
+        if (prevNoProxy === undefined) delete process.env.NO_PROXY;
+        else process.env.NO_PROXY = prevNoProxy;
+        fs.rmSync(home, { recursive: true, force: true });
+    }
+});
+
+test("runLaunch dsh: no loopback custom providers — no DSH_HOME overlay (#535 phase 4)", async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "bili-dsh-launch-"));
+    const prevBin = process.env.BILI_CLIENT_BIN;
+    const prevDshHome = process.env.DSH_HOME;
+    const dshHome = path.join(home, ".dsh");
+    fs.mkdirSync(dshHome);
+    fs.writeFileSync(
+        path.join(dshHome, "settings.yaml"),
+        [
+            "llm-pi-ai:",
+            "  providers:",
+            "    anthropic:",
+            "      baseURL: https://api.anthropic.com",
+        ].join("\n"),
+    );
+    const fakeDsh = path.join(home, "fake-dsh");
+    fs.writeFileSync(fakeDsh, "");
+    process.env.BILI_CLIENT_BIN = fakeDsh;
+    process.env.DSH_HOME = dshHome;
+
+    const envSeen: NodeJS.ProcessEnv[] = [];
+    const spawnImpl: SpawnFn = (cmd, args, options) => {
+        if (cmd === fakeDsh) {
+            if (options?.env) envSeen.push(options.env);
+            const child = makeFakeChild(0);
+            const orig = child.on.bind(child);
+            (child as { on: SpawnChild["on"] }).on = (event, listener) => {
+                orig(event, listener);
+                if (event === "exit") setTimeout(() => listener(0, null), 0);
+                return child;
+            };
+            return child;
+        }
+        return makeFakeChild(42423);
+    };
+
+    const prevExit = process.exit;
+    process.exit = ((code?: number) => {
+        return undefined as never;
+    }) as typeof process.exit;
+
+    try {
+        await runLaunch(
+            { client: "dsh", clientArgs: [], overrides: {} },
+            { fetchImpl: async () => ({ ok: true }), spawnImpl, sleep: () => Promise.resolve(), readInstanceFile: () => undefined },
+        );
+        assert.equal(envSeen.length, 1);
+        const seenEnv = envSeen[0];
+        const origin = seenEnv.BILLION_CONTEXT_PROXY;
+        assert.ok(/^http:\/\/127\.0\.0\.1:\d+$/.test(String(origin)));
+        // The single non-loopback https provider still rides cert MITM...
+        assert.equal(seenEnv.HTTPS_PROXY, origin);
+        // ...but nothing needs the settings rewrite, so no overlay redirect —
+        // the inherited DSH_HOME (the real home discovery read) passes through
+        // unchanged; the -bili dir only holds the /acp patch file written by
+        // writeDshAcpPatch.
+        assert.equal(seenEnv.DSH_HOME, dshHome);
+        assert.equal(fs.existsSync(path.join(`${dshHome}-bili`, "settings.yaml")), false);
+        assert.ok(fs.existsSync(path.join(`${dshHome}-bili`, ".bili-acp.patch.yml")));
     } finally {
         process.exit = prevExit;
         if (prevBin === undefined) delete process.env.BILI_CLIENT_BIN;

--- a/tests/launcher.test.ts
+++ b/tests/launcher.test.ts
@@ -1564,7 +1564,7 @@ test("isLoopbackHost: localhost / ::1 / 127.x only", () => {
     for (const h of ["localhost", "LOCALHOST", "::1", "[::1]", "127.0.0.1", "127.5.6.7"]) {
         assert.equal(isLoopbackHost(h), true, h);
     }
-    for (const h of ["1270.0.0.1", "10.0.0.1", "192.168.1.1", "open.bigmodel.cn", ""]) {
+    for (const h of ["1270.0.0.1", "127.evil.com", "127.abc.def", "10.0.0.1", "192.168.1.1", "open.bigmodel.cn", ""]) {
         assert.equal(isLoopbackHost(h), false, h);
     }
 });


### PR DESCRIPTION
## What

Phase 4 of #535 (the last remaining issue item): dsh no longer force-routes **all** upstreams through the `/bili/` settings rewrite. Discovery splits `settings.yaml` endpoints by destination, matching dsh's actual fetch behavior:

| upstream | mechanism |
|---|---|
| loopback (http **or** https) | `/bili/` rewrite via persistent `DSH_HOME` overlay (`~/.dsh-bili`) — the documented exception: dsh's fetch stack bypasses proxy envs for loopback targets unconditionally (`LOOPBACK_NO_PROXY`, "the bypass is not optional") |
| non-loopback https | CONNECT + cert MITM — host added to the MITM whitelist, child gets `HTTPS_PROXY` + `SSL_CERT_FILE` → `combined-ca.pem` (it *replaces* dsh's trust store, so system roots must be bundled — same pattern as codex) |
| non-loopback plain-http | absolute-form forward-proxy requests via `HTTP_PROXY` (server support landed in #538) |
| built-in deepseek-official route | unchanged: `$DEEPSEEK_BASE_URL` wrap |

Behavioral parity: proxy envs are set only when something actually routes through them — a launch with no non-loopback custom providers produces the same child env as before. Inherited proxy vars are fully stripped from the child (same contract as hermes); dsh's loopback exclusion comes from its built-in policy, so no `NO_PROXY` juggling is needed.

## Docs (EN+ZH)

- README: new “Injection priority — no files unless unavoidable” section next to *Two compression modes* (env > CLI/extension API > generated files; bili never owns user data; legacy overlays left in place, never merged back) + updated dsh one-liner.
- CONFIGURATION: redirect table, discovery table and the generated-files section updated for the dsh split — **plus** the pi/omp/hermes rows and bullets that phases 1–2 left stale (they still described the removed `PI_CODING_AGENT_DIR` / `HERMES_HOME` overlays). All phases are merged now, so the docs finally match the code.

## Pre-flight

- `npm run typecheck` clean
- `npm test`: 1028/1029 pass — sole failure is the sandbox-only `resolveClientCommand: codex/claude resolve to themselves` (`/usr/bin/codex` exists in this sandbox; fails on pristine master too)
- `npm run build` OK

New tests: `isLoopbackHost` units; dsh discovery split (loopback→rewrite, https→whitelist, http→env-routes, wrapped-value unwrap, dedupe, malformed skip); runLaunch dsh combined fixture (proxy envs + NO_PROXY strip + MITM-domain capture + overlay rewrites ONLY the loopback line + real home byte-identical); runLaunch dsh no-loopback fixture (no `DSH_HOME`, patch-only `-bili` dir).

## Notes

- This is the final phase of #535. After merge, the only generated-file mechanisms left in the launcher are opencode's temp `opencode.json` (removed on exit) and the dsh loopback overlay — both documented as last-resort exceptions. Full `refreshOverlayHome` abolition can be revisited once dsh gains a settings-path env or an upstream loopback opt-out.
- No version bump (release flow territory).