### PR TITLE
docs: drop stale kernel-bump guard from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,9 +101,9 @@ misattributes on decompress. Consequences for this repo:
   the highest-numbered (newest) messages stay resident so the cursor does not
   drop, but this is a theoretical re-issue window — drop the map-prune once
   the kernel's ref-space widening (post-#191 direction) makes it unnecessary.
-- Do not bump `acp-kernel` to ≥0.0.48/0.0.49 (contain ref-slot reclamation,
-  reverted in kernel #191); resume bumping at the release that lands the
-  revert.
+- Historical note: kernel 0.0.48/0.0.49 briefly contained ref-slot
+  reclamation (reverted in kernel #191, see `persist/store.ts`). The guard
+  "do not bump past 0.0.47" is obsolete — master pins 0.0.56.
 
 ## 3. Development Standards
 


### PR DESCRIPTION
### What
Removes the obsolete paragraph `AGENTS.md:104-106` ("Do not bump `acp-kernel` to >=0.0.48/0.0.49 ...") that #494 merged verbatim, replacing it with a one-line historical note (reclamation experiment reverted in kernel #191; master pins 0.0.56 since #607).

### Why
The guard directly contradicts the current pin (`package.json` = 0.0.56) and would mislead the next kernel bump into "rolling back". Flagged in my #494 review but the PR merged before the edit.

### Pre-flight
Docs-only (3 lines in AGENTS.md); master pre-flight just re-verified clean: typecheck ✓, build ✓, tests 1178 pass / 2 known `plugin-agent.test.ts` env fails.

Refs #600