### PR TITLE
release v0.1.87

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.86",
+  "version": "0.1.87",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Version-only release bump for **v0.1.87**.

## Changes since v0.1.86
- PR#567 (closes #386): acp_status uses one estimator scale — 3 `buildStatusReport` call sites switched `estimateTokensFast` (chars/4) → `defaultCountTokens` (CJK-aware), matching the nudge/panel side; acp-kernel pinned 0.0.54 (tool-results attributed to their calling tool via toolCallId map, pct() floor removed, ranges label dominant tool). 2 regression tests.
- PR#370 (closes #156): break the small-model same-parameter compress failure loop early — `failedSignatures` records canonicalized args (parse + recursive key sort) of failed compress/decompress calls; a round consisting purely of byte-identical re-submissions of previously failed calls now terminates gracefully instead of burning all 10 MAX_LOOP_ROUNDS. 2 test files extended.

## Pre-flight
- typecheck ✓
- tests 1062/1064 (2 known permanent env fails in plugin-agent.test.ts, unchanged baseline) ✓
- build ✓