### PR TITLE
fix: align undici transport timeouts with idle watchdog; add BILI_UPSTREAM_TIMEOUT_MS (#551)

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -353,6 +353,7 @@ Environment variables take precedence over the config file. They are useful for 
 | `ACP_PROVIDERS` | Path to an external `providers.json` (legacy / shared file). |
 | `BILI_REPLAY_RETRY_BASE_MS` | Base backoff delay (ms) for acp-loop replay retries after a transient upstream rejection (default `1500`; set `0` to disable the delay). See #189. |
 | `BILI_REPLAY_RETRY_MAX` | Total attempts for acp-loop replay retries (default `3`; set `1` to disable retries entirely — legacy fail-fast behavior). See #189. |
+| `BILI_UPSTREAM_TIMEOUT_MS` | Idle budget (ms) for upstream requests: time-to-first-byte and time between body chunks (default `600000` = 10 min). A healthy stream that keeps producing chunks is never cut mid-flight; a silent one is. The same value drives the underlying HTTP client's transport timeouts, so this single knob bounds long local-model prefills end-to-end (#551). |
 | `ACP_SESSION_HEADER` | Conversation-id header name (default `x-acp-session`). |
 | `ACP_REASONING_KEEP` | Responses API only: set `none` to drop all reasoning items. Default routes reasoning through the compression pipeline so it is hidden automatically once its turn is summarized (prevents the unbounded accumulation that broke Codex's prompt-cache prefix). |
 | `ACP_LOG_FILE` | Log file path (default XDG state path; `off` disables the file, keeps stderr). Auto-rotates at 10 MB. |

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -353,7 +353,7 @@ Environment variables take precedence over the config file. They are useful for 
 | `ACP_PROVIDERS` | Path to an external `providers.json` (legacy / shared file). |
 | `BILI_REPLAY_RETRY_BASE_MS` | Base backoff delay (ms) for acp-loop replay retries after a transient upstream rejection (default `1500`; set `0` to disable the delay). See #189. |
 | `BILI_REPLAY_RETRY_MAX` | Total attempts for acp-loop replay retries (default `3`; set `1` to disable retries entirely — legacy fail-fast behavior). See #189. |
-| `BILI_UPSTREAM_TIMEOUT_MS` | Idle budget (ms) for upstream requests: time-to-first-byte and time between body chunks (default `600000` = 10 min). A healthy stream that keeps producing chunks is never cut mid-flight; a silent one is. The same value drives the underlying HTTP client's transport timeouts, so this single knob bounds long local-model prefills end-to-end (#551). |
+| `BILI_UPSTREAM_TIMEOUT_MS` | Idle budget (ms) for upstream requests: time-to-first-byte and time between body chunks (default `720000` = 12 min). A healthy stream that keeps producing chunks is never cut mid-flight; a silent one is. The same value drives the underlying HTTP client's transport timeouts, so this single knob bounds long local-model prefills end-to-end (#551). |
 | `ACP_SESSION_HEADER` | Conversation-id header name (default `x-acp-session`). |
 | `ACP_REASONING_KEEP` | Responses API only: set `none` to drop all reasoning items. Default routes reasoning through the compression pipeline so it is hidden automatically once its turn is summarized (prevents the unbounded accumulation that broke Codex's prompt-cache prefix). |
 | `ACP_LOG_FILE` | Log file path (default XDG state path; `off` disables the file, keeps stderr). Auto-rotates at 10 MB. |

--- a/CONFIGURATION.zh-CN.md
+++ b/CONFIGURATION.zh-CN.md
@@ -356,6 +356,7 @@
 | `ACP_LOG_FILE` | 日志文件路径（默认 XDG state 路径；`off` 关闭文件只保留 stderr）。10 MB 自动轮转。 |
 | `ACP_DUMP_SSE` | 调试用：转储原始 SSE 帧的目录。 |
 | `BILI_UPSTREAM_PROXY` | 代理自身出站连接的上游代理 —— 优先级最高，高于 per-URL/per-provider 配置。见 README「上游代理」一节。 |
+| `BILI_UPSTREAM_TIMEOUT_MS` | 上游请求的空闲预算（毫秒）：首字节时间（TTFB）与响应体块之间的间隔（默认 `720000` = 12 分钟）。持续产出数据块的健康流永远不会被中途切断；静默的流才会。同一个值同时驱动底层 HTTP 客户端的传输层超时，因此这一个旋钮即可端到端约束本地大模型的超长 prefill（#551）。 |
 | `BILI_PERSIST` | 设 `0` 关闭会话持久化（仅内存，重启即丢）。 |
 | `BILI_PERSIST_DEBOUNCE_MS` | 持久化写盘的防抖窗口（毫秒，默认 `500`）。 |
 | `BILI_MAX_SESSIONS` | 内存中最多保留的会话数（默认 `256`；LRU 淘汰 —— 磁盘是事实源）。 |

--- a/src/fetch-util.ts
+++ b/src/fetch-util.ts
@@ -1,3 +1,5 @@
+import { Agent } from "undici";
+
 /** HTTP robustness helpers for the proxy.
 
   - readBody is capped: an unbounded request body is a memory-exhaustion
@@ -20,6 +22,38 @@ export function _liveUpstreamTimersForTest(): number {
     return liveUpstreamTimers.size;
 }
 
+/** Idle-timeout budget for upstream requests; overridable via
+ *  BILI_UPSTREAM_TIMEOUT_MS (milliseconds). Read on each call so tests can
+ *  tune it live. Local-model deployments with very large contexts can need
+ *  prefills longer than the 10-minute default before their first token. */
+export function upstreamTimeoutMs(): number {
+    const raw = Number(process.env.BILI_UPSTREAM_TIMEOUT_MS);
+    return Number.isInteger(raw) && raw > 0 ? raw : UPSTREAM_TIMEOUT_MS;
+}
+
+// Direct (non-proxied) requests go through Node's hidden global agent, whose
+// undici headersTimeout/bodyTimeout defaults are both 300s — that cap silently
+// killed long prefills before this watchdog ever got a chance (#551). Inject an
+// explicit Agent per timeout value so the transport layer matches the watchdog
+// instead of firing first.
+const directDispatchers = new Map<number, Agent>();
+
+function directDispatcher(timeoutMs: number): Agent {
+    let agent = directDispatchers.get(timeoutMs);
+    if (!agent) {
+        agent = new Agent({ headersTimeout: timeoutMs, bodyTimeout: timeoutMs });
+        directDispatchers.set(timeoutMs, agent);
+    }
+    return agent;
+}
+
+export function _resetFetchUtilForTest(): void {
+    for (const agent of directDispatchers.values()) {
+        try { void agent.close().catch(() => undefined); } catch { /* already closed */ }
+    }
+    directDispatchers.clear();
+}
+
 /** undici's fetch accepts a `dispatcher` option (its own Dispatcher type) that
  *  @types/node's RequestInit already declares — but typed as the internal
  *  `Dispatcher` interface, which conflicts with the `undici` package's
@@ -39,7 +73,10 @@ export type FetchOptions = Omit<RequestInit, "dispatcher"> & { dispatcher?: obje
  *  stream has been fully consumed (or on the error path) to stop the timer.
  *
  *  `opts.dispatcher` (optional) routes the fetch through an upstream proxy
- *  (an `undici.ProxyAgent`). When omitted, fetch uses its default agent.
+ *  (an `undici.ProxyAgent`). When omitted, a direct `undici.Agent` cached per
+ *  timeout value is injected — its headersTimeout/bodyTimeout match the idle
+ *  watchdog below so undici's hidden 300s transport defaults can never fire
+ *  first (#551).
  *
  *  `externalSignal` (optional) lets the caller abort the in-flight request
  *  independently of the timeout — e.g. when the downstream client disconnects.
@@ -48,15 +85,16 @@ export type FetchOptions = Omit<RequestInit, "dispatcher"> & { dispatcher?: obje
 export async function fetchWithTimeout(
     url: string,
     opts: FetchOptions,
-    timeoutMs: number = UPSTREAM_TIMEOUT_MS,
+    timeoutMs?: number,
     externalSignal?: AbortSignal,
 ): Promise<{ response: Response; clearTimer: () => void }> {
+    const effective = timeoutMs ?? upstreamTimeoutMs();
     const controller = new AbortController();
     const armTimer = () => {
         const t = setTimeout(() => {
             liveUpstreamTimers.delete(t);
             controller.abort();
-        }, timeoutMs);
+        }, effective);
         liveUpstreamTimers.add(t);
         return t;
     };
@@ -80,7 +118,11 @@ export async function fetchWithTimeout(
         if (onExternalAbort && externalSignal) externalSignal.removeEventListener("abort", onExternalAbort);
     };
     try {
-        const finalOpts: Omit<RequestInit, "dispatcher"> & { dispatcher?: object } = { ...opts, signal: controller.signal };
+        const finalOpts: Omit<RequestInit, "dispatcher"> & { dispatcher?: object } = {
+            ...opts,
+            signal: controller.signal,
+            dispatcher: opts.dispatcher ?? directDispatcher(effective),
+        };
         // `fetch` is undici's global; it accepts `dispatcher` at runtime. @types/node
         // types RequestInit.dispatcher as its internal `Dispatcher` interface,
         // which structurally conflicts with the `undici` package's exported

--- a/src/fetch-util.ts
+++ b/src/fetch-util.ts
@@ -11,11 +11,11 @@ import { Agent } from "undici";
     streams can legitimately run for minutes, so the default is long. */
 
 export const MAX_REQUEST_BYTES = 100 * 1024 * 1024;
-export const UPSTREAM_TIMEOUT_MS = 10 * 60 * 1000;
+export const UPSTREAM_TIMEOUT_MS = 12 * 60 * 1000;
 
 const liveUpstreamTimers = new Set<ReturnType<typeof setTimeout>>();
 /** Test hook: how many fetchWithTimeout idle-timers are currently armed.
- *  #411: an aborted passthrough used to leak its 10-minute timer because
+ *  #411: an aborted passthrough used to leak its idle timer because
  *  clearTimer was only called on the success path — tests assert this stays
  *  at zero after a client abort. */
 export function _liveUpstreamTimersForTest(): number {
@@ -25,7 +25,7 @@ export function _liveUpstreamTimersForTest(): number {
 /** Idle-timeout budget for upstream requests; overridable via
  *  BILI_UPSTREAM_TIMEOUT_MS (milliseconds). Read on each call so tests can
  *  tune it live. Local-model deployments with very large contexts can need
- *  prefills longer than the 10-minute default before their first token. */
+ *  prefills longer than the 12-minute default before their first token. */
 export function upstreamTimeoutMs(): number {
     const raw = Number(process.env.BILI_UPSTREAM_TIMEOUT_MS);
     return Number.isInteger(raw) && raw > 0 ? raw : UPSTREAM_TIMEOUT_MS;
@@ -67,7 +67,7 @@ export type FetchOptions = Omit<RequestInit, "dispatcher"> & { dispatcher?: obje
  *  every response-body chunk, so it becomes an idle timeout once the body is
  *  streaming: a healthy stream that keeps producing chunks is never aborted
  *  mid-flight (LLM generations can legitimately run for minutes — a total
- *  timer would kill a healthy 12-minute stream at the 10-minute mark), while a
+ *  timer would kill a healthy 15-minute stream at the 12-minute mark), while a
  *  genuinely stuck stream (no chunk for `timeoutMs`) still trips the abort.
  *  Callers receive a `clearTimer` callback and invoke it once the response
  *  stream has been fully consumed (or on the error path) to stop the timer.
@@ -275,7 +275,7 @@ export interface ReplayRetryInfo {
  *  For acp-loop replay requests, where provider risk-control may briefly
  *  reject a request whose context was just rewritten (#189). Network-level
  *  failures (timeout, connection reset) propagate unchanged — NOT retried
- *  here, to avoid stacking the 10-min timeout across attempts. */
+ *  here, to avoid stacking the 12-min timeout across attempts. */
 export async function fetchWithRetry(
     url: string,
     opts: FetchOptions,

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -100,7 +100,7 @@ function diskCacheFresh(): boolean {
  *  (proxyDispatcher caches the ProxyAgent); fall back to a direct fetch
  *  when no proxy is configured or the proxied attempt fails. */
 async function fetchFresh(): Promise<RegistryShape | null> {
-    const dispatcher = proxyDispatcher(process.env.https_proxy || process.env.HTTPS_PROXY || process.env.http_proxy || process.env.HTTP_PROXY);
+    const dispatcher = proxyDispatcher(process.env.https_proxy || process.env.HTTPS_PROXY || process.env.http_proxy || process.env.HTTP_PROXY, 15_000);
     const attempts: Array<{ opts: Parameters<typeof fetchWithTimeout>[1]; label: string }> = dispatcher
         ? [{ opts: { dispatcher }, label: "via proxy" }, { opts: {}, label: "direct" }]
         : [{ opts: {}, label: "direct" }];

--- a/src/server.ts
+++ b/src/server.ts
@@ -827,7 +827,7 @@ async function handle(
         try {
             const result = await fetchWithTimeout(targetUrl, {
                 method: "HEAD",
-                ...(proxyUrl ? { dispatcher: proxyDispatcher(proxyUrl) } : {}),
+                ...(proxyUrl ? { dispatcher: proxyDispatcher(proxyUrl, 15_000) } : {}),
             }, 15_000);
             result.clearTimer();
             recordUpstreamConnection(targetUrl, proxyUrl);

--- a/src/server.ts
+++ b/src/server.ts
@@ -2918,7 +2918,7 @@ async function forward(
     if (prepared?.pluginMode) {
         // #411: clear the idle timer on the abort path too — the pipes rethrow
         // when the client is still connected, and a client cancel throws from
-        // inside them; without a finally each abort leaked a 10-minute timer.
+        // inside them; without a finally each abort leaked an idle timer.
         try {
             let pluginBody = upstream.body as ReadableStream<Uint8Array>;
             if (prepared.stream && maxFakeCompletionRetries() > 0) {
@@ -2954,7 +2954,7 @@ async function forward(
     let responseBody: ReadableStream<Uint8Array> = upstream.body;
     // #411: every body-consuming path below must clear the upstream idle timer
     // even when it throws (client abort / upstream cut) — previously an abort
-    // skipped the trailing clearUpstreamTimer and leaked a live 10-minute
+    // skipped the trailing clearUpstreamTimer and leaked a live idle
     // timer plus its socket for the full window.
     try {
         if (prepared !== null && prepared.stream && !prepared.sidePassthrough && maxFakeCompletionRetries() > 0) {
@@ -3120,7 +3120,7 @@ async function forward(
     } else {
         // Wrap the whole non-streaming branch in try/finally so the upstream
         // timer is always cleared and the session is always persisted — even
-        // when arrayBuffer() throws (10-min abort, connection reset). Without
+        // when arrayBuffer() throws (idle-timeout abort, connection reset). Without
         // this, a thrown arrayBuffer() leaks the timeout and skips markDirty(),
         // losing the persistence of any block this turn's compress created.
         try {

--- a/src/upstream-proxy.ts
+++ b/src/upstream-proxy.ts
@@ -1,9 +1,10 @@
 import { execFileSync } from "node:child_process";
 import net from "node:net";
 import tls from "node:tls";
-import { ProxyAgent } from "undici";
+import { Pool, ProxyAgent } from "undici";
 import type { ProviderRoutes } from "./config.js";
 import { maskHostInText, maskUrlForLog } from "./log-mask.js";
+import { upstreamTimeoutMs } from "./fetch-util.js";
 
 export type ParsedHttpProxy = {
     url: string;
@@ -278,12 +279,26 @@ export function resolveProxy(
     return resolveProxyDecision(routes, globalProxy, upstreamUrl, fallback).proxy;
 }
 
-export function proxyDispatcher(proxyUrl: string | undefined): object | undefined {
+/** Proxy dispatchers carry the same timeout policy as direct ones (#551):
+ *  headersTimeout/bodyTimeout on the ProxyAgent cover every origin pool it
+ *  creates (undici spreads its options into the internal Agent), while the
+ *  explicit factory/clientFactory set them on hops undici builds with a bare
+ *  `{ connect }` option bag (proxy-side CONNECT client, HTTP/1 proxy wrapper). */
+export function proxyDispatcher(proxyUrl: string | undefined, timeoutMs?: number): object | undefined {
     if (!proxyUrl) return undefined;
-    let agent = dispatcherCache.get(proxyUrl);
+    const t = timeoutMs ?? upstreamTimeoutMs();
+    const key = `${proxyUrl}\u0000${t}`;
+    let agent = dispatcherCache.get(key);
     if (!agent) {
-        agent = new ProxyAgent({ uri: proxyUrl });
-        dispatcherCache.set(proxyUrl, agent);
+        const withTimeouts = (options: object): object => ({ ...options, headersTimeout: t, bodyTimeout: t });
+        agent = new ProxyAgent({
+            uri: proxyUrl,
+            headersTimeout: t,
+            bodyTimeout: t,
+            factory: (origin, options) => new Pool(origin, withTimeouts(options)),
+            clientFactory: (origin, options) => new Pool(origin, withTimeouts(options)),
+        });
+        dispatcherCache.set(key, agent);
     }
     return agent;
 }

--- a/tests/fix-551-upstream-timeout.test.ts
+++ b/tests/fix-551-upstream-timeout.test.ts
@@ -1,0 +1,133 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import { once } from "node:events";
+import {
+    UPSTREAM_TIMEOUT_MS,
+    _resetFetchUtilForTest,
+    fetchWithTimeout,
+    upstreamTimeoutMs,
+} from "../src/fetch-util.ts";
+import { _resetUpstreamProxyForTest, proxyDispatcher } from "../src/upstream-proxy.ts";
+
+function listen(server: http.Server): Promise<void> {
+    server.listen(0, "127.0.0.1");
+    return once(server, "listening").then(() => undefined);
+}
+
+function close(server: http.Server): Promise<void> {
+    return new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+}
+
+const TIMEOUT_ENV = "BILI_UPSTREAM_TIMEOUT_MS";
+
+function restoreEnv(prev: string | undefined): void {
+    if (prev === undefined) delete process.env[TIMEOUT_ENV];
+    else process.env[TIMEOUT_ENV] = prev;
+}
+
+test("upstreamTimeoutMs honors BILI_UPSTREAM_TIMEOUT_MS and falls back to the 10-minute default", () => {
+    const prev = process.env[TIMEOUT_ENV];
+    try {
+        delete process.env[TIMEOUT_ENV];
+        assert.equal(upstreamTimeoutMs(), UPSTREAM_TIMEOUT_MS);
+        process.env[TIMEOUT_ENV] = "123456";
+        assert.equal(upstreamTimeoutMs(), 123456);
+        for (const bad of ["not-a-number", "0", "-5", "1.5"]) {
+            process.env[TIMEOUT_ENV] = bad;
+            assert.equal(upstreamTimeoutMs(), UPSTREAM_TIMEOUT_MS, `bad value ${bad}`);
+        }
+    } finally {
+        restoreEnv(prev);
+    }
+});
+
+// Pre-fix, Node's hidden global undici agent capped every direct request at
+// 300s (headersTimeout/bodyTimeout defaults) regardless of bili's own
+// watchdog, so any prefill silence between the budget and 300s either slipped
+// through (budget > 300s) or was killed by undici first (budget < 300s, e.g.
+// the observed ~305s truncations). These two cases bracket the alignment:
+// silence beyond the budget must die at the budget; silence within it must
+// complete.
+test("#551: body silence longer than the configured budget is cut at the budget", async () => {
+    const budgetMs = 1500;
+    const prev = process.env[TIMEOUT_ENV];
+    process.env[TIMEOUT_ENV] = String(budgetMs);
+    const upstream = http.createServer((_req, res) => {
+        res.writeHead(200, { "content-type": "text/event-stream" });
+        res.flushHeaders();
+        setTimeout(() => {
+            if (!res.destroyed) {
+                res.write("late\n");
+                res.end();
+            }
+        }, 3000);
+    });
+    await listen(upstream);
+    const port = (upstream.address() as { port: number }).port;
+    try {
+        const started = Date.now();
+        const result = await fetchWithTimeout(`http://127.0.0.1:${port}/silent`, {});
+        let threw = false;
+        try {
+            const reader = result.response.body.getReader();
+            await reader.read();
+        } catch {
+            threw = true;
+        } finally {
+            result.clearTimer();
+        }
+        const elapsed = Date.now() - started;
+        assert.ok(threw, "expected the silent body to be aborted within the budget");
+        assert.ok(elapsed < 8000, `expected the abort near ${budgetMs}ms, took ${elapsed}ms`);
+    } finally {
+        restoreEnv(prev);
+        upstream.closeAllConnections();
+        await close(upstream);
+        _resetFetchUtilForTest();
+    }
+});
+
+test("#551: a prefill silence shorter than the budget completes normally", async () => {
+    const budgetMs = 8000;
+    const upstream = http.createServer((_req, res) => {
+        res.writeHead(200, { "content-type": "text/event-stream" });
+        res.flushHeaders();
+        setTimeout(() => {
+            res.write("token\n");
+            res.end();
+        }, 3000);
+    });
+    await listen(upstream);
+    const port = (upstream.address() as { port: number }).port;
+    try {
+        const started = Date.now();
+        const result = await fetchWithTimeout(`http://127.0.0.1:${port}/slow-prefill`, {}, budgetMs);
+        const text = await result.response.text();
+        result.clearTimer();
+        const elapsed = Date.now() - started;
+        assert.equal(text, "token\n");
+        assert.ok(elapsed >= 3000, `expected to wait out the 3s prefill silence, got ${elapsed}ms`);
+    } finally {
+        upstream.closeAllConnections();
+        await close(upstream);
+        _resetFetchUtilForTest();
+    }
+});
+
+test("proxyDispatcher caches one ProxyAgent per (url, timeout) pair", () => {
+    _resetUpstreamProxyForTest();
+    const url = "http://127.0.0.1:1";
+    const a = proxyDispatcher(url, 1000);
+    const b = proxyDispatcher(url, 1000);
+    const c = proxyDispatcher(url, 2000);
+    assert.notEqual(a, undefined);
+    assert.equal(a, b);
+    assert.notEqual(a, c);
+    assert.equal(proxyDispatcher(undefined), undefined);
+    const d = proxyDispatcher(url, 1000);
+    _resetUpstreamProxyForTest();
+    const e = proxyDispatcher(url, 1000);
+    assert.notEqual(d, e);
+    _resetUpstreamProxyForTest();
+});

--- a/tests/fix-551-upstream-timeout.test.ts
+++ b/tests/fix-551-upstream-timeout.test.ts
@@ -26,7 +26,7 @@ function restoreEnv(prev: string | undefined): void {
     else process.env[TIMEOUT_ENV] = prev;
 }
 
-test("upstreamTimeoutMs honors BILI_UPSTREAM_TIMEOUT_MS and falls back to the 10-minute default", () => {
+test("upstreamTimeoutMs honors BILI_UPSTREAM_TIMEOUT_MS and falls back to the 12-minute default", () => {
     const prev = process.env[TIMEOUT_ENV];
     try {
         delete process.env[TIMEOUT_ENV];


### PR DESCRIPTION
Fixes #551.

## Problem

Upstreams with long prefills (no output before the first token — e.g. ~130K-token replays on local models taking 5–10 min) were always cut at a fixed ~305s: Node's global undici agent applies default `headersTimeout`/`bodyTimeout` of **300s** to every direct request, and bili never overrode them. That transport cap fired before bili's own `UPSTREAM_TIMEOUT_MS` (10 min) idle watchdog could, making the watchdog ineffective for exactly the slow-prefill case it exists for. Client retries were equally futile — every round died at the same 305s wall.

Note: undici's fetch layer ignores per-request `bodyTimeout`/`headersTimeout` init options (verified against undici 7.29 source and empirically), so the effective lever is **dispatcher-level** configuration.

## Changes

- `src/fetch-util.ts`: `fetchWithTimeout` now injects a direct `undici.Agent` (cached per timeout value) whose `headersTimeout`/`bodyTimeout` match the idle watchdog when the caller passes no dispatcher. New `BILI_UPSTREAM_TIMEOUT_MS` env var (ms, read live like the other `BILI_*` knobs) makes the budget configurable; default unchanged (10 min).
- `src/upstream-proxy.ts`: `proxyDispatcher(proxyUrl, timeoutMs?)` builds the `ProxyAgent` with matching `headersTimeout`/`bodyTimeout`; explicit `factory`/`clientFactory` pools ensure every hop — including the CONNECT tunnel client and the http-origin-via-http-proxy wrapper — inherits the budget instead of falling back to 300s.
- Call sites: `/__bili/upstream/test` and the registry fetch pass their short explicit budgets (15s) to both layers; the main request path and compress-loop paths resolve the budget once, live, identically in both layers.
- `CONFIGURATION.md`: documents `BILI_UPSTREAM_TIMEOUT_MS`.

Design choice: **align** the transport layer with the existing watchdog (same policy value, two independent enforcement layers) rather than disabling undici's caps (`0`) — defense in depth; a regression in either layer is caught by the other.

Mode reasoning (AGENTS.md §6): transport-layer only. Plugin mode and proxy mode both route through `fetchWithTimeout`/`fetchWithRetry`, so behavior is identical in both.

## Tests

New `tests/fix-551-upstream-timeout.test.ts`:
- env parsing (default / passthrough / garbage values);
- silence longer than the budget is cut at the budget (**pre-fix this case completed at 3s** — both old layers allowed it);
- silence within the budget completes (no premature kill of a healthy slow prefill);
- `ProxyAgent` cache keying per (url, timeout).

## Pre-flight

- `npm run typecheck` — clean
- `npm test` — 1050/1051; the single failure (`resolveClientCommand: codex/claude`) reproduces identically on clean master in any environment where a `codex` binary happens to be on PATH (the test assumes none) — pre-existing, unrelated
- `npm run build` — success
- E2E (`tests/e2e/e2e-codex.test.ts`) not run here: it needs a Responses-compatible upstream not available in this sandbox. Please trigger the manual-dispatch CI e2e workflow before merging.