### PR TITLE
fix: preflight tries all viable ranges before declaring exhaustion

### DIFF
--- a/src/preflight.ts
+++ b/src/preflight.ts
@@ -27,6 +27,9 @@ const CHUNK_FRACTION = 0.6;
 const MIN_CHUNK_TOKENS = 2000;
 const MIN_SUMMARY_CHARS = 50;
 const MAX_SUMMARY_OUTPUT_TOKENS = 8192;
+// #574: bound on upstream summarization calls per invocation — the multi-range
+// walk can otherwise spend a call per viable range in a block-dense history.
+const MAX_SUMMARY_CALLS_PER_PREFLIGHT = 8;
 
 export type PreflightProtocol = "anthropic" | "openai" | "responses";
 
@@ -297,6 +300,14 @@ export async function preflightCompress(deps: PreflightDeps, messages: CoreMessa
         `the payload still exceeds the window after folding everything compressible, including the soft-protected recent zone ` +
         `(last ${deps.config.preserveRecentMessages} messages + most recent user message), which was relaxed under overflow; hard protectedTools remain excluded. ` +
         `Raise the model context window or restart the session to recover.`;
+    // #574/#569: walk every viable range oldest-first until one folds; declare
+    // exhaustion only after all are tried (legacy stopped at the first bad range).
+    // skipSet keys are stable across folds because refs are content-fingerprinted,
+    // so a range found unusable is never retried within this invocation.
+    const skipSet = new Set<string>();
+    let summaryCalls = 0;
+    let budgetHit = false;
+    let rangesTried = 0;
     for (let round = 0; round < MAX_PREFLIGHT_ROUNDS; round++) {
         if (deps.signal?.aborted) {
             failure = ABORTED_FAILURE;
@@ -332,92 +343,121 @@ export async function preflightCompress(deps: PreflightDeps, messages: CoreMessa
             if (!relaxed && result.payloadEstimate >= limit) {
                 activeConfig = relaxedConfig(deps.config);
                 relaxed = true;
+                // #575-merge: the summarization budget counts per protection
+                // regime — reset it on relax, else bad summaries burned under
+                // normal protection can starve the relaxed walk entirely and
+                // reintroduce the #330 unrecoverable stall.
+                summaryCalls = 0;
+                budgetHit = false;
                 deps.log("warn", "[preflight] no compressible ranges outside the protected recent zone; relaxing soft protection (preserveRecentMessages/Tokens -> 0) and retrying");
                 continue;
             }
             failure = { kind: "exhausted", detail: relaxed ? relaxedExhaustedDetail : "no compressible ranges remain in the conversation" };
             break;
         }
-        const range = [...ranges].sort((a, b) => refNum(a.startRef) - refNum(b.startRef))[0];
-        const { refToIdx } = refMaps(messages, deps.session.state);
-        const startIdx = refToIdx.get(range.startRef);
-        const endIdx = refToIdx.get(range.endRef);
-        if (startIdx === undefined || endIdx === undefined || startIdx > endIdx) {
-            failure = { kind: "exhausted", detail: "the compressible range no longer resolves to payload messages" };
-            break;
-        }
+        const ordered = [...ranges].sort((a, b) => refNum(a.startRef) - refNum(b.startRef));
         let appliedThisRound = 0;
-        for (const [cs, ce] of splitChunks(messages, startIdx, endIdx, budget)) {
+        for (const range of ordered) {
             if (currentTokens < limit) break;
             if (deps.signal?.aborted) {
                 failure = ABORTED_FAILURE;
                 break;
             }
-            const maps = refMaps(messages, deps.session.state);
-            const startRef = maps.idxToRef.get(cs);
-            const endRef = maps.idxToRef.get(ce);
-            if (!startRef || !endRef) continue;
-            if (rangeChars(messages, cs, ce) < minChars) continue;
-            const content = renderRange(messages, cs, ce);
-            if (content.length === 0) continue;
-            let summary: string | null;
-            try {
-                summary = await summarizeRange(deps, content, startRef, endRef);
-            } catch (err) {
-                if (err instanceof UpstreamHttpError) {
-                    failure = {
-                        kind: "upstream",
-                        status: err.status,
-                        detail: err.status === 429
-                            ? `the summarization call was rate-limited by the upstream (HTTP 429)`
-                            : `the summarization call was rejected by the upstream (HTTP ${err.status})`,
-                    };
-                    deps.log("warn", `[preflight] summarization failed: HTTP ${err.status} ${err.body.slice(0, 200)}`);
-                } else if (deps.signal?.aborted) {
-                    failure = ABORTED_FAILURE;
-                    deps.log("warn", `[preflight] summarization aborted: client disconnected`);
-                } else {
-                    failure = { kind: "upstream", detail: `the summarization call failed: ${String(err)}` };
-                    deps.log("warn", `[preflight] summarization failed: ${String(err)}`);
-                }
-                break;
-            }
-            if (!summary) continue;
-            const ctx: RewriteCtx = {
-                core: deps.core,
-                config: activeConfig,
-                messages,
-                session: deps.session,
-                log: (msg) => deps.log("info", msg),
-            };
-            const creditBefore = deps.session.stats.compressCreditTokens;
-            const applied = applyRanges(parseCompressInput({ content: [{ startId: startRef, endId: endRef, summary, topic: "preflight overflow compress" }] }), ctx);
-            if (applied.startsWith("[Compression FAILED")) {
-                deps.log("warn", `[preflight] ${applied}`);
+            if (budgetHit) break;
+            const skipKey = `${range.startRef}:${range.endRef}`;
+            if (skipSet.has(skipKey)) continue;
+            const { refToIdx } = refMaps(messages, deps.session.state);
+            const startIdx = refToIdx.get(range.startRef);
+            const endIdx = refToIdx.get(range.endRef);
+            if (startIdx === undefined || endIdx === undefined || startIdx > endIdx) {
+                skipSet.add(skipKey);
                 continue;
             }
-            // The summary itself re-enters the payload; net its cost against
-            // both the folded size and the session's input baseline.
-            const compressed = deps.session.stats.compressCreditTokens - creditBefore;
-            currentTokens = Math.max(0, currentTokens - compressed + defaultCountTokens(summary));
-            deps.session.stats.lastInputTokens += defaultCountTokens(summary);
-            appliedThisRound += 1;
-            result.compressedRanges += 1;
-        }
-        if (appliedThisRound === 0) {
-            if (!failure) {
-                failure = { kind: "exhausted", detail: "no range could be compressed (chunks below minCompressRange or the summarization responses were unusable)" };
+            rangesTried += 1;
+            for (const [cs, ce] of splitChunks(messages, startIdx, endIdx, budget)) {
+                if (currentTokens < limit) break;
+                if (deps.signal?.aborted) {
+                    failure = ABORTED_FAILURE;
+                    break;
+                }
+                if (budgetHit) break;
+                const maps = refMaps(messages, deps.session.state);
+                const startRef = maps.idxToRef.get(cs);
+                const endRef = maps.idxToRef.get(ce);
+                if (!startRef || !endRef) continue;
+                if (rangeChars(messages, cs, ce) < minChars) continue;
+                const content = renderRange(messages, cs, ce);
+                if (content.length === 0) continue;
+                if (summaryCalls >= MAX_SUMMARY_CALLS_PER_PREFLIGHT) {
+                    budgetHit = true;
+                    break;
+                }
+                summaryCalls += 1;
+                let summary: string | null;
+                try {
+                    summary = await summarizeRange(deps, content, startRef, endRef);
+                } catch (err) {
+                    if (err instanceof UpstreamHttpError) {
+                        failure = {
+                            kind: "upstream",
+                            status: err.status,
+                            detail: err.status === 429
+                                ? `the summarization call was rate-limited by the upstream (HTTP 429)`
+                                : `the summarization call was rejected by the upstream (HTTP ${err.status})`,
+                        };
+                        deps.log("warn", `[preflight] summarization failed: HTTP ${err.status} ${err.body.slice(0, 200)}`);
+                    } else if (deps.signal?.aborted) {
+                        failure = ABORTED_FAILURE;
+                        deps.log("warn", `[preflight] summarization aborted: client disconnected`);
+                    } else {
+                        failure = { kind: "upstream", detail: `the summarization call failed: ${String(err)}` };
+                        deps.log("warn", `[preflight] summarization failed: ${String(err)}`);
+                    }
+                    break;
+                }
+                if (!summary) {
+                    deps.log("warn", `[preflight] range ${skipKey} produced no usable summary; skipping it`);
+                    skipSet.add(skipKey);
+                    break;
+                }
+                const ctx: RewriteCtx = {
+                    core: deps.core,
+                    config: activeConfig,
+                    messages,
+                    session: deps.session,
+                    log: (msg) => deps.log("info", msg),
+                };
+                const creditBefore = deps.session.stats.compressCreditTokens;
+                const applied = applyRanges(parseCompressInput({ content: [{ startId: startRef, endId: endRef, summary, topic: "preflight overflow compress" }] }), ctx);
+                if (applied.startsWith("[Compression FAILED")) {
+                    deps.log("warn", `[preflight] ${applied}`);
+                    skipSet.add(skipKey);
+                    break;
+                }
+                // The summary itself re-enters the payload; net its cost against
+                // both the folded size and the session's input baseline.
+                const compressed = deps.session.stats.compressCreditTokens - creditBefore;
+                currentTokens = Math.max(0, currentTokens - compressed + defaultCountTokens(summary));
+                deps.session.stats.lastInputTokens += defaultCountTokens(summary);
+                appliedThisRound += 1;
+                result.compressedRanges += 1;
+                break;
             }
-            break;
+            if (appliedThisRound > 0) break;
+            if (failure || budgetHit) break;
         }
+        if (appliedThisRound === 0) break;
     }
-    if (!failure && currentTokens >= limit) {
-        failure = {
-            kind: "exhausted",
-            detail: relaxed
-                ? relaxedExhaustedDetail
-                : `the compress budget was exhausted after ${MAX_PREFLIGHT_ROUNDS} rounds`,
-        };
+    if (currentTokens >= limit && !failure) {
+        if (budgetHit) {
+            failure = { kind: "exhausted", detail: `the preflight summarization budget (${MAX_SUMMARY_CALLS_PER_PREFLIGHT} calls per protection regime) was exhausted before the payload fit the window` };
+        } else if (relaxed && result.compressedRanges > 0) {
+            failure = { kind: "exhausted", detail: relaxedExhaustedDetail };
+        } else if (result.compressedRanges === 0) {
+            failure = { kind: "exhausted", detail: `no range could be compressed across ${rangesTried} viable range${rangesTried === 1 ? "" : "s"} (each was below minCompressRange, had an unusable summary, or failed to apply)` };
+        } else {
+            failure = { kind: "exhausted", detail: `the compress budget was exhausted after ${MAX_PREFLIGHT_ROUNDS} rounds` };
+        }
     }
     if (result.compressedRanges > 0) deps.session.stats.lastInputTokens = currentTokens;
     result.savedTokens = Math.max(0, startTokens - currentTokens);

--- a/tests/preflight-multi-range.test.ts
+++ b/tests/preflight-multi-range.test.ts
@@ -1,0 +1,215 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import { once } from "node:events";
+import test from "node:test";
+
+process.env.NODE_ENV = "test";
+
+import { defaultConfig } from "acp-kernel";
+import { startServer, type ProxyOptions } from "../src/server.ts";
+import { SessionStore, _setStoreForTest } from "../src/persist.ts";
+import { _setForTest as setRegistryForTest } from "../src/registry.ts";
+import { listSessions } from "../src/session.ts";
+
+// #574/#569: preflight used to try exactly ONE range per round (the oldest)
+// and declare GLOBAL exhaustion when that single range yielded no applied
+// chunk — so one bad leading edge (an unusable summary) produced a false 502
+// on a still-recoverable session while later spans were compressible. These
+// E2E tests drive the real proxy against a mock Anthropic upstream whose
+// summarization responses can be made usable or unusable per call, and pin the
+// fixed walk: try every viable range until one folds, bound the summarization
+// cost, and report a truthful exhaustion.
+
+const SUMMARY_TEXT =
+    "PREFLIGHT SUMMARY: the segment covered a multi-step debugging session. " +
+    "Key decisions: chose the multi-range walk over lossy truncation because the payload must stay coherent. " +
+    "Files touched: src/a.ts:10, src/b.ts:20. Outcome: fixed and verified by tests.";
+
+function okSse(inputTokens: number): string {
+    return (
+        `event: message_start\ndata: ${JSON.stringify({ type: "message_start", message: { id: "m1", role: "assistant", usage: { input_tokens: inputTokens } } })}\n\n` +
+        `event: content_block_start\ndata: ${JSON.stringify({ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } })}\n\n` +
+        `event: content_block_delta\ndata: ${JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "ok" } })}\n\n` +
+        `event: content_block_stop\ndata: ${JSON.stringify({ type: "content_block_stop", index: 0 })}\n\n` +
+        `event: message_delta\ndata: ${JSON.stringify({ type: "message_delta", delta: { stop_reason: "end_turn", stop_sequence: null }, usage: { output_tokens: 3 } })}\n\n` +
+        `event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`
+    );
+}
+
+function conversation(n: number): Array<{ role: string; content: string }> {
+    const msgs: Array<{ role: string; content: string }> = [];
+    for (let i = 0; i < n; i++) {
+        const role = i % 2 === 0 ? "user" : "assistant";
+        msgs.push({ role, content: `Message ${i} of the long conversation. ` + `MARKER_${i}_content_`.repeat(250) });
+    }
+    return msgs;
+}
+
+type Call = { stream: boolean; body: string };
+
+// Mock Anthropic upstream. Main requests are stream:true (answered with SSE);
+// preflight summarization calls are stream:false (answered with a JSON message
+// whose text is SUMMARY_TEXT when usable(idx) else empty — the proxy treats an
+// empty/too-short summary as unusable and skips that range).
+function makeUpstream(usable: (idx: number) => boolean): { server: http.Server; calls: Call[] } {
+    const calls: Call[] = [];
+    let summaryIdx = 0;
+    const server = http.createServer((req, res) => {
+        const chunks: Buffer[] = [];
+        req.on("data", (c: Buffer) => chunks.push(c));
+        req.on("end", () => {
+            const raw = Buffer.concat(chunks).toString("utf8");
+            let parsed: { stream?: boolean } = {};
+            try { parsed = JSON.parse(raw); } catch { /* keep {} */ }
+            calls.push({ stream: !!parsed.stream, body: raw });
+            if (parsed.stream) {
+                res.writeHead(200, { "content-type": "text/event-stream" });
+                res.end(okSse(1000));
+            } else {
+                summaryIdx += 1;
+                const text = usable(summaryIdx) ? SUMMARY_TEXT : "";
+                res.writeHead(200, { "content-type": "application/json" });
+                res.end(JSON.stringify({
+                    id: "msg_summary", type: "message", role: "assistant", model: "claude-small",
+                    content: [{ type: "text", text }], stop_reason: "end_turn",
+                    usage: { input_tokens: 500, output_tokens: 50 },
+                }));
+            }
+        });
+    });
+    return { server, calls };
+}
+
+function startProxy(upstreamPort: number, models: Record<string, { context: number }>): Promise<http.Server> {
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    setRegistryForTest({});
+    return startServer({
+        port: 0,
+        host: "127.0.0.1",
+        upstream: "http://127.0.0.1",
+        routes: { [`http://127.0.0.1:${upstreamPort}`]: { models } },
+        modelContextLimit: 400_000,
+        kernelConfig: defaultConfig(400_000),
+        compress: { injectTool: true, injectNudge: true },
+        promptCache: { routing: "auto" },
+        sessionHeader: "x-acp-session",
+        log: false,
+        debug: false,
+        passthrough: false,
+        autoUpdate: false,
+        mitm: { enabled: false, domains: [] },
+    } as ProxyOptions);
+}
+
+test("#574 regression: oldest range's summary unusable → preflight moves to the next range and forwards (200)", async () => {
+    // First summarization call (the oldest range) returns an unusable summary;
+    // every later call is usable. Legacy stopped at the first bad range → 502.
+    const { server: upstream, calls } = makeUpstream((idx) => idx > 1);
+    upstream.listen(0, "127.0.0.1");
+    await once(upstream, "listening");
+    const upstreamPort = upstream.address().port;
+
+    // Window sits between the post-fold floor (un-foldable oldest range +
+    // preserved-recent zone ≈ 10.2k for this 24-message history) and the raw
+    // total (~26.6k), so folding the later usable ranges brings it under.
+    const proxy = await startProxy(upstreamPort, { "claude-small": { context: 15_000 } });
+    await once(proxy, "listening");
+    const proxyPort = proxy.address().port;
+
+    try {
+        const r = await fetch(`http://127.0.0.1:${proxyPort}/bili/http://127.0.0.1:${upstreamPort}/v1/messages`, {
+            method: "POST",
+            headers: { "content-type": "application/json", "x-acp-session": "multi-range-regress-sess" },
+            body: JSON.stringify({ model: "claude-small", max_tokens: 1024, stream: true, messages: conversation(24) }),
+        });
+        assert.equal(r.status, 200, "the request succeeds even though the oldest range's summary is unusable");
+        await r.text();
+
+        const summaryCalls = calls.filter((c) => !c.stream);
+        assert.ok(summaryCalls.length >= 2, `preflight moved past the bad oldest range to a later one (got ${summaryCalls.length} summary call(s))`);
+        assert.equal(calls.filter((c) => c.stream).length, 1, "the rebuilt, fitting payload was forwarded");
+
+        const s = listSessions()[0];
+        const activeBlocks = (s?.state.blocks ?? []).filter((b) => b.active);
+        assert.ok(activeBlocks.length >= 1, `a later range was folded into a block (got ${activeBlocks.length})`);
+    } finally {
+        proxy.close();
+        await once(proxy, "close");
+        upstream.close();
+        await once(upstream, "close");
+    }
+});
+
+test("#574 truthful exhaustion: every range's summary unusable → 502 only after all ranges tried, no forward, no blocks", async () => {
+    const { server: upstream, calls } = makeUpstream(() => false);
+    upstream.listen(0, "127.0.0.1");
+    await once(upstream, "listening");
+    const upstreamPort = upstream.address().port;
+
+    const proxy = await startProxy(upstreamPort, { "claude-small": { context: 10_000 } });
+    await once(proxy, "listening");
+    const proxyPort = proxy.address().port;
+
+    try {
+        const r = await fetch(`http://127.0.0.1:${proxyPort}/bili/http://127.0.0.1:${upstreamPort}/v1/messages`, {
+            method: "POST",
+            headers: { "content-type": "application/json", "x-acp-session": "multi-range-exhaust-sess" },
+            body: JSON.stringify({ model: "claude-small", max_tokens: 1024, stream: true, messages: conversation(16) }),
+        });
+        assert.equal(r.status, 502, "nothing compressible → fail-fast 502");
+        const json = JSON.parse(await r.text()) as { error?: { code?: string; retryable?: boolean; message?: string } };
+        assert.equal(json.error?.code, "preflight_compress_failed");
+        assert.equal(json.error?.retryable, false);
+        assert.match(json.error?.message ?? "", /no range could be compressed/i, `exhaustion names the multi-range attempt (got: ${json.error?.message})`);
+
+        const summaryCalls = calls.filter((c) => !c.stream);
+        assert.ok(summaryCalls.length >= 2, `every viable range was tried, not just the first (got ${summaryCalls.length}; legacy made exactly 1)`);
+        assert.equal(calls.filter((c) => c.stream).length, 0, "the over-window payload was NOT forwarded");
+
+        const s = listSessions()[0];
+        const activeBlocks = (s?.state.blocks ?? []).filter((b) => b.active);
+        assert.equal(activeBlocks.length, 0, "no blocks created when nothing could be compressed");
+    } finally {
+        proxy.close();
+        await once(proxy, "close");
+        upstream.close();
+        await once(upstream, "close");
+    }
+});
+
+test("#574 budget cap: many unusable ranges → exactly MAX_SUMMARY_CALLS_PER_PREFLIGHT summary calls, budget-exhausted detail", async () => {
+    const { server: upstream, calls } = makeUpstream(() => false);
+    upstream.listen(0, "127.0.0.1");
+    await once(upstream, "listening");
+    const upstreamPort = upstream.address().port;
+
+    const proxy = await startProxy(upstreamPort, { "claude-small": { context: 10_000 } });
+    await once(proxy, "listening");
+    const proxyPort = proxy.address().port;
+
+    try {
+        const r = await fetch(`http://127.0.0.1:${proxyPort}/bili/http://127.0.0.1:${upstreamPort}/v1/messages`, {
+            method: "POST",
+            headers: { "content-type": "application/json", "x-acp-session": "multi-range-budget-sess" },
+            body: JSON.stringify({ model: "claude-small", max_tokens: 1024, stream: true, messages: conversation(48) }),
+        });
+        assert.equal(r.status, 502, "still over-window after the budget → fail-fast 502");
+        const json = JSON.parse(await r.text()) as { error?: { code?: string; retryable?: boolean; message?: string } };
+        assert.equal(json.error?.code, "preflight_compress_failed");
+        assert.equal(json.error?.retryable, false);
+        assert.match(json.error?.message ?? "", /summarization budget/i, `the budget variant is reported (got: ${json.error?.message})`);
+
+        const summaryCalls = calls.filter((c) => !c.stream);
+        assert.equal(summaryCalls.length, 8, `exactly MAX_SUMMARY_CALLS_PER_PREFLIGHT summary calls (got ${summaryCalls.length})`);
+        assert.equal(calls.filter((c) => c.stream).length, 0, "the over-window payload was NOT forwarded");
+
+        const s = listSessions()[0];
+        const activeBlocks = (s?.state.blocks ?? []).filter((b) => b.active);
+        assert.equal(activeBlocks.length, 0, "no blocks created when nothing could be compressed");
+    } finally {
+        proxy.close();
+        await once(proxy, "close");
+        upstream.close();
+        await once(upstream, "close");
+    }
+});


### PR DESCRIPTION
## What

Preflight fail-fast returned `502 retryable=false` ("no range could be compressed") while later spans of the same history were still compressible — minutes later the session owner's in-band compress shrank it 88% (#569).

## Root cause

`preflightCompress` (`src/preflight.ts`) picked exactly **one** range per round — the oldest viable one — and when that single range yielded no applied chunk (sub-`minCompressRange` chunk, empty content, unusable summary, or kernel apply rejection) it declared **global** exhaustion and broke out of the round loop. Remaining viable ranges were never tried, so one bad leading edge produced a false terminal verdict on a still-recoverable session. In block-dense histories this is likely: the kernel's min-gate sums only non-summary message text, while preflight's char precheck counts all view text including block summaries — so a leading range can pass preflight yet be rejected at apply time.

## Fix (`src/preflight.ts`)

- Iterate **all** viable ranges (oldest-first, prefix-cache-stable) within a round until one yields an applied chunk; declare `exhausted` only after every range has been tried and nothing applied.
- A range whose summary was unusable / apply failed / refs unresolvable is added to a skip-set (refs are content-fingerprinted → stable across folds) so it is never retried within the invocation — no wasted upstream calls, no infinite churn.
- New cost cap `MAX_SUMMARY_CALLS_PER_PREFLIGHT = 8` bounds summarization calls per invocation (legacy worst case was also 8); hitting it reports a distinct budget-exhausted detail instead of the generic one.
- Exhaustion detail now names how many ranges were tried, making the 502 truthful and diagnosable.
- Upstream-error (429→503 retryable), abort, and credit-math semantics unchanged. No wire-shape change: mode-agnostic core only (both plugin and proxy modes affected identically, per AGENTS.md §6).

## Tests (`tests/preflight-multi-range.test.ts`, new)

E2E through the real proxy with a mock Anthropic upstream whose summarization responses are usable/unusable per call:
1. **Regression**: oldest range's summary unusable → now 200 with a later range folded (legacy: 502).
2. **Truthful exhaustion**: every summary unusable → 502 only after all ranges tried (`summaryCalls ≥ 2`; legacy made exactly 1), no forward, no blocks.
3. **Budget cap**: 48-message history, all summaries unusable → exactly `MAX_SUMMARY_CALLS_PER_PREFLIGHT` summarization calls, budget variant in the error.

## Pre-flight

- `npm run typecheck`: pass
- New suite: 3/3 pass; **RED confirmed on legacy** (test 1: expected 200, actual 502; test 2: `summaryCalls ≥ 2`; test 3: budget variant + exact count)
- Full `npm test`: 1050/1051 — the single failure (`launcher.test.ts` `resolveClientCommand` codex) is pre-existing and environment-specific (this sandbox resolves `codex` to `/usr/bin/codex`); unrelated to this change
- `npm run build`: success

Fixes #574. Source incident: #569.
