### PR TITLE
test: wire-exit enumeration matrix (#588) — registry + missing abort/error cells

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@types/node": "^22.0.0",
         "@types/node-forge": "^1.3.14",
-        "acp-kernel": "0.0.54",
+        "acp-kernel": "0.0.56",
         "fzstd": "0.1.1",
         "node-forge": "^1.4.0",
         "tar": "^7.5.22",
@@ -988,9 +988,9 @@
       }
     },
     "node_modules/acp-kernel": {
-      "version": "0.0.54",
-      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.54.tgz",
-      "integrity": "sha512-7ETdru+1jn0zLd0uAEfIUDVi/UlyZbcis13BwBJpHqBE768Jw3f2CgNecTy8U5sXGiNG29nYKD6ctKHYDGdsQg==",
+      "version": "0.0.56",
+      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.56.tgz",
+      "integrity": "sha512-5bNbzKHmbojWAHxA3dOa7yL1WD+6DSPe+szTLCGYE4k3afUUIz/v6akrGGUfn8tzkckVBno9SfPlT6iVj14D6g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/node-forge": "^1.3.14",
-    "acp-kernel": "0.0.54",
+    "acp-kernel": "0.0.56",
     "fzstd": "0.1.1",
     "node-forge": "^1.4.0",
     "tar": "^7.5.22",

--- a/src/exit-matrix.ts
+++ b/src/exit-matrix.ts
@@ -1,0 +1,155 @@
+import { emitStreamError, emitPreflightError } from "./stream-error.js";
+import { backfillHostUsage } from "./util.js";
+import { pipePluginChatWithStrip, pipePluginResponsesWithStrip, pipePluginJson } from "./plugin.js";
+import { startServer } from "./server.js";
+
+// Exit-enumeration matrix (#588): every wire exit x cross-cutting concern
+// must have an explicit cell here. `Record<WireExitId, ExitCell>` is the
+// compile-time guard — adding an exit to WIRE_EXITS without filling its row
+// in EVERY concern table fails typecheck. `implementer` holds live symbol
+// references (moving/deleting an implementation breaks the import), and
+// `coveredBy` names the test file(s) asserting the cell's contract — the
+// matrix test (tests/wire-exit-matrix.test.ts) fails if a listed file is
+// missing, and behavior tests iterate WIRE_EXITS so a new exit with no
+// scenario coverage fails the run. This is a registry only: no runtime
+// behavior is routed through it.
+
+export const WIRE_EXITS = [
+    "proxy-openai-sse",
+    "proxy-anthropic-sse",
+    "proxy-responses-sse",
+    "proxy-json",
+    "plugin-chat-sse",
+    "plugin-responses-sse",
+    "plugin-json",
+] as const;
+
+export type WireExitId = (typeof WIRE_EXITS)[number];
+
+export interface ExitCell {
+    readonly implementer: readonly unknown[];
+    readonly contract: string;
+    readonly coveredBy: readonly string[];
+}
+
+export const ERROR_DELIVERY: Record<WireExitId, ExitCell> = {
+    "proxy-openai-sse": {
+        implementer: [emitStreamError, emitPreflightError, startServer],
+        contract: "mid-stream upstream failure → inline `error` delta + finish + [DONE]; late (early-committed) preflight failure → top-level error object + [DONE] in-band",
+        coveredBy: ["tests/proxy-stream-error.test.ts", "tests/wire-exit-matrix.test.ts"],
+    },
+    "proxy-anthropic-sse": {
+        implementer: [emitStreamError, emitPreflightError, startServer],
+        contract: "mid-stream failure → content_block_delta error + message_stop; late preflight failure → event: error payload in-band",
+        coveredBy: ["tests/proxy-stream-error.test.ts", "tests/preflight-hold.test.ts"],
+    },
+    "proxy-responses-sse": {
+        implementer: [emitStreamError, emitPreflightError, startServer],
+        contract: "mid-stream failure → full item lifecycle (added → delta → done) + response.failed; late preflight failure → event: error in-band",
+        coveredBy: ["tests/proxy-stream-error.test.ts", "tests/preflight-hold.test.ts"],
+    },
+    "proxy-json": {
+        implementer: [emitPreflightError, startServer],
+        contract: "pre-headers failure → 4xx/5xx `{error}` JSON; post-early-commit failure → identical `{error}` JSON body on the already-committed 200",
+        coveredBy: ["tests/preflight-hold.test.ts", "tests/preflight-fail-fast.test.ts"],
+    },
+    "plugin-chat-sse": {
+        implementer: [pipePluginChatWithStrip],
+        contract: "byte-faithful passthrough: pre-stream fetch failure → JSON `{error: formatUpstreamError}` before any SSE byte; mid-stream cut → stream simply ends (no synthetic error event — the agent's tool loop must not see fabricated events)",
+        coveredBy: ["tests/issue411-abort-usage.test.ts", "tests/plugin-agent.test.ts"],
+    },
+    "plugin-responses-sse": {
+        implementer: [pipePluginResponsesWithStrip],
+        contract: "same as plugin-chat-sse, responses wire",
+        coveredBy: ["tests/issue411-abort-usage.test.ts"],
+    },
+    "plugin-json": {
+        implementer: [pipePluginJson],
+        contract: "upstream non-2xx/fetch failure → `{error: formatUpstreamError}` JSON; client abort mid-body → clean end, timer cleared",
+        coveredBy: ["tests/issue411-abort-usage.test.ts", "tests/host-usage-backfill.test.ts"],
+    },
+};
+
+export const ABORT_PROPAGATION: Record<WireExitId, ExitCell> = {
+    "proxy-openai-sse": {
+        implementer: [startServer],
+        contract: "client disconnects mid-stream → the in-flight upstream request is destroyed (no orphaned summarization/forward), session lock released",
+        coveredBy: ["tests/wire-exit-matrix.test.ts"],
+    },
+    "proxy-anthropic-sse": {
+        implementer: [startServer],
+        contract: "same as proxy-openai-sse, anthropic wire",
+        coveredBy: ["tests/wire-exit-matrix.test.ts"],
+    },
+    "proxy-responses-sse": {
+        implementer: [startServer],
+        contract: "same as proxy-openai-sse, responses wire",
+        coveredBy: ["tests/wire-exit-matrix.test.ts"],
+    },
+    "proxy-json": {
+        implementer: [startServer],
+        contract: "client disconnects while awaiting the buffered JSON → upstream request destroyed",
+        coveredBy: ["tests/wire-exit-matrix.test.ts"],
+    },
+    "plugin-chat-sse": {
+        implementer: [pipePluginChatWithStrip],
+        contract: "client abort → upstream stream cancelled, fetch-util timer cleared, sniffed usage kept (#411); repeated aborts do not accumulate timers",
+        coveredBy: ["tests/issue411-abort-usage.test.ts"],
+    },
+    "plugin-responses-sse": {
+        implementer: [pipePluginResponsesWithStrip],
+        contract: "same as plugin-chat-sse, responses wire",
+        coveredBy: ["tests/issue411-abort-usage.test.ts"],
+    },
+    "plugin-json": {
+        implementer: [pipePluginJson],
+        contract: "client abort mid-body → no crash, timer cleared (#411)",
+        coveredBy: ["tests/issue411-abort-usage.test.ts"],
+    },
+};
+
+export const HOST_USAGE_BACKFILL: Record<WireExitId, ExitCell> = {
+    "proxy-openai-sse": {
+        implementer: [backfillHostUsage],
+        contract: "usage frame from the upstream terminal event is credited to the session (input/cached/output), fallback samples on truncation",
+        coveredBy: ["tests/host-usage-backfill.test.ts"],
+    },
+    "proxy-anthropic-sse": {
+        implementer: [backfillHostUsage],
+        contract: "message_start/message_delta usage frames credited",
+        coveredBy: ["tests/host-usage-backfill.test.ts"],
+    },
+    "proxy-responses-sse": {
+        implementer: [backfillHostUsage],
+        contract: "response.completed usage frame credited (issue #589 frame shape)",
+        coveredBy: ["tests/issue589-usage-frame.test.ts", "tests/host-usage-backfill.test.ts"],
+    },
+    "proxy-json": {
+        implementer: [backfillHostUsage],
+        contract: "non-stream usage object credited; no session → skipped (title-gen must not clobber lastInputTokens)",
+        coveredBy: ["tests/host-usage-backfill.test.ts"],
+    },
+    "plugin-chat-sse": {
+        implementer: [pipePluginChatWithStrip, backfillHostUsage],
+        contract: "sniffed usage credited unless the call is session-less (#460 title-gen skip)",
+        coveredBy: ["tests/host-usage-backfill.test.ts", "tests/issue411-abort-usage.test.ts"],
+    },
+    "plugin-responses-sse": {
+        implementer: [pipePluginResponsesWithStrip, backfillHostUsage],
+        contract: "sniffed usage credited; verbatim variant skips accounting by design",
+        coveredBy: ["tests/host-usage-backfill.test.ts"],
+    },
+    "plugin-json": {
+        implementer: [pipePluginJson, backfillHostUsage],
+        contract: "JSON usage object credited",
+        coveredBy: ["tests/host-usage-backfill.test.ts"],
+    },
+};
+
+export const EXIT_CONCERNS = {
+    errorDelivery: ERROR_DELIVERY,
+    abortPropagation: ABORT_PROPAGATION,
+    hostUsageBackfill: HOST_USAGE_BACKFILL,
+} as const;
+
+export type ExitConcernId = keyof typeof EXIT_CONCERNS;

--- a/tests/wire-exit-matrix.test.ts
+++ b/tests/wire-exit-matrix.test.ts
@@ -1,0 +1,341 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import { once } from "node:events";
+import test from "node:test";
+import { existsSync } from "node:fs";
+
+process.env.NODE_ENV = "test";
+process.env.BILI_REPLAY_RETRY_MAX = "1";
+process.env.BILI_PREFLIGHT_HOLD_MS = "300";
+
+import { defaultConfig } from "acp-kernel";
+import { startServer, type ProxyOptions } from "../src/server.ts";
+import { SessionStore, _setStoreForTest } from "../src/persist.ts";
+import { _setForTest as setRegistryForTest } from "../src/registry.ts";
+import { EXIT_CONCERNS, WIRE_EXITS, type ExitConcernId } from "../src/exit-matrix.ts";
+
+// #588 exit-enumeration matrix. Two layers:
+//
+// 1. META: the registry (src/exit-matrix.ts) is exhaustive over exits x
+//    concerns and every `coveredBy` file exists on disk — renaming or
+//    deleting a covering test breaks the matrix here, and adding a wire
+//    exit without registry rows already fails typecheck.
+// 2. BEHAVIOR: per-cell scenarios for the cells that had NO coverage before
+//    this file: proxy-side client-abort propagation on all four proxy
+//    exits, and the openai-chat in-band preflight error (the other in-band
+//    cells were covered by tests/preflight-hold.test.ts).
+
+const SLOW_MS = 1500;
+
+const SUMMARY_TEXT =
+    "PREFLIGHT SUMMARY: the segment covered a debugging session. " +
+    "Key decisions: chose the preflight approach. Files touched: src/a.ts:10. Outcome: fixed.";
+
+function anthropicSse(): string {
+    return (
+        `event: message_start\ndata: ${JSON.stringify({ type: "message_start", message: { id: "m1", role: "assistant", usage: { input_tokens: 1000 } } })}\n\n` +
+        `event: content_block_delta\ndata: ${JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "ok" } })}\n\n` +
+        `event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`
+    );
+}
+
+function openaiSsePartial(): string {
+    return `data: ${JSON.stringify({ id: "c1", object: "chat.completion.chunk", choices: [{ index: 0, delta: { content: "par" }, finish_reason: null }] })}\n\n`;
+}
+
+function responsesSsePartial(): string {
+    return `event: response.created\ndata: ${JSON.stringify({ response: { id: "r1", status: "in_progress" } })}\n\n`;
+}
+
+function bigConversation(turns = 12): Array<{ role: string; content: string }> {
+    const msgs: Array<{ role: string; content: string }> = [];
+    for (let i = 0; i < turns; i++) {
+        const role = i % 2 === 0 ? "user" : "assistant";
+        msgs.push({ role, content: `Message ${i} of the long conversation. ` + `MARKER_${i}_content_`.repeat(250) });
+    }
+    return msgs;
+}
+
+function bigResponsesInput(): Array<{ type: string; role: string; content: string }> {
+    const input: Array<{ type: string; role: string; content: string }> = [];
+    for (let i = 0; i < 12; i++) {
+        input.push({ type: "message", role: i % 2 === 0 ? "user" : "assistant", content: `Message ${i} of the working session. ` + `WORK_${i}_content_`.repeat(290) });
+    }
+    return input;
+}
+
+type UpstreamMode = "hang-openai" | "hang-anthropic" | "hang-responses" | "hang-json" | "slow-summary-fwd-429" | "slow-summary-429";
+
+function startUpstream(mode: UpstreamMode): Promise<{ server: http.Server; port: number; socketsClosed: () => number; requests: () => number }> {
+    let closed = 0;
+    let requests = 0;
+    const server = http.createServer((req, res) => {
+        const chunks: Buffer[] = [];
+        req.on("data", (c: Buffer) => chunks.push(c));
+        req.on("close", () => {
+            closed++;
+        });
+        req.on("end", () => {
+            requests++;
+            const raw = Buffer.concat(chunks).toString("utf8");
+            let parsed: { stream?: boolean; messages?: unknown[] } = {};
+            try { parsed = JSON.parse(raw); } catch { /* keep {} */ }
+            const isSummary = !parsed.stream;
+            if (mode === "slow-summary-fwd-429" || mode === "slow-summary-429") {
+                if (isSummary && mode === "slow-summary-429") {
+                    // Fail the summarization itself AFTER the hold grace so the
+                    // early 200 is already committed (→ emitPreflightError path).
+                    setTimeout(() => {
+                        res.writeHead(429, { "content-type": "application/json" });
+                        res.end(JSON.stringify({ error: { message: "rate limited", type: "rate_limit_error" } }));
+                    }, SLOW_MS);
+                    return;
+                }
+                if (isSummary) {
+                    setTimeout(() => {
+                        res.writeHead(200, { "content-type": "application/json" });
+                        res.end(JSON.stringify({ id: "sum", object: "chat.completion", choices: [{ index: 0, message: { role: "assistant", content: SUMMARY_TEXT }, finish_reason: "stop" }], usage: { prompt_tokens: 500, completion_tokens: 50, total_tokens: 550 } }));
+                    }, SLOW_MS);
+                    return;
+                }
+                // The post-preflight FORWARD fails fast — after the early commit
+                // (→ emitStreamError mid-stream path).
+                res.writeHead(429, { "content-type": "text/event-stream" });
+                res.end(`data: ${JSON.stringify({ error: { message: "rate limited", type: "rate_limit_error" } })}\n\ndata: [DONE]\n\n`);
+                return;
+            }
+            // hang-* modes: commit headers + one partial chunk, then never end.
+            // The proxy MUST destroy this socket when its client aborts.
+            if (mode === "hang-openai") {
+                res.writeHead(200, { "content-type": "text/event-stream" });
+                res.write(openaiSsePartial());
+            } else if (mode === "hang-anthropic") {
+                res.writeHead(200, { "content-type": "text/event-stream" });
+                res.write(anthropicSse().split("event: content_block_delta")[0]!);
+            } else if (mode === "hang-responses") {
+                res.writeHead(200, { "content-type": "text/event-stream" });
+                res.write(responsesSsePartial());
+            } else {
+                // hang-json: nothing at all — headers withheld.
+            }
+        });
+    });
+    return new Promise((resolve) => {
+        server.listen(0, "127.0.0.1", () => {
+            resolve({ server, port: server.address().port, socketsClosed: () => closed, requests: () => requests });
+        });
+    });
+}
+
+function startProxy(upstreamPort: number): Promise<http.Server> {
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    setRegistryForTest({});
+    return startServer({
+        port: 0,
+        host: "127.0.0.1",
+        upstream: "http://127.0.0.1",
+        routes: { [`http://127.0.0.1:${upstreamPort}`]: { models: { "m-test": { context: 10_000 } } } },
+        modelContextLimit: 400_000,
+        kernelConfig: defaultConfig(400_000),
+        compress: { injectTool: true, injectNudge: true },
+        promptCache: { routing: "auto" },
+        sessionHeader: "x-acp-session",
+        log: false,
+        debug: false,
+        passthrough: false,
+        autoUpdate: false,
+        mitm: { enabled: false, domains: [] },
+    } as ProxyOptions);
+}
+
+/** Opens a request, waits for the first body byte (or headers for JSON),
+ *  then destroys the client socket — simulating a user hitting Ctrl-C. */
+function abortAfterFirstByte(url: string, headers: Record<string, string>, body: string): Promise<"header" | "first-byte"> {
+    return new Promise((resolve, reject) => {
+        const req = http.request(url, { method: "POST", headers }, (res) => {
+            res.once("data", () => {
+                req.destroy();
+                resolve("first-byte");
+            });
+            // hang-json never sends a body — abort on headers after a beat.
+            res.once("end", () => resolve("header"));
+        });
+        req.on("error", (e: NodeJS.ErrnoException) => {
+            if (e.code === "ECONNRESET") resolve("first-byte");
+            else reject(e);
+        });
+        setTimeout(() => {
+            req.destroy();
+            resolve("header");
+        }, 400).unref();
+        req.end(body);
+    });
+}
+
+test("matrix meta: every concern table is exhaustive and every coveredBy test file exists", () => {
+    const concernIds = Object.keys(EXIT_CONCERNS) as ExitConcernId[];
+    assert.ok(concernIds.length >= 3);
+    for (const concern of concernIds) {
+        const table = EXIT_CONCERNS[concern] as Record<string, { implementer: unknown[]; contract: string; coveredBy: string[] }>;
+        assert.deepEqual(
+            Object.keys(table).sort(),
+            [...WIRE_EXITS].sort(),
+            `${concern} must enumerate exactly WIRE_EXITS (a new exit needs a row here — and typecheck enforces it)`,
+        );
+        for (const [exitId, cell] of Object.entries(table)) {
+            assert.ok(cell.implementer.length > 0, `${concern}/${exitId}: implementer refs are live imports, not strings`);
+            assert.ok(cell.contract.length > 20, `${concern}/${exitId}: contract must state the cell's observable behavior`);
+            for (const f of cell.coveredBy) {
+                assert.ok(existsSync(f), `${concern}/${exitId}: coveredBy "${f}" does not exist — coverage reference went stale`);
+            }
+        }
+    }
+});
+
+test("abort x proxy-openai-sse: client abort mid-stream destroys the upstream request", async () => {
+    const up = await startUpstream("hang-openai");
+    const proxy = await startProxy(up.port);
+    await once(proxy, "listening");
+    const proxyPort = (proxy.address() as { port: number }).port;
+    try {
+        const url = `http://127.0.0.1:${proxyPort}/bili/http://127.0.0.1:${up.port}/v1/chat/completions`;
+        const outcome = await abortAfterFirstByte(url, { "content-type": "application/json", "x-acp-session": "mx-abort-oai" }, JSON.stringify({ model: "m-test", max_tokens: 1024, stream: true, messages: [{ role: "user", content: "hi" }] }));
+        assert.ok(outcome === "first-byte" || outcome === "header");
+        await new Promise((r) => setTimeout(r, 300));
+        assert.ok(up.socketsClosed() >= 1, `upstream socket(s) must be destroyed after the client abort (closed=${up.socketsClosed()})`);
+        assert.equal(up.requests(), 1, "exactly one upstream request");
+    } finally {
+        proxy.close();
+        await once(proxy, "close");
+        up.server.close();
+        await once(up.server, "close");
+    }
+});
+
+test("abort x proxy-anthropic-sse: client abort mid-stream destroys the upstream request", async () => {
+    const up = await startUpstream("hang-anthropic");
+    const proxy = await startProxy(up.port);
+    await once(proxy, "listening");
+    const proxyPort = (proxy.address() as { port: number }).port;
+    try {
+        const url = `http://127.0.0.1:${proxyPort}/bili/http://127.0.0.1:${up.port}/v1/messages`;
+        await abortAfterFirstByte(url, { "content-type": "application/json", "x-acp-session": "mx-abort-ant" }, JSON.stringify({ model: "m-test", max_tokens: 1024, stream: true, messages: [{ role: "user", content: "hi" }] }));
+        await new Promise((r) => setTimeout(r, 300));
+        assert.ok(up.socketsClosed() >= 1, `upstream socket(s) destroyed after client abort (closed=${up.socketsClosed()})`);
+    } finally {
+        proxy.close();
+        await once(proxy, "close");
+        up.server.close();
+        await once(up.server, "close");
+    }
+});
+
+test("abort x proxy-responses-sse: client abort mid-stream destroys the upstream request", async () => {
+    const up = await startUpstream("hang-responses");
+    const proxy = await startProxy(up.port);
+    await once(proxy, "listening");
+    const proxyPort = (proxy.address() as { port: number }).port;
+    try {
+        const url = `http://127.0.0.1:${proxyPort}/bili/http://127.0.0.1:${up.port}/v1/responses`;
+        await abortAfterFirstByte(url, { "content-type": "application/json", "x-acp-session": "mx-abort-resp" }, JSON.stringify({ model: "m-test", max_tokens: 1024, stream: true, instructions: "You are a test agent.", input: [{ type: "message", role: "user", content: "hi" }] }));
+        await new Promise((r) => setTimeout(r, 300));
+        assert.ok(up.socketsClosed() >= 1, `upstream socket(s) destroyed after client abort (closed=${up.socketsClosed()})`);
+    } finally {
+        proxy.close();
+        await once(proxy, "close");
+        up.server.close();
+        await once(up.server, "close");
+    }
+});
+
+test("abort x proxy-json: client abort while the JSON is buffering destroys the upstream request", async () => {
+    const up = await startUpstream("hang-json");
+    const proxy = await startProxy(up.port);
+    await once(proxy, "listening");
+    const proxyPort = (proxy.address() as { port: number }).port;
+    try {
+        const url = `http://127.0.0.1:${proxyPort}/bili/http://127.0.0.1:${up.port}/v1/chat/completions`;
+        await abortAfterFirstByte(url, { "content-type": "application/json", "x-acp-session": "mx-abort-json" }, JSON.stringify({ model: "m-test", max_tokens: 1024, messages: [{ role: "user", content: "hi" }] }));
+        await new Promise((r) => setTimeout(r, 300));
+        assert.ok(up.socketsClosed() >= 1, `upstream socket(s) destroyed after client abort (closed=${up.socketsClosed()})`);
+    } finally {
+        proxy.close();
+        await once(proxy, "close");
+        up.server.close();
+        await once(up.server, "close");
+    }
+});
+
+test("error-delivery x proxy-openai-sse: upstream 429 AFTER the early 200 commit arrives in-band as an error delta + [DONE]", async () => {
+    const up = await startUpstream("slow-summary-fwd-429");
+    const proxy = await startProxy(up.port);
+    await once(proxy, "listening");
+    const proxyPort = (proxy.address() as { port: number }).port;
+    try {
+        // ~13k-token history vs 10k window → preflight; the summary call is
+        // slow (outlives the 300ms hold grace) and the FORWARD after it hits
+        // 429 — both after the early 200 commit, so the error must arrive
+        // in-band on the openai wire.
+        const r = await new Promise<{ status: number; headers: http.IncomingHttpHeaders; tHeaderMs: number; body: string }>((resolve, reject) => {
+            const t0 = Date.now();
+            const req = http.request(`http://127.0.0.1:${proxyPort}/bili/http://127.0.0.1:${up.port}/v1/chat/completions`, { method: "POST", headers: { "content-type": "application/json", "x-acp-session": "mx-inband-oai" } }, (res) => {
+                const tHeaderMs = Date.now() - t0;
+                const chunks: Buffer[] = [];
+                res.on("data", (c: Buffer) => chunks.push(c));
+                res.on("end", () => resolve({ status: res.statusCode ?? 0, headers: res.headers, tHeaderMs, body: Buffer.concat(chunks).toString("utf8") }));
+            });
+            req.on("error", reject);
+            req.end(JSON.stringify({ model: "m-test", max_tokens: 1024, stream: true, messages: bigConversation() }));
+        });
+        assert.equal(r.status, 200, "early commit owns the status line");
+        assert.equal(String(r.headers["content-type"]), "text/event-stream");
+        assert.ok(r.tHeaderMs < SLOW_MS, `headers committed before the slow preflight finished (${r.tHeaderMs}ms)`);
+        assert.ok(r.body.includes(": bili-preflight"), "keep-alive comment present");
+        // Post-commit upstream failure goes through emitStreamError: openai
+        // shape = inline error delta + finish_reason + [DONE].
+        assert.ok(r.body.includes("upstream HTTP 429"), `in-band error delta carries the upstream status body=${r.body.slice(-600)}`);
+        assert.ok(r.body.includes('"finish_reason"'), "delta finishes the choice");
+        assert.ok(r.body.includes("data: [DONE]"), "stream terminates with [DONE]");
+        assert.ok(!r.body.includes('"choices":[{"index":0,"message"'), "no fabricated model content after the failure");
+    } finally {
+        proxy.close();
+        await once(proxy, "close");
+        up.server.close();
+        await once(up.server, "close");
+    }
+});
+
+test("error-delivery x proxy-openai-sse: preflight failure after the early commit arrives in-band as a top-level error + [DONE]", async () => {
+    const up = await startUpstream("slow-summary-429");
+    const proxy = await startProxy(up.port);
+    await once(proxy, "listening");
+    const proxyPort = (proxy.address() as { port: number }).port;
+    try {
+        const r = await new Promise<{ status: number; headers: http.IncomingHttpHeaders; tHeaderMs: number; body: string }>((resolve, reject) => {
+            const t0 = Date.now();
+            const req = http.request(`http://127.0.0.1:${proxyPort}/bili/http://127.0.0.1:${up.port}/v1/chat/completions`, { method: "POST", headers: { "content-type": "application/json", "x-acp-session": "mx-inband-oai2" } }, (res) => {
+                const tHeaderMs = Date.now() - t0;
+                const chunks: Buffer[] = [];
+                res.on("data", (c: Buffer) => chunks.push(c));
+                res.on("end", () => resolve({ status: res.statusCode ?? 0, headers: res.headers, tHeaderMs, body: Buffer.concat(chunks).toString("utf8") }));
+            });
+            req.on("error", reject);
+            req.end(JSON.stringify({ model: "m-test", max_tokens: 1024, stream: true, messages: bigConversation() }));
+        });
+        assert.equal(r.status, 200, "early commit owns the status line");
+        assert.equal(String(r.headers["content-type"]), "text/event-stream");
+        assert.ok(r.tHeaderMs < SLOW_MS, `headers committed before the slow summarization failed (${r.tHeaderMs}ms)`);
+        assert.ok(r.body.includes(": bili-preflight"), "keep-alive comment present");
+        // Post-commit PREFLIGHT failure goes through emitPreflightError: openai
+        // shape = top-level {error} object + [DONE] (no choices framing).
+        assert.ok(r.body.includes('"error"'), "top-level in-band error object present");
+        assert.ok(r.body.includes("data: [DONE]"), "stream terminates with [DONE]");
+        assert.ok(!r.body.includes('"choices"'), "no model content fabricated after the failure");
+        assert.equal(up.requests(), 1, "the failed preflight means no forward happened");
+    } finally {
+        proxy.close();
+        await once(proxy, "close");
+        up.server.close();
+        await once(up.server, "close");
+    }
+});


### PR DESCRIPTION
Implements the cheapest #588 item: converts "漏掉一格就是一类 bug" into typecheck/test failures. No runtime behavior change — the registry is data + live symbol references only.

## 1. `src/exit-matrix.ts` — compile-time registry

- `WIRE_EXITS`: 7 exits (proxy openai/anthropic/responses SSE + JSON, plugin chat/responses SSE + JSON).
- Three concern tables `ERROR_DELIVERY` / `ABORT_PROPAGATION` / `HOST_USAGE_BACKFILL`, each `Record<WireExitId, ExitCell>` — **adding an exit to `WIRE_EXITS` without filling its row in every table fails typecheck** (the "编译器可见" ask).
- Each cell: `implementer` = live imported symbols (moving/deleting an implementation breaks the build), `contract` = the cell's observable behavior, `coveredBy` = test files (liveness-checked).

## 2. `tests/wire-exit-matrix.test.ts` — meta + behavior

- **Meta test**: tables exhaustive over `WIRE_EXITS`, every `coveredBy` file exists on disk (renaming a covering test file goes red), contracts non-vacuous.
- **New cells that had no coverage before**:
  - client-abort propagation on all four proxy exits (openai/anthropic/responses SSE + JSON): client aborts mid-stream → the in-flight upstream request is destroyed.
  - openai-chat in-band error delivery after the #568 early commit, both shapes: upstream 429 on the post-preflight forward (`emitStreamError` error delta + `[DONE]`) and preflight failure (`emitPreflightError` top-level `error` + `[DONE]`).

The usage row was already covered by `tests/host-usage-backfill.test.ts` (19 tests) — registry only.

## Pre-flight

- `npm run typecheck` ✅
- `npm test` — 1178/1178 ✅ **when run with acp-kernel 0.0.56** (PR #607). On plain master the 2 pre-existing `acp-status-estimator` failures remain (kernel 0.0.54 bug, fixed by #607) — merge #607 first.
- `npm run build` ✅

Ref #588 (patch layer; the full loop/ fold-in stays deferred as tracked there).