### PR TITLE
release v0.1.89

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.88",
+  "version": "0.1.89",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Changes since v0.1.88

Six bug-fix PRs:

| PR | Issue | Fix |
|---|---|---|
| #593 | #589 | forward the trailing usage-only frame (`choices:[]` + `usage`) on raw tool-call rounds — include_usage clients (dsh, official OpenAI SDK) saw 0/0 per tool round |
| #550 | #549 | accept `data:`-only SSE frames in the Responses adapter (WHATWG-legal; was rejected → synthetic response.failed) |
| #558 | #553 | preflight for anonymous zero-baseline (fork) sessions judges size by a char upper bound (1 char = 1 token) instead of the optimistic 4-chars/token estimate that undercounted dense replays ~4x and forwarded over-window payloads raw |
| #571 | #568 | preflight hold: after a 30s grace (`BILI_PREFLIGHT_HOLD_MS`) the proxy commits 200 + keep-alive bytes (SSE comments / JSON whitespace) so long preflight compression no longer dies on client header timeouts; late failures delivered in-band |
| #572 | #570 | weak-overflow self-correction: provenance split (confirmed vs learned context limits), retraction when a later turn succeeds above a learned window, llama.cpp `exceed_context_size_error` body parsing |
| #585 | #583 | compat auto-fix second chance: dev→system retry that still 400s retries dev→user and learns the provider's combination |

acp-kernel stays 0.0.54 (no kernel changes in this release).

Docs: `BILI_PREFLIGHT_HOLD_MS` added to CONFIGURATION.md / CONFIGURATION.zh-CN.md env reference.

## Pre-flight

- typecheck ✓
- tests 1169/1171 (2 known env-only failures in plugin-agent.test.ts, identical on master)
- build ✓
