### PR TITLE
release v0.1.94

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.93",
+  "version": "0.1.94",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Since v0.1.93:

- **#204 / #602 — update channel**: `updateTag` config (file key / `ACP_UPDATE_TAG` env, default `latest`) — auto-updater and `bili update` follow the configured dist-tag; semver-prerelease-aware version compare (a `0.1.47-beta.1` install now sees `0.1.47` as newer instead of equal). This is the §5-validated updater change: the no-op v0.1.93 release confirmed the existing upgrade path end-to-end (real `auto-updated 0.1.92 → 0.1.93` observed) before this ships.
- **#631 / #601 — export handoff delegation**: `bili export` rendering now delegates to the kernel's `renderHandoff` (single renderer, no drift); acp-kernel pinned **0.0.56 → 0.0.57** (handoff `folded`/`blocksFull`).

Pre-flight: typecheck ✓ · tests 1238/1240 (2 known `plugin-agent.test.ts` env fails) ✓ · build ✓ (kernel 0.0.57 bundled)
