### PR TITLE
docs: AGENTS.md — require issue tracking for discovered/fixed problems

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,6 +221,22 @@ When an Agent picks up an issue, these deliverables are MANDATORY:
    minor UX quirks) are reported in the current issue thread only — do NOT
    open separate issues for them.
 
+### Problem Discovery & Fix Reporting (MANDATORY)
+
+Problems discovered or fixed while working MUST leave a trace in the issue
+tracker — never fixed silently and moved on.
+
+1. **Discovered a problem** (bug, defect, wrong behavior, spec violation) —
+   whether while working on this project or any sibling project — file an
+   issue in the project the problem belongs to: repro/steps, impact, root
+   cause (if known), suggested fix.
+2. **Fixed a problem** — after the fix, submit an issue to the owning project
+   recording the problem and how it was fixed. For problems in this project:
+   https://github.com/ranxianglei/billion-context/issues . If the fix ships as
+   a PR, the PR MUST reference its issue (`Fixes #N`); a bare PR without an
+   issue is not acceptable — file the issue first, then link it. An existing
+   PR for the fix counts, but it should carry an accompanying issue.
+
 ### npm Publish — Absolute Prohibition
 
 `npm publish` is **handled by CI automatically** (see §5). The Agent MUST

--- a/devlog/2026-09-06_agents-md-problem-reporting/REQ.md
+++ b/devlog/2026-09-06_agents-md-problem-reporting/REQ.md
@@ -1,0 +1,44 @@
+# REQ - AGENTS.md problem discovery & fix reporting clause
+
+- Task ID: `2026-09-06_agents-md-problem-reporting`
+- Home Repo: `billion-context`
+- Created: 2026-09-06
+- Status: InProgress
+- Priority: P2
+- Owner: ranxianglei (agent)
+- References: https://github.com/ranxianglei/billion-context/issues/584
+
+## 1. Background & Problem Statement
+
+- **Context**: Agents frequently discover problems while working, and fixes sometimes land without any issue tracking — the problem, its impact, and the fix rationale exist only in a chat thread or nowhere.
+- **Current behavior (symptom)**: AGENTS.md's "Issue Work — Required Deliverables" covers issues an Agent *picks up*, but says nothing about problems discovered or fixed *along the way*; such fixes can be silent.
+- **Expected behavior**: A MANDATORY clause requires that every discovered problem is filed as an issue in the owning project, and every fix is followed by an issue recording the problem + fix (or a PR referencing its issue; issue first, then link). The clause references this project's GitHub address.
+- **Impact**: Traceability of all agent-driven fixes across the billion-context family.
+
+## 2. Reproduction (if applicable)
+
+N/A — documentation/policy change.
+
+## 3. Constraints & Non-Goals
+
+- **Constraints**:
+  - Backward compatibility: none (docs only).
+  - Performance requirements: n/a.
+  - Resource limits: n/a.
+- **Non-Goals** (explicitly out of scope): no code changes; no CI enforcement (policy lives in AGENTS.md); sibling repos get equivalent clauses via their own PRs (billion-context-pi, opencode-acp).
+
+## 4. Acceptance Criteria (must be testable)
+
+- **Correctness**:
+  - [x] AGENTS.md §4 contains a new subsection "Problem Discovery & Fix Reporting (MANDATORY)" covering both cases: discovered-but-unfixed → file issue; fixed → issue after fix, or PR referencing its issue (`Fixes #N`).
+  - [x] Clause references https://github.com/ranxianglei/billion-context/issues .
+- **Performance / Stability**: n/a.
+- **Regression**:
+  - [x] No code changes — typecheck/test/build not required (docs-only commit).
+
+## 5. Proposed Approach (optional)
+
+- **Affected modules & entry files**:
+  - `AGENTS.md` — new subsection under §4 Git Safety Rules, after "Issue Work — Required Deliverables".
+- **Risks**: None (documentation).
+- **Rollback strategy**: Revert the single docs commit.

--- a/devlog/2026-09-06_agents-md-problem-reporting/WORKLOG.md
+++ b/devlog/2026-09-06_agents-md-problem-reporting/WORKLOG.md
@@ -1,0 +1,47 @@
+# WORKLOG - AGENTS.md problem discovery & fix reporting clause
+
+- Task ID: `2026-09-06_agents-md-problem-reporting`
+- Home Repo: `billion-context`
+- Status: Done
+- Updated: 2026-09-06 22:10
+
+## 1. Summary
+
+- **What was done**: Added a MANDATORY subsection "Problem Discovery & Fix Reporting" to AGENTS.md §4 requiring issue tracking for every discovered problem and for every fix (issue first, PR references it via `Fixes #N`).
+- **Why** (issue #584): fixes discovered/made by agents were not required to leave a trace in the project's issue tracker; the clause makes that mandatory and points at this project's GitHub address.
+- **Behavior / compatibility changes**: No (documentation only).
+- **Risk level**: Low.
+
+## 2. Change Log
+
+### Commits
+
+| Commit | Description |
+|--------|-------------|
+| head of this branch | docs: AGENTS.md — require issue tracking for discovered/fixed problems (#584) |
+
+### Key Files
+
+- `AGENTS.md` — new subsection under §4 Git Safety Rules, between "Issue Work — Required Deliverables" and "npm Publish — Absolute Prohibition".
+- `devlog/2026-09-06_agents-md-problem-reporting/REQ.md`, `WORKLOG.md` — this entry.
+
+## 3. Design & Implementation Notes
+
+- Clause covers both directions requested in #584: (a) problem discovered (in this project or a sibling) → file an issue in the owning project; (b) problem fixed → after the fix, submit an issue recording problem + fix, or ship the PR referencing its issue (`Fixes #N`) — a bare PR without an issue is not acceptable; an existing PR counts but should carry an accompanying issue.
+- References https://github.com/ranxianglei/billion-context/issues per "agents.md 引用对应的项目地址".
+
+## 4. Testing & Verification
+
+### Build & Test Commands
+
+Docs-only change — no build/test required.
+
+### Results
+
+- **PASS/FAIL**: PASS (markdown edit; verified by re-read).
+
+## 5. Risk Assessment & Rollback
+
+- **Risk points**: none.
+- **Rollback method**: revert the single docs commit.
+- **Compatibility notes**: No.


### PR DESCRIPTION
Source issue: [ranxianglei/billion-context#584](https://github.com/ranxianglei/billion-context/issues/584)

Adds a MANDATORY subsection "Problem Discovery & Fix Reporting" to AGENTS.md §4 (Git Safety Rules):

1. **Discovered a problem** (bug, defect, wrong behavior, spec violation) — whether while working on this project or any sibling project — file an issue in the project the problem belongs to: repro/steps, impact, root cause (if known), suggested fix.
2. **Fixed a problem** — after the fix, submit an issue to the owning project recording the problem and how it was fixed (https://github.com/ranxianglei/billion-context/issues). If the fix ships as a PR, the PR MUST reference its issue (`Fixes #N`) — a bare PR without an issue is not acceptable; an existing PR counts but should carry an accompanying issue.

Docs-only change (AGENTS.md + devlog entry per repo convention). No code touched.

Sibling repos get equivalent clauses in their own PRs (billion-context-pi, opencode-acp), each referencing its own project address.

Fixes #584