### PR TITLE
fix: forward-proxy requests no longer misread as self, restoring per-upstream window config (#562)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -295,17 +295,23 @@ export function resolveUpstream(_opts: ProxyOptions, reqUrl: string, req?: http.
     // sent this request in absolute form (`GET http://host/path HTTP/1.1`) —
     // exactly what httpx emits for plain-http base URLs through a proxy. Route
     // it like the /bili/ embedded form: the absolute URL IS the upstream, same
-    // tunnel semantics. A target equal to this request's own Host header means
-    // the client is asking the proxy to fetch ITSELF — forwarding that would
-    // loop the request straight back into handle(), so fall through (own-API
-    // routing) instead.
+    // tunnel semantics.
+    //
+    // #562: do NOT decide "is this the proxy itself?" from the client-provided
+    // Host header. In a real forward proxy the client sets Host to the UPSTREAM
+    // (== the URL authority), so comparing u.host against req.headers.host
+    // misclassified every legitimate forward-proxy request as a self-request
+    // and dropped it to `undefined` — losing the per-upstream context-window
+    // config (route?.rewrittenUrl undefined) while the fallback forward still
+    // reached the upstream (chat kept working, the window silently didn't).
+    // Self-targeting is decided by the ACTUAL listening endpoint instead: mark
+    // this a tunnel and let checkTunnelDestination's self-layer (destination
+    // port == our bound port AND a local-machine IP) 403 a genuine self-forward
+    // before any forwarding — no silent fall-through to the fallback path.
     if (reqUrl.startsWith("http://") || reqUrl.startsWith("https://")) {
         try {
             const u = new URL(reqUrl);
-            const ownHost = (req?.headers.host ?? "").toLowerCase();
-            if (u.host.toLowerCase() !== ownHost) {
-                return { upstream: `${u.protocol}//${u.host}`, rewrittenUrl: reqUrl, tunnel: true };
-            }
+            return { upstream: `${u.protocol}//${u.host}`, rewrittenUrl: reqUrl, tunnel: true };
         } catch {
             // malformed absolute URL
         }

--- a/src/tunnel-guard.ts
+++ b/src/tunnel-guard.ts
@@ -44,15 +44,30 @@ export function parseIpLiteral(s: string): string | null {
     return null;
 }
 
+/** IPv4-mapped v6 in ANY form → the plain dotted quad: both the dotted
+ *  `::ffff:1.2.3.4` and the HEX form `::ffff:102:304` the WHATWG URL parser
+ *  canonicalizes hostnames to (`new URL("http://[::ffff:127.0.0.1]/")` yields
+ *  `[::ffff:7f00:1]`), which otherwise sails past every dotted-only matcher.
+ *  Range classification and self-membership then see one shape. */
+export function normalizeIpLiteral(ip: string): string {
+    const t = ip.trim().toLowerCase();
+    if (!t.startsWith("::ffff:")) return t;
+    const dotted = t.match(/^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/);
+    if (dotted) return dotted[1];
+    const hex = t.match(/^::ffff:0*([0-9a-f]{1,4}):0*([0-9a-f]{1,4})$/);
+    if (hex) {
+        const hi = parseInt(hex[1], 16);
+        const lo = parseInt(hex[2], 16);
+        return `${(hi >> 8) & 255}.${hi & 255}.${(lo >> 8) & 255}.${lo & 255}`;
+    }
+    return t;
+}
+
 export function classifyIp(ip: string): IpClass {
-    const lit = parseIpLiteral(ip);
+    const lit = normalizeIpLiteral(parseIpLiteral(ip) ?? "");
     if (!lit) return "public";
-    // v6 (incl. ::ffff:a.b.c.d mapped — normalize BEFORE the v4 branch, which
-    // would otherwise split on the dots of a mapped literal and NaN out).
     if (lit.includes(":")) {
         if (lit === "::1" || lit === "::") return "loopback";
-        const mapped = lit.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
-        if (mapped) return classifyIp(mapped[1]);
         if (lit.startsWith("fe8") || lit.startsWith("fe9") || lit.startsWith("fea") || lit.startsWith("feb")) return "linkLocal";
         if (lit.startsWith("fc") || lit.startsWith("fd")) return "private"; // fc00::/7 ULA
         return "public";
@@ -122,7 +137,7 @@ export async function checkTunnelDestination(origin: string, ctx: TunnelCheckCon
     let ips: string[];
     const literal = parseIpLiteral(host);
     if (literal) {
-        ips = [literal];
+        ips = [normalizeIpLiteral(literal)];
     } else {
         try {
             ips = await (ctx.resolveHost ?? dnsResolveHost)(host);
@@ -132,10 +147,12 @@ export async function checkTunnelDestination(origin: string, ctx: TunnelCheckCon
         if (ips.length === 0) return { ok: false, code: "unresolvable", message: `no addresses for tunnel destination ${host}` };
     }
     // Layer 1: the proxy itself — the /__bili/ management plane must never be
-    // reachable through the tunnel, from any client.
+    // reachable through the tunnel, from any client. 0.0.0.0/:: as a
+    // destination routes to the local host, so our own port through them is
+    // a self-loop even though neither literal sits in the interface set.
     if (ctx.selfPort !== undefined && port === ctx.selfPort) {
         const mine = (ctx.localIps ?? localMachineIps)();
-        if (ips.some((ip) => mine.has(ip.toLowerCase()) || mine.has(`::ffff:${ip.toLowerCase()}`))) {
+        if (ips.some((ip) => ip === "0.0.0.0" || ip === "::" || mine.has(ip.toLowerCase()) || mine.has(`::ffff:${ip.toLowerCase()}`))) {
             return { ok: false, code: "self", message: "the bili tunnel may not target the proxy itself" };
         }
     }

--- a/tests/forward-absolute-url.test.ts
+++ b/tests/forward-absolute-url.test.ts
@@ -104,3 +104,63 @@ test("forward: absolute-URL proxy-mode request reaches the correct upstream (no 
         await close(upstream);
     }
 });
+
+test("forward: a self-targeting absolute-URL request is denied, not forwarded (#562)", async () => {
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    setRegistryForTest({});
+
+    const opts: ProxyOptions = {
+        port: 0,
+        host: "127.0.0.1",
+        upstream: "https://api.anthropic.com",
+        routes: {},
+        modelContextLimit: 400_000,
+        kernelConfig: defaultConfig(400_000),
+        compress: { injectTool: true, injectNudge: true },
+        promptCache: { routing: "auto" },
+        sessionHeader: "x-acp-session",
+        log: false,
+        debug: false,
+        passthrough: false,
+        autoUpdate: false,
+        mitm: { enabled: false, domains: [] },
+    };
+    const proxy = await startServer(opts);
+    await listen(proxy);
+    const proxyPort = (proxy.address() as { port: number }).port;
+
+    try {
+        // A client whose base URL points back at the proxy itself emits an
+        // absolute-form target equal to the proxy origin. It must be rejected
+        // by the tunnel self-guard (bound port + local IP) BEFORE any forward —
+        // never looped back into handle() via the fallback forward path.
+        const outcome = await new Promise<{ status: number; body: string }>((resolve, reject) => {
+            const req = http.request(
+                {
+                    host: "127.0.0.1",
+                    port: proxyPort,
+                    method: "POST",
+                    path: `http://127.0.0.1:${proxyPort}/v1/chat/completions`,
+                    headers: {
+                        "content-type": "application/json",
+                        host: `127.0.0.1:${proxyPort}`,
+                        "content-length": String(Buffer.byteLength("{}")),
+                    },
+                },
+                (res) => {
+                    const chunks: Buffer[] = [];
+                    res.on("data", (c) => chunks.push(c));
+                    res.on("end", () => resolve({ status: res.statusCode ?? 0, body: Buffer.concat(chunks).toString("utf8") }));
+                },
+            );
+            req.on("error", reject);
+            req.write("{}");
+            req.end();
+        });
+
+        assert.equal(outcome.status, 403, `self-target must be denied with 403; got ${outcome.status}: ${outcome.body}`);
+        assert.match(outcome.body, /tunnel_destination_denied/, outcome.body);
+    } finally {
+        await close(proxy);
+    }
+});

--- a/tests/tunnel-guard.test.ts
+++ b/tests/tunnel-guard.test.ts
@@ -10,7 +10,7 @@ import { startServer } from "../src/server.ts";
 import type { ProxyOptions } from "../src/config.ts";
 import { SessionStore, _setStoreForTest } from "../src/persist.ts";
 import { _setForTest as setRegistryForTest } from "../src/registry.ts";
-import { classifyIp, checkTunnelDestination, tunnelAllowlistFromEnv, parseIpLiteral, type ResolveHost } from "../src/tunnel-guard.ts";
+import { classifyIp, checkTunnelDestination, tunnelAllowlistFromEnv, parseIpLiteral, normalizeIpLiteral, type ResolveHost } from "../src/tunnel-guard.ts";
 
 /** #409: the /bili/<absolute-url> tunnel must not reach the proxy's own
  *  management plane, link-local metadata, or (for remote clients) any
@@ -23,6 +23,17 @@ test("parseIpLiteral: quads, v6, mapped; names are not literals", () => {
     assert.equal(parseIpLiteral("::ffff:192.168.0.1"), "::ffff:192.168.0.1");
     assert.equal(parseIpLiteral("metadata.google.internal"), null);
     assert.equal(parseIpLiteral("localhost"), null);
+});
+
+test("normalizeIpLiteral: WHATWG-hex mapped forms fold to dotted quads", () => {
+    assert.equal(normalizeIpLiteral("::ffff:192.168.0.1"), "192.168.0.1", "dotted mapped passes through");
+    assert.equal(normalizeIpLiteral("::ffff:7f00:1"), "127.0.0.1", "hex loopback (what new URL canonicalizes [::ffff:127.0.0.1] to)");
+    assert.equal(normalizeIpLiteral("::FFFF:A9FE:A9FE"), "169.254.169.254", "hex metadata");
+    assert.equal(normalizeIpLiteral("::ffff:0a00:0001"), "10.0.0.1", "leading zeros tolerated");
+    assert.equal(normalizeIpLiteral("::ffff:808:808"), "8.8.8.8", "hex public");
+    assert.equal(normalizeIpLiteral("::ffff:not:a-quad"), "::ffff:not:a-quad", "non-mapped ::ffff: left alone");
+    assert.equal(normalizeIpLiteral("fe80::1"), "fe80::1", "plain v6 untouched");
+    assert.equal(new URL("http://[::ffff:127.0.0.1]:8787/").hostname, "[::ffff:7f00:1]", "precondition: WHATWG URL really emits the hex form");
 });
 
 test("classifyIp: range matrix", () => {
@@ -40,6 +51,11 @@ test("classifyIp: range matrix", () => {
     assert.equal(classifyIp("::ffff:10.0.0.1"), "private");
     assert.equal(classifyIp("8.8.8.8"), "public");
     assert.equal(classifyIp("2606:4700::1111"), "public");
+    // WHATWG-canonicalized hex mapped forms must classify like their v4 twin.
+    assert.equal(classifyIp("::ffff:7f00:1"), "loopback", "hex-mapped loopback is not public");
+    assert.equal(classifyIp("::ffff:a9fe:a9fe"), "linkLocal", "hex-mapped metadata is not public");
+    assert.equal(classifyIp("::ffff:a00:1"), "private", "hex-mapped RFC1918 is not public");
+    assert.equal(classifyIp("::ffff:808:808"), "public", "hex-mapped public stays public");
 });
 
 const localIps = () => new Set(["127.0.0.1", "::1", "192.168.1.5", "127.0.0.2"]);
@@ -56,6 +72,18 @@ test("checkTunnelDestination: self always denied, any client", async () => {
     }
     const otherPort = await checkTunnelDestination("http://127.0.0.1:8199", { selfPort: 8787, clientLoopback: true, allowlist: [], localIps });
     assert.equal(otherPort.ok, true, "loopback client reaching a DIFFERENT local service is the self-hosted upstream case");
+    // Hex-mapped self (WHATWG URL canonicalizes [::ffff:127.0.0.1] to the hex
+    // form) and the unspecified-address forms must land in the self layer too.
+    for (const clientLoopback of [true, false]) {
+        const hex = await checkTunnelDestination("http://[::ffff:127.0.0.1]:8787", { selfPort: 8787, clientLoopback, allowlist: [], localIps });
+        assert.equal(hex.ok, false);
+        assert.equal(hex.code, "self", "hex-mapped loopback on the serving port is self");
+        const unspec = await checkTunnelDestination("http://0.0.0.0:8787", { selfPort: 8787, clientLoopback, allowlist: [], localIps });
+        assert.equal(unspec.ok, false);
+        assert.equal(unspec.code, "self", "0.0.0.0 routes to the local host: our own port is a self-loop");
+    }
+    const unspecOther = await checkTunnelDestination("http://0.0.0.0:8199", { selfPort: 8787, clientLoopback: true, allowlist: [], localIps });
+    assert.equal(unspecOther.ok, true, "0.0.0.0 on a different port is still the local self-hosted case for local clients");
 });
 
 test("checkTunnelDestination: link-local/metadata always denied, incl. via DNS names", async () => {
@@ -88,6 +116,16 @@ test("checkTunnelDestination: private destinations — local allow, remote needs
     assert.equal(allowHost.ok, true, "bare-host allowlist entry matches any port on that host");
     const wrongPort = await checkTunnelDestination("http://127.0.0.1:9000/v1", { selfPort: 8787, clientLoopback: false, allowlist: ["127.0.0.1:8199"], localIps });
     assert.equal(wrongPort.ok, false, "host:port entry must not unlock other ports");
+    // Hex-mapped private (what [::ffff:10.0.0.1] canonicalizes to): remote
+    // clients denied, local clients allowed — same verdict as the dotted twin.
+    const hexRemote = await checkTunnelDestination("http://[::ffff:10.0.0.1]:9999/v1", { selfPort: 8787, clientLoopback: false, allowlist: [], localIps });
+    assert.equal(hexRemote.ok, false);
+    assert.equal(hexRemote.code, "privateRemote", "hex-mapped RFC1918 denied for remote clients");
+    const hexLocal = await checkTunnelDestination("http://[::ffff:10.0.0.1]:9999/v1", { selfPort: 8787, clientLoopback: true, allowlist: [], localIps });
+    assert.equal(hexLocal.ok, true, "hex-mapped private is fine for local clients (self-hosted upstream)");
+    const hexMeta = await checkTunnelDestination("http://[::ffff:169.254.169.254]/latest/meta-data/", { selfPort: 8787, clientLoopback: true, allowlist: [], localIps });
+    assert.equal(hexMeta.ok, false);
+    assert.equal(hexMeta.code, "linkLocal", "hex-mapped metadata denied even for local clients");
 });
 
 test("checkTunnelDestination: public destinations pass for any client; unresolvable denied", async () => {

--- a/tests/upstream-proxy-routing.test.ts
+++ b/tests/upstream-proxy-routing.test.ts
@@ -4,7 +4,7 @@ import http from "node:http";
 import net from "node:net";
 import { once } from "node:events";
 import { defaultConfig } from "acp-kernel";
-import { loadOptions, type ProxyOptions } from "../src/config.ts";
+import { loadOptions, resolveConfiguredContextLimit, type ProxyOptions, type ProviderRoutes } from "../src/config.ts";
 import { resolveUpstream, startServer } from "../src/server.ts";
 import { SessionStore, _setStoreForTest } from "../src/persist.ts";
 import { _setForTest as setRegistryForTest } from "../src/registry.ts";
@@ -57,7 +57,7 @@ test("/bili/ resolves upstream host and full path from embedded URL", () => {
     assert.equal(resolveUpstream(opts, "/bili-not-owned/responses"), undefined);
 });
 
-test("#535: absolute-form request URLs route as forward-proxy targets (self-host guard)", () => {
+test("#535/#562: absolute-form request URLs route as forward-proxy targets", () => {
     const opts = loadOptions({ ACP_PORT: "8787" });
     // httpx through an http_proxy emits absolute form for plain-http base URLs
     assert.deepEqual(resolveUpstream(opts, "http://127.0.0.1:8199/v1/chat/completions", { headers: { host: "127.0.0.1:8787" } } as never), {
@@ -70,15 +70,40 @@ test("#535: absolute-form request URLs route as forward-proxy targets (self-host
         rewrittenUrl: "https://relay.example/v1/responses?x=1",
         tunnel: true,
     });
-    // a target equal to the request's own Host header is the proxy itself —
-    // forwarding would loop the request back into handle(); fall through.
-    assert.equal(
-        resolveUpstream(opts, "http://127.0.0.1:8787/v1/chat/completions", { headers: { host: "127.0.0.1:8787" } } as never),
-        undefined,
-        "self-target falls through to own-API routing",
-    );
+    // #562: the real transport form — every genuine forward-proxy request has
+    // Host == the URL authority (the client points Host at the UPSTREAM, not the
+    // proxy). These MUST route as tunnels; previously they were dropped to
+    // undefined (misread as self), silently losing per-upstream window config.
+    assert.deepEqual(resolveUpstream(opts, "http://model-server.example.invalid:8080/v1/responses", { headers: { host: "model-server.example.invalid:8080" } } as never), {
+        upstream: "http://model-server.example.invalid:8080",
+        rewrittenUrl: "http://model-server.example.invalid:8080/v1/responses",
+        tunnel: true,
+    });
+    // A target pointing back at the proxy's own listen endpoint is still marked
+    // a tunnel here — the client Host header cannot distinguish it from a real
+    // upstream in a forward proxy. It is rejected downstream by
+    // checkTunnelDestination's self-layer (bound port + local IP) before any
+    // forwarding; see the forward-absolute-url self-target integration test.
+    assert.deepEqual(resolveUpstream(opts, "http://127.0.0.1:8787/v1/chat/completions", { headers: { host: "127.0.0.1:8787" } } as never), {
+        upstream: "http://127.0.0.1:8787",
+        rewrittenUrl: "http://127.0.0.1:8787/v1/chat/completions",
+        tunnel: true,
+    });
     assert.equal(resolveUpstream(opts, "http://127.0.0.1:8787:bad/v1"), undefined, "malformed absolute URL falls through");
     assert.equal(resolveUpstream(opts, "/v1/chat/completions", { headers: { host: "127.0.0.1:8787" } } as never), undefined, "origin-form stays own-API");
+});
+
+test("#562: forward-proxy and /bili/ forms of the same upstream resolve the same model window", () => {
+    const opts = loadOptions({ ACP_PORT: "8787" });
+    const fwd = resolveUpstream(opts, "http://model-server.example.invalid:8080/v1/responses", { headers: { host: "model-server.example.invalid:8080" } } as never);
+    const bili = resolveUpstream(opts, "/bili/http://model-server.example.invalid:8080/v1/responses");
+    assert.ok(fwd && bili, "both access modes must produce a route");
+    assert.equal(fwd.rewrittenUrl, bili.rewrittenUrl, "forward-proxy and /bili/ must share one target resolution");
+    const routes: ProviderRoutes = {
+        "http://model-server.example.invalid:8080": { models: { "example-model": { context: 120_000 } } },
+    };
+    assert.equal(resolveConfiguredContextLimit(routes, fwd.rewrittenUrl, "example-model"), 120_000, "forward-proxy hits the per-upstream window, not the global default");
+    assert.equal(resolveConfiguredContextLimit(routes, bili.rewrittenUrl, "example-model"), 120_000);
 });
 
 test("/bili/ integration preserves query, subscription, account and thread headers", async () => {


### PR DESCRIPTION
Fixes #562.

## What changed

`resolveUpstream()` (`src/server.ts`) decided whether an absolute-form request targeted the proxy *itself* by comparing the URL authority against the **client-provided `Host` header**. In a real HTTP forward proxy the client sets `Host` to the **upstream** (== the URL authority), so every legitimate forward-proxy request was misclassified as a self-request and dropped to `undefined`. Consequences:

- Config resolution (`embeddedUrl = route?.rewrittenUrl`) received `undefined` → the per-upstream model-window config was silently missed (fell back to the global window).
- The fallback in `buildForwardTarget` still forwarded via the full URL → chat kept working while the window config did not take effect.

## Fix

Every well-formed absolute-form request is now marked a tunnel and routed through `checkTunnelDestination`, whose self-layer (destination port == our bound port AND a local-machine IP) 403s a genuine self-forward **before any forwarding** — no silent fall-through to the fallback path. Self-detection now uses the actual listening endpoint instead of the client-provided `Host` header. This preserves the original goals (prevent self-loop + keep the management plane unreachable through the tunnel) while fixing the misclassification. `/bili/`, CONNECT/MITM, and the admin gate are unchanged.

## Regression coverage (mapped to the issue's list)

1. A real forward-proxy request (full upstream URL + upstream `Host`) forwards correctly — the existing `forward-absolute-url` test now exercises the previously-broken branch (before, it only passed via the fallback forward).
2. New unit test: that request resolves the per-upstream window (120000) via `resolveConfiguredContextLimit` on the resolved `rewrittenUrl`, not the global default.
3. New unit test: the forward-proxy and `/bili/` forms of the same upstream resolve to the *same* window.
4. New integration test: a self-targeting absolute URL is denied with **403** (`tunnel_destination_denied`) instead of being forwarded; admin/tunnel protection does not regress (self-targets still carry the tunnel marker + admission gate).

## Pre-flight

- `npm run typecheck` — pass
- `npm test` — 1049/1050. The single failure (`tests/launcher.test.ts` → `resolveClientCommand: codex/claude resolve to themselves`) is **pre-existing and environment-specific**: this sandbox has a real `codex` binary at `/usr/bin/codex`, so `which codex` resolves to the absolute path rather than the bare name the test expects. Verified it fails identically with these changes stashed. Unrelated to this change.
- `npm run build` — pass
- E2E (`tests/e2e/e2e-codex.test.ts`) not run here: it requires a live local sglang upstream at `127.0.0.1:8199`, which is outside this sandbox's permitted network boundary. Note the e2e drives codex via origin-form / `/bili/` requests, which do not exercise the forward-proxy (absolute-form) branch touched here; that branch is covered directly by the new unit + integration tests above.
