### PR TITLE
fix #589: forward trailing usage-only frame on raw tool-call rounds

### DIFF
--- a/src/loop/adapter-openai.ts
+++ b/src/loop/adapter-openai.ts
@@ -115,6 +115,27 @@ function stripFinishReasonChunk(buf: Buffer): Buffer {
     }
 }
 
+function patchUsageChunk(eventStr: string, parsed: Record<string, unknown>, u: Record<string, unknown>, hostCredit: number): Buffer {
+    const pu = typeof u.prompt_tokens === "number" ? u.prompt_tokens : undefined;
+    const tu = typeof u.total_tokens === "number" ? u.total_tokens : undefined;
+    if (hostCredit > 0 && (pu !== undefined || tu !== undefined)) {
+        const patched = {
+            ...parsed,
+            usage: {
+                ...u,
+                ...(pu !== undefined ? { prompt_tokens: pu + hostCredit } : {}),
+                ...(tu !== undefined ? { total_tokens: tu + hostCredit } : {}),
+            },
+        };
+        const out = eventStr
+            .split("\n")
+            .map((l) => (l.startsWith("data:") ? `data: ${JSON.stringify(patched)}` : l))
+            .join("\n");
+        return Buffer.from(out + "\n\n", "utf8");
+    }
+    return Buffer.from(eventStr + "\n\n", "utf8");
+}
+
 export function createOpenaiAdapter(requestBody: Record<string, unknown>, clientSystem?: string, hostCredit = 0): CompressLoopAdapter {
     const model = (requestBody.model as string) ?? "unknown";
     let responseId = `chatcmpl-proxy-${Date.now()}`;
@@ -311,6 +332,13 @@ export function createOpenaiAdapter(requestBody: Record<string, unknown>, client
                             outputTokens: typeof u.completion_tokens === "number" ? u.completion_tokens : undefined,
                             cachedTokens: typeof pd?.cached_tokens === "number" ? pd.cached_tokens : undefined,
                         } as ParsedStreamEvent;
+                        // #589: include_usage clients (dsh, OpenAI SDK) read usage
+                        // from this trailing empty-choices frame; raw tool-call rounds
+                        // must forward it (with the prepare-time credit), not swallow
+                        // it into the internal ledger.
+                        if (sawRealToolCall) {
+                            yield { kind: "meta", chunk: patchUsageChunk(eventStr, parsed, u, hostCredit) } as ParsedStreamEvent;
+                        }
                     }
                     continue;
                 }
