### PR TITLE
chore: bump acp-kernel to 0.0.56 (fixes red acp_status estimator tests)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@types/node": "^22.0.0",
         "@types/node-forge": "^1.3.14",
-        "acp-kernel": "0.0.54",
+        "acp-kernel": "0.0.56",
         "fzstd": "0.1.1",
         "node-forge": "^1.4.0",
         "tar": "^7.5.22",
@@ -988,9 +988,9 @@
       }
     },
     "node_modules/acp-kernel": {
-      "version": "0.0.54",
-      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.54.tgz",
-      "integrity": "sha512-7ETdru+1jn0zLd0uAEfIUDVi/UlyZbcis13BwBJpHqBE768Jw3f2CgNecTy8U5sXGiNG29nYKD6ctKHYDGdsQg==",
+      "version": "0.0.56",
+      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.56.tgz",
+      "integrity": "sha512-5bNbzKHmbojWAHxA3dOa7yL1WD+6DSPe+szTLCGYE4k3afUUIz/v6akrGGUfn8tzkckVBno9SfPlT6iVj14D6g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/node-forge": "^1.3.14",
-    "acp-kernel": "0.0.54",
+    "acp-kernel": "0.0.56",
     "fzstd": "0.1.1",
     "node-forge": "^1.4.0",
     "tar": "^7.5.22",


### PR DESCRIPTION
## What

`acp-kernel` pin 0.0.54 → 0.0.56 (exact pin per AGENTS.md; 0.0.56 verified live on npm before bumping).

## Why

`tests/acp-status-estimator.test.ts` (added by #386, `ec303e1`) is red **on current master** — the PR merged with a failing CI cell. Root cause is in the kernel, not our code: `buildStatusReport` in 0.0.54 attributes `tool-result` messages to the **text** bucket instead of their calling tool.

Repro against the pinned kernel alone (0.0.54 vs 0.0.56):

```
0.0.54: 2 tool (1%) | 6.1K text (100%)   Top tools: text (100%), bash (1%), read (1%)
0.0.56: 6.0K tool (98%) | 111 text (2%)  Top tools: bash (65%), read (33%), text (2%)
```

Exactly what the #386 tests assert (tool ≈ 6.0K CJK 1:1, bash dominating Top tools).

## Pre-flight

- `npm run typecheck` ✅
- `npm test` — **1178/1178 ✅** (the 2 estimator failures gone, nothing else regressed across the two kernel patch releases)
- `npm run build` ✅

## Notes

- Zero source changes — dependency pin + lockfile only.
- Merge this **before** the #588 exit-matrix PR so that PR's CI runs green.