### PR TITLE
fix: bump kernel 0.0.59, delegate #603 quote-salvage to kernel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.93",
+  "version": "0.1.94",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.93",
+      "version": "0.1.94",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@types/node": "^22.0.0",
         "@types/node-forge": "^1.3.14",
-        "acp-kernel": "0.0.57",
+        "acp-kernel": "0.0.59",
         "fzstd": "0.1.1",
         "node-forge": "^1.4.0",
         "tar": "^7.5.22",
@@ -988,9 +988,9 @@
       }
     },
     "node_modules/acp-kernel": {
-      "version": "0.0.57",
-      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.57.tgz",
-      "integrity": "sha512-HyDLMrIj6SBEsypuApFp9WePTnitNvijij6sDVFo/K4xqiwByJragb65KJghPVtKS1ZQylMxxTWQwuUQBMX6DA==",
+      "version": "0.0.59",
+      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.59.tgz",
+      "integrity": "sha512-CegmdDbyM6hMlsPFDzDJrbBAUaAvZZfv2SG8pojho/8cC4tRq5qrKLHY1yf7jp8eAwyY2x4YdBEQvspv0AwHUg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/node-forge": "^1.3.14",
-    "acp-kernel": "0.0.57",
+    "acp-kernel": "0.0.59",
     "fzstd": "0.1.1",
     "node-forge": "^1.4.0",
     "tar": "^7.5.22",

--- a/src/compress-tool.ts
+++ b/src/compress-tool.ts
@@ -6,9 +6,9 @@
  * historical import paths and names stable:
  *  - PROXY_TOOL_NAMES / MUTATING_PROXY_TOOLS / READONLY_PROXY_TOOLS alias the
  *    kernel's ACP_* names ("proxy" is a misnomer once shared);
- *  - parseCompressInput wires the kernel's onWarn hook into the proxy logger
- *    and adds the #603 quote-salvage fallback (single→double quote repair)
- *    for the one malformation class the kernel ladder does not cover.
+ *  - parseCompressInput wires the kernel's onWarn hook into the proxy logger.
+ *    (The #603 single-quote salvage lives in the kernel ladder since 0.0.59;
+ *    this wrapper only surfaces its diagnostics.)
  */
 import { parseCompressArgs, ABSORB_TOOL_OPENAI } from "acp-kernel";
 import { log as loggerLog } from "./logger.js";
@@ -65,112 +65,14 @@ export const ABSORB_TOOL_RESPONSES = {
 };
 
 export function parseCompressInput(input: unknown, callId?: string) {
-    const first = parseCompressArgs(input, { callId });
-    // #603: the kernel ladder covers fences, trailing commas, raw newlines,
-    // double-stringification and truncated/prose-wrapped arrays — but not
-    // single-quoted JSON (the class weak local models actually emit, omp#121).
-    // Retry once with quotes normalized; keep whichever pass recovered more.
-    if (first.ranges.length === 0 || first.diagnostics.invalidItems > 0) {
-        const normalized = normalizeQuoteShape(input);
-        if (normalized !== undefined) {
-            const retry = parseCompressArgs(normalized, { callId });
-            if (retry.ranges.length > first.ranges.length) {
-                loggerLog("warn", `[acp-compress-input] quote-salvage: recovered ${retry.ranges.length} range(s) after single->double quote normalization (was ${first.ranges.length}, kind=${first.diagnostics.kind})`);
-                return { ranges: retry.ranges, diagnostics: retry.diagnostics };
-            }
-        }
+    const parsed = parseCompressArgs(input, { callId });
+    if (parsed.diagnostics.quoteSalvage === true) {
+        loggerLog("warn", `[acp-compress-input] quote-salvage: recovered ${parsed.ranges.length} range(s) after single->double quote normalization (kind=${parsed.diagnostics.kind})`);
     }
-    if (!first.diagnostics.ok && first.diagnostics.kind !== "ok") {
-        loggerLog("warn", `[acp-compress-input] rejected: kind=${first.diagnostics.kind} invalidItems=${first.diagnostics.invalidItems}${first.diagnostics.keys ? ` keys=[${first.diagnostics.keys.join(",")}]` : ""}${first.diagnostics.length !== undefined ? ` len=${first.diagnostics.length}` : ""}${first.diagnostics.invalidReasons && first.diagnostics.invalidReasons.length > 0 ? ` reasons=[${first.diagnostics.invalidReasons.join(" | ")}]` : ""}`);
+    if (!parsed.diagnostics.ok && parsed.diagnostics.kind !== "ok") {
+        loggerLog("warn", `[acp-compress-input] rejected: kind=${parsed.diagnostics.kind} invalidItems=${parsed.diagnostics.invalidItems}${parsed.diagnostics.keys ? ` keys=[${parsed.diagnostics.keys.join(",")}]` : ""}${parsed.diagnostics.length !== undefined ? ` len=${parsed.diagnostics.length}` : ""}${parsed.diagnostics.invalidReasons && parsed.diagnostics.invalidReasons.length > 0 ? ` reasons=[${parsed.diagnostics.invalidReasons.join(" | ")}]` : ""}`);
     }
-    return { ranges: first.ranges, diagnostics: first.diagnostics };
-}
-
-// #603: quote-shape salvage. Weak models emit single-quoted JSON args
-// ({'content': [...]}) or a single-quoted array as a stringified content
-// value; both hard-fail strict parsing and waste the round. This is a pure
-// text repair — it never invents structure, so anything it cannot make into
-// valid JSON simply stays unrecovered (the existing reject path applies).
-function normalizeQuoteShape(input: unknown): unknown {
-    if (typeof input === "string") return normalizeSingleQuotes(input);
-    if (input !== null && typeof input === "object" && !Array.isArray(input)) {
-        const obj = input as Record<string, unknown>;
-        if (typeof obj["content"] === "string") {
-            const fixed = normalizeSingleQuotes(obj["content"]);
-            if (fixed !== undefined) return { ...obj, content: fixed };
-        }
-    }
-    return undefined;
-}
-
-// State machine that converts single-quoted strings to double-quoted ones.
-// Apostrophes inside double-quoted strings are data and are copied verbatim;
-// control characters inside single-quoted regions become JSON escapes.
-// Returns undefined when nothing was converted (input unchanged).
-function normalizeSingleQuotes(raw: string): string | undefined {
-    if (!raw.includes("'") || (!raw.includes("{") && !raw.includes("["))) return undefined;
-    let out = "";
-    let changed = false;
-    let inDouble = false;
-    let inSingle = false;
-    for (let i = 0; i < raw.length; i++) {
-        const ch = raw.charAt(i);
-        if (inDouble) {
-            out += ch;
-            if (ch === "\\" && i + 1 < raw.length) {
-                out += raw.charAt(i + 1);
-                i++;
-            } else if (ch === '"') {
-                inDouble = false;
-            }
-            continue;
-        }
-        if (inSingle) {
-            if (ch === "\\" && i + 1 < raw.length) {
-                const next = raw.charAt(i + 1);
-                out += next === "'" ? "'" : "\\" + next;
-                i++;
-                continue;
-            }
-            if (ch === "'") {
-                out += '"';
-                inSingle = false;
-                changed = true;
-                continue;
-            }
-            if (ch === '"') {
-                out += '\\"';
-                continue;
-            }
-            if (ch === "\n") {
-                out += "\\n";
-                continue;
-            }
-            if (ch === "\r") {
-                out += "\\r";
-                continue;
-            }
-            if (ch === "\t") {
-                out += "\\t";
-                continue;
-            }
-            out += ch;
-            continue;
-        }
-        if (ch === '"') {
-            inDouble = true;
-            out += ch;
-            continue;
-        }
-        if (ch === "'") {
-            inSingle = true;
-            out += '"';
-            changed = true;
-            continue;
-        }
-        out += ch;
-    }
-    return changed ? out : undefined;
+    return { ranges: parsed.ranges, diagnostics: parsed.diagnostics };
 }
 
 // #189 staged-compression / prefix-survival guidance, appended to the nudge

--- a/tests/compat-roles.test.ts
+++ b/tests/compat-roles.test.ts
@@ -113,9 +113,13 @@ function upstreamServer(status: number, onBody: (path: string, body: unknown) =>
 
 interface StartOpts {
     compatJson: string;
+    /** G/H drive the #583 ladder with injectTool/injectNudge OFF so the wire is
+     *  the bare conversation — bili's own injected system prompt would otherwise
+     *  sit at index 0 and muddy the placement asserts. */
+    bareWire?: boolean;
 }
 
-async function startProxy(upstream: http.Server, { compatJson }: StartOpts): Promise<{ port: number; opts: ProxyOptions; stop: () => Promise<void>; cleanup: () => void }> {
+async function startProxy(upstream: http.Server, { compatJson, bareWire }: StartOpts): Promise<{ port: number; opts: ProxyOptions; stop: () => Promise<void>; cleanup: () => void }> {
     _setStoreForTest(new SessionStore({ enabled: false }));
     setRegistryForTest({});
     const root = path.join(tmpdir(), `bili-compat-roles-${process.pid}-${Date.now()}`);
@@ -136,7 +140,7 @@ async function startProxy(upstream: http.Server, { compatJson }: StartOpts): Pro
         proxySource: "direct",
         modelContextLimit: 400_000,
         kernelConfig: defaultConfig(400_000),
-        compress: { injectTool: true, injectNudge: true },
+        compress: bareWire ? { injectTool: false, injectNudge: false } : { injectTool: true, injectNudge: true },
         promptCache: { routing: "auto" },
         compat: { roles: parseCompatRoles(JSON.parse(compatJson).compat?.roles) ?? {} },
         sessionHeader: "x-acp-session",
@@ -397,22 +401,27 @@ function rolesOf(body: unknown): string[] {
     return [...(b.input ?? []), ...(b.messages ?? [])].map((m) => m.role ?? "?");
 }
 
-// Payload that keeps a developer MID-LIST at the forward boundary. A well-formed
-// TYPED developer is hoisted to index 0 by the kernel (injectResponsesDeveloperMessage),
-// so the primary developer→system retry already lands at index 0 and succeeds — it
-// can never produce a mid-list system. A non-normalized type-less item is left in
-// place by the projection, which is exactly the precondition #583 needs.
-const MIDLIST_DEV_PAYLOAD = JSON.stringify({ model: "test", input: [
-    { type: "message", role: "user", content: "a" },
-    { role: "developer", content: "sys" },
-    { type: "message", role: "user", content: "b" },
+// Payload that still reaches the #583 placement edge after kernel #102 — via
+// the OPENAI chat path and a mid-list ASSISTANT. On Responses every developer
+// (typed or, post-#102, type-less EasyInput) collapses into the single
+// injected prefix message; on the openai path a mid-list developer is hoisted
+// into the index-0 system too. The one conversation role that survives
+// mid-list on the rebuilt wire is ASSISTANT (openaiToCore/coreToOpenai keep
+// conversation messages in place), so an assistant→system rewrite produces a
+// system at index 1 — exactly the #377-class "system only at index 0"
+// placement 400 the second-chance hop needs.
+const MIDLIST_ASSISTANT_PAYLOAD = JSON.stringify({ model: "test", messages: [
+    { role: "user", content: "a" },
+    { role: "assistant", content: "sys" },
+    { role: "user", content: "b" },
 ]});
 
-// Upstream enforcing BOTH halves of the #583 edge: rejects any unknown role
-// (developer) AND enforces system-at-index-0 only (a mid-list system is a
-// #377-class placement 400). acceptUser decides whether the final developer→user
-// rewrite is accepted (true = second-chance succeeds; false = every hop fails,
-// exercising the hard cap). Records every hit's roles.
+// Upstream enforcing BOTH halves of the #583 edge: rejects the unsupported
+// mid-list role (assistant — any of developer/assistant trips it) AND enforces
+// system-at-index-0 only (a mid-list system is a #377-class placement 400).
+// acceptUser decides whether the final assistant→user rewrite is accepted
+// (true = second-chance succeeds; false = every hop fails, exercising the hard
+// cap). Records every hit's roles.
 function ladderUpstream(acceptUser: boolean): Promise<{ server: http.Server; seen: string[][] }> {
     const seen: string[][] = [];
     const server = http.createServer((req, res) => {
@@ -424,9 +433,10 @@ function ladderUpstream(acceptUser: boolean): Promise<{ server: http.Server; see
             seen.push(roles);
             const json = (obj: unknown) => JSON.stringify(obj);
             const offZero = roles.map((r, i) => (r === "system" ? i : -1)).filter((i) => i >= 0).find((i) => i !== 0);
-            if (roles.includes("developer")) {
+            const odd = roles.find((r) => r === "developer" || r === "assistant");
+            if (odd) {
                 res.writeHead(400, { "content-type": "application/json" });
-                res.end(json({ error: { message: "Invalid role: developer" } }));
+                res.end(json({ error: { message: `Invalid role: ${odd}` } }));
             } else if (offZero !== undefined) {
                 res.writeHead(400, { "content-type": "application/json" });
                 res.end(json({ error: { message: `Value error: system messages are only allowed at index 0 (found system at index ${offZero})` } }));
@@ -435,37 +445,37 @@ function ladderUpstream(acceptUser: boolean): Promise<{ server: http.Server; see
                 res.end(json({ ok: true }));
             } else {
                 res.writeHead(400, { "content-type": "application/json" });
-                res.end(json({ error: { message: "Invalid role: developer" } }));
+                res.end(json({ error: { message: "Invalid role: assistant" } }));
             }
         });
     });
     return new Promise((resolve) => server.listen(0, "127.0.0.1", () => resolve({ server, seen })));
 }
 
-test("e2e #583 G: mid-list developer→system 400s on a placement-strict backend; second-chance learns developer→user", async () => {
+test("e2e #583 G: mid-list assistant→system 400s on a placement-strict backend; second-chance learns assistant→user", async () => {
     const { server: upstream, seen } = await ladderUpstream(true);
-    const harness = await startProxy(upstream, { compatJson: `{"providers":{}}` });
+    const harness = await startProxy(upstream, { compatJson: `{"providers":{}}`, bareWire: true });
     try {
-        const res1 = await fetch(`http://127.0.0.1:${harness.port}/v1/responses`, {
+        const res1 = await fetch(`http://127.0.0.1:${harness.port}/v1/chat/completions`, {
             method: "POST",
             headers: { "content-type": "application/json", "x-session-id": "compat-second-chance" },
-            body: MIDLIST_DEV_PAYLOAD,
+            body: MIDLIST_ASSISTANT_PAYLOAD,
         });
         assert.equal(res1.status, 200, "client sees a transparent 200 after the second-chance retry");
-        assert.equal(seen.length, 3, `expected 3 upstream hits (dev→sys→user), got ${JSON.stringify(seen)}`);
-        assert.ok(seen[0].includes("developer"), "hit 1 carries a developer role → rejected");
-        assert.ok(!seen[1].includes("developer") && seen[1].includes("system"), "hit 2: primary hop rewrote developer→system (mid-list → placement 400)");
-        assert.ok(!seen[2].includes("developer") && !seen[2].includes("system"), "hit 3: second-chance rewrote developer→user → accepted");
-        // Second request: the session learned developer→user, so every developer
-        // (typed or type-less) is pre-rewritten BEFORE fetch — no 400 round-trip.
-        const res2 = await fetch(`http://127.0.0.1:${harness.port}/v1/responses`, {
+        assert.equal(seen.length, 3, `expected 3 upstream hits (asst→sys→user), got ${JSON.stringify(seen)}`);
+        assert.ok(seen[0].includes("assistant"), "hit 1 carries an assistant role → rejected");
+        assert.ok(!seen[1].includes("assistant") && seen[1].includes("system"), "hit 2: primary hop rewrote assistant→system (mid-list → placement 400)");
+        assert.ok(!seen[2].includes("assistant") && !seen[2].includes("system"), "hit 3: second-chance rewrote assistant→user → accepted");
+        // Second request: the session learned assistant→user, so every assistant
+        // is pre-rewritten BEFORE fetch — no 400 round-trip.
+        const res2 = await fetch(`http://127.0.0.1:${harness.port}/v1/chat/completions`, {
             method: "POST",
             headers: { "content-type": "application/json", "x-session-id": "compat-second-chance" },
-            body: MIDLIST_DEV_PAYLOAD,
+            body: MIDLIST_ASSISTANT_PAYLOAD,
         });
         assert.equal(res2.status, 200);
         assert.equal(seen.length, 4, `expected 4 upstream hits total (3 + 1), got ${JSON.stringify(seen)}`);
-        assert.ok(!seen[3].includes("developer") && !seen[3].includes("system"), "second request pre-rewritten via learned map");
+        assert.ok(!seen[3].includes("assistant") && !seen[3].includes("system"), "second request pre-rewritten via learned map");
         await waitFor(() => _liveUpstreamTimersForTest() === 0);
         assert.equal(_liveUpstreamTimersForTest(), 0, "abandoned retry bodies must not re-arm the idle timer");
     } finally {
@@ -477,16 +487,16 @@ test("e2e #583 G: mid-list developer→system 400s on a placement-strict backend
 
 test("e2e #583 H: ladder is capped — every hop failing passes the ORIGINAL 400 verbatim, no loop", async () => {
     const { server: upstream, seen } = await ladderUpstream(false);
-    const harness = await startProxy(upstream, { compatJson: `{"providers":{}}` });
+    const harness = await startProxy(upstream, { compatJson: `{"providers":{}}`, bareWire: true });
     try {
-        const res = await fetch(`http://127.0.0.1:${harness.port}/v1/responses`, {
+        const res = await fetch(`http://127.0.0.1:${harness.port}/v1/chat/completions`, {
             method: "POST",
             headers: { "content-type": "application/json", "x-session-id": "compat-second-chance-cap" },
-            body: MIDLIST_DEV_PAYLOAD,
+            body: MIDLIST_ASSISTANT_PAYLOAD,
         });
         assert.equal(res.status, 400, "client receives a 400 when every hop fails");
         const text = await res.text();
-        assert.ok(text.includes("Invalid role: developer"), `original error preserved verbatim, got: ${text}`);
+        assert.ok(text.includes("Invalid role: assistant"), `original error preserved verbatim, got: ${text}`);
         assert.equal(seen.length, 3, `expected exactly 3 upstream hits (original + 2 retries), got ${JSON.stringify(seen)}`);
         await waitFor(() => _liveUpstreamTimersForTest() === 0);
         assert.equal(_liveUpstreamTimersForTest(), 0, "abandoned retry bodies must not re-arm the idle timer");


### PR DESCRIPTION
## What

- **Pin acp-kernel 0.0.57 → 0.0.59** and rebuild (real `npm install`, not lock-only — dist now bundles 0.0.59). Kernel deltas this picks up:
  - **#190** — `allImageParts` read `image_url.url` without a guard → null-content images crashed the proxy (bili-side crash class).
  - **#102** — EasyInput normalization on the responses path (type-less `developer` items now normalize to `type:"message"`).
  - **#212** — single-quote salvage ported back into kernel `parseCompressArgs` (originally bili #603/#610).
  - **#209** — array-adjacency segmentation in `recommend.ts` (dsh surface-replace hosts no longer fragment ranges; append-only hosts byte-identical).
- **Dedup #603**: `src/compress-tool.ts` now delegates to kernel `parseCompressArgs`; the quote-salvage warning is driven by `parsed.diagnostics.quoteSalvage`. Local `normalizeQuoteShape` / `normalizeSingleQuotes` (~100 lines) deleted — one implementation, kernel-owned. `basic.test.ts` keeps the full #603 matrix, now exercising the kernel path (29/29).

## Test migration (compat-roles #583 G/H)

Kernel #102 changed a test precondition: bili's rebuilt wire **hoists every system/developer into the index-0 prefix on BOTH the responses and openai paths**, so a developer→system compat rewrite can no longer land off index 0 — the #583 placement-400 edge was unreachable with developer payloads. G/H migrated to the **openai chat path with a mid-list ASSISTANT** (the one conversation role that survives mid-list) + a `bareWire` harness option (injectTool/injectNudge off, so the wire is the bare conversation). Ladder verified role-generic; upstream stub now rejects `developer|assistant`.

## Pre-flight

- typecheck ✓
- full suite: **1238/1240** (2 known env fails in plugin-agent.test.ts, unrelated)
- build ✓, verified dist bundles kernel salvage code and no local copy remains

Fixes #603 (dedup side; original fix shipped earlier — this removes the duplicated implementation)