### PR TITLE
fix: skip auto-update when running from a git source checkout (#580)

### DIFF
--- a/src/update.ts
+++ b/src/update.ts
@@ -113,6 +113,20 @@ async function findInstallDir(packageName: string): Promise<string | undefined> 
     }
 }
 
+/** True when `dir` is a git working tree: `.git` present as a directory
+ *  (normal clone) or as a file (linked worktree / submodule pointer). npm
+ *  installs never contain one — `npm pack` strips VCS metadata — so its
+ *  presence marks a source checkout, not an install. Exported for tests.
+ *  (#580) */
+export async function isGitWorkingTree(dir: string): Promise<boolean> {
+    try {
+        await access(path.join(dir, ".git"));
+        return true;
+    } catch {
+        return false;
+    }
+}
+
 /** Read the version from the on-disk package.json (not the startup constant). */
 async function readDiskVersion(installDir: string): Promise<string | undefined> {
     try {
@@ -335,6 +349,18 @@ export async function checkForUpdate(opts: UpdateOptions, force = false): Promis
         }
         await writeLastCheck(now);
         firstCheckDone = true;
+
+        // Source-checkout guard (#580): findInstallDir() walks up from the
+        // running dist/ and lands on the repo root when bili runs from a git
+        // clone (node dist/index.js start). An in-place tarball copy would
+        // silently rewrite tracked files (the version pin, READMEs), so refuse
+        // to self-update here instead of proceeding.
+        const installDir = await findInstallDir(opts.packageName);
+        if (installDir && await isGitWorkingTree(installDir)) {
+            loggerLog("info", `[update] running from a source checkout (${installDir}) \u2014 skipping auto-update (use npm install -g ${opts.packageName})`);
+            return;
+        }
+
         loggerLog("info", `[update] checking npm registry for ${opts.packageName}${sinceLastSec < 0 ? " (startup check)" : sinceLastSec === 0 ? "" : ` (last check ${sinceLastSec}s ago)`}\u2026`);
 
         const url = `${REGISTRY_BASE}/${opts.packageName}/latest`;
@@ -358,7 +384,6 @@ export async function checkForUpdate(opts: UpdateOptions, force = false): Promis
 
         // Read current version from disk (not from startup constant) so that
         // a successful in-place update is detected without a restart.
-        const installDir = await findInstallDir(opts.packageName);
         const diskVersion = installDir ? await readDiskVersion(installDir) : undefined;
         const currentVersion = diskVersion ?? opts.currentVersion;
 
@@ -451,6 +476,14 @@ export async function installViaTarball(
         await access(installDir, constants.W_OK);
     } catch {
         return { ok: false, error: `install dir not writable: ${installDir}` };
+    }
+
+    // Source-checkout guard (#580): a git working tree must never be merged
+    // over by a published tarball — that rewrites tracked files. checkForUpdate
+    // filters these out already; this keeps the refusal structural for direct
+    // callers.
+    if (await isGitWorkingTree(installDir)) {
+        return { ok: false, error: `install dir is a git working tree (${installDir}) \u2014 refusing to overwrite a source checkout (use npm install -g)` };
     }
 
     // Download tarball. Stream into memory with a hard size cap so a corrupt

--- a/tests/update-tarball.test.ts
+++ b/tests/update-tarball.test.ts
@@ -5,7 +5,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync
 import { tmpdir } from "node:os";
 import path from "node:path";
 import * as tar from "tar";
-import { installViaTarball, declaredEntryRelPaths } from "../src/update.ts";
+import { installViaTarball, declaredEntryRelPaths, isGitWorkingTree } from "../src/update.ts";
 
 function integrityField(buf: Buffer, alg = "sha512"): string {
     return `${alg}-${crypto.createHash(alg).update(buf).digest("base64")}`;
@@ -142,6 +142,54 @@ test("installViaTarball: tarball missing its declared entry is rejected in stagi
         assert.equal(r.ok, false);
         assert.match(r.error ?? "", /staging verification failed: entry missing: dist\/index\.js/);
         assert.equal(JSON.parse(readFileSync(path.join(fx.installDir, "package.json"), "utf-8")).version, "1.2.3");
+    } finally {
+        delete process.env.XDG_CACHE_HOME;
+        rmSync(fx.root, { recursive: true, force: true });
+    }
+});
+
+test("isGitWorkingTree: .git dir (clone), .git file (worktree), absent", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "bc-gittest-"));
+    try {
+        const clone = path.join(root, "clone");
+        mkdirSync(path.join(clone, ".git"), { recursive: true });
+        assert.equal(await isGitWorkingTree(clone), true, "normal clone (.git directory)");
+
+        const worktree = path.join(root, "worktree");
+        mkdirSync(worktree, { recursive: true });
+        writeFileSync(path.join(worktree, ".git"), "gitdir: /elsewhere/repo/.git/worktrees/wt\n");
+        assert.equal(await isGitWorkingTree(worktree), true, "linked worktree (.git file)");
+
+        const plain = path.join(root, "plain");
+        mkdirSync(plain, { recursive: true });
+        assert.equal(await isGitWorkingTree(plain), false, "no .git entry");
+    } finally {
+        rmSync(root, { recursive: true, force: true });
+    }
+});
+
+test("installViaTarball: refuses to overwrite a git working tree, install untouched", { timeout: 30_000 }, async () => {
+    const fx = makeFixture();
+    process.env.XDG_CACHE_HOME = fx.cacheDir;
+    try {
+        // Simulate running from a source checkout: the resolved install dir IS a git working tree.
+        mkdirSync(path.join(fx.installDir, ".git"), { recursive: true });
+        writeFileSync(path.join(fx.installDir, "README.md"), "# local docs\n");
+        const { tgz, integrity } = fx.makeTarball({
+            "package.json": pkgJson("2.0.0"),
+            "dist/index.js": "export const loaded = '2.0.0';\n",
+            "README.md": "# published docs\n",
+        });
+        const r = await withTarballFetch(
+            tgz,
+            () => installViaTarball("2.0.0", "https://registry.test/x.tgz", fx.installDir, integrity),
+        );
+        assert.equal(r.ok, false);
+        assert.match(r.error ?? "", /git working tree/);
+        // Anti-corruption guarantee: tracked files byte-for-byte intact.
+        assert.equal(JSON.parse(readFileSync(path.join(fx.installDir, "package.json"), "utf-8")).version, "1.2.3");
+        assert.equal(readFileSync(path.join(fx.installDir, "README.md"), "utf-8"), "# local docs\n");
+        assert.match(readFileSync(path.join(fx.installDir, "dist", "index.js"), "utf-8"), /1\.2\.3/);
     } finally {
         delete process.env.XDG_CACHE_HOME;
         rmSync(fx.root, { recursive: true, force: true });


### PR DESCRIPTION
Fixes #580.

## Problem

When bili runs from a **git source checkout** (`node dist/index.js start`), `findInstallDir()` walks up from the running `dist/index.js` until it finds a `package.json` whose name matches — which resolves to the **repo root**. Auto-update then backs that directory up and merge-copies the published tarball over it (`cp(stagingDir → installDir, { recursive: true, force: true })`), silently rewriting tracked files: `package.json` (including the `version` field and pinned devDeps such as the exact `acp-kernel` pin), READMEs, etc. The only pre-flight was a writability check.

The incident already happened once during development (`devlog/2026-08-25_remote-host-bind/WORKLOG.md`: repo-dist server 0.1.52 auto-updated itself to 0.1.53 and rewrote the repo's package.json), and #580 reports it deterministically 3 more times (local 0.1.84 vs registry 0.1.85 / 0.1.87).

## Fix (as suggested in the issue)

Skip in-place self-update when the resolved install dir is a git working tree:

- New `isGitWorkingTree(dir)` in `src/update.ts`: checks for a `.git` entry — directory (normal clone) or file (linked worktree / submodule pointer). npm installs never contain `.git` (`npm pack` strips VCS metadata), so its presence reliably marks a source checkout.
- `checkForUpdate()`: resolves the install dir early and returns before touching the registry, logging `[update] running from a source checkout (… ) — skipping auto-update (use npm install -g billion-context)`. Covers both the periodic auto-update loop and the manual `bili update` command (both go through `checkForUpdate`).
- `installViaTarball()`: structural pre-flight refusal for direct callers of the exported function.

Behavior for genuine non-git install locations (npm global installs, manual extraction) is unchanged. I deliberately did not also adopt the issue's alternative "refuse if not under the global npm prefix": prefix detection is fragile across homebrew/pnpm/yarn/Windows/manual layouts, while the `.git` marker is precise for the reported failure mode.

Known limitation (out of scope): a monorepo sub-package (e.g. `packages/billion-context` inside a larger git repo) has no `.git` at its own root, so it is not covered by this guard.

## Tests

- `isGitWorkingTree`: true for `.git` dir, true for `.git` file (worktree pointer), false when absent.
- `installViaTarball`: refuses when the install dir contains `.git`; asserts tracked files remain byte-for-byte intact (package.json version, README, dist entry).

End-to-end repro verified locally: built `dist` from this checkout, ran `node dist/index.js start`, the startup check logged the skip message, and `git status` stayed clean.

## Pre-flight

- `npm run typecheck` ✅
- `npm test` — 1065/1066 pass; the single failure (`launcher.test.ts: resolveClientCommand: codex/claude resolve to themselves`) is environment-dependent and pre-existing on the pristine tree (this sandbox has `/usr/bin/codex` on PATH; fails identically without this change)
- `npm run build` ✅
- E2E suite not run: change is confined to `src/update.ts` (not part of the request pipeline per AGENTS.md §3) and requires a local upstream that is unavailable here