### PR TITLE
fix: separate confirmed overflow evidence from weak truncation guesses in window self-heal (#570)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -71,6 +71,7 @@ import { consumePluginRegisterFor, flushConversations, handlePluginCompact, hand
 import { setupMitm, readMitmUpstream } from "./mitm.js";
 import type { BiliMessage } from "acp-kernel/wire";
 import { backfillHostUsage, isLoopbackAddress, inspectContextOverflow, reserveOutputHeadroom, shouldReserveOutputHeadroom, systemToUser, usageTotals, type WireProtocol } from "./util.js";
+import { resolveConfirmedLimit, resolveLearnedLimit, resolveSpeculativeLimit, retractStaleLearnedLimits } from "./weak-overflow.js";
 import { BILI_TUNNEL_HEADER, checkTunnelDestination, tunnelAllowlistFromEnv } from "./tunnel-guard.js";
 
 import { decodeRequestBody } from "./content-encoding.js";
@@ -1390,10 +1391,10 @@ async function handle(
             // hammering the upstream). Gate on the raw body estimate and fail
             // fast locally instead of forwarding (#301 precedent).
             const reqModel = (parsed as { model?: string }).model;
-            const learnedMap = session.metadata.learnedContextLimits as Record<string, number> | undefined;
-            const learnedLimit =
-                (reqModel && learnedMap ? learnedMap[reqModel] : undefined) ??
-                (session.metadata.learnedContextLimit as number | undefined);
+            // #572-merge: read through the resolver (confirmed → speculative, per-model
+            // then scalar) — the learner now writes the confirmed channel, so the
+            // legacy direct map read would miss windows learned from real 400s.
+            const learnedLimit = resolveLearnedLimit(session, reqModel);
             const guard = sideRequestGuard(parsed, protocol, reqConfig.modelContextLimit, learnedLimit);
             if (guard.blocked) {
                 log("warn", `[${session.id}] side request (~${guard.estimate} tokens) ≥ effective window ${guard.limit} (model=${reqModel ?? "?"}) — NOT forwarded: guaranteed upstream 400 (side requests bypass preflight by design, #388)`);
@@ -1426,26 +1427,32 @@ async function handle(
         }
         // Self-heal the context window: a prior upstream overflow may have
         // taught us the real window (forward()'s overflow detection persists it
-        // to metadata.learnedContextLimits, keyed by model, or the legacy scalar
-        // metadata.learnedContextLimit). If it is smaller than what we resolved this
-        // turn (e.g. the 200k fallback for an unknown model on a relay), re-center
-        // the kernel on it so the nudge/truncate bands sit below the real limit
-        // instead of above it. A limit learned for a DIFFERENT model does not
-        // apply — the user can switch models mid-conversation (same session),
-        // and a stale smaller window would cap the bigger model prematurely.
-        // Spread into a new object — never mutate the shared global config.
+        // to metadata.confirmedContextLimits, keyed by model, or the legacy
+        // scalar metadata.confirmedContextLimit; the weak-overflow heuristic
+        // keeps its hypotheses in metadata.learnedContextLimits / scalar). If
+        // it is smaller than what we resolved this turn (e.g. the 200k fallback
+        // for an unknown model on a relay), re-center the kernel on it so the
+        // nudge/truncate bands sit below the real limit instead of above it.
+        // A limit learned for a DIFFERENT model does not apply — the user can
+        // switch models mid-conversation (same session), and a stale smaller
+        // window would cap the bigger model prematurely. Spread into a new
+        // object — never mutate the shared global config.
         const reqModel = (parsed as { model?: string }).model;
-        const learnedMap = session.metadata.learnedContextLimits as Record<string, number> | undefined;
-        const learnedLimit =
-            (reqModel && learnedMap ? learnedMap[reqModel] : undefined) ??
-            (session.metadata.learnedContextLimit as number | undefined);
+        // #570: a learned window is a hypothesis — if a later turn SUCCEEDED
+        // with reported input above it, it is stale (KV-pressure false
+        // positive, resized server, ...) and must not keep throttling this
+        // session. Runs before the resolution below so this request already
+        // sees the corrected window.
+        retractStaleLearnedLimits(session, reqModel);
+        const confirmedLimit = resolveConfirmedLimit(session, reqModel);
+        const learnedLimit = confirmedLimit ?? resolveSpeculativeLimit(session, reqModel);
         if (learnedLimit && learnedLimit > 0 && learnedLimit < reqConfig.modelContextLimit) {
             const resolved = reqConfig.modelContextLimit;
             reqConfig = { ...reqConfig, modelContextLimit: learnedLimit };
             // A learned limit is ground truth from a real overflow — it must
             // not be floored back up (that would undo the self-heal).
             nativeFromFallback = false;
-            log("info", `[${session.id}] self-healed context window: ${resolved} → ${learnedLimit} (learned from an upstream overflow)`);
+            log("info", `[${session.id}] self-healed context window: ${resolved} → ${learnedLimit} (${confirmedLimit !== undefined ? "confirmed by an upstream overflow error" : "weak-overflow heuristic"})`);
         } else if (nativeFromFallback && reqModel) {
             // Self-heal UPWARD — complement of the overflow self-heal above. An
             // overflow only proves the window is SMALLER; a too-small fallback
@@ -1462,11 +1469,14 @@ async function handle(
             const prevWindow = session.metadata.lastTurnWindow as number | undefined;
             const resolved = reqConfig.modelContextLimit;
             if (prevWindow !== undefined && prevInput > prevWindow && prevInput > resolved && prevInput >= 1000) {
-                const map = (session.metadata.learnedContextLimits as Record<string, number> | undefined) ?? {};
+                // #570: a successful turn's reported input is grounded evidence
+                // (the upstream accepted it), so it lands in the CONFIRMED
+                // fields — a later weak-overflow heuristic must not clobber it.
+                const map = (session.metadata.confirmedContextLimits as Record<string, number> | undefined) ?? {};
                 const prev = map[reqModel];
                 if (prev === undefined || prevInput > prev) {
                     map[reqModel] = prevInput;
-                    session.metadata.learnedContextLimits = map;
+                    session.metadata.confirmedContextLimits = map;
                     markDirty(session);
                 }
                 reqConfig = { ...reqConfig, modelContextLimit: prevInput };
@@ -2774,10 +2784,7 @@ async function preflightCompressIfNeeded(
     // (it counts rejected image tokens) → later requests fail-fast. #488's 400 loop stays
     // broken (exactly one rejected forward). With either evidence signal present we trust
     // the estimate and fall through to fold / fail-fast below.
-    const learnedMap = session.metadata.learnedContextLimits as Record<string, number> | undefined;
-    const learnedLimit =
-        (model ? learnedMap?.[model] : undefined) ??
-        (session.metadata.learnedContextLimit as number | undefined);
+    const learnedLimit = resolveLearnedLimit(session, model);
     const noOverflowEvidence = session.stats.lastInputTokens < limit && learnedLimit === undefined;
     if (imageTokens > 0 && textEstimate < limit && noOverflowEvidence) {
         log("warn", `[${session.id}] image-dominated payload (~${textEstimate} text + ~${imageTokens} image tokens) exceeds window ${limit} by estimate only, no upstream overflow evidence — forwarding once so the upstream arbitrates billing (#496)`);
@@ -3185,15 +3192,19 @@ async function forward(
                 } catch {
                     reqModel = undefined; // non-JSON body — fall back to the legacy scalar
                 }
-                const learnedMap = (s.metadata.learnedContextLimits as Record<string, number> | undefined) ?? {};
+                // #570 provenance: an actual non-2xx overflow rejection is
+                // STRONG evidence — it lands in the CONFIRMED fields, which
+                // take precedence over the weak-overflow heuristic's guesses
+                // and are never clobbered by them.
+                const confirmedMap = (s.metadata.confirmedContextLimits as Record<string, number> | undefined) ?? {};
                 if (info.window) {
-                    const prev = (reqModel ? learnedMap[reqModel] : undefined) ?? (s.metadata.learnedContextLimit as number | undefined);
+                    const prev = (reqModel ? confirmedMap[reqModel] : undefined) ?? (s.metadata.confirmedContextLimit as number | undefined);
                     // Persist the real window to a STABLE field (effectiveContextLimit
                     // is re-resolved every turn in plugin mode and would be overwritten);
                     // handle() reads it (per model) to re-center the kernel next turn.
-                    if (reqModel) learnedMap[reqModel] = info.window;
-                    else s.metadata.learnedContextLimit = info.window;
-                    s.metadata.learnedContextLimits = learnedMap;
+                    if (reqModel) confirmedMap[reqModel] = info.window;
+                    else s.metadata.confirmedContextLimit = info.window;
+                    s.metadata.confirmedContextLimits = confirmedMap;
                     log("warn", `[${s.id}] upstream context overflow — learned real window ${info.window} for ${reqModel ?? "(unknown model)"} (was ${prev ?? "unset"}); arming emergency shrink`);
                 } else {
                     // No window number in the body (e.g. Codex's
@@ -3207,11 +3218,11 @@ async function forward(
                     const payloadEstimate = (prepared.processedMessages.length > 0
                         ? estimateCoreMessages(prepared.processedMessages)
                         : estimateRawBodyTokens(parsedBody)) + rejectedImageTokens;
-                    const prev = (reqModel ? learnedMap[reqModel] : undefined) ?? (s.metadata.learnedContextLimit as number | undefined);
+                    const prev = (reqModel ? confirmedMap[reqModel] : undefined) ?? (s.metadata.confirmedContextLimit as number | undefined);
                     if (payloadEstimate >= 1000 && (prev === undefined || payloadEstimate < prev)) {
-                        if (reqModel) learnedMap[reqModel] = payloadEstimate;
-                        else s.metadata.learnedContextLimit = payloadEstimate;
-                        s.metadata.learnedContextLimits = learnedMap;
+                        if (reqModel) confirmedMap[reqModel] = payloadEstimate;
+                        else s.metadata.confirmedContextLimit = payloadEstimate;
+                        s.metadata.confirmedContextLimits = confirmedMap;
                         log("warn", `[${s.id}] upstream context overflow (window not parseable) — learned conservative window ${payloadEstimate} for ${reqModel ?? "(unknown model)"} from rejected payload size (was ${prev ?? "unset"}); arming emergency shrink`);
                     } else {
                         log("warn", `[${s.id}] upstream context overflow (window not parseable): ${info.message}`);
@@ -3219,16 +3230,22 @@ async function forward(
                 }
                 // Arm the emergency shrink: force the next turn's usage to >=100%
                 // so the kernel's emergency nudge + tool-result truncate fire.
-                // lastInputTokens is a lower bound here (the context overflowed,
-                // so it is at least the window); a real usage report from the
-                // next successful turn overwrites it.
-                const floor =
-                    info.window ??
-                    (reqModel ? learnedMap[reqModel] : undefined) ??
-                    (s.metadata.learnedContextLimit as number | undefined) ??
-                    (s.metadata.effectiveContextLimit as number | undefined) ??
-                    0;
-                if (floor > 0) s.stats.lastInputTokens = Math.max(s.stats.lastInputTokens, floor);
+                // With a parsed window, arm at EXACTLY it: a turn cannot succeed
+                // above the real window, so any higher armed value came from an
+                // earlier FAILED turn, and #570's retraction must not mistake
+                // that failure's size for a success and delete the window we
+                // just learned. Without one, keep the max-floor (a real usage
+                // report from the next successful turn overwrites either way).
+                if (info.window) {
+                    s.stats.lastInputTokens = info.window;
+                } else {
+                    const floor =
+                        (reqModel ? confirmedMap[reqModel] : undefined) ??
+                        (s.metadata.confirmedContextLimit as number | undefined) ??
+                        (s.metadata.effectiveContextLimit as number | undefined) ??
+                        0;
+                    if (floor > 0) s.stats.lastInputTokens = Math.max(s.stats.lastInputTokens, floor);
+                }
                 // The learned window (metadata) and the armed emergency
                 // (lastInputTokens) live in memory only until scheduled —
                 // the error path returns before forward()'s trailing

--- a/src/util.ts
+++ b/src/util.ts
@@ -171,6 +171,7 @@ const CONTEXT_OVERFLOW_PATTERNS: RegExp[] = [
     /token limit exceeded/i,
     // #554: llama.cpp-family "exceed_context_size_error (A / B > W)" — carried by
     // side requests that bypass preflight; without it the learned channel learns nothing.
+    // #570: its body also carries the real window, see parseOverflowWindow.
     /exceed[_\s]?context[_\s]?size/i,
 ];
 
@@ -188,9 +189,9 @@ function parseOverflowWindow(text: string): number | undefined {
     // "130000 tokens > 128000 maximum" (Anthropic) → the maximum, not the total.
     let m = text.match(/>\s*(\d[\d,]*)\s*maximum/i);
     if (m) return toTokenNumber(m[1]);
-    // #554: "exceed_context_size_error (198,277 / 198,661 > 150,528)" (llama.cpp
-    // family) — A/B are payload sizes; only the number after ">" inside the
-    // parens is the limit.
+    // #554/#570: "exceed_context_size_error (198,277 / 198,661 > 150,528)"
+    // (llama.cpp family) — A/B are payload sizes; only the number after ">" inside
+    // the parens is the limit.
     m = text.match(/\(\s*\d[\d,]*\s*\/\s*\d[\d,]*\s*>\s*(\d[\d,]+)\s*\)/);
     if (m) return toTokenNumber(m[1]);
     m =

--- a/src/weak-overflow.ts
+++ b/src/weak-overflow.ts
@@ -20,12 +20,38 @@ import { log as loggerLog } from "./logger.js";
  * #351/#499 failure family: oversized requests never succeed, never cache,
  * and never self-heal — without this, the session loops on truncated
  * streams until the client gives up.
+ *
+ * #570: everything learned here is a HYPOTHESIS. A high-usage truncation
+ * cannot be distinguished in-band from other mid-stream deaths (upstream KV
+ * exhaustion under concurrent sessions, OOM, network reset), so a confirmed
+ * pattern can be a false positive that permanently throttles the session
+ * below its true window once persisted. Two guards make the mechanism
+ * self-correcting:
+ *   - PROVENANCE: strong evidence (an actual non-2xx overflow rejection)
+ *     lives in metadata.confirmedContextLimits and takes precedence over any
+ *     weak hypothesis; noteWeakOverflow never writes while a confirmed
+ *     window governs, so speculation can no longer clobber ground truth.
+ *   - RETRACTION: a learned/confirmed window is deleted as soon as a later
+ *     turn SUCCEEDS with upstream-reported input above it (retractStaleLearnedLimits,
+ *     called from server.ts handle() before self-heal resolution) — the
+ *     upstream demonstrably accepted more than the "window", so the value is
+ *     stale regardless of how it was learned. A true overflow can never be
+ *     contradicted this way: a request above the real window cannot succeed,
+ *     and failed turns cannot fake one — while a window governs, their armed
+ *     lastInputTokens is capped at the governing value (a parsed overflow
+ *     resets it to exactly the learned window).
  */
 
 const MIN_USAGE = 0.9;
 const WINDOW_MS = 15 * 60 * 1000;
 const MIN_EVENTS = 3;
 const MAX_TRACKED_SESSIONS = 512;
+// #570 retraction margin: lastInputTokens is upstream-reported on success but
+// estimate-netted after folds — only retract beyond this so estimation noise
+// can't undo a genuinely-needed small window (a false retraction self-heals:
+// the next overflow re-learns).
+const RETRACT_MARGIN_PCT = 0.03;
+const RETRACT_MIN_DELTA = 256;
 
 interface WeakOverflowState {
     events: number[];
@@ -33,9 +59,63 @@ interface WeakOverflowState {
 
 const states = new Map<string, WeakOverflowState>();
 
-function resolvedWindow(session: Session): number {
+/** Strong evidence only: windows the upstream itself stated in an overflow
+ *  rejection (or established from a rejected payload's size). Per-model entry
+ *  first, then the model-unknown scalar fallback. */
+export function resolveConfirmedLimit(session: Session, model?: string): number | undefined {
     const md = (session.metadata ?? {}) as Record<string, unknown>;
-    const learned = md.learnedContextLimit as number | undefined;
+    const map = md.confirmedContextLimits as Record<string, number> | undefined;
+    return (model ? map?.[model] : undefined) ?? (md.confirmedContextLimit as number | undefined);
+}
+
+/** Weak hypotheses only: values written by noteWeakOverflow (and legacy
+ *  stores, where weak and strong values share these fields). */
+export function resolveSpeculativeLimit(session: Session, model?: string): number | undefined {
+    const md = (session.metadata ?? {}) as Record<string, unknown>;
+    const map = md.learnedContextLimits as Record<string, number> | undefined;
+    return (model ? map?.[model] : undefined) ?? (md.learnedContextLimit as number | undefined);
+}
+
+/** Best known limit for this session/model (#570 provenance order):
+ *  confirmed per-model > speculative per-model > confirmed scalar > speculative scalar. */
+export function resolveLearnedLimit(session: Session, model?: string): number | undefined {
+    const perModel = model
+        ? (resolveConfirmedLimit(session, model) ?? resolveSpeculativeLimit(session, model))
+        : undefined;
+    return perModel ?? resolveConfirmedLimit(session) ?? resolveSpeculativeLimit(session);
+}
+
+/** #570: a window that a later SUCCESSFUL turn exceeded is stale — the
+ *  upstream accepted more input than the "window", so it is a false positive
+ *  (KV pressure / OOM / network death counted as overflow) or the server was
+ *  resized. Delete every stale value for this model (plus the model-unknown
+ *  scalars) so the configured window applies again. Returns true when
+ *  anything was retracted. */
+export function retractStaleLearnedLimits(session: Session, model?: string): boolean {
+    const x = session.stats?.lastInputTokens ?? 0;
+    if (!(x > 0)) return false;
+    const stale = (v: unknown): v is number =>
+        typeof v === "number" && v > 0 && x - v >= Math.max(RETRACT_MIN_DELTA, v * RETRACT_MARGIN_PCT);
+    const md = (session.metadata ?? {}) as Record<string, unknown>;
+    const removed: string[] = [];
+    const cm = md.confirmedContextLimits as Record<string, number> | undefined;
+    const lm = md.learnedContextLimits as Record<string, number> | undefined;
+    if (model) {
+        if (cm && stale(cm[model])) { removed.push(`confirmed ${cm[model]}`); delete cm[model]; }
+        if (lm && stale(lm[model])) { removed.push(`learned ${lm[model]}`); delete lm[model]; }
+    }
+    if (stale(md.confirmedContextLimit)) { removed.push(`confirmed ${String(md.confirmedContextLimit)}`); delete md.confirmedContextLimit; }
+    if (stale(md.learnedContextLimit)) { removed.push(`learned ${String(md.learnedContextLimit)}`); delete md.learnedContextLimit; }
+    if (removed.length === 0) return false;
+    session.metadata = md;
+    loggerLog("warn", `[${session.id}] retracted stale context window(s) [${removed.join(", ")}] for ${model ?? "(unknown model)"} — a later turn succeeded at ${x} input tokens above them; using the configured window again`);
+    markDirty(session);
+    return true;
+}
+
+function resolvedWindow(session: Session, model?: string): number {
+    const md = (session.metadata ?? {}) as Record<string, unknown>;
+    const learned = resolveLearnedLimit(session, model);
     const effective = md.effectiveContextLimit as number | undefined;
     const candidates = [learned, effective].filter((v): v is number => typeof v === "number" && v > 0);
     if (candidates.length === 0) return 0;
@@ -52,7 +132,7 @@ export function noteWeakOverflow(
     session: Session,
     opts: { inputTokens?: number; model?: string; reason: string },
 ): void {
-    const window = resolvedWindow(session);
+    const window = resolvedWindow(session, opts.model);
     if (window <= 0) return;
     const input = opts.inputTokens && opts.inputTokens > 0 ? opts.inputTokens : session.stats?.lastInputTokens ?? 0;
     if (input <= 0) return;
@@ -74,21 +154,36 @@ export function noteWeakOverflow(
     states.delete(session.id);
 
     const md = ((session.metadata ?? {}) as Record<string, unknown>);
-    if (md.learnedContextLimits === undefined) md.learnedContextLimits = {};
-    const learnedMap = md.learnedContextLimits as Record<string, number>;
     const reqModel = opts.model;
-    const prev = (reqModel ? learnedMap[reqModel] : undefined) ?? (md.learnedContextLimit as number | undefined);
-    // Shrink-only: a previously learned (smaller) value is the tighter bound.
-    if (prev === undefined || input < prev) {
-        if (reqModel) learnedMap[reqModel] = input;
-        else md.learnedContextLimit = input;
-        session.metadata = md;
-        loggerLog("warn", `[${session.id}] weak overflow confirmed (${MIN_EVENTS}× high-usage failures, ${opts.reason}) — learned conservative window ${input} for ${reqModel ?? "(unknown model)"} (was ${prev ?? "unset"}); arming emergency shrink`);
+    // #570: ground truth governs. While a CONFIRMED window (learned from an
+    // actual upstream overflow rejection) exists for this model, a speculative
+    // truncation count must not overwrite it with a smaller guess — that is
+    // exactly how KV-pressure false positives poisoned real windows. The
+    // transient emergency shrink below still unblocks the loop either way.
+    const confirmed = resolveConfirmedLimit(session, reqModel);
+    // A mid-stream death ABOVE a governing confirmed window cannot be a window
+    // overflow (above the real window the upstream rejects outright, it does
+    // not kill mid-stream) — cap the armed value at the window so #570's
+    // retraction never reads this failure's size as "a later success".
+    const armInput = confirmed !== undefined && confirmed > 0 ? Math.min(input, confirmed) : input;
+    if (confirmed !== undefined && confirmed > 0) {
+        loggerLog("warn", `[${session.id}] weak overflow confirmed (${MIN_EVENTS}× high-usage failures, ${opts.reason}) — confirmed window ${confirmed} governs (failing input ${input}); arming emergency shrink only, learned window untouched`);
     } else {
-        loggerLog("warn", `[${session.id}] weak overflow confirmed (${MIN_EVENTS}× high-usage failures, ${opts.reason}) — conservative window ${input} not below learned ${prev}; arming emergency shrink only`);
+        if (md.learnedContextLimits === undefined) md.learnedContextLimits = {};
+        const learnedMap = md.learnedContextLimits as Record<string, number>;
+        const prev = (reqModel ? learnedMap[reqModel] : undefined) ?? (md.learnedContextLimit as number | undefined);
+        // Shrink-only: a previously learned (smaller) value is the tighter bound.
+        if (prev === undefined || input < prev) {
+            if (reqModel) learnedMap[reqModel] = input;
+            else md.learnedContextLimit = input;
+            session.metadata = md;
+            loggerLog("warn", `[${session.id}] weak overflow confirmed (${MIN_EVENTS}× high-usage failures, ${opts.reason}) — learned conservative window ${input} for ${reqModel ?? "(unknown model)"} (was ${prev ?? "unset"}); arming emergency shrink`);
+        } else {
+            loggerLog("warn", `[${session.id}] weak overflow confirmed (${MIN_EVENTS}× high-usage failures, ${opts.reason}) — conservative window ${input} not below learned ${prev}; arming emergency shrink only`);
+        }
     }
-    if (!session.stats) session.stats = { lastInputTokens: input } as Session["stats"];
-    else session.stats.lastInputTokens = Math.max(session.stats.lastInputTokens, input);
+    if (!session.stats) session.stats = { lastInputTokens: armInput } as Session["stats"];
+    else session.stats.lastInputTokens = Math.max(session.stats.lastInputTokens, armInput);
     markDirty(session);
 }
 

--- a/tests/context-overflow.test.ts
+++ b/tests/context-overflow.test.ts
@@ -53,6 +53,18 @@ test("sglang: 'input (N tokens) is longer than the model's context length (M tok
     assert.equal(info2.window, 262144);
 });
 
+test("llama.cpp: 'exceed_context_size_error (N / M > W)' → overflow + window W (#570)", () => {
+    // Captured shape from a real llama-server rejection. The window must be W
+    // (the limit AFTER '>'), not N or M — learning either of those would
+    // self-heal to a window far above the real one.
+    const body = JSON.stringify({
+        error: { message: "exceed_context_size_error (198,277 / 198,661 > 150,528)", type: "invalid_request_error", code: 400 },
+    });
+    const info = inspectContextOverflow(400, body);
+    assert.equal(info.isOverflow, true);
+    assert.equal(info.window, 150528);
+});
+
 test("Anthropic: 'prompt is too long: X tokens > Y maximum' → window is Y", () => {    const body = JSON.stringify({
         type: "error",
         error: { type: "invalid_request_error", message: "prompt is too long: 130000 tokens > 128000 maximum" },

--- a/tests/e2e-overflow-selfheal.test.ts
+++ b/tests/e2e-overflow-selfheal.test.ts
@@ -10,13 +10,14 @@ import { startServer, type ProxyOptions } from "../src/server.ts";
 import { SessionStore, _setStoreForTest } from "../src/persist.ts";
 import { _setForTest as setRegistryForTest } from "../src/registry.ts";
 import { listSessions, type Session } from "../src/session.ts";
+import { noteWeakOverflow } from "../src/weak-overflow.ts";
 
 // The configured window here is deliberately LARGE (400k) so it plays the role
 // of a wrong/mis-detected window (the 200k-fallback footgun for an unknown
 // model on a relay). The upstream truthfully reports its real window (128000)
 // via a context-overflow 400. The proxy must:
 //   1. detect the overflow and pass the 400 + body through verbatim;
-//   2. learn the real window (128000) into session.metadata.learnedContextLimits,
+//   2. learn the real window (128000) into session.metadata.confirmedContextLimits,
 //      keyed by the model that overflowed;
 //   3. arm an emergency shrink (lastInputTokens >= window);
 //   4. let the NEXT request recover (self-healed window, upstream 200);
@@ -109,10 +110,10 @@ test("e2e: upstream context overflow → learn window + arm shrink + pass throug
         assert.ok(r1text.includes("prompt is too long"), "error body must pass through");
 
         // The session learned the real window (per model) and armed the emergency shrink.
-        const s = listSessions().find((x) => (x.metadata.learnedContextLimits as Record<string, number> | undefined)?.["claude-test"] === 128000);
+        const s = listSessions().find((x) => (x.metadata.confirmedContextLimits as Record<string, number> | undefined)?.["claude-test"] === 128000);
         assert.ok(s, "a session learned the real window from the overflow (keyed by model)");
-        assert.equal(s!.metadata.learnedContextLimit, undefined, "no legacy scalar when the model is known");
-        assert.ok(s!.stats.lastInputTokens >= 128000, "emergency shrink armed (lastInputTokens >= window)");
+        assert.equal(s!.metadata.confirmedContextLimit, undefined, "no legacy scalar when the model is known");
+        assert.equal(s!.stats.lastInputTokens, 128000, "emergency shrink armed at exactly the parsed window (#570 guard)");
 
         // The prepare phase marks the session dirty once per request; the
         // overflow error path must add its OWN save for the learned window +
@@ -145,7 +146,7 @@ test("e2e: upstream context overflow → learn window + arm shrink + pass throug
         assert.equal(r3.status, 200);
         await r3.text(); // drain
         const s3 = listSessions().find((x) => x.id === s!.id);
-        const limits = s3?.metadata.learnedContextLimits as Record<string, number> | undefined;
+        const limits = s3?.metadata.confirmedContextLimits as Record<string, number> | undefined;
         assert.equal(limits?.["claude-big"], undefined, "no learned limit for the other model");
         assert.deepEqual(Object.keys(limits ?? {}), ["claude-test"], "only the overflowing model is scoped");
     } finally {
@@ -270,10 +271,10 @@ test("e2e #280: Codex overflow without window number → learn conservative wind
         // The proxy recognized the overflow and learned a conservative window
         // from the rejected payload's size (~13k tokens, NOT the configured 400k).
         const s = listSessions().find(
-            (x) => (x.metadata.learnedContextLimits as Record<string, number> | undefined)?.["claude-test"] !== undefined,
+            (x) => (x.metadata.confirmedContextLimits as Record<string, number> | undefined)?.["claude-test"] !== undefined,
         );
         assert.ok(s, "session learned a conservative window from the rejected payload");
-        const learned = (s!.metadata.learnedContextLimits as Record<string, number>)["claude-test"];
+        const learned = (s!.metadata.confirmedContextLimits as Record<string, number>)["claude-test"];
         assert.ok(learned >= 1000 && learned < 20_000, `conservative window ≈ rejected payload size (got ${learned})`);
         assert.ok(s!.stats.lastInputTokens >= learned, "emergency shrink armed (lastInputTokens >= learned window)");
 
@@ -302,6 +303,96 @@ test("e2e #280: Codex overflow without window number → learn conservative wind
         // through the proxy, so it lands no usage on this session.)
         const s2 = listSessions().find((x) => x.id === s!.id);
         assert.equal(s2?.stats.lastInputTokens, 5000);
+    } finally {
+        proxy.close();
+        await once(proxy, "close");
+        upstream.close();
+        await once(upstream, "close");
+    }
+});
+
+// #570 review guard: three KV-pressure-style mid-stream deaths ABOVE the true
+// window inflate lastInputTokens via noteWeakOverflow. When the genuine
+// overflow then parses the real window, the armed value must be reset to
+// EXACTLY it — otherwise the next request's retraction check reads the
+// failures' size as "a later success" and deletes the just-learned confirmed
+// window, contradicting the fix's own invariant (a true overflow cannot be
+// contradicted by a success, because one cannot happen above the real window).
+test("e2e #570: failed-turn arms above the true window do not retract the learned window", async () => {
+    let call = 0;
+    const upstream = http.createServer((req, res) => {
+        req.on("data", () => {});
+        req.on("end", () => {
+            // call 0: warmup success; call 1: genuine overflow 400; rest: 200.
+            if (call === 1) {
+                res.writeHead(400, { "content-type": "application/json" });
+                res.end(OVERFLOW_BODY);
+            } else {
+                res.writeHead(200, { "content-type": "text/event-stream" });
+                res.end(okSse());
+            }
+            call += 1;
+        });
+    });
+    upstream.listen(0, "127.0.0.1");
+    await once(upstream, "listening");
+    const upstreamPort = upstream.address().port;
+
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    setRegistryForTest({});
+    const proxy = await startServer({
+        port: 0,
+        host: "127.0.0.1",
+        upstream: "http://127.0.0.1",
+        routes: { [`http://127.0.0.1:${upstreamPort}`]: { models: { "claude-test": { context: 400_000 } } } },
+        modelContextLimit: 400_000,
+        kernelConfig: defaultConfig(400_000),
+        compress: { injectTool: true, injectNudge: true },
+        promptCache: { routing: "auto" },
+        sessionHeader: "x-acp-session",
+        log: false,
+        debug: false,
+        passthrough: false,
+        autoUpdate: false,
+        mitm: { enabled: false, domains: [] },
+    } as ProxyOptions);
+    await once(proxy, "listening");
+    const proxyPort = proxy.address().port;
+
+    try {
+        const url = `http://127.0.0.1:${proxyPort}/bili/http://127.0.0.1:${upstreamPort}/v1/messages`;
+        const body = JSON.stringify({ model: "claude-test", max_tokens: 1024, stream: true, messages: [{ role: "user", content: "hello" }] });
+        const headers = { "content-type": "application/json", "x-acp-session": "retract-sess" };
+
+        const before = new Set(listSessions().map((x) => x.id));
+        const r0 = await fetch(url, { method: "POST", headers, body });
+        assert.equal(r0.status, 200);
+        await r0.text();
+        const sess = listSessions().find((x) => !before.has(x.id));
+        assert.ok(sess, "warmup request created the session");
+
+        // Three high-usage mid-stream deaths at 370k — above the true window
+        // (128000), >= 90% of the configured 400k: the #570 KV-pressure pattern.
+        for (const r of ["r1", "r2", "r3"]) {
+            noteWeakOverflow(sess!, { inputTokens: 370_000, model: "claude-test", reason: r });
+        }
+        assert.equal(sess!.stats.lastInputTokens, 370_000, "failure arms inflated the high-water mark above the true window");
+
+        // The genuine overflow learns the real window.
+        const r1 = await fetch(url, { method: "POST", headers, body });
+        assert.equal(r1.status, 400);
+        await r1.text();
+        const s1 = listSessions().find((x) => x.id === sess!.id);
+        assert.equal((s1!.metadata.confirmedContextLimits as Record<string, number>)["claude-test"], 128000, "real window learned from the overflow body");
+        assert.equal(s1!.stats.lastInputTokens, 128000, "#570 guard: armed at exactly the parsed window, not the failures' 370k");
+
+        // Next request: retraction runs BEFORE resolution — the capped arm must
+        // not delete the just-learned window.
+        const r2 = await fetch(url, { method: "POST", headers, body });
+        assert.equal(r2.status, 200, "recovery request succeeds");
+        await r2.text();
+        const s2 = listSessions().find((x) => x.id === sess!.id);
+        assert.equal((s2!.metadata.confirmedContextLimits as Record<string, number>)["claude-test"], 128000, "learned window survived the next request's retraction check");
     } finally {
         proxy.close();
         await once(proxy, "close");

--- a/tests/issue-393-registry-window.test.ts
+++ b/tests/issue-393-registry-window.test.ts
@@ -183,7 +183,7 @@ test("#393: self-heal raises a too-small fallback window when a turn exceeded it
         await r2.text();
         sess = listSessions().find((s) => s.id === "selfheal-sess")!;
         assert.equal(sess.metadata.effectiveContextLimit, 300_000, "window raised to the observed input");
-        assert.equal((sess.metadata.learnedContextLimits as Record<string, number>)["claude-unknown"], 300_000, "learned window persisted per model");
+        assert.equal((sess.metadata.confirmedContextLimits as Record<string, number>)["claude-unknown"], 300_000, "learned window persisted per model");
     } finally {
         await closeRig(rig);
     }

--- a/tests/issue496-forward-once-learn.test.ts
+++ b/tests/issue496-forward-once-learn.test.ts
@@ -111,9 +111,9 @@ test("e2e #496 (byte-counting relay): one rejected forward, then fail-fast — t
 
         // The self-heal recognized the overflow and learned a conservative window from
         // the REJECTED payload size (which counts the images, #488), arming the shrink.
-        const s = listSessions().find((x) => (x.metadata.learnedContextLimits as Record<string, number> | undefined)?.["claude-img"] !== undefined);
+        const s = listSessions().find((x) => (x.metadata.confirmedContextLimits as Record<string, number> | undefined)?.["claude-img"] !== undefined);
         assert.ok(s, "session learned a conservative window from the rejected multimodal payload");
-        const learned = (s!.metadata.learnedContextLimits as Record<string, number>)["claude-img"];
+        const learned = (s!.metadata.confirmedContextLimits as Record<string, number>)["claude-img"];
         assert.ok(learned >= 1000 && learned > 10_000, `learned window reflects the image-heavy payload (got ${learned})`);
         assert.ok(s!.stats.lastInputTokens >= learned, "emergency shrink armed (lastInputTokens >= learned window)");
 

--- a/tests/side-request-isolation.test.ts
+++ b/tests/side-request-isolation.test.ts
@@ -447,7 +447,7 @@ test("e2e: overflow 400 on a side request learns the real window; next one is bl
         await r1.text();
         const s1 = getSession(SESSION);
         assert.ok(s1);
-        assert.equal((s1.metadata.learnedContextLimits as Record<string, number>)[MODEL], 120_000, "real window learned from the overflow marker");
+        assert.equal((s1.metadata.confirmedContextLimits as Record<string, number>)[MODEL], 120_000, "real window learned (confirmed channel, #572) from the overflow marker");
         assert.equal(s1.stats.lastInputTokens, 120_000, "emergency shrink armed at the learned window");
 
         // Identical second request: now blocked locally — no second upstream hit.

--- a/tests/weak-overflow.test.ts
+++ b/tests/weak-overflow.test.ts
@@ -1,6 +1,6 @@
 import { test, beforeEach } from "node:test";
 import assert from "node:assert/strict";
-import { noteWeakOverflow, resetWeakOverflow } from "../src/weak-overflow.ts";
+import { noteWeakOverflow, resetWeakOverflow, resolveConfirmedLimit, resolveLearnedLimit, retractStaleLearnedLimits } from "../src/weak-overflow.ts";
 import type { Session } from "../src/session.ts";
 
 const ids: string[] = [];
@@ -88,4 +88,107 @@ test("falls back to lastInputTokens when inputTokens is absent", () => {
     noteWeakOverflow(session, { reason: "r2" });
     noteWeakOverflow(session, { reason: "r3" });
     assert.equal(session.metadata.learnedContextLimit, 92000);
+});
+
+function makeSessionWithMaps(opts: {
+    window?: number;
+    learnedMap?: Record<string, number>;
+    confirmedMap?: Record<string, number>;
+    learnedScalar?: number;
+    confirmedScalar?: number;
+    lastInput?: number;
+}): Session {
+    const metadata: Record<string, unknown> = { effectiveContextLimit: opts.window ?? 140000 };
+    if (opts.learnedMap) metadata.learnedContextLimits = opts.learnedMap;
+    if (opts.confirmedMap) metadata.confirmedContextLimits = opts.confirmedMap;
+    if (opts.learnedScalar !== undefined) metadata.learnedContextLimit = opts.learnedScalar;
+    if (opts.confirmedScalar !== undefined) metadata.confirmedContextLimit = opts.confirmedScalar;
+    const session = {
+        id: `weak-${Math.random().toString(36).slice(2, 8)}`,
+        metadata,
+        stats: { lastInputTokens: opts.lastInput ?? 0 },
+    } as unknown as Session;
+    ids.push(session.id);
+    return session;
+}
+
+test("#570: a confirmed window governs — weak confirmations never clobber it", () => {
+    const session = makeSessionWithMaps({ confirmedMap: { qwen: 150528 } });
+    for (const r of ["r1", "r2", "r3"]) {
+        noteWeakOverflow(session, { inputTokens: 134000, model: "qwen", reason: r });
+    }
+    assert.deepEqual(session.metadata.confirmedContextLimits, { qwen: 150528 }, "confirmed window untouched");
+    assert.equal(session.metadata.learnedContextLimits, undefined, "no speculative write while a confirmed value governs");
+    assert.equal((session.stats as { lastInputTokens: number }).lastInputTokens, 134000, "emergency shrink still armed");
+});
+
+test("#570: weak confirmations still refine their own speculative values", () => {
+    const session = makeSessionWithMaps({ learnedMap: { qwen: 130000 } });
+    for (const r of ["r1", "r2", "r3"]) {
+        noteWeakOverflow(session, { inputTokens: 125000, model: "qwen", reason: r });
+    }
+    assert.equal((session.metadata.learnedContextLimits as Record<string, number>).qwen, 125000);
+});
+
+test("#570 retraction: a successful turn above the learned window removes it", () => {
+    const session = makeSessionWithMaps({ learnedMap: { qwen: 121815 }, lastInput: 126000 });
+    assert.equal(retractStaleLearnedLimits(session, "qwen"), true);
+    assert.equal((session.metadata.learnedContextLimits as Record<string, number>).qwen, undefined);
+});
+
+test("#570 retraction: within the margin the value survives (estimation noise)", () => {
+    const session = makeSessionWithMaps({ learnedMap: { qwen: 121815 }, lastInput: 125000 });
+    assert.equal(retractStaleLearnedLimits(session, "qwen"), false);
+    assert.equal((session.metadata.learnedContextLimits as Record<string, number>).qwen, 121815);
+});
+
+test("#570 retraction: the armed emergency value (== learned) never retracts itself", () => {
+    const session = makeSessionWithMaps({ learnedMap: { qwen: 121815 }, lastInput: 121815 });
+    assert.equal(retractStaleLearnedLimits(session, "qwen"), false);
+    assert.equal((session.metadata.learnedContextLimits as Record<string, number>).qwen, 121815);
+});
+
+test("#570 retraction: confirmed values retract too (resized server / KV growth)", () => {
+    const session = makeSessionWithMaps({ confirmedMap: { qwen: 150528 }, lastInput: 160000 });
+    assert.equal(retractStaleLearnedLimits(session, "qwen"), true);
+    assert.equal((session.metadata.confirmedContextLimits as Record<string, number>).qwen, undefined);
+});
+
+test("#570 retraction: other models' entries survive; stale model-unknown scalars go too", () => {
+    const session = makeSessionWithMaps({
+        learnedMap: { qwen: 121815, other: 90000 },
+        learnedScalar: 110000,
+        lastInput: 130000,
+    });
+    assert.equal(retractStaleLearnedLimits(session, "qwen"), true);
+    assert.equal((session.metadata.learnedContextLimits as Record<string, number>).other, 90000, "other model untouched");
+    assert.equal(session.metadata.learnedContextLimit, undefined, "stale scalar retracted");
+});
+
+test("#570 resolvers: confirmed > speculative, per-model > scalar", () => {
+    const s = makeSessionWithMaps({
+        learnedMap: { qwen: 100000 },
+        confirmedMap: { qwen: 150000 },
+        learnedScalar: 90000,
+        confirmedScalar: 80000,
+    });
+    assert.equal(resolveLearnedLimit(s, "qwen"), 150000, "confirmed per-model wins");
+    assert.equal(resolveLearnedLimit(s, "other"), 80000, "unknown model → confirmed scalar");
+    const s2 = makeSessionWithMaps({ learnedMap: { qwen: 100000 }, learnedScalar: 90000 });
+    assert.equal(resolveLearnedLimit(s2, "qwen"), 100000, "speculative per-model next");
+    assert.equal(resolveLearnedLimit(s2, "other"), 90000, "falls back to the speculative scalar");
+    assert.equal(resolveConfirmedLimit(s2, "other"), undefined);
+});
+
+test("#570 guard: weak confirmations under a confirmed window cap the armed value at the window", () => {
+    // A mid-stream death ABOVE the confirmed window is a non-window kill mode
+    // (KV pressure / OOM / reset) — arming at its size would let retraction
+    // mistake the failure for "a later success" and delete the ground truth.
+    const session = makeSessionWithMaps({ confirmedMap: { qwen: 150528 }, window: 200000 });
+    for (const r of ["r1", "r2", "r3"]) {
+        noteWeakOverflow(session, { inputTokens: 185000, model: "qwen", reason: r });
+    }
+    assert.equal((session.stats as { lastInputTokens: number }).lastInputTokens, 150528, "armed at the confirmed window, not the failure's size");
+    assert.equal(retractStaleLearnedLimits(session, "qwen"), false, "the capped arm cannot retract the governing window");
+    assert.deepEqual(session.metadata.confirmedContextLimits, { qwen: 150528 }, "confirmed window intact");
 });


### PR DESCRIPTION
## Problem (#570)

The weak-overflow heuristic (3 high-usage stream truncations in 15 min) and the strong path (a real non-2xx overflow rejection) both wrote into the same per-model `learnedContextLimits`. Any mid-stream death — llama.cpp shared-KV exhaustion (`failed to find free space in the KV cache`), OOM, network reset — looked like an overflow, so one misjudged session permanently shrank the model's window for every later session, across restarts, with no correction path: the only upward self-heal is gated on fallback windows, never on the authoritative configured value.

## Fix (three parts)

1. **Provenance split.** Strong evidence (an actual non-2xx overflow rejection, incl. the payload-size upper bound) now lands in `metadata.confirmedContextLimits` / `confirmedContextLimit`; the weak heuristic keeps writing only to `learnedContextLimits` / `learnedContextLimit`. Resolution order is confirmed > speculative, so a weak guess can no longer clobber a confirmed window.

2. **Retraction.** A successful turn whose upstream-reported input exceeds a learned window beyond a margin (`max(256 tokens, 3%)`) proves it stale — KV-pressure false positive, resized server, … — and removes it *before* this request's config is resolved. True overflows cannot be contradicted (a turn cannot succeed above the real window); the armed emergency value (== the learned value exactly) sits below the margin and never retracts itself.

3. **Ground truth for llama.cpp.** `inspectContextOverflow` now recognizes `exceed_context_size_error` and parses the real limit from the `(N / M > W)` body shape, so a genuine overflow learns W instead of letting the weak path guess.

Both compression modes considered: plugin mode (agent-owned compression; proxy suppresses injection) and proxy mode — the changed paths are upstream-facing (error inspection, per-request limit resolution, session metadata) and identical on both; no wire-format change.

## Pre-flight

- `npm run typecheck` — clean
- `npm test` — 1056/1057 pass; the single failure (`launcher.test.ts: resolveClientCommand codex/claude resolve to themselves`) is pre-existing on clean master in this environment (sandbox stub at `/usr/bin/codex` makes the resolver return an absolute path) and unrelated to this change
- `npm run build` — success
- New unit coverage: provenance precedence (confirmed governs; weak can't clobber), retraction (stale removed, margin respected, armed no-op, confirmed retracts too, other models untouched), llama.cpp body parsing → window 150528

Note: the real-client E2E suite (`tests/e2e/`, needs `ACP_TEST_E2E=1` + live Responses upstream) was not runnable in this sandbox; the local e2e-style self-heal tests (`tests/e2e-overflow-selfheal.test.ts`, `issue-393`, `issue496`) all pass.