### PR TITLE
test: poll instead of fixed sleeps for debounced persist writes (Windows CI flake)

### DIFF
--- a/tests/e2e-export-handoff.test.ts
+++ b/tests/e2e-export-handoff.test.ts
@@ -165,12 +165,16 @@ test("e2e export: real proxy compresses via real tool call, block persists, bili
             `compression result not observed: bodies=${bodies.length} final=${finalText.slice(0, 120)}`,
         );
 
-        // debounceMs: 0 — the debounced persistence write lands within a tick.
-        await new Promise((r) => setTimeout(r, 100));
-
-        // `bili export` reads the SAME dir with a fresh store — proving the
-        // on-disk file is self-sufficient, not an artifact of the live session.
-        const sessions = await listSessions({ dir });
+        // debounceMs: 0 — the debounced write lands within a tick, BUT a
+        // transient ENOENT (CI Windows temp sweep) defers the flush into the
+        // kernel's retry ladder (~1.5s) or the spill. Poll with headroom
+        // instead of a fixed 100ms sleep.
+        const deadline = Date.now() + 10_000;
+        let sessions = await listSessions({ dir });
+        while ((sessions.length < 1 || (sessions[0]?.blocks ?? 0) < 1) && Date.now() < deadline) {
+            await new Promise((r) => setTimeout(r, 25));
+            sessions = await listSessions({ dir });
+        }
         assert.equal(sessions.length, 1, `expected 1 persisted session, got ${sessions.length}: ${sessions.map((s) => s.id).join(",")}`);
         assert.ok(sessions[0]!.blocks >= 1, "real compression block did not persist");
 

--- a/tests/proxy-persist.test.ts
+++ b/tests/proxy-persist.test.ts
@@ -52,6 +52,21 @@ async function settle(ms = 30): Promise<void> {
     await new Promise((r) => setTimeout(r, ms));
 }
 
+/** Poll probe() until it returns non-nullish, failing after deadlineMs.
+ *  Used where a write can legitimately land late: acp-kernel retries
+ *  transient ENOENT/ENOTDIR (CI Windows temp sweeps) with backoff, so a
+ *  debounced flush may surface seconds after its 5ms timer — a fixed
+ *  sleep would flake even though the data is safe. */
+async function waitFor<T>(probe: () => T | null | undefined, deadlineMs: number, what: string): Promise<T> {
+    const start = Date.now();
+    for (;;) {
+        const v = probe();
+        if (v != null) return v;
+        if (Date.now() - start > deadlineMs) throw new Error(`timed out after ${deadlineMs}ms waiting for ${what}`);
+        await settle(10);
+    }
+}
+
 await withTempStore("writeNow round-trips state + blockContents", async (store, dir) => {
     const s = makeSession("sess-1");
     s.stats.requests = 42;
@@ -103,9 +118,12 @@ await withTempStore("scheduleSave debounces and eventually writes", async (store
     store.scheduleSave(s);
     s.stats.requests = 3;
     store.scheduleSave(s);
-    await settle();
+    // Poll rather than one fixed settle(): if the flush hits a transient
+    // ENOENT (temp sweep) the kernel retries with backoff, so the write can
+    // land well past the 5ms debounce. Deadline covers the retry ladder
+    // (~1.5s) with headroom.
+    const loaded = await waitFor(() => store.loadSync("debounce-1"), 5000, "debounced write to land");
     assert.equal(readdirSync(dir).length, 1, "exactly one top-level entry (the _unknown subdir) happened");
-    const loaded = store.loadSync("debounce-1");
     assert.equal(loaded!.stats.requests, 3, "latest value persisted");
 });
 


### PR DESCRIPTION
## What

Fixes the recurring **windows-22 CI flake** seen on recent PRs (#540/#535/#539/#337…), where two tests intermittently fail:

- `tests/proxy-persist.test.ts:109` — `scheduleSave debounces and eventually writes` → `Cannot read properties of null (reading 'stats')`
- `tests/e2e-export-handoff.test.ts:174` — `expected 1 persisted session, got 0`

Both failures share the same upstream signature:

```
[persist] write failed for <id>: ENOENT: no such file or directory,
rename '...Temp\bili-persist-XXX\_unknown\.tmp-...' -> '...json';
SPILLOVER ALSO FAILED — data at risk
```

## Root cause (two layers, this PR is layer 2)

1. **Data layer — acp-kernel PR #201** (separate repo, awaiting merge + release v0.0.53): GitHub Windows runners periodically sweep `%TEMP%`, deleting freshly-created files/dirs between `writeFile(tmp)` and `rename`. The kernel's old retry set (`EPERM/EBUSY/EACCES`) rethrew `ENOENT` immediately. #201 retries the whole write cycle (mkdir + fresh tmp + write + rename) on transient `ENOENT/ENOTDIR` and retries the spill too.
2. **Test layer — this PR**: once the kernel retries, the debounced write can legitimately land well past its 5ms debounce (backoff ladder ~1.5s). A fixed `settle(30ms)` / `setTimeout(100)` assert would still flake even though the data is safe. Polling makes the tests observe the eventual write instead of racing it.

## Changes

- `tests/proxy-persist.test.ts`: new `waitFor()` poll helper; the debounce test now polls `loadSync()` with a 5s deadline (covers the kernel retry ladder with headroom).
- `tests/e2e-export-handoff.test.ts`: poll `listSessions()` until the persisted session shows the compression block (`blocks >= 1`), deadline 10s. Note: polling on `length` alone raced the first pre-compression snapshot and failed `blocks >= 1` — the poll condition must match the assertion.

No production code touched.

## Pre-flight

- `npm run typecheck` ✓
- `npm test` 1046/1048 (2 known env-dependent fails in `plugin-agent.test.ts`, unrelated)
- `npm run build` ✓

## Follow-up

Once acp-kernel v0.0.53 is live on npm, a separate change will bump the `acp-kernel` pin here so the retry fix ships in the next bili release.