### PR TITLE
release v0.1.95

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.94",
+  "version": "0.1.95",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Changes since v0.1.94 (tag)

| PR | Issue | What |
|----|-------|------|
| #633 | #603 (dedup) | kernel pin 0.0.57 → 0.0.59 (crash guard #190, EasyInput normalization #102, quote-salvage #212, array-adjacency segmentation #209); compress-tool delegates quote-salvage to kernel, ~100 lines of duplicated salvage code deleted |

Pure version bump otherwise (kernel stays as bundled in master — 0.0.59).

Note: 0.1.94 → 0.1.95 is the first real upgrade hop running the NEW updater code (registryUrlFor / #204). Local install will be watched for the `auto-updated 0.1.94 → 0.1.95` log line after publish.

Pre-flight: typecheck ✓ · 1238/1240 tests (2 known env fails in plugin-agent.test.ts) · build ✓