### PR TITLE
fix: acp_status uses one estimator scale — defaultCountTokens (#386)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.85",
+  "version": "0.1.86",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.85",
+      "version": "0.1.86",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@types/node": "^22.0.0",
         "@types/node-forge": "^1.3.14",
-        "acp-kernel": "0.0.53",
+        "acp-kernel": "0.0.54",
         "fzstd": "0.1.1",
         "node-forge": "^1.4.0",
         "tar": "^7.5.22",
@@ -988,9 +988,9 @@
       }
     },
     "node_modules/acp-kernel": {
-      "version": "0.0.53",
-      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.53.tgz",
-      "integrity": "sha512-BjaXGnzd5wwBY1b4JWs/GxAH66afXN1tPu0+3F+cZb/r8L5EP6gZ8LdX2bM6SiJb33hxB+mQ7PfYPFeYaHO4rA==",
+      "version": "0.0.54",
+      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.54.tgz",
+      "integrity": "sha512-7ETdru+1jn0zLd0uAEfIUDVi/UlyZbcis13BwBJpHqBE768Jw3f2CgNecTy8U5sXGiNG29nYKD6ctKHYDGdsQg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/node-forge": "^1.3.14",
-    "acp-kernel": "0.0.53",
+    "acp-kernel": "0.0.54",
     "fzstd": "0.1.1",
     "node-forge": "^1.4.0",
     "tar": "^7.5.22",

--- a/src/compress-loop-responses.ts
+++ b/src/compress-loop-responses.ts
@@ -1,6 +1,6 @@
 import {
     buildStatusReport,
-    estimateTokensFast,
+    defaultCountTokens,
     type CompressionCore,
     type Config,
     type CoreMessage,
@@ -102,7 +102,7 @@ function executeProxyTool(
         return `Found ${blocks.length} block(s) for "${query}":\n\n${lines.join("\n\n")}`;
     }
     if (toolName === "acp_status") {
-        return buildStatusReport(ctx.session.state, ctx.messages, estimateTokensFast);
+        return buildStatusReport(ctx.session.state, ctx.messages, defaultCountTokens);
     }
     return `[Unknown proxy tool: ${toolName}]`;
 }

--- a/src/loop/core.ts
+++ b/src/loop/core.ts
@@ -1,6 +1,6 @@
 import {
     buildStatusReport,
-    estimateTokensFast,
+    defaultCountTokens,
     formatRanges,
     hideConsumedCompressCalls,
     type CompressionCore,
@@ -145,7 +145,7 @@ function handleAcpStatus(args: Record<string, unknown>, ctx: LoopCtx): string {
     const tool = typeof args.tool === "string" ? args.tool : undefined;
     const sort = typeof args.sort === "string" ? (args.sort as "size" | "time" | "tool" | "age") : undefined;
     const limit = typeof args.limit === "number" ? args.limit : undefined;
-    const base = buildStatusReport(ctx.session.state, ctx.messages, estimateTokensFast, { scope, view, tool, sort, limit });
+    const base = buildStatusReport(ctx.session.state, ctx.messages, defaultCountTokens, { scope, view, tool, sort, limit });
     if (scope) return base;
     const nudge = ctx.nudge;
     const ranges = nudge?.compressibleRanges ?? [];

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1,4 +1,4 @@
-import { buildStatusReport, collectBlockContent, estimateTokensFast, type CompressionCore, type Config, type CoreMessage, type CompressionState } from "acp-kernel";
+import { buildStatusReport, collectBlockContent, defaultCountTokens, type CompressionCore, type Config, type CoreMessage, type CompressionState } from "acp-kernel";
 import { type Session, cacheBlockContent } from "./session.js";
 import { COMPRESS_TOOL_NAME, parseCompressInput, PROXY_TOOL_NAMES } from "./compress-tool.js";
 import { resolveDecompress } from "./decompress-shared.js";
@@ -43,7 +43,7 @@ function executeAnthropicProxyTool(toolName: string, args: Record<string, unknow
         return `Found ${blocks.length} block(s) for "${query}":\n\n${lines.join("\n\n")}`;
     }
     if (toolName === "acp_status") {
-        return buildStatusReport(ctx.session.state, ctx.messages, estimateTokensFast);
+        return buildStatusReport(ctx.session.state, ctx.messages, defaultCountTokens);
     }
     return `[Unknown proxy tool: ${toolName}]`;
 }

--- a/tests/acp-status-estimator.test.ts
+++ b/tests/acp-status-estimator.test.ts
@@ -1,0 +1,64 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createCore, createInitialState, defaultConfig, type CoreMessage } from "acp-kernel";
+import type { Session } from "../src/session.ts";
+import { executeProxyTool } from "../src/loop/core.ts";
+
+function makeSession(): Session {
+    return {
+        id: `test-${Math.random().toString(36).slice(2)}`,
+        meta: {},
+        stats: { requests: 0, tokensSaved: 0, inputTokens: 0, cachedTokens: 0, outputTokens: 0, cacheSamples: 0, lastInputTokens: 0, contextTokens: 0 },
+        metadata: {},
+        state: createInitialState(),
+        createdAt: Date.now(),
+        lastSeen: Date.now(),
+        blockContents: new Map(),
+        inFlight: 0,
+        persisted: false,
+    };
+}
+
+// CJK payload: defaultCountTokens counts it ~1:1 while the old
+// estimateTokensFast (chars/4) under-counts 4x. Asserting the 1:1 figure
+// guards against a regression back to the mixed-scale reporting (#386).
+const cjk = (n: number): string => "中".repeat(n);
+
+function cjkToolSession(): { session: Session; messages: CoreMessage[] } {
+    const session = makeSession();
+    const core = createCore();
+    const config = defaultConfig(200000);
+    const messages: CoreMessage[] = [
+        { id: "u1", role: "user", contentType: "text", text: cjk(100) },
+        { id: "call-c1", role: "assistant", contentType: "tool-call", toolName: "bash", toolCallId: "c1", text: "{}" },
+        { id: "res-c1", role: "user", contentType: "tool-result", toolCallId: "c1", text: cjk(4000) },
+        { id: "call-c2", role: "assistant", contentType: "tool-call", toolName: "read", toolCallId: "c2", text: "{}" },
+        { id: "res-c2", role: "user", contentType: "tool-result", toolCallId: "c2", text: cjk(2000) },
+    ];
+    const turn = core.processTurn({ messages, state: session.state, config, tokenCount: 9999, renderTags: "text-only" });
+    session.state = turn.state;
+    return { session, messages: turn.messages };
+}
+
+test("acp_status reports CJK at 1:1 scale (defaultCountTokens, not chars/4) (#386)", () => {
+    const { session, messages } = cjkToolSession();
+    const ctx = { core: createCore(), config: defaultConfig(200000), messages, session, log: (_msg: string) => {} };
+    const out = executeProxyTool("acp_status", {}, ctx);
+    const line = out.split("\n").find((l) => l.includes(" tool (") && l.includes(" text ("));
+    assert.ok(line, `no breakdown line in:\n${out}`);
+    assert.ok(line.includes("6.0K tool"), `tool bucket should be ~6000 CJK tokens (1:1), not chars/4: ${line}`);
+    const toolPct = Number(/tool \((\d+)%\)/.exec(line)?.[1] ?? -1);
+    assert.ok(toolPct >= 95, `tool should dominate: ${line}`);
+});
+
+test("acp_status attributes CJK tool-results to their calling tools (#386)", () => {
+    const { session, messages } = cjkToolSession();
+    const ctx = { core: createCore(), config: defaultConfig(200000), messages, session, log: (_msg: string) => {} };
+    const out = executeProxyTool("acp_status", {}, ctx);
+    const top = out.split("\n").find((l) => l.startsWith("  Top tools:"));
+    assert.ok(top, `no Top tools line in:\n${out}`);
+    assert.ok(top.includes("bash"), `bash missing: ${top}`);
+    assert.ok(top.includes("read"), `read missing: ${top}`);
+    const textPct = /text \((\d+)%\)/.exec(top)?.[1];
+    assert.ok(!textPct || Number(textPct) <= 5, `text must not dominate Top tools: ${top}`);
+});


### PR DESCRIPTION
Closes #386 (bili side, paired with acp-kernel PR#203 / v0.0.54, already live on npm).

## Root causes fixed
1. **tool bucket ~0.6% of real volume** (kernel 0.0.54): wire adapters set `toolName` only on tool-calls, so `report.ts`'s `toolName ?? "text"` dumped every tool-result into the text bucket. Now results resolve back to their calling tool via a `toolCallId → toolName` map.
2. **two estimator scales in one acp_status output** (this PR): the 3 `buildStatusReport` call sites passed `estimateTokensFast` (chars/4) while the nudge/panel side uses the kernel default CJK-aware `defaultCountTokens` — Chinese content was under-counted 4x on one line and correct on the next. All 3 sites now pass `defaultCountTokens`.
3. **pct() floor** (kernel 0.0.54): `Math.max(1,…)` forced non-empty buckets to ≥1%, so three buckets could sum >100%.
4. Bonus (kernel 0.0.54): merged ranges in the uncompressed view label the true dominant tool (was: first message's tool).

## Changes
- `src/loop/core.ts:148`, `src/compress-loop-responses.ts:105`, `src/stream.ts:46` — `estimateTokensFast` → `defaultCountTokens`.
- `package.json` — acp-kernel pinned `0.0.53` → `0.0.54` (exact, verified live on npm; real `npm install` + rebuild, node_modules confirmed 0.0.54).
- `tests/acp-status-estimator.test.ts` — 2 regression tests: CJK counted 1:1 (guards against slipping back to chars/4); CJK tool-results attributed to `bash`/`read` in Top tools with text ≤5%.

## Pre-flight
- typecheck ✓
- tests 1060/1062 (the 2 failures are the known permanent env fails in plugin-agent.test.ts, unchanged baseline) ✓
- build ✓

Note: the two new tests fail against 0.0.53 exactly as expected (`6.1K text (100%)` / `2 tool (1%)`) and pass against 0.0.54 (`6.0K tool (98%)`) — they pin both the estimator scale and the kernel attribution fix.

Downstream follow-up (separate): close acp-kernel#177 as superseded and port its structural wins (leaf module `message-kind.ts`, `compress.ts` predicate dedup, `isTool` flag) per the review on acp-kernel#203.