### PR TITLE
docs: correct false renumber claim in preflight comment (#387)

### DIFF
--- a/src/preflight.ts
+++ b/src/preflight.ts
@@ -271,8 +271,10 @@ export async function preflightCompress(deps: PreflightDeps, messages: CoreMessa
             failure = ABORTED_FAILURE;
             break;
         }
-        // Re-run the pipeline each round: every successful compress renumbers
-        // the surviving refs, so the previous round's range refs are stale.
+        // Re-run the pipeline each round: a successful compress hides its
+        // range behind a new block, changing the visible view; refs stay
+        // stable per-session snapshots (#387), but which ranges are
+        // compressible under them does not.
         const turn = deps.core.processTurn({
             messages,
             state: deps.session.state,


### PR DESCRIPTION
Closes #595 — tracking issue for this PR.

## What

Follow-up to ranxianglei/billion-context#387. The kernel fix (acp-kernel PR #175, merged 2026-08-31, shipped in acp-kernel — now pinned at 0.0.54) removed the false `a prior compress renumbered the remaining refs` claim from all user-visible text. One remnant of the same false claim survived in this repo as a code comment:

`src/preflight.ts` (preflight loop):
> ~~Re-run the pipeline each round: every successful compress **renumbers** the surviving refs, so the previous round's range refs are stale.~~

## Why it matters

Not user-visible, but it propagates the exact misconception that caused #387 to any future reader of the preflight loop. The corrected rationale: a successful compress **hides its range behind a new block**, changing which ranges remain compressible under the same (stable, per-session-snapshot) refs — that is why the pipeline must re-run each round.

## Scope

- Comment-only change (verified by diff): 1 file, 4 insertions, 2 deletions, zero code changes.
- After this lands, `grep -r renumber src/ tests/` returns nothing in this repo.

## Pre-flight

- No code changed; no test/typecheck delta possible (diff is entirely within one comment block).