### PR TITLE
fix: accept data-only SSE streams in responses adapter (#549)

### DIFF
--- a/src/loop/adapter-responses.ts
+++ b/src/loop/adapter-responses.ts
@@ -316,15 +316,21 @@ export function createResponsesAdapter(textProtocol?: boolean, projection?: Resp
                 }
             };
             for await (const eventStr of iterSseEvents(upstream)) {
-                const type = extractEventType(eventStr);
+                const explicitType = extractEventType(eventStr);
                 const dataLine = extractDataLine(eventStr);
-                if (!type || !dataLine) continue;
+                if (!dataLine) continue;
                 let obj: Record<string, unknown>;
                 try {
                     obj = JSON.parse(dataLine);
                 } catch {
                     continue;
                 }
+                // #549: `event:` is optional per the WHATWG SSE spec (defaults to
+                // "message"); many OpenAI-compatible gateways emit pure data: frames.
+                // Responses payloads carry a `type` equal to the event name — fall
+                // back to it when no event: line is present (explicit line still wins).
+                const type = explicitType ?? (typeof obj.type === "string" ? obj.type : null);
+                if (!type) continue;
                 const rawBuf = Buffer.from(eventStr + "\n\n", "utf8");
                 if (round === 1 && typeof obj.output_index === "number") {
                     outputIndex = Math.max(outputIndex, obj.output_index + 1);

--- a/tests/loop-adapters.test.ts
+++ b/tests/loop-adapters.test.ts
@@ -41,7 +41,7 @@ function makeCtx(id: string, messages: CoreMessage[] = []): {
 async function drain(
     stream: ReadableStream<Uint8Array>,
     ctx: ReturnType<typeof makeCtx>,
-    adapter: ReturnType<typeof createOpenaiAdapter> | ReturnType<typeof createAnthropicAdapter>,
+    adapter: ReturnType<typeof createOpenaiAdapter> | ReturnType<typeof createAnthropicAdapter> | ReturnType<typeof createResponsesAdapter>,
     requestBody: Record<string, unknown>,
 ): Promise<string> {
     const chunks: Buffer[] = [];
@@ -593,4 +593,51 @@ test("openai emitCompletion: usage with absent token counts still serializes com
     const realLine = real.split("\n").find((l) => l.startsWith("data: ") && l.includes("finish_reason"));
     const realParsed = JSON.parse(realLine!.slice("data: ".length)) as { usage?: Record<string, unknown> };
     assert.deepEqual({ p: realParsed.usage!.prompt_tokens, c: realParsed.usage!.completion_tokens, t: realParsed.usage!.total_tokens }, { p: 7, c: 3, t: 10 });
+});
+
+test("F8 (#549): responses adapter accepts data-only SSE frames (no event: lines)", async () => {
+    const stream = mockStream(
+        `data: ${JSON.stringify({ type: "response.created", response: { id: "resp_1", status: "in_progress", output: [] } })}\n\n`,
+        `data: ${JSON.stringify({ type: "response.output_item.added", output_index: 0, item: { type: "message", id: "m1", role: "assistant", content: [] } })}\n\n`,
+        `data: ${JSON.stringify({ type: "response.output_text.delta", item_id: "m1", output_index: 0, delta: "HelloDataOnly" })}\n\n`,
+        `data: ${JSON.stringify({ type: "response.completed", response: { id: "resp_1", status: "completed", output: [], usage: { input_tokens: 10, output_tokens: 5 } } })}\n\n`,
+    );
+    const events = await collectParseEvents(createResponsesAdapter(), stream, 1);
+    const textEv = events.find((e) => e.kind === "text");
+    assert.ok(textEv, "text delta yielded from data-only frame");
+    if (textEv && textEv.kind === "text") assert.equal(textEv.delta, "HelloDataOnly", "delta content intact");
+    const done = events.find((e) => e.kind === "done");
+    assert.ok(done, "terminal done yielded");
+    if (done && done.kind === "done") {
+        assert.equal(done.finishReason, "completed", "terminal kind taken from data payload type");
+        assert.notEqual(done.truncated, true, "not a synthetic truncation failure");
+    }
+});
+
+test("F8 (#549): explicit event: line wins over data payload type", async () => {
+    const stream = mockStream(
+        `event: response.completed\ndata: ${JSON.stringify({ type: "response.output_text.delta", item_id: "m1", output_index: 0, delta: "X" })}\n\n`,
+    );
+    const events = await collectParseEvents(createResponsesAdapter(), stream, 1);
+    const done = events.find((e) => e.kind === "done");
+    assert.ok(done, "done yielded");
+    if (done && done.kind === "done") assert.equal(done.finishReason, "completed", "explicit event: takes precedence over data type");
+});
+
+test("F8 (#549): data-only responses stream completes cleanly end-to-end (no synthetic failure)", async () => {
+    const round1 = [
+        `data: ${JSON.stringify({ type: "response.created", response: { id: "resp_1", status: "in_progress", output: [] } })}\n\n`,
+        `data: ${JSON.stringify({ type: "response.output_item.added", output_index: 0, item: { type: "message", id: "m1", role: "assistant", content: [] } })}\n\n`,
+        `data: ${JSON.stringify({ type: "response.output_text.delta", item_id: "m1", output_index: 0, delta: "HelloDataOnly" })}\n\n`,
+        `data: ${JSON.stringify({ type: "response.completed", response: { id: "resp_1", status: "completed", output: [], usage: { input_tokens: 10, output_tokens: 5 } } })}\n\n`,
+    ].join("");
+    const out = await drain(
+        new Response(round1, { status: 200 }).body!,
+        makeCtx("responses-dataonly"),
+        createResponsesAdapter(),
+        { model: "gpt-5", input: [], stream: true },
+    );
+    assert.ok(out.includes("HelloDataOnly"), "text streamed live");
+    assert.ok(out.includes('"status":"completed"'), "completion emitted with completed status");
+    assert.ok(!out.includes("upstream returned no response"), "no synthetic failure for a valid data-only stream");
 });


### PR DESCRIPTION
## What changed

`src/loop/adapter-responses.ts` — `parseStream` now falls back to the `type` field inside the `data:` JSON payload when a frame carries no explicit `event:` line.

Per the WHATWG SSE spec `event:` is optional (defaults to `message`), and many OpenAI-compatible gateways emit pure `data:` frames. Previously every such frame was skipped (`if (!type || !dataLine) continue;`), so no terminal event was ever observed and a cleanly-finished upstream stream produced the synthetic `response.failed` / "upstream returned no response" error reported in #549.

- An explicit `event:` line still wins over the payload `type`.
- Strictly additive: non-JSON data or payloads without a string `type` are still skipped exactly as before.
- The payload is parsed once; the fallback reads the already-parsed object instead of re-parsing inside `extractEventType` (same semantics as the patch proposed in the issue, without the double parse).

## Tests

Three regression tests added in `tests/loop-adapters.test.ts` (F8):
1. data-only stream (created → item.added → text.delta → completed) yields text + usage + `done/completed`, not a synthetic truncation failure;
2. explicit `event:` takes precedence over the payload `type`;
3. end-to-end drain of a data-only stream emits `response.completed` and never "upstream returned no response".

Verified tests 1 and 3 fail against the unfixed code.

Note: `parseAnthropicSse` in `src/loop/adapter-anthropic.ts` has the same strictness (requires an `event:` line). Left unchanged — Anthropic streams always carry event lines and no compatible gateway omitting them has been reported; flagged for awareness.

## Pre-flight

- `npm run typecheck`: pass
- `npm test`: 949/950 pass; the single failure (`resolveClientCommand: codex/claude resolve to themselves`) fails identically on the clean tree in this environment (client binaries not installed) — unrelated
- `npm run build`: pass