### PR TITLE
fix #623: omp plugin mode reports folded usage, suppress host backfill

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1778,13 +1778,17 @@ function diagNudge(turn: { nudge?: { shouldInject: boolean; reason: string; cont
     return `[${sessionId}] nudge ${inject}: usage=${pct} (${tokenCount}/${limit}), growth=${growth}/${floor} (ref=${ref}, interval=${interval}), pendingT1=${pendingT1}/${interval}${modelTag}, reason="${n.reason.slice(0, 120)}"`;
 }
 
-// #590: hosts that get the #408 uncompressed-baseline usage backfill. pi's
-// plugin cancels pi's own auto-compaction (billion-context-pi
-// wireCompactionDisable: "ACP owns compression"), so the baseline drives
-// nothing there — reporting it only put a >100% footer on the host that
-// mismatches the folded request actually forwarded. Hosts whose native
-// compaction stays live (omp anchored-rewrite accounting, codex native-compact
-// interception, plain proxy clients) keep the #408 behavior.
+// #408/#590/#623: hosts that get the #408 uncompressed-baseline usage
+// backfill. pi's AND omp's bili extensions cancel the host's NATIVE compaction
+// so ACP owns compression — pi cancels auto-compaction, omp cancels ALL
+// compaction (its session_before_compact event carries no reason field, so
+// manual /compact can't be preserved). With the host's compaction off, the
+// uncompressed baseline drives nothing on the host side; reporting it only puts
+// a >100% footer that mismatches the folded request actually forwarded
+// (#590 pi 302.7%, #623 omp 205%). Gate on pluginAgent so ONLY the
+// bili-launched extensions are exempted: plain proxy clients and codex
+// native-compact interception keep the #408 behavior (their native compaction
+// stays live and consumes the baseline).
 function armHostUsageCredit(
     session: Session,
     originalMessages: CoreMessage[],
@@ -1792,7 +1796,7 @@ function armHostUsageCredit(
     log: (level: string, msg: string) => void,
 ): void {
     session.hostCreditTokens = 0;
-    if (session.metadata.pluginAgent === "pi") return;
+    if (session.metadata.pluginAgent === "pi" || session.metadata.pluginAgent === "omp") return;
     // #408: tokens folded out of the forwarded view vs the host's own (unfolded)
     // view — added back into the usage reported to the host so its anchor
     // reflects the uncompressed baseline. Same estimator both sides, so

--- a/tests/host-usage-backfill.test.ts
+++ b/tests/host-usage-backfill.test.ts
@@ -632,3 +632,119 @@ test("#590: pi plugin mode reports folded usage — host backfill suppressed", a
         await new Promise<void>((resolve, reject) => relay.close((e) => (e ? reject(e) : resolve())));
     }
 });
+
+test("#623: omp plugin mode reports folded usage — host backfill suppressed", async () => {
+    // Mirrors the #590 pi e2e, binding the session as omp. The wire is
+    // incidental — armHostUsageCredit's pluginAgent gate is protocol-agnostic;
+    // reusing the proven pi fixture guarantees a real fold (not a vacuous pass).
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    setRegistryForTest({});
+    _resetPluginStateForTest();
+    const upstreamBodies: string[] = [];
+    const anthropicSse = (event: string, data: unknown): string => `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+    const relay = http.createServer((req, res) => {
+        const chunks: Buffer[] = [];
+        req.on("data", (c: Buffer) => chunks.push(c));
+        req.on("end", () => {
+            const body = Buffer.concat(chunks).toString("utf8");
+            upstreamBodies.push(body);
+            res.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache" });
+            res.write(anthropicSse("message_start", { type: "message_start", message: { id: "msg_omp_1", role: "assistant", usage: { input_tokens: 100, output_tokens: 3 } } }));
+            res.write(anthropicSse("content_block_start", { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } }));
+            res.write(anthropicSse("content_block_delta", { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "ok" } }));
+            res.write(anthropicSse("content_block_stop", { type: "content_block_stop", index: 0 }));
+            res.write(anthropicSse("message_delta", { type: "message_delta", delta: { stop_reason: "end_turn", stop_sequence: null }, usage: { output_tokens: 3 } }));
+            res.write(anthropicSse("message_stop", { type: "message_stop" }));
+            res.end();
+        });
+    });
+    relay.listen(0, "127.0.0.1");
+    await once(relay, "listening");
+    const relayPort = (relay.address() as { port: number }).port;
+    const opts: ProxyOptions = {
+        port: 0,
+        host: "127.0.0.1",
+        upstream: "http://127.0.0.1",
+        routes: { [`http://127.0.0.1:${relayPort}`]: { models: { "claude-test": { context: 400_000 } } } } as ProxyOptions["routes"],
+        modelContextLimit: 400_000,
+        kernelConfig: defaultConfig(400_000),
+        compress: { injectTool: true, injectNudge: false },
+        promptCache: { routing: "auto" },
+        sessionHeader: "x-acp-session",
+        log: false,
+        debug: false,
+        passthrough: false,
+        autoUpdate: false,
+        mitm: { enabled: false, domains: [] },
+    };
+    const proxy = await startServer(opts);
+    await once(proxy, "listening");
+    const proxyPort = (proxy.address() as { port: number }).port;
+    const url = `http://127.0.0.1:${proxyPort}/bili/http://127.0.0.1:${relayPort}/v1/messages`;
+    const headFiller = "lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. ".repeat(28);
+    const tailFiller = "enim ad minim veniam quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat duis aute irure dolor in reprehenderit in voluptate. ".repeat(28);
+    type AnthropicMessage = { role: string; content: string | Array<Record<string, unknown>> };
+    const history: AnthropicMessage[] = [];
+    for (let i = 1; i <= 2; i++) {
+        history.push({ role: "user", content: `turn-${i}-marker question: ${headFiller}` });
+        history.push({ role: "assistant", content: `turn-${i}-marker ${i === 1 ? "SENTINEL_FOLD_GONE " : ""}answer: ${headFiller}` });
+    }
+    for (let i = 3; i <= 5; i++) {
+        history.push({ role: "user", content: `turn-${i} padding question: ${tailFiller}` });
+        history.push({ role: "assistant", content: `turn-${i} padding answer: ${tailFiller}` });
+    }
+    const conv = "omp-folded-usage-1";
+    const post = async (messages: AnthropicMessage[]): Promise<string> => {
+        const res = await fetch(url, {
+            method: "POST",
+            headers: {
+                "content-type": "application/json",
+                "x-acp-session": conv,
+                "x-bili-plugin": "omp",
+                "x-bili-plugin-conversation": conv,
+            },
+            body: JSON.stringify({ model: "claude-test", max_tokens: 1024, stream: true, system: "You are a test assistant.", messages }),
+        });
+        if (!res.ok) {
+            const text = await res.text();
+            assert.fail(`HTTP ${res.status}: ${text}`);
+        }
+        let raw = "";
+        for await (const chunk of res.body!) raw += Buffer.from(chunk).toString("utf8");
+        return raw;
+    };
+    const inputTokensOf = (raw: string): number => {
+        const m = raw.match(/"input_tokens":(\d+)/);
+        assert.ok(m, `message_start usage missing: ${raw.slice(0, 400)}`);
+        return Number(m[1]);
+    };
+    try {
+        const r1 = await post(history);
+        assert.equal(inputTokensOf(r1), 100, "pre-fold turn must pass the raw usage through");
+
+        const toolResp = await fetch(`http://127.0.0.1:${proxyPort}/__bili/plugin/tool`, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+                conversationId: conv,
+                tool: "compress",
+                args: { content: [{ topic: "omp-folded-usage", startId: "m00001", endId: "m00002", summary: "omp-side compress of the two early turns covering the lorem-ipsum questions and answers" }] },
+            }),
+        });
+        assert.equal(toolResp.status, 200);
+        const toolJson = (await toolResp.json()) as { ok: boolean; result: string };
+        assert.equal(toolJson.ok, true, `compress tool reported failure: ${toolJson.result}`);
+
+        const r2 = await post([
+            ...history,
+            { role: "assistant", content: [{ type: "tool_use", id: "toolu_omp_1", name: "compress", input: { startId: "m00001", endId: "m00002", topic: "omp-folded-usage", summary: "omp-side compress of the two early turns covering the lorem-ipsum questions and answers" } }] },
+            { role: "user", content: [{ type: "tool_result", tool_use_id: "toolu_omp_1", content: toolJson.result }] },
+        ]);
+        assert.equal(upstreamBodies.length, 2);
+        assert.ok(!upstreamBodies[1]!.includes("SENTINEL_FOLD_GONE"), "post-fold upstream body must not carry the folded head content");
+        assert.equal(inputTokensOf(r2), 100, "omp plugin mode must report the folded request's own usage — no uncompressed-baseline backfill (#623)");
+    } finally {
+        await new Promise<void>((resolve, reject) => proxy.close((e) => (e ? reject(e) : resolve())));
+        await new Promise<void>((resolve, reject) => relay.close((e) => (e ? reject(e) : resolve())));
+    }
+});


