### PR TITLE
release v0.1.85

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.84",
+  "version": "0.1.85",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.84",
+      "version": "0.1.85",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@types/node": "^22.0.0",
         "@types/node-forge": "^1.3.14",
-        "acp-kernel": "0.0.51",
+        "acp-kernel": "0.0.52",
         "fzstd": "0.1.1",
         "node-forge": "^1.4.0",
         "tar": "^7.5.22",
@@ -988,9 +988,9 @@
       }
     },
     "node_modules/acp-kernel": {
-      "version": "0.0.51",
-      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.51.tgz",
-      "integrity": "sha512-XFYPJwX9N3CU/VMAapG5d4CUJDazOVh/r8mPOKSYPTHmi8V2llUFcbY1O9ydxuVJIKVWqi6NTRzZMDyB9VBYQg==",
+      "version": "0.0.52",
+      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.52.tgz",
+      "integrity": "sha512-t7tP68qmu1v3DYr3aBbVMtmfme4DUlOW1AGZT64cvG0C7vb6OpZz0OpP4VN4m3QEGeL8SK6D8E/j6MFc65lcwQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.84",
+  "version": "0.1.85",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/node-forge": "^1.3.14",
-    "acp-kernel": "0.0.51",
+    "acp-kernel": "0.0.52",
     "fzstd": "0.1.1",
     "node-forge": "^1.4.0",
     "tar": "^7.5.22",


### PR DESCRIPTION
Version-only release bump (carries master content since v0.1.84) + acp-kernel pin 0.0.51 → 0.0.52 (same pattern as v0.1.79).

## Changes since v0.1.84

- **#535 injection goes file-free (phases 1–3)** — `bili pi` / `bili omp` / `bili hermes` no longer maintain overlay/shadow home dirs:
  - PR #536 (pi): `BILI_PROVIDER_REWRITES` env manifest + `registerProvider` URL rewrite, `session_before_compact` cancel replaces settings.json compaction-off generation, pre-spawn refusal when the extension cannot load. Real `~/.pi/agent` is used directly; user settings edits can no longer be lost.
  - PR #538/#543 (omp + hermes): omp file-free via `-e` injection + `setModel` repin on `session_start`; hermes switched to env routing (`HTTPS_PROXY` + `HERMES_CA_BUNDLE`), no identity plugin / shadow home. Absolute-form proxy requests (`GET http://host/...` through the proxy) now forward; MITM host certs hardened (AKI/basic-constraints critical).
- **#359/#430 (PR #360)**: `/acp` status panel is now a persistent card in pi/omp (`sendMessage` custom message) instead of a transient toast, and the proxy strips it from the model context before projection.
- **#539 (PR #540)**: acp-loop preserves `reasoning_content` on assistant messages; degraded-retry limited to Anthropic.
- **#541 (PR #542)**: SSE decoder hoisted out of the per-message hot path.
- Test stability: `findFreePort` preferred-free test made deterministic (Windows ephemeral-range flake).

## Kernel

- acp-kernel **0.0.51 → 0.0.52** (kernel PR #199, fixes kernel #198): pressure-band nudge now requires a minimum benefit (`bestPending >= max(5000, modelContextLimit × 1%)`, overridable via `nudge.minPressureBenefitTokens`). Prevents zero-yield compression loops where a tiny pending block at high usage kept re-triggering nudges.

## Pre-flight

- `npm run typecheck` clean
- `npm test` 1040/1042 — 2 fails are the known env-dependent plugin-agent tests (pass 35/35 with `BILLION_CONTEXT_PROXY` unset)
- `npm run build` OK; bundle verified to contain kernel 0.0.52 (`minPressureBenefit` present in dist)