### PR TITLE
release v0.1.90

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.89",
+  "version": "0.1.90",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## release v0.1.90

Version-only release commit on top of master. Ships 11 PRs merged since v0.1.89.

**⚠️ This release doubles as the §5 no-op-validation hop for #613** — none of the included changes touch `src/update.ts`, so the 0.1.89 → 0.1.90 upgrade exercises the v0.1.89 updater code end-to-end. #613 (updater egress proxy) merges only after this hop is observed succeeding.

### Changes since v0.1.89

| PR | Change |
|---|---|
| #607 | chore: bump acp-kernel to 0.0.56 (fixes acp_status tool-result bucket attribution, #386) |
| #608 | test: wire-exit enumeration matrix — compile-time registry + abort/in-band-error cells (#588) |
| #578 | docs: correct false renumber claim in preflight comment (#595/#387) |
| #481 | fix(launcher): fail fast when spawned proxy child exits pre-bind (#596) |
| #442 | chore(#436): log context-window source per model — diagnostic (#597) |
| #522 | fix: skip dead-pid proxy-origin records in MCP shell origin resolution (#599) |
| #494 | docs: record kernel id-immutability contract in AGENTS.md (#600) |
| #614 | docs: drop stale kernel-bump guard from AGENTS.md |
| #610 | fix: salvage single-quoted compress args before hard rejection (#603) |
| #611 | fix: arm emergency shrink on upstream 5xx/network failure (#604) |
| #612 | test: wire-exit gap cells — preflight-emitter shapes, post-commit JSON errors, abort-storm convergence (#588) |

### Pre-flight

- typecheck ✓
- tests 1192/1194 (2 known env fails in plugin-agent.test.ts, environment-only) ✓
- build ✓
