### PR TITLE
release v0.1.86

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.85",
+  "version": "0.1.86",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Version bump only.

## Changes since v0.1.85

*(Body corrected post-merge — originally written when master had only #559/#560; the tag actually shipped all six PRs below, matching the auto-generated [v0.1.86 release notes](https://github.com/ranxianglei/billion-context/releases/tag/v0.1.86).)*

- **PR #547** (closes #405) — fix: surface passthrough everywhere it silently killed compression (banner, env-knob enumeration, `/__bili/config` GET/PUT with 409 when env forces, hot flip, web UI banner)
- **PR #548** (closes #546) — fix: starved tool-carrying main requests no longer demote to side requests (budget high-water restore)
- **PR #555** (closes #276 ①) — fix: drop previous `.old` before logger rotation rename (Windows-safe)
- **PR #559** — test: poll instead of fixed sleeps for debounced persist writes (windows-22 CI flake, test layer)
- **PR #560** — chore: bump acp-kernel 0.0.52 → **0.0.53** (persist ENOENT whole-cycle retry, data layer)
- **PR #373** (closes #367) — feat: one-shot actionable EPERM diagnostic alert on Windows (Defender exclusion guidance, `BILI_PERSIST_EPERM_ALERT_THRESHOLD`/`_REPEAT_MS`) + AV-exclusion docs (EN/zh-CN)

Together #559/#560 close out the recurring Windows CI flake: `proxy-persist.test.ts` and `e2e-export-handoff.test.ts` no longer race temp-swept writes.

## Pre-flight

- typecheck ✓
- `npm test` 1046/1048 (2 known env-dependent fails in `plugin-agent.test.ts`) — count at branch-create time; post-#373 master ran 1058/1060
- build ✓