### PR TITLE
fix: drop previous .old before logger rotation rename (Windows-safe)

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -16,7 +16,7 @@
  *   - If stderr's reader is gone (broken pipe), process.stderr.write throws
  *     EPIPE — swallowed so logging can never crash the server.
  */
-import { createWriteStream, fstatSync, mkdirSync, statSync, renameSync, type WriteStream } from "node:fs";
+import { createWriteStream, fstatSync, mkdirSync, statSync, renameSync, unlinkSync, type WriteStream } from "node:fs";
 import path from "node:path";
 
 const MAX_BYTES = 10 * 1024 * 1024; // 10 MB → rotate
@@ -43,6 +43,9 @@ function openStream(file: string): WriteStream {
         existingSize = statSync(file).size;
         if (existingSize >= MAX_BYTES) {
             try {
+                // Drop the previous generation first: keep at most one .old,
+                // and on Windows renameSync cannot overwrite an existing target.
+                try { unlinkSync(file + ".old"); } catch { /* no previous generation */ }
                 renameSync(file, file + ".old");
                 existingSize = 0;
             } catch {

--- a/tests/logger-rotate.test.ts
+++ b/tests/logger-rotate.test.ts
@@ -1,0 +1,37 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { configureLogger, closeLogger, log } from "../src/logger.ts";
+
+const MAX_BYTES = 10 * 1024 * 1024;
+
+test("log rotation keeps at most one .old generation", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "bili-logrot-"));
+    const p = path.join(dir, "bili.log");
+    try {
+        // Round 1: a full-size file triggers rotation on the first write.
+        fs.writeFileSync(p, Buffer.alloc(MAX_BYTES, 65));
+        configureLogger(p);
+        log("info", "gen-b");
+        assert.ok(fs.existsSync(p + ".old"), "rotation produced .old");
+        assert.ok(fs.statSync(p + ".old").size >= MAX_BYTES);
+        closeLogger();
+
+        // Round 2: a pre-existing .old (sentinel) must be dropped, not kept
+        // alongside the new one.
+        fs.writeFileSync(p, Buffer.alloc(MAX_BYTES, 66));
+        fs.writeFileSync(p + ".old", "sentinel-old-generation");
+        configureLogger(p);
+        log("info", "gen-c");
+        assert.ok(fs.existsSync(p + ".old"));
+        const old = fs.readFileSync(p + ".old");
+        assert.ok(!old.includes("sentinel"), "previous .old generation was deleted");
+        assert.ok(old.length >= MAX_BYTES);
+        closeLogger();
+    } finally {
+        closeLogger();
+        fs.rmSync(dir, { recursive: true, force: true });
+    }
+});


### PR DESCRIPTION
Split out of PR#277 per maintainer decision: only the one production-impacting fix from #276 is kept; the debug-dump GC and launcher tmplog sweep are dropped (debug-only concern / tmpdir hygiene).

**Problem** (#276, item ③): `openStream` rotates `bili.log` → `bili.log.old` with `renameSync` without removing an existing `.old` first. On POSIX `rename` overwrites, so rotation works and at most one generation survives. On **Windows** `renameSync` cannot overwrite an existing target — it throws, the surrounding `catch` swallows it, and rotation **silently never happens**: `bili.log` grows unbounded for the life of the install.

**Fix**: `try { unlinkSync(file + ".old") } catch {}` immediately before the rename. Windows-safe (target can't pre-exist), and on POSIX it makes the ≤1-generation guarantee explicit instead of relying on overwrite semantics.

**Test**: `tests/logger-rotate.test.ts` — writes two generations past MAX_BYTES through the real logger and asserts exactly one `.old` exists and the fresh log is post-rotation.

Pre-flight: typecheck ✓ · logger tests 18/18 ✓ · build ✓.