### PR TITLE
release v0.1.92

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.91",
+  "version": "0.1.92",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Changes since v0.1.91

- **#626** (PR #627): Codex ChatGPT 登录上游强制流式（`stream must be set to true`）导致 preflight 摘要请求 400 → 502 卡死。现在识别该 400 后用 `stream:true` 重试一次并从 SSE 提取摘要（三协议），成功后会话级记住（持久化），后续 preflight 直接流式首发。非流式上游路径不变。
- **#623** (PR #625): omp 插件模式下 #408 未压缩基线回填无消费者，footer 显示 205%/1M 与实际折叠请求不符。`pluginAgent === "pi" || "omp"` 时跳过回填，omp footer 现显示真实折叠后 usage。

Version-only release commit (kernel stays acp-kernel 0.0.56).

Pre-flight: typecheck ✓ · tests 1225/1227 (2 known env fails in plugin-agent.test.ts) · build ✓
