### PR TITLE
fix: add second-chance developer->user compat learn (#583)

### DIFF
--- a/src/compat-roles.ts
+++ b/src/compat-roles.ts
@@ -101,6 +101,30 @@ export function detectRoleRejection(status: number, bodyText: string): { role: s
     return null;
 }
 
+/** Detect the OTHER half of the #552 edge (#583): a backend that ACCEPTS the
+ *  role name but rejects a `system` message that is not at index 0 (or more
+ *  than one system message) — the SGLang-style strict-placement class behind
+ *  #377. Distinct from detectRoleRejection, which names an unsupported ROLE;
+ *  here the role is fine and the POSITION/count is the problem, so there is no
+ *  role to capture — just a boolean gate for the second-chance developer→user
+ *  hop. Conservative: requires a 400 plus the literal word "system" plus one
+ *  strong placement/multiplicity marker, so unrelated 400s (quota, overflow,
+ *  missing-system, auth) never trip it. Quotes/brackets are normalized away so
+ *  phrasings like "Only one 'system' message…" still match. */
+export function detectSystemPlacementError(status: number, bodyText: string): boolean {
+    if (status !== 400) return false;
+    const head = bodyText.slice(0, 4096);
+    if (!/system/i.test(head)) return false;
+    const norm = head.replace(/['"`[\](){}]/g, " ");
+    const PLACEMENT_MARKERS = [
+        /\b(multiple|more\s+than\s+one|exactly\s+one|only\s+one|single|another|second|third)\s+system/i,
+        /\b[2-9]\d*\s+system\s+messages?\b/i,
+        /system\s+messages?\b[^.\n]{0,50}\bindex\s*\d+\b/i,
+        /(system\s+messages?|system\s+roles?)\b[^.\n]{0,50}\b(beginning|start|front|first\s+message|must\s+be\s+first)/i,
+    ];
+    return PLACEMENT_MARKERS.some((re) => re.test(norm));
+}
+
 export function applyCompatRoles(
     body: string,
     protocol: "openai" | "responses",

--- a/src/server.ts
+++ b/src/server.ts
@@ -74,7 +74,7 @@ import { systemToUser, isLoopbackAddress, inspectContextOverflow, reserveOutputH
 import { BILI_TUNNEL_HEADER, checkTunnelDestination, tunnelAllowlistFromEnv } from "./tunnel-guard.js";
 
 import { decodeRequestBody } from "./content-encoding.js";
-import { applyCompatRoles, applyCompatRolesJson, detectRoleRejection, resolveCompatRoles, type CompatRoles } from "./compat-roles.js";
+import { applyCompatRoles, applyCompatRolesJson, detectRoleRejection, detectSystemPlacementError, resolveCompatRoles, type CompatRoles } from "./compat-roles.js";
 
 // Body dumps (dumps/req-*.json, raw/*-REQ.txt, raw/*-RES.txt, raw/*-INCOMING.txt,
 // req-*-REREQUEST.json) write the full plaintext request body and are off by
@@ -2864,32 +2864,58 @@ async function forward(
             };
             const rejection = detectRoleRejection(upstreamResult.response.status, roleErrText);
             if (rejection && rejection.role !== "system") {
-                const fixed = applyCompatRoles(wireBody, compatProtocol, { [rejection.role]: "system" });
-                if (fixed.rewritten > 0) {
-                    try {
-                        const retry = await fetchWithTimeout(upstreamUrl, { ...init, body: fixed.body }, undefined, clientAbort.signal);
-                        if (retry.response.ok) {
-                            upstreamResult.clearTimer();
-                            const s = prepared?.session;
-                            if (s) {
-                                const prev = (s.metadata.learnedCompatRoles as CompatRoles | undefined) ?? {};
-                                s.metadata.learnedCompatRoles = { ...prev, [rejection.role]: "system" };
-                                markDirty(s);
-                            }
-                            // Same-request re-sends (compress-retry loops) must
-                            // carry the rewrite too — wireTransform reads this
-                            // variable at call time.
-                            compatRoles = { ...compatRoles, [rejection.role]: "system" };
-                            const providerKey = new URL(upstreamUrl).origin;
-                            log("info", `[${prepared?.session.id ?? "passthrough"}] [compat] upstream rejected role "${rejection.role}" — auto-rewrote ${fixed.rewritten} message role(s) to "system", retry OK (remembered for this session only). To make permanent, add: {"providers":{"${providerKey}":{"compat":{"roles":{"${rejection.role}":"system"}}}}`);
-                            upstreamResult = retry;
-                        } else {
-                            retry.clearTimer();
-                        }
-                    } catch {
-                        // retry transport failure — keep the original 400
+                // Learn-on-failure ladder — primary hop (#552: offending role →
+                // "system") plus a SECOND-CHANCE hop (#583: → "user") fired only
+                // when the system hop 400'd with a #377-class system-PLACEMENT
+                // error (backend accepts the role name but forbids system off
+                // index 0, so a mid-list developer→system still 400s). Each hop
+                // rewrites the one offending role to a single target and forwards
+                // exactly once; the sequence is fixed (never a loop), hard-capped
+                // at original + 2 retries. Any other failure stops the ladder and
+                // the original 400 passes through verbatim.
+                const cp = compatProtocol;
+                const wb = wireBody;
+                const remember = (target: string, rewritten: number): void => {
+                    const s = prepared?.session;
+                    if (s) {
+                        const prev = (s.metadata.learnedCompatRoles as CompatRoles | undefined) ?? {};
+                        s.metadata.learnedCompatRoles = { ...prev, [rejection.role]: target };
+                        markDirty(s);
                     }
-                }
+                    // Same-request re-sends (compress-retry loops) carry the
+                    // rewrite too — wireTransform reads compatRoles at call time.
+                    compatRoles = { ...compatRoles, [rejection.role]: target };
+                    const providerKey = new URL(upstreamUrl).origin;
+                    log("info", `[${prepared?.session.id ?? "passthrough"}] [compat] upstream rejected role "${rejection.role}" — auto-rewrote ${rewritten} message role(s) to "${target}", retry OK (remembered for this session only). To make permanent, add: {"providers":{"${providerKey}":{"compat":{"roles":{"${rejection.role}":"${target}"}}}}`);
+                };
+                type HopOutcome = "ok" | "placement-400" | "other";
+                const hop = async (target: string): Promise<HopOutcome> => {
+                    const fixed = applyCompatRoles(wb, cp, { [rejection.role]: target });
+                    if (fixed.rewritten === 0) return "other";
+                    let r: Awaited<ReturnType<typeof fetchWithTimeout>>;
+                    try {
+                        r = await fetchWithTimeout(upstreamUrl, { ...init, body: fixed.body }, undefined, clientAbort.signal);
+                    } catch {
+                        return "other"; // transport failure — keep the original 400
+                    }
+                    if (r.response.ok) {
+                        upstreamResult.clearTimer();
+                        remember(target, fixed.rewritten);
+                        upstreamResult = r;
+                        return "ok";
+                    }
+                    let errText: string | null = null;
+                    if (r.response.body) {
+                        try {
+                            errText = (await readStreamToBuffer(r.response.body)).toString("utf8");
+                        } catch {
+                            errText = null;
+                        }
+                    }
+                    r.clearTimer();
+                    return errText !== null && detectSystemPlacementError(r.response.status, errText) ? "placement-400" : "other";
+                };
+                if ((await hop("system")) === "placement-400") await hop("user");
             }
         }
     }

--- a/tests/compat-roles.test.ts
+++ b/tests/compat-roles.test.ts
@@ -10,7 +10,7 @@ import { startServer } from "../src/server.ts";
 import { loadRoutes, type ProxyOptions } from "../src/config.ts";
 import { SessionStore, _setStoreForTest } from "../src/persist.ts";
 import { _setForTest as setRegistryForTest } from "../src/registry.ts";
-import { applyCompatRoles, applyCompatRolesJson, detectRoleRejection, parseCompatRoles, resolveCompatRoles } from "../src/compat-roles.ts";
+import { applyCompatRoles, applyCompatRolesJson, detectRoleRejection, detectSystemPlacementError, parseCompatRoles, resolveCompatRoles } from "../src/compat-roles.ts";
 import { _liveUpstreamTimersForTest } from "../src/fetch-util.ts";
 
 function close(server: http.Server): Promise<void> {
@@ -278,6 +278,34 @@ test("detectRoleRejection: extracts the offending role, conservative otherwise",
     assert.equal(detectRoleRejection(400, '[{"loc":["body","messages",0,"role"],"msg":"Input should be \'system\', \'user\', \'tool\' or \'assistant\'"}]'), null);
 });
 
+test("detectSystemPlacementError: flags #377-class placement 400s, ignores role-name/quota/overflow/auth", () => {
+    const positive = [
+        "Only one 'system' message is allowed and it must be at the beginning",
+        "Multiple system messages found in the request",
+        "Found 2 system messages; expected exactly one",
+        "Expected exactly one system message, got 2",
+        "system message must be at the beginning of the conversation",
+        "system message at index 3 is not allowed",
+        "Value error: system messages are only allowed at index 0 (found system at index 1)",
+        "a second system message was supplied",
+    ];
+    for (const msg of positive) {
+        assert.equal(detectSystemPlacementError(400, JSON.stringify({ error: { message: msg } })), true, `should detect placement error: ${msg}`);
+    }
+    const negative = [
+        '{"error":{"message":"Invalid role: developer"}}',
+        '{"error":{"message":"insufficient quota"}}',
+        '{"error":{"message":"context_length_exceeded"}}',
+        '{"error":{"message":"Missing required parameter: system prompt"}}',
+        "system prompt is required",
+        '{"error":{"message":"invalid api key"}}',
+    ];
+    for (const msg of negative) {
+        assert.equal(detectSystemPlacementError(400, msg), false, `should NOT detect: ${msg}`);
+    }
+    assert.equal(detectSystemPlacementError(401, "Multiple system messages found"), false);
+});
+
 function roleRejectingUpstream(): Promise<{ server: http.Server; seen: string[][] }> {
     const seen: string[][] = [];
     const server = http.createServer((req, res) => {
@@ -357,6 +385,111 @@ test("e2e #552 F: retry that still fails passes the original 400 through verbati
         assert.equal(hits.length, 2, "exactly one retry, no loop");
         await waitFor(() => _liveUpstreamTimersForTest() === 0);
         assert.equal(_liveUpstreamTimersForTest(), 0, "abandoned retry body must not re-arm the idle timer after clearTimer");
+    } finally {
+        await harness.stop();
+        harness.cleanup();
+        await close(upstream);
+    }
+});
+
+function rolesOf(body: unknown): string[] {
+    const b = body as { input?: Array<{ role?: string }>; messages?: Array<{ role?: string }> };
+    return [...(b.input ?? []), ...(b.messages ?? [])].map((m) => m.role ?? "?");
+}
+
+// Payload that keeps a developer MID-LIST at the forward boundary. A well-formed
+// TYPED developer is hoisted to index 0 by the kernel (injectResponsesDeveloperMessage),
+// so the primary developer→system retry already lands at index 0 and succeeds — it
+// can never produce a mid-list system. A non-normalized type-less item is left in
+// place by the projection, which is exactly the precondition #583 needs.
+const MIDLIST_DEV_PAYLOAD = JSON.stringify({ model: "test", input: [
+    { type: "message", role: "user", content: "a" },
+    { role: "developer", content: "sys" },
+    { type: "message", role: "user", content: "b" },
+]});
+
+// Upstream enforcing BOTH halves of the #583 edge: rejects any unknown role
+// (developer) AND enforces system-at-index-0 only (a mid-list system is a
+// #377-class placement 400). acceptUser decides whether the final developer→user
+// rewrite is accepted (true = second-chance succeeds; false = every hop fails,
+// exercising the hard cap). Records every hit's roles.
+function ladderUpstream(acceptUser: boolean): Promise<{ server: http.Server; seen: string[][] }> {
+    const seen: string[][] = [];
+    const server = http.createServer((req, res) => {
+        const chunks: Buffer[] = [];
+        req.on("data", (c: Buffer) => chunks.push(c));
+        req.on("end", () => {
+            let roles: string[] = [];
+            try { roles = rolesOf(JSON.parse(Buffer.concat(chunks).toString("utf8"))); } catch { /* ignore */ }
+            seen.push(roles);
+            const json = (obj: unknown) => JSON.stringify(obj);
+            const offZero = roles.map((r, i) => (r === "system" ? i : -1)).filter((i) => i >= 0).find((i) => i !== 0);
+            if (roles.includes("developer")) {
+                res.writeHead(400, { "content-type": "application/json" });
+                res.end(json({ error: { message: "Invalid role: developer" } }));
+            } else if (offZero !== undefined) {
+                res.writeHead(400, { "content-type": "application/json" });
+                res.end(json({ error: { message: `Value error: system messages are only allowed at index 0 (found system at index ${offZero})` } }));
+            } else if (acceptUser) {
+                res.writeHead(200, { "content-type": "application/json" });
+                res.end(json({ ok: true }));
+            } else {
+                res.writeHead(400, { "content-type": "application/json" });
+                res.end(json({ error: { message: "Invalid role: developer" } }));
+            }
+        });
+    });
+    return new Promise((resolve) => server.listen(0, "127.0.0.1", () => resolve({ server, seen })));
+}
+
+test("e2e #583 G: mid-list developer→system 400s on a placement-strict backend; second-chance learns developer→user", async () => {
+    const { server: upstream, seen } = await ladderUpstream(true);
+    const harness = await startProxy(upstream, { compatJson: `{"providers":{}}` });
+    try {
+        const res1 = await fetch(`http://127.0.0.1:${harness.port}/v1/responses`, {
+            method: "POST",
+            headers: { "content-type": "application/json", "x-session-id": "compat-second-chance" },
+            body: MIDLIST_DEV_PAYLOAD,
+        });
+        assert.equal(res1.status, 200, "client sees a transparent 200 after the second-chance retry");
+        assert.equal(seen.length, 3, `expected 3 upstream hits (dev→sys→user), got ${JSON.stringify(seen)}`);
+        assert.ok(seen[0].includes("developer"), "hit 1 carries a developer role → rejected");
+        assert.ok(!seen[1].includes("developer") && seen[1].includes("system"), "hit 2: primary hop rewrote developer→system (mid-list → placement 400)");
+        assert.ok(!seen[2].includes("developer") && !seen[2].includes("system"), "hit 3: second-chance rewrote developer→user → accepted");
+        // Second request: the session learned developer→user, so every developer
+        // (typed or type-less) is pre-rewritten BEFORE fetch — no 400 round-trip.
+        const res2 = await fetch(`http://127.0.0.1:${harness.port}/v1/responses`, {
+            method: "POST",
+            headers: { "content-type": "application/json", "x-session-id": "compat-second-chance" },
+            body: MIDLIST_DEV_PAYLOAD,
+        });
+        assert.equal(res2.status, 200);
+        assert.equal(seen.length, 4, `expected 4 upstream hits total (3 + 1), got ${JSON.stringify(seen)}`);
+        assert.ok(!seen[3].includes("developer") && !seen[3].includes("system"), "second request pre-rewritten via learned map");
+        await waitFor(() => _liveUpstreamTimersForTest() === 0);
+        assert.equal(_liveUpstreamTimersForTest(), 0, "abandoned retry bodies must not re-arm the idle timer");
+    } finally {
+        await harness.stop();
+        harness.cleanup();
+        await close(upstream);
+    }
+});
+
+test("e2e #583 H: ladder is capped — every hop failing passes the ORIGINAL 400 verbatim, no loop", async () => {
+    const { server: upstream, seen } = await ladderUpstream(false);
+    const harness = await startProxy(upstream, { compatJson: `{"providers":{}}` });
+    try {
+        const res = await fetch(`http://127.0.0.1:${harness.port}/v1/responses`, {
+            method: "POST",
+            headers: { "content-type": "application/json", "x-session-id": "compat-second-chance-cap" },
+            body: MIDLIST_DEV_PAYLOAD,
+        });
+        assert.equal(res.status, 400, "client receives a 400 when every hop fails");
+        const text = await res.text();
+        assert.ok(text.includes("Invalid role: developer"), `original error preserved verbatim, got: ${text}`);
+        assert.equal(seen.length, 3, `expected exactly 3 upstream hits (original + 2 retries), got ${JSON.stringify(seen)}`);
+        await waitFor(() => _liveUpstreamTimersForTest() === 0);
+        assert.equal(_liveUpstreamTimersForTest(), 0, "abandoned retry bodies must not re-arm the idle timer");
     } finally {
         await harness.stop();
         harness.cleanup();


### PR DESCRIPTION
## Summary

Adds a bounded **second-chance** hop to the #552 learn-on-failure compat auto-fix, closing the edge described in #583.

On the Responses path, if a backend rejects an unknown role (`developer` -> 400) **and** only accepts `system` at index 0 (#377-class placement), the existing single retry rewrites the offending role to `system`. When that `developer` sits mid-list, the rewritten `system` is also mid-list -> the retry 400s again with a *placement* error (not a role-name error) -> the original 400 passes through verbatim and the auto-learn never engages.

This change adds one more controlled retry for exactly that case:

- New `detectSystemPlacementError(status, bodyText)` in `src/compat-roles.ts` — a conservative detector for system-placement 400s (`Only one 'system' ... at the beginning`, `Multiple system messages`, `system ... at index N`, ...). It requires a 400 plus the word "system" plus a strong placement/multiplicity marker, so quota / overflow / missing-system / auth 400s never trip it.
- In `src/server.ts` the single-retry block becomes a fixed **ladder**: primary `developer->system`; if (and only if) that 400s with a placement error, one more `developer->user`. On success the session learns the winning mapping (`developer->user` wins over the generic `->system`). Hard cap stays at original + 2 retries, never a loop; anything still failing passes the original 400 through verbatim.

## Scope notes (triage finding)

- **Chat path unaffected** — `systemToUser(coreToOpenai(...))` already normalizes mid-list `system`/`developer` to `user` before the wire, so the rewrite is a no-op there.
- One nuance worth flagging: through the *normal* compression pipeline a rejected `developer` is **hoisted to index 0** by the kernel (`injectResponsesDeveloperMessage`), so the primary `->system` retry already lands at index 0 and succeeds on placement-strict backends. A `developer` reaches the boundary **mid-list** only when it is non-normalized (e.g. missing `type`) or when the unchanged body is forwarded (transform-failure fallback). Both are covered by the new hop — so this is a defensive safety-net rather than a common-path fix, but it closes the class cleanly.

## Tests

- Unit test for `detectSystemPlacementError` (positive placement messages incl. quoted `'system'`; negative role/quota/overflow/auth; non-400 status).
- e2e **G**: mid-list `developer` -> primary `system` placement-400 -> second-chance `user` -> transparent 200; the next request on the same session pre-rewrites via the learned map (no round-trip). Asserts the exact 3-hit ladder + no idle-timer leak.
- e2e **H**: every hop fails -> exactly 3 hits, original 400 passed through verbatim, no loop, no timer leak.
- Existing **#552 E/F** regression tests still pass (primary hop unchanged; F's constant `Invalid role:` body does not match the placement detector, so it stays a single retry).

## Pre-flight

- `tsc --noEmit` clean
- `npm run build` OK (self-contained `dist/index.js`)
- Full suite green except a pre-existing, environment-dependent `launcher.test.ts` case (`codex resolve to themselves`) that fails identically on a clean tree whenever a real `codex` binary is present on PATH — unrelated to this change.
- Responses e2e (`tests/e2e/e2e-codex.test.ts`, gated by `ACP_TEST_E2E=1`) not run here (needs a live upstream); CI manual-dispatch covers it.

<!-- ework-agent-pr -->