### PR TITLE
release v0.1.88

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.86",
+  "version": "0.1.88",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.86",
+      "version": "0.1.88",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.87",
+  "version": "0.1.88",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Version-only release. Changes since v0.1.87 (17 merged PRs):

### Fixes
- **#591 / #590** — pi plugin 模式宿主 usage 回填改折叠口径：`armHostUsageCredit` 在 arming chokepoint 对 `pluginAgent === "pi"` 关闸（pi 插件取消了 pi 自身 auto-compact，未压缩基线只造成 footer 302.7% 显示混乱）；omp / codex / 普通代理客户端保留 #408 未压缩基线
- **#575 / #569** — preflight 遍历所有可行 range 才宣告耗尽
- **#544 / #535** — dsh phase 4：按目的地分流（loopback → /bili/ overlay，远端 https → CONNECT+MITM，明文 http → env 路由）；loopback 判定改 dotted-quad 127/8
- **#534 / #532** — 状态面板计入出站 system prompt + tool schema tokens
- **#563 / #562** — forward-proxy 请求不再被误判为 self，恢复 per-upstream window 配置
- **#528 / #527** — 实例注册表 lost-update 修复：per-instance marker 文件
- **#425 / #408** — 宿主 usage 上报未压缩基线 + 负值持久化 token 统计 clamp
- **#565 / #564** — Responses 压缩后保持 assistant 历史合法
- **#557 / #554** — side request 防 over-window payload（估计器偏差容忍）
- **#587 / #401** — 持久化改有界折叠快照（BILI_PERSIST_TAIL_TOKENS 默认 16384），磁盘占用从 63.2% 降到个位数百分比
- **#556 / #551** — 上游空闲超时 12 分钟 + `BILI_UPSTREAM_TIMEOUT_MS`
- **#581 / #580** — git source checkout 跳过 auto-update
- **#576 / #470** — preflight 触发器计入 system+tools wire overhead
- **#579 / #552** — compat role 改写（dev↔system/user 自动学习重试）+ fetch-util 定时器竞态
- **#397 / #387** — `/acp` status 现算 live ranges（统一 3 处 dispatcher）
- **#337 / #330** — preflight 软区降零（fit gate 含 imageTokens）

### Docs
- **#586** — AGENTS.md：问题发现/修复必须留 issue 痕迹

### Pre-flight
typecheck ✓ · tests 1140/1142（2 个已知 plugin-agent 环境失败）✓ · build ✓