@@ -334,26 +362,7 @@ export function createOpenaiAdapter(requestBody: Record<string, unknown>, client
                         // post-fold usage) reaches the host verbatim — add the
                         // prepare-time credit back so the host anchors on the
                         // uncompressed baseline.
-                        let chunk = rawBuf;
-                        if (hostCredit > 0 && u) {
-                            const pu = typeof u.prompt_tokens === "number" ? u.prompt_tokens : undefined;
-                            const tu = typeof u.total_tokens === "number" ? u.total_tokens : undefined;
-                            if (pu !== undefined || tu !== undefined) {
-                                const patched = {
-                                    ...parsed,
-                                    usage: {
-                                        ...u,
-                                        ...(pu !== undefined ? { prompt_tokens: pu + hostCredit } : {}),
-                                        ...(tu !== undefined ? { total_tokens: tu + hostCredit } : {}),
-                                    },
-                                };
-                                const out = eventStr
-                                    .split("\n")
-                                    .map((l) => (l.startsWith("data:") ? `data: ${JSON.stringify(patched)}` : l))
-                                    .join("\n");
-                                chunk = Buffer.from(out + "\n\n", "utf8");
-                            }
-                        }
+                        const chunk = patchUsageChunk(eventStr, parsed, u ?? {}, hostCredit);
                         // This verbatim chunk IS the round's authoritative completion
                         // (suppressCompletion); write it once and never fall through
                         // to the text/reasoning branches (which would re-emit the same

--- a/tests/issue589-usage-frame.test.ts
+++ b/tests/issue589-usage-frame.test.ts
@@ -1,0 +1,68 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createOpenaiAdapter } from "../src/loop/index.ts";
+
+function streamOf(events: string[]): ReadableStream<Uint8Array> {
+    let i = 0;
+    return new ReadableStream<Uint8Array>({
+        pull(controller) {
+            if (i < events.length) {
+                controller.enqueue(Buffer.from(events[i++], "utf8"));
+            } else {
+                controller.close();
+            }
+        },
+    });
+}
+
+const chunk = (o: unknown): string => `data: ${JSON.stringify(o)}\n\n`;
+
+const toolDelta = { id: "c1", object: "chat.completion.chunk", created: 1, model: "m", choices: [{ index: 0, delta: { tool_calls: [{ index: 0, id: "call_1", type: "function", function: { name: "get_weather", arguments: "" } }] } }] };
+const finishChunk = { id: "c1", object: "chat.completion.chunk", created: 1, model: "m", choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }] };
+const usageFrame = { id: "c1", object: "chat.completion.chunk", created: 1, model: "m", choices: [], usage: { prompt_tokens: 50000, completion_tokens: 10, total_tokens: 50010 } };
+
+async function collect(adapter: ReturnType<typeof createOpenaiAdapter>, events: string[]): Promise<{ meta: string; kinds: string[] }> {
+    let meta = "";
+    const kinds: string[] = [];
+    for await (const ev of adapter.parseStream(streamOf(events), 1)) {
+        kinds.push(ev.kind);
+        if (ev.kind === "meta") meta += ev.chunk.toString("utf8");
+    }
+    return { meta, kinds };
+}
+
+test("#589: raw tool-call round forwards the trailing usage-only frame, patched with credit", async () => {
+    const adapter = createOpenaiAdapter({ model: "m" }, undefined, 40000);
+    const { meta } = await collect(adapter, [chunk(toolDelta), chunk(finishChunk), chunk(usageFrame), "data: [DONE]\n\n"]);
+    const usageAt = meta.indexOf('"prompt_tokens":90000');
+    const finishAt = meta.indexOf('"finish_reason":"tool_calls"');
+    const doneAt = meta.indexOf("[DONE]");
+    assert.ok(usageAt >= 0, `expected patched usage frame in client stream: ${meta}`);
+    assert.ok(meta.includes('"total_tokens":90010'), meta);
+    assert.ok(finishAt >= 0 && usageAt > finishAt, `usage frame must come after the finish chunk: ${meta}`);
+    assert.ok(doneAt >= 0 && usageAt < doneAt, `usage frame must come before [DONE]: ${meta}`);
+});
+
+test("#589: trailing usage-only frame forwarded verbatim when no credit", async () => {
+    const adapter = createOpenaiAdapter({ model: "m" }, undefined, 0);
+    const { meta } = await collect(adapter, [chunk(toolDelta), chunk(finishChunk), chunk(usageFrame), "data: [DONE]\n\n"]);
+    assert.ok(meta.includes('"prompt_tokens":50000'), meta);
+    assert.ok(!meta.includes('"prompt_tokens":90000'), meta);
+});
+
+test("#589: non-tool rounds keep swallowing the trailing frame (rebuild embeds usage)", async () => {
+    const adapter = createOpenaiAdapter({ model: "m" }, undefined, 40000);
+    const textDelta = { id: "c1", object: "chat.completion.chunk", created: 1, model: "m", choices: [{ index: 0, delta: { content: "hi there" } }] };
+    const finishText = { id: "c1", object: "chat.completion.chunk", created: 1, model: "m", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] };
+    const { meta } = await collect(adapter, [chunk(textDelta), chunk(finishText), chunk(usageFrame), "data: [DONE]\n\n"]);
+    assert.ok(!meta.includes("prompt_tokens"), `rebuild round must not forward the raw usage frame: ${meta}`);
+});
+
+test("#589: usage-only frame without usage field is not forwarded", async () => {
+    const adapter = createOpenaiAdapter({ model: "m" }, undefined, 40000);
+    const emptyChoices = { id: "c1", object: "chat.completion.chunk", created: 1, model: "m", choices: [] };
+    const { meta } = await collect(adapter, [chunk(toolDelta), chunk(finishChunk), chunk(emptyChoices), "data: [DONE]\n\n"]);
+    assert.ok(!meta.includes("chat.completion.chunk\" }"), meta);
+    const frames = meta.split("data: ").length - 1;
+    assert.equal(frames, 3, `expected only tool-delta + finish + [DONE] frames: ${meta}`);
+});


### PR DESCRIPTION
## Root cause

dsh sends `stream_options: {include_usage: true}`. SGLang/vLLM deliver usage in a **trailing empty-choices frame** (`choices:[]` + `usage`), sent AFTER the finish chunk and BEFORE `[DONE]`.

In the OpenAI loop adapter, tool-call rounds take the raw-passthrough path (`sawRealToolCall`): the finish chunk forwards verbatim (SGLang puts no usage there), but the trailing usage frame hit the `!choice` branch of `parseStream`, was parsed into the internal usage event, then `continue` — **never forwarded to the client**. Result: every tool-call round reported 0/0 usage; dsh's context circle (last-wins pressure from usage chunks) collapsed to a few hundred tokens (surface-only growth). Rebuilt rounds were unaffected (usage embedded via `emitCompletion`), which is why only tool-call STEPS in the user's session jsonl carried `inputTokens:0`.

Not #590-class (that was pi over-reporting via the #408 backfill); this is under-reporting via a dropped frame. Affects **all** include_usage clients, not just dsh.

Repro (before): direct upstream sends finish → `choices:[] usage:{...}` → `[DONE]`; via bili the usage frame vanished.

## Fix

`src/loop/adapter-openai.ts`:
- extract `patchUsageChunk(eventStr, parsed, u, hostCredit)` — the #408 finish-chunk credit patch, now reused by both call sites
- `!choice` branch: when `sawRealToolCall`, additionally `yield {kind:"meta", chunk: patchUsageChunk(...)}` so the client receives the trailing usage frame, credited like the finish chunk. Rebuilt rounds stay unchanged (emitCompletion already embeds usage; forwarding the raw frame there would duplicate it AND undercut the backfill for last-wins clients).

## Verification

- new `tests/issue589-usage-frame.test.ts` (4 tests): raw round forwards the frame patched + ordered finish→usage→[DONE]; verbatim when credit=0; non-tool rounds keep swallowing it (no dup); frames without usage not forwarded
- full suite: only the 2 known plugin-agent env fails; typecheck + build clean
- live: replayed a dsh-shaped tool-call request through a local build — client now receives the trailing usage frame before `[DONE]`

Fixes #589
