### PR TITLE
test: make resolveClientCommand codex/claude tests hermetic (#642)

### DIFF
--- a/tests/launcher.test.ts
+++ b/tests/launcher.test.ts
@@ -1061,15 +1061,42 @@ test("isOnPath: finds a known binary on PATH, misses bogus name", () => {
     assert.equal(isOnPath(nodeName, {}), false);
 });
 
-test("resolveClientCommand: codex/claude resolve to themselves", () => {
-    assert.deepEqual(resolveClientCommand("codex", { PATH: "/usr/bin" }), {
-        command: "codex",
-        prefixArgs: [],
-    });
-    assert.deepEqual(resolveClientCommand("claude", { PATH: "/usr/bin" }), {
-        command: "claude",
-        prefixArgs: [],
-    });
+test("resolveClientCommand: codex/claude not on PATH fall back to bare name", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "bili-path-"));
+    try {
+        assert.deepEqual(resolveClientCommand("codex", { PATH: tmp }), {
+            command: "codex",
+            prefixArgs: [],
+        });
+        assert.deepEqual(resolveClientCommand("claude", { PATH: tmp }), {
+            command: "claude",
+            prefixArgs: [],
+        });
+    } finally {
+        fs.rmdirSync(tmp);
+    }
+});
+
+test("resolveClientCommand: codex/claude on PATH resolve to full path", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "bili-path-"));
+    const codexFile = path.join(tmp, "codex");
+    const claudeFile = path.join(tmp, "claude");
+    fs.writeFileSync(codexFile, "#!/bin/sh\necho codex\n", { mode: 0o755 });
+    fs.writeFileSync(claudeFile, "#!/bin/sh\necho claude\n", { mode: 0o755 });
+    try {
+        assert.deepEqual(resolveClientCommand("codex", { PATH: tmp }), {
+            command: codexFile,
+            prefixArgs: [],
+        });
+        assert.deepEqual(resolveClientCommand("claude", { PATH: tmp }), {
+            command: claudeFile,
+            prefixArgs: [],
+        });
+    } finally {
+        fs.unlinkSync(codexFile);
+        fs.unlinkSync(claudeFile);
+        fs.rmdirSync(tmp);
+    }
 });
 
 test("resolveClientCommand: pi prefers PI_BIN env", () => {


### PR DESCRIPTION
Fixes #642

## Problem

`tests/launcher.test.ts:1064` — `resolveClientCommand: codex/claude resolve to themselves` hard-coded `/usr/bin` as a PATH that does NOT contain codex/claude. On any machine with those CLIs in `/usr/bin` the not-on-PATH assertion fails:

```
AssertionError: Expected values to be strictly deep-equal:
  {
+   command: '/usr/bin/codex',
-   command: 'codex',
  }
```

Reproduced in this sandbox (has `/usr/bin/codex` + `/usr/bin/claude`): 1 failure before the fix, 0 after.

## Change

Split the test into two hermetic tests, following the existing pi / codebuddy (#641) pattern:

- **not on PATH**: `PATH` points at an empty temp dir → bare-name fallback (`codex` / `claude`)
- **on PATH**: fake `codex` / `claude` executables created in a temp bin dir → the absolute path is returned

Test-only change; `src/launcher.ts` untouched (`resolveOnPath` was already correct).

## Pre-flight

- `npm run typecheck` — clean
- `npm test` — 1241/1241 pass (on this sandbox, where the old test failed)
- `npm run build` — success