### PR TITLE
release v0.1.93

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.92",
+  "version": "0.1.93",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
**No-op validation release** (version bump only) — first step of the AGENTS.md §5 sequence for PR#204.

## Why

PR#204 changes `src/update.ts` (version-check + update channel). Per AGENTS.md §5, any change to the auto-update mechanism itself must be validated with a no-op release FIRST: prove the existing upgrade path is healthy end-to-end before the new updater code ships.

## What's in 0.1.92 → 0.1.93

Code already on master since v0.1.92:

- #622 / #619 — relay undecodable content-encoding bodies verbatim instead of 400 (+ gzip-bomb 413 guard)
- #517 / #598 — SessionStore rollback guard (dual-instance stale-save protection)

Neither touches `src/update.ts`. This release commit itself is the version bump only.

## Sequence

1. ✅ This PR — merge → CI publishes 0.1.93
2. Observe a real auto-upgrade: running install logs `auto-updated 0.1.92 → 0.1.93`
3. Only then merge PR#204 (updateTag channel), which rides the NEXT release

## Pre-flight

- typecheck ✓
- tests 1233/1235 (2 known `plugin-agent.test.ts` env fails) ✓
- build ✓
