### PR TITLE
fix: starved tool-carrying main requests no longer demote to side requests (#546)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -618,12 +618,56 @@ type Prepared = {
 // #388: side requests (title-gen etc.) share the main session key but must not
 // touch kernel state. Identified by a tiny output budget (same heuristic as
 // prepareOpenai's isTitleGen); a missing/non-positive budget is never a side req.
+// #546: a non-empty tools array marks an agent MAIN turn — clients that size the
+// output budget from their raw (uncompressed) history shrink max_tokens to
+// <=200 on long sessions; that must never demote the request to a side pass
+// (title-gen requests never carry tools).
 const SIDE_REQUEST_MAX_TOKENS = 200;
 export function isSideRequest(parsed: unknown): boolean {
     if (!parsed || typeof parsed !== "object") return false;
     const p = parsed as Record<string, unknown>;
+    if (Array.isArray(p.tools) && p.tools.length > 0) return false;
     const raw = p.max_tokens ?? p.max_completion_tokens ?? p.max_output_tokens;
     return typeof raw === "number" && raw > 0 && raw <= SIDE_REQUEST_MAX_TOKENS;
+}
+
+export type OutputBudgetField = "max_tokens" | "max_completion_tokens" | "max_output_tokens";
+
+export function outputBudgetField(parsed: unknown): OutputBudgetField | null {
+    if (!parsed || typeof parsed !== "object") return null;
+    const p = parsed as Record<string, unknown>;
+    for (const field of ["max_tokens", "max_completion_tokens", "max_output_tokens"] as const) {
+        if (typeof p[field] === "number" && (p[field] as number) > 0) return field;
+    }
+    return null;
+}
+
+/** #546: clients that derive the output budget from their RAW (uncompressed)
+ *  history drive it down to <=200 tokens on long sessions, then truncate every
+ *  reply mid-thought — the model cannot even emit a compress tool call, so the
+ *  loop can never rescue the session. The proxy's compressed view still fits
+ *  the window, so remember the healthy budget per session (last non-starved
+ *  value wins) and restore it on tool-carrying main requests whose budget has
+ *  starved. Mutates `parsed` in place BEFORE prepare() serializes it. */
+export function restoreOutputBudget(
+    parsed: unknown,
+    session: { id: string; metadata: Record<string, unknown> },
+    log: (level: string, msg: string) => void,
+): void {
+    const field = outputBudgetField(parsed);
+    if (!field) return;
+    const p = parsed as Record<string, unknown>;
+    const value = p[field] as number;
+    if (value > SIDE_REQUEST_MAX_TOKENS) {
+        session.metadata.outputBudgetHighWater = value;
+        return;
+    }
+    if (!Array.isArray(p.tools) || p.tools.length === 0) return;
+    const highWater = session.metadata.outputBudgetHighWater;
+    if (typeof highWater === "number" && highWater > SIDE_REQUEST_MAX_TOKENS) {
+        p[field] = highWater;
+        log("info", `[${session.id}] output budget restored ${value} -> ${highWater} (#546: client shrank it from its raw-history estimate)`);
+    }
 }
 
 function isTrustedAdminOrigin(origin: string | undefined, host: string | undefined, trustedHosts: Set<string>): boolean {
@@ -1289,6 +1333,10 @@ async function handle(
         //    exactly one system at index 0, #377) accept it and the head system
         //    message stays byte-stable for the prefix cache.
         const pluginMode = pluginAgent !== undefined;
+        // #546: restore a client-shrunk output budget BEFORE the side gate so a
+        // tool-carrying main request re-enters the pipeline at full budget (see
+        // restoreOutputBudget for the starvation mechanism).
+        restoreOutputBudget(parsed, session, log);
         // #388: side requests (title-gen etc.) share the main session key but
         // must not touch kernel state (processTurn/snapshot/usage would pollute
         // the main view). Forward with a minimal prepared marked sidePassthrough:

--- a/tests/side-request-isolation.test.ts
+++ b/tests/side-request-isolation.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import http from "node:http";
 import { once } from "node:events";
 import { defaultConfig, createInitialState } from "acp-kernel";
-import { startServer, type ProxyOptions, isSideRequest } from "../src/server.ts";
+import { startServer, type ProxyOptions, isSideRequest, outputBudgetField, restoreOutputBudget } from "../src/server.ts";
 import { SessionStore, _setStoreForTest } from "../src/persist.ts";
 import { _setForTest as setRegistryForTest } from "../src/registry.ts";
 import { getSession } from "../src/session.ts";
@@ -27,6 +27,58 @@ test("isSideRequest: tiny output budget across protocol field names", () => {
     assert.equal(isSideRequest({ max_tokens: 0 }), false, "zero budget");
     assert.equal(isSideRequest({ max_tokens: -5 }), false, "negative budget");
     assert.equal(isSideRequest({ max_tokens: "100" }), false, "string budget is not a number");
+    assert.equal(isSideRequest({ max_tokens: 100, tools: [{ name: "compress" }] }), false, "#546: tool-carrying request is a MAIN turn even with a starved budget");
+    assert.equal(isSideRequest({ max_tokens: 100, tools: [] }), true, "empty tools array does not rescue a tiny budget");
+    assert.equal(isSideRequest({ max_output_tokens: 16, tools: [{ type: "function", function: { name: "f" } }] }), false, "#546: responses wire, starved budget + tools → main");
+});
+
+const noopLog = (): void => {};
+
+function metaSession(id: string): { id: string; metadata: Record<string, unknown> } {
+    return { id, metadata: {} };
+}
+
+test("outputBudgetField: first positive numeric field wins (#546)", () => {
+    assert.equal(outputBudgetField({ max_tokens: 5 }), "max_tokens");
+    assert.equal(outputBudgetField({ max_completion_tokens: 5 }), "max_completion_tokens");
+    assert.equal(outputBudgetField({ max_output_tokens: 5 }), "max_output_tokens");
+    assert.equal(outputBudgetField({ max_tokens: 0, max_completion_tokens: 7 }), "max_completion_tokens", "zero/negative fields skipped");
+    assert.equal(outputBudgetField({ max_tokens: "16" }), null, "string budget ignored");
+    assert.equal(outputBudgetField({}), null);
+    assert.equal(outputBudgetField(null), null);
+});
+
+test("restoreOutputBudget: high-water learning + starved-budget restore (#546)", () => {
+    const s = metaSession("hw");
+    // Healthy request → learns the high-water (last non-starved value wins).
+    restoreOutputBudget({ max_tokens: 32768 }, s, noopLog);
+    assert.equal(s.metadata.outputBudgetHighWater, 32768);
+    // Starved main request (tools present) → restored to the high-water.
+    const starved = { max_tokens: 16, tools: [{ name: "compress" }] } as { max_tokens: number; tools: unknown[] };
+    restoreOutputBudget(starved, s, noopLog);
+    assert.equal(starved.max_tokens, 32768, "starved budget restored to high-water");
+    // No high-water yet + starved + tools → nothing to restore to, untouched.
+    const fresh = metaSession("fresh");
+    const noWater = { max_tokens: 16, tools: [{ name: "compress" }] };
+    restoreOutputBudget(noWater, fresh, noopLog);
+    assert.equal(noWater.max_tokens, 16);
+    // Side request (tiny budget, NO tools) → never touched, stays a side req.
+    const side = { max_tokens: 100 };
+    restoreOutputBudget(side, s, noopLog);
+    assert.equal(side.max_tokens, 100, "side request budget must not be restored");
+    assert.equal(isSideRequest(side), true);
+    // High-water re-learns downward on a new healthy budget (config change).
+    restoreOutputBudget({ max_tokens: 8000 }, s, noopLog);
+    assert.equal(s.metadata.outputBudgetHighWater, 8000, "last non-starved value wins");
+    const starved2 = { max_tokens: 200, tools: [{ name: "t" }] } as { max_tokens: number };
+    restoreOutputBudget(starved2, s, noopLog);
+    assert.equal(starved2.max_tokens, 8000, "boundary 200 restored too (isSideRequest would misfire without tools)");
+    // Field-name fidelity: restore writes the SAME field the client used.
+    const s2 = metaSession("hw2");
+    restoreOutputBudget({ max_output_tokens: 32689 }, s2, noopLog);
+    const responsesStarved = { max_output_tokens: 1, tools: [{ type: "function" }] } as { max_output_tokens: number };
+    restoreOutputBudget(responsesStarved, s2, noopLog);
+    assert.equal(responsesStarved.max_output_tokens, 32689, "responses field restored on the same field");
 });
 
 const MODEL = "claude-sonnet-4-5";
@@ -61,10 +113,12 @@ interface Rig {
     /** When set, served verbatim for side requests (max_tokens<=200) instead
      *  of the generated okSse stream. */
     sideScript: string | null;
+    /** Last request body received by the upstream (for wire assertions). */
+    lastBody: Record<string, unknown> | null;
 }
 
 async function startRig(): Promise<Rig> {
-    const rig: Rig = { proxyPort: 0, upstreamPort: 0, proxy: null as unknown as http.Server, upstream: null as unknown as http.Server, sideScript: null };
+    const rig: Rig = { proxyPort: 0, upstreamPort: 0, proxy: null as unknown as http.Server, upstream: null as unknown as http.Server, sideScript: null, lastBody: null };
     const upstream = http.createServer((req, res) => {
         const chunks: Buffer[] = [];
         req.on("data", (c: Buffer) => chunks.push(c));
@@ -72,6 +126,7 @@ async function startRig(): Promise<Rig> {
             const raw = Buffer.concat(chunks).toString("utf8");
             let parsed: { max_tokens?: number } = {};
             try { parsed = JSON.parse(raw); } catch { /* keep {} */ }
+            rig.lastBody = parsed as Record<string, unknown>;
             // Side requests (tiny max_tokens) report a TINY context; main requests
             // report a large one. The proxy must NOT capture the side request's
             // usage — that is exactly the pollution this regression guards.
@@ -194,6 +249,48 @@ test("e2e: anthropic side request (title-gen) leaves main session kernel state u
         assert.ok(s3, "session exists after main request 2");
         assert.notEqual(JSON.stringify(s3.state), stateAfterMain1, "main request 2 must advance kernel state (driven only by main requests)");
         assert.ok(s3.stats.requests > requestsAfterMain1, "main request 2 increments the request counter");
+    } finally {
+        await closeRig(rig);
+    }
+});
+
+test("e2e: starved tool-carrying main request re-enters pipeline at restored budget (#546)", async () => {
+    const rig = await startRig();
+    try {
+        const url = `http://127.0.0.1:${rig.proxyPort}/bili/http://127.0.0.1:${rig.upstreamPort}/v1/messages`;
+        const headers: Record<string, string> = { "content-type": "application/json", "x-acp-session": SESSION };
+        const tools = [{ name: "compress", description: "compress", input_schema: { type: "object", properties: {} } }];
+
+        // Healthy main turn WITH tools: teaches the session its output budget.
+        const r1 = await fetch(url, { method: "POST", headers, body: JSON.stringify({ model: MODEL, max_tokens: 1024, stream: true, tools, messages: mainConversation(8) }) });
+        assert.equal(r1.status, 200);
+        await r1.text();
+        const s1 = getSession(SESSION);
+        const requestsAfterMain1 = s1.stats.requests;
+        assert.equal(s1.metadata.outputBudgetHighWater, 1024, "high-water learned from the healthy main turn");
+
+        // Death-spiral turn: the client shrank the budget to 16 tokens off its
+        // raw-history estimate. The request still carries tools → it is a MAIN
+        // turn: the pipeline must run (no side passthrough) and the budget must
+        // reach the upstream restored to the high-water.
+        const r2 = await fetch(url, { method: "POST", headers, body: JSON.stringify({ model: MODEL, max_tokens: 16, stream: true, tools, messages: mainConversation(9) }) });
+        assert.equal(r2.status, 200);
+        await r2.text();
+        const s2 = getSession(SESSION);
+        assert.ok(s2.stats.requests > requestsAfterMain1, "starved main turn must go through the pipeline, not side passthrough");
+        assert.equal(rig.lastBody && rig.lastBody.max_tokens, 1024, "upstream received the restored budget (#546)");
+
+        // A real side request (no tools, tiny budget) on the same session stays
+        // a pure passthrough: budget NOT restored, kernel untouched.
+        const stateBeforeSide = JSON.stringify(s2.state);
+        const statsBeforeSide = JSON.stringify(s2.stats);
+        const r3 = await fetch(url, { method: "POST", headers, body: JSON.stringify({ model: MODEL, max_tokens: 100, stream: true, messages: [{ role: "user", content: "short title" }] }) });
+        assert.equal(r3.status, 200);
+        await r3.text();
+        assert.equal(rig.lastBody && rig.lastBody.max_tokens, 100, "side request budget untouched");
+        const s3 = getSession(SESSION);
+        assert.equal(JSON.stringify(s3.state), stateBeforeSide, "side request left kernel state untouched");
+        assert.equal(JSON.stringify(s3.stats), statsBeforeSide, "side request left stats untouched");
     } finally {
         await closeRig(rig);
     }


### PR DESCRIPTION
Fixes #546.

## Root cause

`dsh` (and any client that sizes its output budget from its **raw, uncompressed** history) computes `available = contextWindow - estimate(context) - 4096` and clamps `max_tokens` to it. On long sessions the estimate keeps growing, so the budget slides 32689 → … → 16 (while the proxy's compressed view sits at ~44% usage). Once it crosses ≤200, the #388 side-request heuristic (`SIDE_REQUEST_MAX_TOKENS = 200`) misjudges the **main** turn as a title-gen side request → `sidePassthrough` → no `processTurn`, no preflight, no compression loop → replies truncated to 1–16 tokens forever (the model can't even emit a compress tool call at 16 output tokens).

## Fix (two parts, one signal)

Signal: **a non-empty `tools` array marks an agent main turn** — title-gen / side requests never carry tools (verified in deepseek-harness: `session-title-llm` builds `GenerateOptions` without `tools`).

1. `isSideRequest` returns `false` when `tools` is non-empty → a starved main request always re-enters the full pipeline.
2. `restoreOutputBudget` (new, runs **before** the side gate so `prepare`'s re-serialization picks it up):
   - remembers the session's healthy output budget in `session.metadata.outputBudgetHighWater` (last non-starved value wins → survives restart via persist, self-corrects on config changes);
   - when a tool-carrying turn arrives with a starved budget (≤200), rewrites that **same budget field** (`max_tokens` / `max_completion_tokens` / `max_output_tokens` — all three covered) back to the high-water, with a log line `output budget restored N -> M (#546)`.
   - Side requests (no tools) are never touched.

The restore is load-bearing: classification alone would run the pipeline but the turn would still hit the model with 16 output tokens and truncate. Complements the existing `clampOutgoingOutput` (#453), which clamps from the **compressed** view and therefore never re-starves a healthy session.

Fallback when no high-water exists yet (fresh session restored mid-spiral): the tools check alone still routes the turn through the pipeline, preflight compresses, and the client's own history shrinks → budget recovers next turn.

## Tests

`tests/side-request-isolation.test.ts` +3:
- `isSideRequest`: tools non-empty → main (anthropic + responses wire), empty `tools: []` stays side.
- `outputBudgetField` unit: first positive numeric field wins, strings/zeros ignored.
- `restoreOutputBudget` unit: high-water learning (last-wins), restore on same field, boundary 200 restored, no-tools never restored, no-high-water no-op.
- e2e (anthropic rig, upstream body capture): healthy tools turn (1024) → starved tools turn (16) arrives at upstream as **1024** and advances kernel state; a real no-tools side request (100) stays passthrough with budget and state untouched.

## Pre-flight

- `npm run typecheck` ✅
- `npm test` 1045/1047 (the 2 known `plugin-agent` env fails; `BILLION_CONTEXT_PROXY` unset → 35/35) ✅
- `npm run build` ✅