### PR TITLE
chore: bump acp-kernel to 0.0.53 (persist ENOENT whole-cycle retry)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@types/node": "^22.0.0",
         "@types/node-forge": "^1.3.14",
-        "acp-kernel": "0.0.52",
+        "acp-kernel": "0.0.53",
         "fzstd": "0.1.1",
         "node-forge": "^1.4.0",
         "tar": "^7.5.22",
@@ -988,9 +988,9 @@
       }
     },
     "node_modules/acp-kernel": {
-      "version": "0.0.52",
-      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.52.tgz",
-      "integrity": "sha512-t7tP68qmu1v3DYr3aBbVMtmfme4DUlOW1AGZT64cvG0C7vb6OpZz0OpP4VN4m3QEGeL8SK6D8E/j6MFc65lcwQ==",
+      "version": "0.0.53",
+      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.53.tgz",
+      "integrity": "sha512-BjaXGnzd5wwBY1b4JWs/GxAH66afXN1tPu0+3F+cZb/r8L5EP6gZ8LdX2bM6SiJb33hxB+mQ7PfYPFeYaHO4rA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/node-forge": "^1.3.14",
-    "acp-kernel": "0.0.52",
+    "acp-kernel": "0.0.53",
     "fzstd": "0.1.1",
     "node-forge": "^1.4.0",
     "tar": "^7.5.22",


### PR DESCRIPTION
## What

Bumps the `acp-kernel` pin from 0.0.52 → **0.0.53** (exact pin per AGENTS.md §2; real `npm install` so the bundle picks up the new kernel).

## What 0.0.53 carries

acp-kernel PR #201 — `fix: retry whole write cycle on transient ENOENT/ENOTDIR (CI Windows temp sweep)`:

- New `isTransientFsError` covers EPERM/EBUSY/EACCES/**ENOENT/ENOTDIR**; the old code rethrew ENOENT immediately.
- `writeInner` / `flushSync` retry the **whole cycle** per attempt (mkdir moved inside the loop, fresh tmp name, write, rename) — a swept directory is recreated.
- The spill write gets its own transient retry window.
- 4 new fault-injection tests; kernel suite 575/575.

This closes the loop on the windows-22 CI flake (data layer): GitHub runners sweep `%TEMP%` mid-test, killing the tmp file between write and rename. Companion test-layer fix (polling instead of fixed sleeps) already landed in PR #559.

## Pre-flight

- typecheck ✓
- `npm test` 1046/1048 (2 known env-dependent fails in `plugin-agent.test.ts`, unrelated)
- build ✓
- verified `node_modules/acp-kernel` = 0.0.53 before rebuild