### PR DESCRIPTION
## What
Extends #590's pi-only suppression of the #408 uncompressed-baseline usage backfill to omp, so `bili omp` plugin mode reports the folded request's own usage instead of a backfilled value.

## Why
Under `bili omp`, the omp extension cancels **all** native compaction (`src/agent/pi.ts` `session_before_compact` returns `{ cancel: true }` unconditionally for omp — the omp event carries no `reason` field to distinguish auto from manual compaction). So omp's uncompressed baseline no longer drives anything host-side. But #408's backfill was only suppressed for pi (#590), so omp kept getting the folded delta (+~1.6M tok) added back into reported `prompt_tokens`. omp anchors `contextSnapshot.promptTokens` on that → footer = snapshot ÷ window = **205%**, growing monotonically forever (the credit never clears because compaction is off).

Same bug class as #590 (pi). #590 deliberately did not cover omp, on the premise that "omp anchored-rewrite accounting / native compaction stays live"; that premise was invalidated once the omp extension started cancelling all compaction.

Gating on `pluginAgent` means only **bili-launched** extensions are exempted: plain proxy clients and codex native-compact interception keep the #408 behavior (their native compaction stays live and consumes the baseline). Suppression is display-only (host footer + `/acp` panel `hostCredit` line); nudge/compression triggering reads post-fold `lastInputTokens`, independent of `hostCreditTokens`, so compression behavior is unchanged.

## Change
`src/server.ts` `armHostUsageCredit`:
- gate `pluginAgent === "pi"` → `pluginAgent === "pi" || pluginAgent === "omp"`
- comment block updated to reflect both extensions now cancel native compaction

`tests/host-usage-backfill.test.ts`: new e2e `#623: omp plugin mode reports folded usage — host backfill suppressed`, mirroring the existing #590 pi test (Anthropic wire; the proven fixture guarantees a real fold so the assertion is non-vacuous). Asserts post-fold `input_tokens` stays at the upstream-reported 100 (not backfilled) and that the sentinel was folded out of the forwarded body.

## Pre-flight
- `npm run typecheck` ✓
- targeted `tests/host-usage-backfill.test.ts`: 21/21 ✓ (incl new #623 test)
- negative check: reverting the gate to pi-only makes the #623 test fail (`831 !== 100`, backfilled) → test catches the regression ✓
- full `npm test`: 1198/1199 (sole failure = `launcher.test.ts` codex/claude self-resolve — pre-existing environmental, resolves `codex`→`/usr/bin/codex`; fails identically on master baseline)
- `npm run build` ✓

Fixes #623
