### PR TITLE
release v0.1.91

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.90",
+  "version": "0.1.91",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## release v0.1.91

Version-only release commit. Ships **#613** (merged since v0.1.90).

### Changes since v0.1.90

| PR | Change |
|---|---|
| #613 | fix: route updater egress through configured upstream proxy (#609) — undici's global fetch ignored HTTP(S)_PROXY, so registry checks/tarball downloads always went direct even when model traffic was proxied; updater now reuses the same `resolveProxy` decision chain (incl. NO_PROXY, hot-reload), `bili update` honors flag overrides |

### §5 sequencing (satisfied)

#613 touches `src/update.ts`, so per AGENTS.md §5 the upgrade path was validated first:
- v0.1.90 shipped without updater changes ✓ (published 2026-09-07)
- Real hop observed: 0.1.89 install → `bili start` → log `[update] installed 0.1.89 → 0.1.90. Restart to finish.` → global package.json on disk = 0.1.90 ✓
- Only then #613 merged into this release.

### Pre-flight

- typecheck ✓
- tests 1196/1198 (2 known env fails in plugin-agent.test.ts) ✓
- build ✓
