### PR TITLE
fix: route updater egress through configured upstream proxy (#609)

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,9 @@ Rules:
 - Both outbound paths are covered: `/bili/` path-mode (fetch) AND MITM CONNECT
   tunnels (the proxy's connection to the real upstream goes through the HTTP
   CONNECT proxy).
+- The auto-updater's own egress (npm registry check + tarball download) uses
+  the same decision for its hosts, so `bili update` and auto-update work on
+  hosts where npm is only reachable through the proxy (#609).
 
 Env override: `BILI_UPSTREAM_PROXY=http://127.0.0.1:20172` (higher priority than
 the config file). On Windows, common Clash/Mihomo static system proxies are

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,6 +24,7 @@ import { loadOptions, ensureConfigTemplate } from "./config.js";
 import { startServer } from "./server.js";
 import { configFile as defaultConfigFile } from "./paths.js";
 import { checkForUpdate, startAutoUpdate } from "./update.js";
+import { resolveProxy } from "./upstream-proxy.js";
 import { runMcpStdio } from "./mcp.js";
 import { PLUGIN_AGENTS, isPluginAgent, pluginInstall, pluginRemove, pluginStatusAll, type PluginAgent } from "./plugin-install.js";
 import { runLaunch, runTestPi, isLaunchClient, type ClientName } from "./launcher.js";
@@ -374,8 +375,24 @@ export async function main(): Promise<void> {
         return;
     }
     if (command === "update") {
-        // Manual one-shot update — bypasses the throttle.
-        await checkForUpdate({ packageName: PACKAGE_NAME, currentVersion: VERSION, autoUpdate: true }, true);
+        // Manual one-shot update — bypasses the throttle. Apply flag
+        // overrides first so `-F <proxy>` reaches loadOptions; the registry
+        // and tarball egress then honor the same upstream-proxy decision as
+        // model traffic (#609).
+        for (const [k, v] of Object.entries(overrides)) {
+            if (v !== undefined) process.env[k] = v;
+        }
+        let updaterResolveProxy: ((url: string) => string | undefined) | undefined;
+        try {
+            const o = loadOptions();
+            updaterResolveProxy = (url) => resolveProxy(o.routes, o.proxy, url, o.proxyFallback);
+        } catch (e) {
+            console.error(`bili update: config load failed (${String(e)}); updater egress goes direct`);
+        }
+        await checkForUpdate(
+            { packageName: PACKAGE_NAME, currentVersion: VERSION, autoUpdate: true, resolveProxy: updaterResolveProxy },
+            true,
+        );
         return;
     }
     if (command === "test") {
@@ -406,6 +423,13 @@ export async function main(): Promise<void> {
     // Start background auto-update after the server is listening so a slow
     // registry check never delays startup or races the listen socket.
     if (opts.autoUpdate) {
-        startAutoUpdate({ packageName: PACKAGE_NAME, currentVersion: VERSION, autoUpdate: true });
+        // Resolver reads opts fields per call, so web-UI hot-reload of proxy
+        // settings (server.ts mutates opts in place) is picked up live (#609).
+        startAutoUpdate({
+            packageName: PACKAGE_NAME,
+            currentVersion: VERSION,
+            autoUpdate: true,
+            resolveProxy: (url) => resolveProxy(opts.routes, opts.proxy, url, opts.proxyFallback),
+        });
     }
 }

--- a/src/update.ts
+++ b/src/update.ts
@@ -28,6 +28,8 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { cacheDir } from "./paths.js";
 import { log as loggerLog } from "./logger.js";
+import { proxyDispatcher } from "./upstream-proxy.js";
+import type { FetchOptions } from "./fetch-util.js";
 
 const REGISTRY_BASE = "https://registry.npmjs.org";
 const CHECK_INTERVAL_MS = 3 * 60 * 1000;
@@ -331,7 +333,26 @@ export type UpdateOptions = {
     currentVersion: string;
     /** Enable auto-install when a newer version is found. */
     autoUpdate: boolean;
+    /** Egress proxy resolver for the registry/tarball hosts (#609) — the CLI
+     *  wires in bili's upstream-proxy decision chain so updater fetches honor
+     *  the same routing (incl. NO_PROXY) as model traffic. Absent = direct. */
+    resolveProxy?: (url: string) => string | undefined;
 };
+
+/** Fetch dispatcher for updater egress (#609). undici's global fetch ignores
+ *  HTTP(S)_PROXY env vars, so without an explicit dispatcher the registry
+ *  check and tarball download always went direct even when model traffic is
+ *  routed through a configured proxy. undefined result = direct connection. */
+export function egressDispatcher(opts: Pick<UpdateOptions, "resolveProxy">, url: string): object | undefined {
+    return proxyDispatcher(opts.resolveProxy?.(url));
+}
+
+// @types/node types RequestInit.dispatcher as its internal Dispatcher
+// interface, which structurally conflicts with undici's ProxyAgent; at runtime
+// they're the same thing. Cast once here (no `as any`), as fetch-util does.
+function fetchWithEgress(url: string, init: FetchOptions): Promise<Response> {
+    return fetch(url, init as RequestInit);
+}
 
 /** Run a single check (throttled unless `force`). Safe to call frequently. */
 export async function checkForUpdate(opts: UpdateOptions, force = false): Promise<void> {
@@ -364,9 +385,11 @@ export async function checkForUpdate(opts: UpdateOptions, force = false): Promis
         loggerLog("info", `[update] checking npm registry for ${opts.packageName}${sinceLastSec < 0 ? " (startup check)" : sinceLastSec === 0 ? "" : ` (last check ${sinceLastSec}s ago)`}\u2026`);
 
         const url = `${REGISTRY_BASE}/${opts.packageName}/latest`;
-        const res = await fetch(url, {
+        const registryDispatcher = egressDispatcher(opts, url);
+        const res = await fetchWithEgress(url, {
             signal: AbortSignal.timeout(5000),
             headers: { Accept: "application/json" },
+            ...(registryDispatcher ? { dispatcher: registryDispatcher } : {}),
         });
         if (!res.ok) {
             loggerLog("warn", `[update] registry returned ${res.status} ${res.statusText}, skipping`);
@@ -413,7 +436,7 @@ export async function checkForUpdate(opts: UpdateOptions, force = false): Promis
             return;
         }
         try {
-            const result = await installViaTarball(latest, tarballUrl, installDir, integrity, shasum);
+            const result = await installViaTarball(latest, tarballUrl, installDir, integrity, shasum, egressDispatcher(opts, tarballUrl));
             if (result.ok) {
                 loggerLog("info", `[update] installed ${currentVersion} \u2192 ${latest}. Restart to finish.`);
             } else {
@@ -458,7 +481,8 @@ export function verifyTarballIntegrity(buf: Buffer, integrity?: string, shasum?:
 }
 
 /** Download the npm tarball, extract to a temp staging dir, verify, then copy
- *  over the install directory. */
+ *  over the install directory. `dispatcher` (optional) routes the download
+ *  through a proxy (#609); omitted = direct connection. */
 
 export async function installViaTarball(
     version: string,
@@ -466,6 +490,7 @@ export async function installViaTarball(
     installDir: string | undefined,
     integrity?: string,
     shasum?: string,
+    dispatcher?: object,
 ): Promise<{ ok: boolean; error?: string }> {
     if (!installDir) {
         return { ok: false, error: "cannot determine install directory (package.json not found walking up from running binary)" };
@@ -491,7 +516,10 @@ export async function installViaTarball(
     const MAX_TARBALL_BYTES = 100 * 1024 * 1024;
     let tgzBuffer: Buffer;
     try {
-        const tgzRes = await fetch(tarballUrl, { signal: AbortSignal.timeout(60_000) });
+        const tgzRes = await fetchWithEgress(tarballUrl, {
+            signal: AbortSignal.timeout(60_000),
+            ...(dispatcher ? { dispatcher } : {}),
+        });
         if (!tgzRes.ok) {
             return { ok: false, error: `tarball download failed: HTTP ${tgzRes.status} ${tgzRes.statusText}` };
         }

--- a/tests/update-proxy.test.ts
+++ b/tests/update-proxy.test.ts
@@ -1,0 +1,135 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import * as tar from "tar";
+import { installViaTarball, egressDispatcher, type UpdateOptions } from "../src/update.ts";
+import { proxyDispatcher } from "../src/upstream-proxy.ts";
+
+function integrityField(buf: Buffer, alg = "sha512"): string {
+    return `${alg}-${crypto.createHash(alg).update(buf).digest("base64")}`;
+}
+
+function baseOpts(): UpdateOptions {
+    return { packageName: "billion-context", currentVersion: "1.2.3", autoUpdate: true };
+}
+
+test("egressDispatcher: absent resolver or undefined result means direct", () => {
+    const opts = baseOpts();
+    assert.equal(egressDispatcher(opts, "https://registry.npmjs.org/billion-context/latest"), undefined);
+    const none: UpdateOptions = { ...opts, resolveProxy: () => undefined };
+    assert.equal(egressDispatcher(none, "https://cdn.example.com/x.tgz"), undefined);
+});
+
+test("egressDispatcher: resolved proxy URL becomes the cached undici agent", () => {
+    const proxyUrl = "http://127.0.0.1:7897";
+    const opts: UpdateOptions = {
+        ...baseOpts(),
+        resolveProxy: (u) => (u.includes("npmjs.org") ? proxyUrl : undefined),
+    };
+    // Same proxy URL ⇒ same cached ProxyAgent instance (identity, not equality).
+    assert.equal(egressDispatcher(opts, "https://registry.npmjs.org/billion-context/latest"), proxyDispatcher(proxyUrl));
+    assert.notEqual(egressDispatcher(opts, "https://registry.npmjs.org/billion-context/latest"), undefined);
+    // A host the resolver maps to nothing goes direct.
+    assert.equal(egressDispatcher(opts, "https://cdn.other.example/t.tgz"), undefined);
+});
+
+interface Capture {
+    url: string;
+    init: RequestInit & { dispatcher?: unknown };
+}
+
+/** Serve a crafted tarball through a capturing fetch; never touch the network. */
+function withCapturedFetch<T>(tgz: Buffer, captures: Capture[], fn: () => Promise<T>): Promise<T> {
+    const original = globalThis.fetch;
+    globalThis.fetch = ((url: unknown, init?: RequestInit) => {
+        captures.push({ url: String(url), init: (init ?? {}) as Capture["init"] });
+        return Promise.resolve(new Response(tgz));
+    }) as unknown as typeof fetch;
+    return fn().finally(() => {
+        globalThis.fetch = original;
+    });
+}
+
+interface Fixture {
+    root: string;
+    installDir: string;
+    cacheDir: string;
+}
+
+function makeFixture(): Fixture {
+    const root = mkdtempSync(path.join(tmpdir(), "bc-update-proxy-test-"));
+    const installDir = path.join(root, "install");
+    const cacheDir = path.join(root, "cache");
+    mkdirSync(path.join(installDir, "dist"), { recursive: true });
+    writeFileSync(
+        path.join(installDir, "package.json"),
+        JSON.stringify({
+            name: "billion-context",
+            version: "1.2.3",
+            type: "module",
+            main: "dist/index.js",
+            bin: { bili: "./dist/index.js" },
+        }),
+    );
+    writeFileSync(path.join(installDir, "dist", "index.js"), "export const loaded = '1.2.3';\n");
+    return { root, installDir, cacheDir };
+}
+
+function makeTarball(root: string): { tgz: Buffer; integrity: string } {
+    const src = path.join(root, "pkg");
+    mkdirSync(path.join(src, "package"), { recursive: true });
+    writeFileSync(path.join(src, "package", "package.json"), JSON.stringify({
+        name: "billion-context",
+        version: "2.0.0",
+        type: "module",
+        main: "dist/index.js",
+        bin: { bili: "./dist/index.js" },
+    }));
+    mkdirSync(path.join(src, "package", "dist"), { recursive: true });
+    writeFileSync(path.join(src, "package", "dist", "index.js"), "export const loaded = '2.0.0';\n");
+    const tgzPath = path.join(root, "pkg.tgz");
+    tar.c({ cwd: src, file: tgzPath, gzip: true, sync: true }, ["package"]);
+    const tgz = readFileSync(tgzPath);
+    return { tgz, integrity: integrityField(tgz) };
+}
+
+test("installViaTarball: tarball fetch receives the egress dispatcher when provided", { timeout: 30_000 }, async () => {
+    const fx = makeFixture();
+    process.env.XDG_CACHE_HOME = fx.cacheDir;
+    try {
+        const { tgz, integrity } = makeTarball(fx.root);
+        const marker = { __testDispatcher: true };
+        const captures: Capture[] = [];
+        const r = await withCapturedFetch(tgz, captures, () =>
+            installViaTarball("2.0.0", "https://registry.test/x.tgz", fx.installDir, integrity, undefined, marker),
+        );
+        assert.equal(r.ok, true, r.error);
+        assert.equal(captures.length, 1);
+        assert.equal(captures[0].url, "https://registry.test/x.tgz");
+        assert.equal(captures[0].init.dispatcher, marker);
+    } finally {
+        delete process.env.XDG_CACHE_HOME;
+        rmSync(fx.root, { recursive: true, force: true });
+    }
+});
+
+test("installViaTarball: no dispatcher on the fetch when none provided", { timeout: 30_000 }, async () => {
+    const fx = makeFixture();
+    process.env.XDG_CACHE_HOME = fx.cacheDir;
+    try {
+        const { tgz, integrity } = makeTarball(fx.root);
+        const captures: Capture[] = [];
+        const r = await withCapturedFetch(tgz, captures, () =>
+            installViaTarball("2.0.0", "https://registry.test/x.tgz", fx.installDir, integrity),
+        );
+        assert.equal(r.ok, true, r.error);
+        assert.equal(captures.length, 1);
+        assert.ok(!("dispatcher" in captures[0].init), "direct fetch must not carry a dispatcher");
+    } finally {
+        delete process.env.XDG_CACHE_HOME;
+        rmSync(fx.root, { recursive: true, force: true });
+    }
+});


### PR DESCRIPTION
## What

The auto-updater's two outbound fetches (npm registry version check, tarball download) now go through bili's upstream-proxy decision chain — the same one model traffic uses — instead of always connecting direct.

## Why

undici's global `fetch` ignores `HTTP(S)_PROXY`/`ALL_PROXY` env vars unless an explicit `dispatcher` is passed. `src/update.ts:367` (registry) and `src/update.ts:494` (tarball) passed none, so on deployments where npm is reachable only through a proxy (the GFW scenario the README supports for model traffic), every check failed with `[update] check failed:` and auto-update silently never worked.

## Changes

- `src/update.ts`
  - `UpdateOptions` gains an optional resolver callback `resolveProxy?: (url: string) => string | undefined` (keeps update.ts decoupled from config details; absent = direct).
  - Both fetches pass `dispatcher: proxyDispatcher(resolveProxy(url))` when the decision yields a proxy. Per-URL resolution, so the registry origin and the tarball host each get their own decision; `NO_PROXY` is honored inside `resolveProxyDecision`.
  - `installViaTarball` gains a trailing optional `dispatcher` param (existing call sites/tests unaffected).
- `src/cli.ts`
  - Both entry points wire the resolver: startup auto-update and manual `bili update`. The closure reads `opts.routes`/`opts.proxy`/`opts.proxyFallback` per call, so web-UI config hot-reload (server.ts mutates opts in place) is picked up live without restart.
  - Latent bug fixed along the way: the `update` command branch ran **before** the flag/env merge loop, so `-F <proxy>` was silently ignored for manual updates. Flags are now applied first; if config loading fails, updater egress goes direct with a visible CLI error (same effective behavior as before, now explicit).
- `README.md` — documents updater egress coverage in the upstream-proxy section.
- `tests/update-proxy.test.ts` (new, 4 tests) — dispatcher presence/absence at both fetch sites, cached-agent identity with `proxyDispatcher`, NO_PROXY-style non-matching hosts.

## Pre-flight

- `npm run typecheck`: clean
- `npm test`: 1181/1182 — the single failure is pre-existing and env-dependent (`tests/launcher.test.ts` "codex/claude resolve to themselves"; reproduced on the pristine tree in this sandbox, which has `/usr/bin/codex` on PATH)
- `npm run build` (tsup): success
- E2E smoke: isolated install dir + local recording proxy on 127.0.0.1, config `{"proxy": "http://127.0.0.1:47999", "upstreamProxyMode": "auto"}` → `CONNECT registry.npmjs.org:443` observed arriving at the proxy (previously went direct); with the proxy socket destroyed the check degrades gracefully to the usual warn log, no crash.

## ⚠ Release gate (AGENTS.md §5)

This PR touches `src/update.ts` download logic, so per §5 it must be validated by a no-op release **before** merging. v0.1.89 is already live on npm (released from master after this branch's base). If a real-world auto-update to 0.1.89 has been observed succeeding, that validates the existing upgrade path and this PR can merge as-is. Otherwise I'll prepare a no-op v0.1.90 release PR to land first — owner's call on sequencing. No PR is merged by the agent either way.

Fixes #609