### PR TITLE
fix: gate fork sessions on char-count upper bound in preflight (#553)

### DIFF
--- a/src/preflight.ts
+++ b/src/preflight.ts
@@ -49,6 +49,14 @@ export interface PreflightDeps {
     imageFloor?: number;
     /** Constant wire overhead for this request (system prompt + tool definitions, #470). Folding never removes it, so every fit decision must add it — otherwise the loop stops with "text fits" while the billed input still overflows. */
     wireOverhead?: number;
+    /** #553: the caller knows this session's input size is unmeasured AND its
+     *  raw history is untrusted (anonymous prefix-affinity session with
+     *  lastInputTokens == 0 — a fork minted when an ACP compression broke the
+     *  chain hash). Size judgments then use the char-count upper bound
+     *  (estimateCoreMessagesUpper / char-based chunking) instead of the
+     *  optimistic chars/4 estimator, which undercounts code/JSON replays by up
+     *  to ~4x and would let an over-window payload slip through uncompressed. */
+    unknownBaseline?: boolean;
 }
 
 export type PreflightFailureKind = "upstream" | "exhausted" | "aborted";
@@ -69,6 +77,13 @@ export interface PreflightResult {
      *  stale (e.g. a double-counted usage report, #300). The caller uses it
      *  to decide whether forwarding as-is is actually safe. */
     payloadEstimate: number;
+    /** Whether the final payload fits the window, judged with the same
+     *  measure the loop used: the optimistic token estimate for
+     *  measured-baseline sessions (#300 — a stale HIGH baseline must not
+     *  fail-fast a fitting payload), the char-count upper bound for
+     *  unknown-baseline ones (#553 — the optimistic figure can undershoot by
+     *  up to ~4x on dense replays, so only the upper bound proves a fit). */
+    fitsWindow: boolean;
     /** Why the loop stopped while the payload still overflows the window.
      *  Undefined when the payload fits. */
     failure?: PreflightFailure;
@@ -129,6 +144,20 @@ export function estimateRawBodyTokens(parsed: unknown): number {
     return tokens;
 }
 
+// #553: upper-bound variant of estimateCoreMessages — every character counts
+// as one token. A BPE token covers >=1 char (Latin/code) and CJK is already
+// ~1 token/char, so this never undershoots the real count, unlike
+// defaultCountTokens' 4-chars-per-token for non-CJK. Used only for anonymous
+// prefix-affinity sessions without a measured baseline (a fork mints a new
+// session id with lastInputTokens == 0 after an ACP compression breaks the
+// chain hash), where an undershoot lets an over-window payload slip past the
+// trigger and the fit checks and get forwarded raw.
+export function estimateCoreMessagesUpper(messages: CoreMessage[]): number {
+    let chars = 0;
+    for (const m of messages) chars += (m.text ?? "").length;
+    return chars;
+}
+
 function rangeChars(messages: CoreMessage[], startIdx: number, endIdx: number): number {
     let chars = 0;
     for (let i = startIdx; i <= endIdx && i < messages.length; i++) {
@@ -156,16 +185,28 @@ function renderRange(messages: CoreMessage[], startIdx: number, endIdx: number):
     return parts.join("\n\n");
 }
 
-function splitChunks(messages: CoreMessage[], startIdx: number, endIdx: number, budgetTokens: number): Array<[number, number]> {
+// minUnits: never close a chunk below this many countText units while more
+// messages remain — a chunk under config.compress.minCompressRange chars is
+// rejected by applyCompression, so such a chunk would waste a whole round.
+// (The char-count regime needs this because its budget can be far smaller
+// than minCompressRange on small windows.)
+function splitChunks(
+    messages: CoreMessage[],
+    startIdx: number,
+    endIdx: number,
+    budget: number,
+    minUnits: number,
+    countText: (text: string) => number = defaultCountTokens,
+): Array<[number, number]> {
     const chunks: Array<[number, number]> = [];
     let cur = startIdx;
     while (cur <= endIdx) {
-        let tokens = 0;
+        let total = 0;
         let last = cur;
         for (let i = cur; i <= endIdx; i++) {
-            const t = defaultCountTokens(messages[i].text ?? "");
-            if (tokens + t > budgetTokens && i > cur) break;
-            tokens += t;
+            const t = countText(messages[i].text ?? "");
+            if (total + t > budget && i > cur && (minUnits <= 0 || total >= minUnits)) break;
+            total += t;
             last = i;
         }
         chunks.push([cur, last]);
@@ -281,17 +322,25 @@ function noEmergencyTruncate(config: Config): Config {
 
 export async function preflightCompress(deps: PreflightDeps, messages: CoreMessage[]): Promise<PreflightResult> {
     const limit = deps.config.modelContextLimit;
-    const result: PreflightResult = { compressedRanges: 0, savedTokens: 0, payloadEstimate: estimateCoreMessages(messages) + (deps.imageFloor ?? 0) + (deps.wireOverhead ?? 0) };
+    const result: PreflightResult = { compressedRanges: 0, savedTokens: 0, payloadEstimate: estimateCoreMessages(messages) + (deps.imageFloor ?? 0) + (deps.wireOverhead ?? 0), fitsWindow: true };
     if (limit <= 0) return result;
     const budget = Math.max(MIN_CHUNK_TOKENS, Math.floor(limit * CHUNK_FRACTION));
     // applyCompression rejects ranges below config.compress.minCompressRange
     // chars, so never spend a summarization call on a chunk that can't apply.
     const minChars = deps.config.compress.minCompressRange;
     // The fit check runs on the real post-fold payload size, not on
-    // stats.lastInputTokens: a fresh session (its id rotated, e.g. after a
-    // model switch) starts at 0 while still carrying a full raw history that
-    // overflows the smaller window.
-    let currentTokens = deps.session.stats.lastInputTokens;
+    // stats.lastInputTokens: a session without a measured baseline
+    // (lastInputTokens == 0 — fresh, or forked/reloaded after an ACP
+    // compression broke prefix affinity, #553) starts at 0 while still
+    // carrying a full raw history that may overflow the window.
+    // #553: for an unknown-baseline session the optimistic chars/4 estimate can
+    // be off by up to ~4x on code/JSON replays, so judge those by the char-count
+    // upper bound (never undershoots). The regime is caller-decided and fixed
+    // for the whole loop — lastInputTokens mutates mid-loop and must not flip it.
+    const baselineKnown = deps.unknownBaseline !== true;
+    const countText = baselineKnown ? defaultCountTokens : (text: string): number => text.length;
+    let currentTokens = baselineKnown ? deps.session.stats.lastInputTokens : estimateCoreMessagesUpper(messages);
+    let finalUpper = baselineKnown ? 0 : estimateCoreMessagesUpper(messages);
     let startTokens = -1;
     let failure: PreflightFailure | undefined;
     let activeConfig = deps.config;
@@ -327,6 +376,13 @@ export async function preflightCompress(deps: PreflightDeps, messages: CoreMessa
         // input_tokens also covers the system prompt + tool definitions, which
         // are not in turn.messages, so the direct estimate can undershoot.
         currentTokens = Math.max(deps.session.stats.lastInputTokens, estimateCoreMessages(turn.messages) + (deps.imageFloor ?? 0) + (deps.wireOverhead ?? 0));
+        if (!baselineKnown) {
+            // #558-merge: the upper-bound regime also carries the image/wire
+            // floors — they are real billed costs the fold can never remove
+            // (#470/#488 postdate this PR's fork point).
+            finalUpper = estimateCoreMessagesUpper(turn.messages) + (deps.imageFloor ?? 0) + (deps.wireOverhead ?? 0);
+            currentTokens = Math.max(currentTokens, finalUpper);
+        }
         // The caller's forward/fail-fast gate uses the payload's own estimate
         // (the floor can be stale — see PreflightResult.payloadEstimate).
         result.payloadEstimate = estimateCoreMessages(turn.messages) + (deps.imageFloor ?? 0) + (deps.wireOverhead ?? 0);
@@ -374,7 +430,10 @@ export async function preflightCompress(deps: PreflightDeps, messages: CoreMessa
                 continue;
             }
             rangesTried += 1;
-            for (const [cs, ce] of splitChunks(messages, startIdx, endIdx, budget)) {
+            // minUnits only in the char regime: with the optimistic token budget a
+            // sub-minimum chunk is already rare, and keeping minUnits = 0 there
+            // preserves the historical packing exactly.
+            for (const [cs, ce] of splitChunks(messages, startIdx, endIdx, budget, baselineKnown ? 0 : minChars, countText)) {
                 if (currentTokens < limit) break;
                 if (deps.signal?.aborted) {
                     failure = ABORTED_FAILURE;
@@ -435,9 +494,12 @@ export async function preflightCompress(deps: PreflightDeps, messages: CoreMessa
                     break;
                 }
                 // The summary itself re-enters the payload; net its cost against
-                // both the folded size and the session's input baseline.
+                // both the folded size and the session's input baseline. Without a
+                // baseline currentTokens is char-based, so net the folded span's
+                // char count against it instead of the token-based credit.
                 const compressed = deps.session.stats.compressCreditTokens - creditBefore;
-                currentTokens = Math.max(0, currentTokens - compressed + defaultCountTokens(summary));
+                const folded = baselineKnown ? compressed : rangeChars(messages, cs, ce);
+                currentTokens = Math.max(0, currentTokens - folded + countText(summary));
                 deps.session.stats.lastInputTokens += defaultCountTokens(summary);
                 appliedThisRound += 1;
                 result.compressedRanges += 1;
@@ -462,5 +524,6 @@ export async function preflightCompress(deps: PreflightDeps, messages: CoreMessa
     if (result.compressedRanges > 0) deps.session.stats.lastInputTokens = currentTokens;
     result.savedTokens = Math.max(0, startTokens - currentTokens);
     if (currentTokens >= limit) result.failure = failure;
+    result.fitsWindow = baselineKnown ? result.payloadEstimate < limit : finalUpper < limit;
     return result;
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -45,7 +45,7 @@ import { getSession, listSessions, type Session, initSessions, markDirty, flushA
 import { COMPRESS_TOOL, ACP_TOOLS_ANTHROPIC, ACP_TOOLS_OPENAI, ACP_TOOLS_RESPONSES, ACP_READONLY_TOOLS_RESPONSES, COMPRESS_TOOL_NAME, buildCompressSystemPrompt, buildCompressHybridSystemPrompt, withStagedCompressGuidance } from "./compress-tool.js";
 import { rewriteJsonResponse, type RewriteCtx } from "./stream.js";
 import { applyRanges } from "./stream.js";
-import { preflightCompress, estimateCoreMessages, estimateRawBodyTokens } from "./preflight.js";
+import { preflightCompress, estimateCoreMessages, estimateRawBodyTokens, estimateCoreMessagesUpper } from "./preflight.js";
 import { imageTokensInRawBody, imageTokensInParsedBody } from "./image-tokens.js";
 import { renderUI, handleConfigGet, handleConfigPut } from "./web/index.js";
 import { reapOrphanBlocks } from "./orphan-gc.js";
@@ -1573,6 +1573,7 @@ async function handle(
                         (parsed as { model?: string }).model,
                         route,
                         affinity,
+                        anonAffinity !== null,
                         log,
                         instanceId,
                     );
@@ -1764,6 +1765,19 @@ function armHostUsageCredit(
     }
 }
 
+// Zero-baseline sessions are judged conservatively ONLY when they arrived
+// anonymously (prefix-affinity forks/reloads, #553): they carry the full raw
+// history but no measurement yet, so feeding 0 blinds the nudge (usage 0%,
+// growth ref 0) and no compression trigger fires until overflow. Explicit-
+// identity zero-baseline sessions stay at 0 — first-turn or post-native-
+// compaction payloads that are small by construction and self-heal via the
+// next measured usage report.
+function effectiveTokenCount(session: Session, msgs: CoreMessage[]): number {
+    if (session.stats.lastInputTokens > 0) return session.stats.lastInputTokens;
+    if (!session.metadata.anonymousPrefixAffinity) return 0;
+    return estimateCoreMessagesUpper(msgs);
+}
+
 function prepareAnthropic(
     parsed: AnthropicRequestBody,
     req: http.IncomingMessage,
@@ -1812,7 +1826,11 @@ function prepareAnthropic(
         // the fallback path below if we ever need it, but we no longer feed
         // estimates to the kernel.
         extractSystem(parsed.system);
-        const tokenCount = session.stats.lastInputTokens;
+        // #553-follow-up exception to the "never estimates" rule above: anonymous
+        // zero-baseline forks replay their FULL raw history with no measurement,
+        // so feeding 0 blinds the nudge (usage 0%, growth ref 0) and no
+        // compression trigger fires until overflow. See effectiveTokenCount.
+        const tokenCount = effectiveTokenCount(session, msgs);
         const activeBefore = new Set(session.state.blocks.filter((b) => b.active).map((b) => b.blockId));
         const turn = core.processTurn({ messages: msgs, state: session.state, config, tokenCount, renderTags: "text-only" });
         session.state = turn.state;
@@ -2034,8 +2052,9 @@ function prepareOpenai(
         openaiSystemText = systemText;
         originalMessages = msgs;
         // tokenCount = upstream's real input_tokens from the previous turn
-        // (see anthropic branch comment). Never an estimate.
-        const tokenCount = session.stats.lastInputTokens;
+        // tokenCount = upstream's real input_tokens from the previous turn
+        // (see anthropic branch comment + its #553-follow-up exception).
+        const tokenCount = effectiveTokenCount(session, msgs);
         const activeBefore = new Set(session.state.blocks.filter((b) => b.active).map((b) => b.blockId));
         const turn = core.processTurn({ messages: msgs, state: session.state, config, tokenCount, renderTags: "text-only" });
         session.state = turn.state;
@@ -2217,7 +2236,7 @@ function prepareResponses(
         if (process.env.ACP_DEBUG) {
             log("info", `[${sessionId}] input items: ${Array.isArray(parsed.input) ? parsed.input.map((i: ResponseInputItem) => i.type).join(",") : "(string)"}`);
         }
-        const tokenCount = session.stats.lastInputTokens;
+        const tokenCount = effectiveTokenCount(session, msgs);
         const turn = core.processTurn({ messages: msgs, state: session.state, config, tokenCount, renderTags });
         session.state = turn.state;
         // The fold from last turn's compress has now materialized in state —
@@ -2745,6 +2764,7 @@ async function preflightCompressIfNeeded(
     model: string | undefined,
     route: ReturnType<typeof resolveUpstream>,
     affinity: string | undefined,
+    anonymous: boolean,
     log: (level: string, msg: string) => void,
     instanceId: string,
 ): Promise<Prepared | PreflightFailFast> {
@@ -2762,7 +2782,21 @@ async function preflightCompressIfNeeded(
     // under the window while the billed input already overflows it).
     const overheadEstimate = estimateWireOverhead(prepared.protocol, prepared.body);
     const payloadEstimate = textEstimate + overheadEstimate + imageTokens;
-    const tokenCount = Math.max(session.stats.lastInputTokens, payloadEstimate);
+    // #553: anonymous requests resolve their session by prefix affinity. After
+    // an ACP compression breaks the chain hash, the client's replay mints a NEW
+    // session id (a fork) whose lastInputTokens is 0 — yet it carries the full
+    // raw history. Judging that on the optimistic chars/4 estimate undercounts
+    // code/JSON replays by up to ~4x, so an over-window payload triggers
+    // nothing and is forwarded raw (upstream 400 / long-prefill timeout). Judge
+    // exactly those sessions by the char-count upper bound (never undershoots;
+    // the image/wire floors still apply — #488/#470 postdate the fork).
+    // Sessions with a client-provided identity keep the optimistic path: their
+    // 0-baseline means a genuinely new conversation or a post-native-compaction
+    // replay, both small enough to self-heal via the learned-window path.
+    const unknownBaseline = anonymous && session.stats.lastInputTokens <= 0;
+    const tokenCount = unknownBaseline
+        ? estimateCoreMessagesUpper(prepared.processedMessages) + overheadEstimate + imageTokens
+        : Math.max(session.stats.lastInputTokens, payloadEstimate);
     if (limit <= 0 || !model || tokenCount < limit) return prepared;
     // #496 forward-once-then-learn: the default image cost (base64/4) matches byte
     // relays (#488) but overestimates pixel-tile upstreams (a 400KB JPEG ≈ 1.6K real
@@ -2800,11 +2834,23 @@ async function preflightCompressIfNeeded(
         log("error", `[${session.id}] preflight fail-fast ${status} (retryable=${retryable}): ${message}`);
         return { failFast: true, status, message, retryable, respond: !res.writableEnded };
     };
-    if ((prepared.nudge?.compressibleRanges ?? []).length === 0 && payloadEstimate < limit) {
+    if ((prepared.nudge?.compressibleRanges ?? []).length === 0) {
         // #300: the trigger fired on a stale baseline (lastInputTokens) but the
         // payload's own estimate fits the window — forwarding as-is is safe.
-        log("warn", `[${session.id}] preflight trigger fired on a stale baseline (~${tokenCount}) but the payload fits (~${payloadEstimate}/${limit}); forwarding as-is`);
-        return prepared;
+        // #553: only a trusted optimistic fit may clear a raw forward; an
+        // unknown-baseline session's true size is unmeasured, so fail fast
+        // instead of gambling a raw forward past the window.
+        if (!unknownBaseline && payloadEstimate < limit) {
+            log("warn", `[${session.id}] preflight trigger fired on a stale baseline (~${tokenCount}) but the payload fits (~${payloadEstimate}/${limit}); forwarding as-is`);
+            return prepared;
+        }
+        if (unknownBaseline) {
+            return failFast(502, "no part of the conversation is compressible (nothing left to fold)", false);
+        }
+        // Known-baseline over-window: fall through to preflightCompress — its
+        // relax path (#330) folds the soft-protected recent zone when that is
+        // the only foldable content, and its exhaustion detail carries the
+        // operator remedy wording.
     }
     // #330: the payload overflows the window (or nothing is foldable in the
     // normal pass but it doesn't fit). Let preflightCompress try to fold it —
@@ -2837,6 +2883,7 @@ async function preflightCompressIfNeeded(
             log,
             imageFloor: imageTokens,
             wireOverhead: overheadEstimate,
+            unknownBaseline,
         },
         prepared.originalMessages,
     );
@@ -2845,15 +2892,22 @@ async function preflightCompressIfNeeded(
     // that estimate more than the normal-config prepare does, which can turn a
     // guaranteed-400 forward into a false "fits". Images ride the payload
     // verbatim (#488): add their cost back or #496's image-dominated payload
-    // would look "fitting" on its text estimate alone.
+    // would look "fitting" on its text estimate alone. Unknown-baseline
+    // sessions keep the loop's own upper-bound judgment (result.fitsWindow,
+    // #553) — the optimistic re-estimate is exactly what that regime distrusts.
     if (result.compressedRanges > 0) {
         log("info", `[${session.id}] preflight compressed ${result.compressedRanges} range(s), ~${result.savedTokens} tokens saved (${tokenCount} → ${session.stats.lastInputTokens}) in ${Date.now() - started}ms; rebuilding payload`);
         const rebuilt = runPrepare();
         // runPrepare re-incremented stats.requests; the rebuild is internal
         // to this single client request.
         session.stats.requests -= 1;
-        if (estimateCoreMessages(rebuilt.processedMessages) + overheadEstimate + imageTokens < limit) return rebuilt;
-    } else if (estimateCoreMessages(prepared.processedMessages) + overheadEstimate + imageTokens < limit) {
+        const fits = unknownBaseline
+            ? result.fitsWindow
+            : estimateCoreMessages(rebuilt.processedMessages) + overheadEstimate + imageTokens < limit;
+        if (fits) return rebuilt;
+    } else if (unknownBaseline
+        ? result.fitsWindow
+        : estimateCoreMessages(prepared.processedMessages) + overheadEstimate + imageTokens < limit) {
         log("warn", `[${session.id}] preflight made no progress but the payload fits; forwarding as-is`);
         return prepared;
     }

--- a/tests/fork-nudge-trigger.test.ts
+++ b/tests/fork-nudge-trigger.test.ts
@@ -1,0 +1,188 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import { once } from "node:events";
+import test from "node:test";
+
+process.env.NODE_ENV = "test";
+
+import { defaultConfig } from "acp-kernel";
+import { startServer, type ProxyOptions } from "../src/server.ts";
+import { SessionStore, _setStoreForTest } from "../src/persist.ts";
+import { _setForTest as setRegistryForTest } from "../src/registry.ts";
+import { _resetSessionsForTest } from "../src/session.ts";
+
+// #553 follow-up (obs 1): the proxy-side nudge is the PROACTIVE compression
+// trigger — preflight only fires at the hard limit. Its decision (kernel
+// decideNudge) is driven by tokenCount/limit (usage) and a growth floor whose
+// reference falls back to tokenCount itself. Anonymous prefix-affinity forks
+// arrive with lastInputTokens == 0 while replaying their FULL raw history, so
+// usage read 0% and growth 0 forever: a payload sitting just UNDER the window
+// had no compression trigger at all until overflow ("nudge idle: usage=0% ...
+// pendingT1=944861/50000" in the incident log). effectiveTokenCount feeds the
+// char-count upper bound for exactly this regime. These tests pin it:
+//   A. anonymous zero-baseline fork at 90% of window (char measure) → nudge
+//      injects, nothing folded, preflight stays silent (estimates under).
+//   B. explicit-identity control with the identical conversation → NO nudge
+//      (zero baseline there means "new small session", self-heals via the
+//      next measured usage report).
+
+const NUDGE_MARKER = "Context limit reached";
+const WINDOW = 60_000;
+
+function okSse(inputTokens: number): string {
+    return (
+        `event: message_start\ndata: ${JSON.stringify({ type: "message_start", message: { id: "m1", role: "assistant", usage: { input_tokens: inputTokens } } })}\n\n` +
+        `event: content_block_start\ndata: ${JSON.stringify({ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } })}\n\n` +
+        `event: content_block_delta\ndata: ${JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "ok" } })}\n\n` +
+        `event: content_block_stop\ndata: ${JSON.stringify({ type: "content_block_stop", index: 0 })}\n\n` +
+        `event: message_delta\ndata: ${JSON.stringify({ type: "message_delta", delta: { stop_reason: "end_turn", stop_sequence: null }, usage: { output_tokens: 3 } })}\n\n` +
+        `event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`
+    );
+}
+
+function msgText(m: { content?: unknown }): string {
+    const c = m.content;
+    if (typeof c === "string") return c;
+    if (!Array.isArray(c)) return "";
+    return c
+        .map((b) => (b && typeof b === "object" && typeof (b as { text?: unknown }).text === "string" ? (b as { text: string }).text : ""))
+        .join("");
+}
+
+function msgsOf(raw: string): Array<{ role?: string; content?: unknown }> {
+    try {
+        const parsed = JSON.parse(raw) as { messages?: Array<{ role?: string; content?: unknown }> };
+        return parsed.messages ?? [];
+    } catch {
+        return [];
+    }
+}
+
+// 12 messages: 7 OLD code-heavy ones (~5.5k chars each) + 5 tiny recent ones
+// (inside the preserveRecentMessages=5 soft zone). Char-count upper bound:
+// ~54k/60k ≈ 90% of the window (≥ maxContextLimitPct 0.75 → over-limit for
+// decideNudge; T1 pending ≈ 3 ranges × ~1.9k tokens ≥ minPressureBenefit 5k).
+// Optimistic chars/4 estimate: < window (< window → preflight must stay
+// silent). Kernel thresholds differ from the PR's original pin (min pressure
+// benefit 5k) — hence the big-old/tiny-recent shape.
+function forkConversation(): Array<{ role: string; content: string }> {
+    const line = (i: number) =>
+        `const handler_${i} = (req: Request, res: Response) => { res.status(200).json({ status: "ok", id: ${i}, ts: Date.now() }); };`;
+    const msgs: Array<{ role: string; content: string }> = [];
+    for (let i = 0; i < 12; i++) {
+        const role = i % 2 === 0 ? "user" : "assistant";
+        msgs.push({ role, content: `CODE_${i}_` + (i < 7 ? line(i).repeat(62) : line(i)) });
+    }
+    return msgs;
+}
+
+async function runCase(opts: { anonymous: boolean }): Promise<{
+    calls: Array<{ stream: boolean; body: string }>;
+    status: number;
+}> {
+    const calls: Array<{ stream: boolean; body: string }> = [];
+    const upstream = http.createServer((req, res) => {
+        const chunks: Buffer[] = [];
+        req.on("data", (c: Buffer) => chunks.push(c));
+        req.on("end", () => {
+            const raw = Buffer.concat(chunks).toString("utf8");
+            let parsed: { stream?: boolean } = {};
+            try {
+                parsed = JSON.parse(raw);
+            } catch {
+                /* keep {} */
+            }
+            calls.push({ stream: !!parsed.stream, body: raw });
+            if (parsed.stream) {
+                res.writeHead(200, { "content-type": "text/event-stream" });
+                res.end(okSse(1000));
+            } else {
+                res.writeHead(200, { "content-type": "application/json" });
+                res.end(JSON.stringify({
+                    id: "msg_summary",
+                    type: "message",
+                    role: "assistant",
+                    model: "claude-small",
+                    content: [{ type: "text", text: "SUMMARY TEXT" }],
+                    stop_reason: "end_turn",
+                    usage: { input_tokens: 500, output_tokens: 50 },
+                }));
+            }
+        });
+    });
+    upstream.listen(0, "127.0.0.1");
+    await once(upstream, "listening");
+    const upstreamPort = upstream.address().port;
+
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    _resetSessionsForTest();
+    setRegistryForTest({});
+    const proxy = await startServer({
+        port: 0,
+        host: "127.0.0.1",
+        upstream: "http://127.0.0.1",
+        routes: { [`http://127.0.0.1:${upstreamPort}`]: { models: { "claude-small": { context: WINDOW } } } },
+        modelContextLimit: 400_000,
+        kernelConfig: defaultConfig(400_000),
+        compress: { injectTool: true, injectNudge: true },
+        promptCache: { routing: "auto" },
+        sessionHeader: "x-acp-session",
+        log: false,
+        debug: false,
+        passthrough: false,
+        autoUpdate: false,
+        mitm: { enabled: false, domains: [] },
+    } as ProxyOptions);
+    await once(proxy, "listening");
+    const proxyPort = proxy.address().port;
+
+    try {
+        const headers: Record<string, string> = { "content-type": "application/json" };
+        if (!opts.anonymous) headers["x-acp-session"] = "fork-nudge-explicit-sess";
+        const body = JSON.stringify({
+            model: "claude-small",
+            max_tokens: 1024,
+            stream: true,
+            messages: forkConversation(),
+        });
+        const resp = await fetch(`http://127.0.0.1:${proxyPort}/bili/http://127.0.0.1:${upstreamPort}/v1/messages`, {
+            method: "POST",
+            headers,
+            body,
+        });
+        await resp.text();
+        return { calls, status: resp.status };
+    } finally {
+        proxy.close();
+        upstream.close();
+    }
+}
+
+test("e2e: anonymous zero-baseline fork below the window → nudge injects (no fold, preflight silent)", async () => {
+    const { calls, status } = await runCase({ anonymous: true });
+    assert.equal(status, 200);
+    assert.equal(calls.filter((c) => !c.stream).length, 0, "preflight must stay silent (optimistic estimate under window)");
+    const forward = calls.filter((c) => c.stream).at(-1)!;
+    const msgs = msgsOf(forward.body);
+    const last = msgs.at(-1)!;
+    assert.ok(
+        last.role === "user" && msgText(last).includes(NUDGE_MARKER),
+        `expected trailing user nudge, got last message: ${JSON.stringify(forward.body.slice(-800))}`,
+    );
+    for (let i = 0; i < 12; i++) {
+        assert.ok(forward.body.includes(`CODE_${i}_`), `CODE_${i}_ must survive un-folded`);
+    }
+});
+
+test("e2e: explicit-identity zero-baseline session with the same conversation → NO nudge (regime scoping)", async () => {
+    const { calls, status } = await runCase({ anonymous: false });
+    assert.equal(status, 200);
+    assert.equal(calls.filter((c) => !c.stream).length, 0);
+    const forward = calls.filter((c) => c.stream).at(-1)!;
+    assert.ok(!forward.body.includes(NUDGE_MARKER), "explicit-identity zero baseline must stay at 0 (self-heals via measured usage)");
+    const tailMsgs = msgsOf(forward.body);
+    const last = tailMsgs.at(-1)!;
+    // Strip the outbound ACP anchor tag (proxy-mode wire format, AGENTS.md §2) before comparing.
+    const stripped = msgText(last).replace(/^\x3cacp\s[^>]*>[^\x3c]*\x3c\/acp\x3e/, "").trimStart();
+    assert.ok(stripped.startsWith("CODE_11_"), `last message must be the original last message (modulo the outbound ACP anchor tag): ${JSON.stringify(last).slice(0, 200)}`);
+});

--- a/tests/preflight-fork-estimate.test.ts
+++ b/tests/preflight-fork-estimate.test.ts
@@ -1,0 +1,286 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import { once } from "node:events";
+import test from "node:test";
+
+process.env.NODE_ENV = "test";
+
+import { defaultConfig } from "acp-kernel";
+import { startServer, type ProxyOptions } from "../src/server.ts";
+import { SessionStore, _setStoreForTest } from "../src/persist.ts";
+import { _setForTest as setRegistryForTest } from "../src/registry.ts";
+import { listSessions, _resetSessionsForTest } from "../src/session.ts";
+
+// #553: an ANONYMOUS request (no stable identity header/body field) resolves
+// its session by prefix affinity. After an ACP compression breaks the chain
+// hash, the client's replay mints a NEW session id (a fork) with
+// lastInputTokens == 0 — yet it carries the full raw history. That payload was
+// judged by the optimistic chars/4 estimator alone; code/JSON replays run far
+// denser than 4 chars/token, so an over-window payload estimated UNDER the
+// window triggered nothing and was forwarded raw (upstream 400 / long-prefill
+// timeout). These tests assert the fixed behavior: unknown-baseline anonymous
+// sessions are judged by the char-count upper bound (never undershoots),
+// preflight compresses, and the rebuilt payload fits.
+//
+// The mock upstream ENFORCES the model window like a real provider, counting
+// every character of the request body's text (the worst-case dense-code
+// regime where tokens ≈ chars — the exact case the chars/4 estimator misses).
+
+const SUMMARY_TEXT =
+    "PREFLIGHT FORK SUMMARY: the segment covered a multi-step implementation session. " +
+    "Key decisions: chose the streaming approach over batch because latency dominated. " +
+    "Files touched: src/a.ts:10, src/b.ts:20. Outcome: implemented and verified.";
+
+const WINDOW = 40_000;
+
+function okSse(inputTokens: number): string {
+    return (
+        `event: message_start\ndata: ${JSON.stringify({ type: "message_start", message: { id: "m1", role: "assistant", usage: { input_tokens: inputTokens } } })}\n\n` +
+        `event: content_block_start\ndata: ${JSON.stringify({ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } })}\n\n` +
+        `event: content_block_delta\ndata: ${JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "ok" } })}\n\n` +
+        `event: content_block_stop\ndata: ${JSON.stringify({ type: "content_block_stop", index: 0 })}\n\n` +
+        `event: message_delta\ndata: ${JSON.stringify({ type: "message_delta", delta: { stop_reason: "end_turn", stop_sequence: null }, usage: { output_tokens: 3 } })}\n\n` +
+        `event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`
+    );
+}
+
+function textLen(b: unknown): number {
+    if (b && typeof b === "object") {
+        const t = (b as { text?: unknown }).text;
+        if (typeof t === "string") return t.length;
+    }
+    return 0;
+}
+
+function contentChars(c: unknown): number {
+    if (typeof c === "string") return c.length;
+    if (!Array.isArray(c)) return 0;
+    return c.reduce((n, b) => n + textLen(b), 0);
+}
+
+// Worst-case tokenizer model: 1 token per character (dense code/JSON).
+function bodyChars(raw: string): number {
+    let parsed: { system?: unknown; messages?: Array<{ content?: unknown }> } = {};
+    try {
+        parsed = JSON.parse(raw);
+    } catch {
+        return 0;
+    }
+    let total = contentChars(parsed.system);
+    for (const m of parsed.messages ?? []) total += contentChars(m.content);
+    return total;
+}
+
+// 12 alternating messages of dense code-like ASCII, ~4k chars each → ~48k
+// chars total. By the optimistic chars/4 estimator that is only ~12k tokens
+// (< the 40k window — no trigger today); by the char-count upper bound it is
+// ~48k (>= the window — preflight must fire).
+function denseConversation(): Array<{ role: string; content: string }> {
+    const line = (i: number) =>
+        `const handler_${i} = (req: Request, res: Response) => { res.status(200).json({ status: "ok", id: ${i}, ts: Date.now() }); };`;
+    const msgs: Array<{ role: string; content: string }> = [];
+    for (let i = 0; i < 12; i++) {
+        const role = i % 2 === 0 ? "user" : "assistant";
+        msgs.push({ role, content: `CODE_${i}_` + line(i).repeat(37) });
+    }
+    return msgs;
+}
+
+test("e2e: fork/fresh session (lastInputTokens=0) with dense history that estimates under the window → preflight compresses before forward", async () => {
+    const calls: Array<{ stream: boolean; body: string }> = [];
+    let streamCalls = 0;
+    const upstream = http.createServer((req, res) => {
+        const chunks: Buffer[] = [];
+        req.on("data", (c: Buffer) => chunks.push(c));
+        req.on("end", () => {
+            const raw = Buffer.concat(chunks).toString("utf8");
+            let parsed: { stream?: boolean } = {};
+            try {
+                parsed = JSON.parse(raw);
+            } catch {
+                /* keep {} */
+            }
+            calls.push({ stream: !!parsed.stream, body: raw });
+            // Enforce the model window on EVERY call, like a real provider:
+            // the raw (uncompressed) dense history overflows it, so without
+            // preflight the forward itself gets a 400.
+            if (bodyChars(raw) > WINDOW) {
+                res.writeHead(400, { "content-type": "application/json" });
+                res.end(JSON.stringify({
+                    type: "error",
+                    error: { type: "invalid_request_error", message: `prompt is too long: exceeds ${WINDOW} maximum` },
+                }));
+                return;
+            }
+            if (parsed.stream) {
+                streamCalls += 1;
+                res.writeHead(200, { "content-type": "text/event-stream" });
+                res.end(okSse(1000));
+            } else {
+                res.writeHead(200, { "content-type": "application/json" });
+                res.end(JSON.stringify({
+                    id: "msg_summary",
+                    type: "message",
+                    role: "assistant",
+                    model: "claude-small",
+                    content: [{ type: "text", text: SUMMARY_TEXT }],
+                    stop_reason: "end_turn",
+                    usage: { input_tokens: 500, output_tokens: 50 },
+                }));
+            }
+        });
+    });
+    upstream.listen(0, "127.0.0.1");
+    await once(upstream, "listening");
+    const upstreamPort = upstream.address().port;
+
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    _resetSessionsForTest();
+    setRegistryForTest({});
+    const proxy = await startServer({
+        port: 0,
+        host: "127.0.0.1",
+        upstream: "http://127.0.0.1",
+        routes: { [`http://127.0.0.1:${upstreamPort}`]: { models: { "claude-small": { context: WINDOW } } } },
+        modelContextLimit: 400_000,
+        kernelConfig: defaultConfig(400_000),
+        compress: { injectTool: true, injectNudge: true },
+        promptCache: { routing: "auto" },
+        sessionHeader: "x-acp-session",
+        log: false,
+        debug: false,
+        passthrough: false,
+        autoUpdate: false,
+        mitm: { enabled: false, domains: [] },
+    } as ProxyOptions);
+    await once(proxy, "listening");
+    const proxyPort = proxy.address().port;
+
+    try {
+        // No identity header or body field: the request is ANONYMOUS, so the
+        // proxy resolves its session by prefix affinity — exactly what a fork
+        // looks like after an ACP compression broke the chain hash (new pfa-
+        // id, lastInputTokens = 0, full raw history replayed). The optimistic
+        // estimate (~12k) is under the 40k window, so the old code forwarded
+        // raw and the mock answered 400.
+        const r = await fetch(`http://127.0.0.1:${proxyPort}/bili/http://127.0.0.1:${upstreamPort}/v1/messages`, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ model: "claude-small", max_tokens: 1024, stream: true, messages: denseConversation() }),
+        });
+        assert.equal(r.status, 200, "the fork-session request succeeds (no context-full error)");
+        await r.text();
+
+        const summaryCalls = calls.filter((c) => !c.stream);
+        assert.ok(summaryCalls.length >= 1, `preflight made summarization call(s) before forwarding (got ${summaryCalls.length})`);
+        for (const c of summaryCalls) {
+            assert.ok(c.body.includes("Compression") || c.body.includes("compress"), "summarization call carries the compression rules");
+        }
+
+        const s = listSessions()[0];
+        const activeBlocks = (s?.state.blocks ?? []).filter((b) => b.active);
+        assert.ok(activeBlocks.length >= 1, `preflight created compression block(s) (got ${activeBlocks.length})`);
+        assert.ok(activeBlocks.every((b) => b.summary === SUMMARY_TEXT), "blocks hold the upstream-written summaries");
+
+        const forwards = calls.filter((c) => c.stream);
+        const lastForward = forwards[forwards.length - 1];
+        assert.ok(lastForward, "a forward happened");
+        assert.ok(bodyChars(lastForward.body) <= WINDOW, "the forwarded payload fits the enforced window");
+        assert.ok(!lastForward.body.includes("CODE_1_"), "compressed messages are out of the payload");
+        assert.ok(lastForward.body.includes("CODE_11_"), "recent messages remain in the payload");
+        assert.ok(lastForward.body.includes(SUMMARY_TEXT), "the preflight summary is in the rebuilt payload");
+
+        // The successful turn's usage report corrects the char-based figure
+        // to the measured size — the session is not stuck on an inflated one.
+        assert.equal(s?.stats.lastInputTokens, 1000);
+    } finally {
+        proxy.close();
+        await once(proxy, "close");
+        upstream.close();
+        await once(upstream, "close");
+    }
+});
+
+test("e2e: fresh session whose history genuinely fits the window → no preflight (conservative trigger does not over-fire)", async () => {
+    const calls: Array<{ stream: boolean }> = [];
+    const upstream = http.createServer((req, res) => {
+        const chunks: Buffer[] = [];
+        req.on("data", (c: Buffer) => chunks.push(c));
+        req.on("end", () => {
+            let parsed: { stream?: boolean } = {};
+            try {
+                parsed = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+            } catch {
+                /* keep {} */
+            }
+            calls.push({ stream: !!parsed.stream });
+            if (parsed.stream) {
+                res.writeHead(200, { "content-type": "text/event-stream" });
+                res.end(okSse(500));
+            } else {
+                res.writeHead(200, { "content-type": "application/json" });
+                res.end(JSON.stringify({
+                    id: "msg_summary", type: "message", role: "assistant", model: "claude-small",
+                    content: [{ type: "text", text: SUMMARY_TEXT }], stop_reason: "end_turn",
+                    usage: { input_tokens: 500, output_tokens: 50 },
+                }));
+            }
+        });
+    });
+    upstream.listen(0, "127.0.0.1");
+    await once(upstream, "listening");
+    const upstreamPort = upstream.address().port;
+
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    _resetSessionsForTest();
+    setRegistryForTest({});
+    const proxy = await startServer({
+        port: 0,
+        host: "127.0.0.1",
+        upstream: "http://127.0.0.1",
+        routes: { [`http://127.0.0.1:${upstreamPort}`]: { models: { "claude-small": { context: WINDOW } } } },
+        modelContextLimit: 400_000,
+        kernelConfig: defaultConfig(400_000),
+        compress: { injectTool: true, injectNudge: true },
+        promptCache: { routing: "auto" },
+        sessionHeader: "x-acp-session",
+        log: false,
+        debug: false,
+        passthrough: false,
+        mitm: { enabled: false, domains: [] },
+    } as ProxyOptions);
+    await once(proxy, "listening");
+    const proxyPort = proxy.address().port;
+
+    try {
+        // Small ANONYMOUS fresh session: both the optimistic estimate AND the
+        // conservative char-count upper bound are far under the window, so the
+        // trigger must stay quiet even in the conservative regime.
+        const r = await fetch(`http://127.0.0.1:${proxyPort}/bili/http://127.0.0.1:${upstreamPort}/v1/messages`, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+                model: "claude-small",
+                max_tokens: 1024,
+                stream: true,
+                messages: [
+                    { role: "user", content: "hello there" },
+                    { role: "assistant", content: "hi, how can I help?" },
+                    { role: "user", content: "what is the weather?" },
+                    { role: "assistant", content: "I do not have live weather data." },
+                ],
+            }),
+        });
+        assert.equal(r.status, 200);
+        await r.text();
+
+        assert.equal(calls.filter((c) => !c.stream).length, 0, "no summarization calls when the history fits");
+        const s = listSessions()[0];
+        assert.equal((s?.state.blocks ?? []).filter((b) => b.active).length, 0, "no blocks created");
+    } finally {
+        proxy.close();
+        await once(proxy, "close");
+        upstream.close();
+        await once(upstream, "close");
+    }
+});


### PR DESCRIPTION
## Problem (#553)

Anonymous prefix-affinity sessions minted after an ACP compression (forks) start with `lastInputTokens = 0`. Preflight then decided solely on the optimistic `defaultCountTokens` estimate (non-CJK 4 chars/token), which undercounts dense code/JSON replays by up to ~4x — so over-window payloads were forwarded raw upstream: no compression, no interception, doom-looping into #551's 300s transfer cutoffs and `exceed_context_size_error` 400s.

## Fix

When a session has **no measured baseline AND arrived anonymously** (prefix-affinity resolution), judge payload size by a char-count upper bound — 1 token per char, which never undershoots BPE token counts since every token covers at least one character. Applied at three points:

- **Trigger**: `tokenCount` = char upper instead of `max(baseline, optimistic)`, so over-window dense replays enter the compress loop.
- **Nothing-compressible gate**: such sessions fail fast (structured 502) instead of gambling a raw forward past the window.
- **Loop internals**: char-based chunk packing (min-compress-range integrity preserved via a `minUnits` guard so sub-minimum chunks are never emitted), char-based netting, and a regime-aware `PreflightResult.fitsWindow` verdict — optimistic for measured-baseline sessions (preserves the #300 stale-baseline contract byte-for-byte), char upper for unknown-baseline ones (closes the residual gap where the loop exits with failure while the optimistic figure still says "fits").

Explicit-identity zero-baseline sessions keep today's optimistic path: they are genuinely-new or post-native-compaction populations whose payloads are small or shrink, and they self-heal via the learned-window overflow path (`persist.ts` persists `lastInputTokens` across restarts, so zero-baseline anonymous sessions are exactly the fork/reload population).

**Why not an estimator multiplier?** Any fixed k<4 false-fires on repetitive prose that BPE-compresses at ~4+ chars/token (the codex-compact-e2e setup sits at 3.5x window in chars while truly fitting at 87% of window); k=4 is exactly the bug. Content is indistinguishable by char-ratio, so the conservative measure is scoped structurally (anonymous + zero-baseline) instead.

## Tests

- New `tests/preflight-fork-estimate.test.ts`: anonymous fork replay whose optimistic estimate fits but char upper does not → preflight fires, summarizes, forwards within window; small anonymous fresh session → no preflight (no over-fire). Both verified RED on old code / GREEN on fix.
- Full suite: 948/949 (single failure is pre-existing env-only in `launcher.test.ts`, fails identically on clean tree — sandbox lacks client binaries).
- `npm run typecheck` clean; `npm run build` clean.
- E2E: `E2E_CHECK=1` zero-token preflight passes against built dist. Full `ACP_TEST_E2E=1` run is not completable in this sandbox (codex warmup fails identically on the clean tree before any change lands) — flagged for CI/manual run.