### PR TITLE
fix: bound close-side tag-echo tail so a malformed </acp can't eat following content (#644)

### DIFF
--- a/src/loop/tag-echo-filter.ts
+++ b/src/loop/tag-echo-filter.ts
@@ -16,13 +16,13 @@ const LONE_CLOSE = /<\/acp(?=[\s>])[^<>]{0,32}>/;
 // A suffix of the buffer that could still grow into a render tag: either an
 // unterminated `\x3cacp …` opening (attrs so far, no `>` yet) or a short
 // ambiguous prefix like `<`, `<a`, `</ac`, …
-const PARTIAL_TAIL = /(\x3cacp\s[^<>]*|\x3c\/acp(?:\s[^<>]*)?|<\/?a?c?p?)$/;
+const PARTIAL_TAIL = /(\x3cacp\s[^<>]*|\x3c\/acp(?:\s[^<>]{0,32})?|<\/?a?c?p?)$/;
 // An unterminated render-tag opening at the end of a string: `<acp ` plus
 // attrs, no `>` — a truncated imitation, never prose (triggers use `<acp_`).
 const TRUNC_OPEN = /\x3cacp\s[^<>]*$/;
 // A truncated render-tag CLOSE at the end of a string: `` or `` —
 // a truncated imitation close, never prose. Mirrors TRUNC_OPEN on the close side.
-const TRUNC_CLOSE = /\x3c\/acp(?:\s[^<>]*)?$/;
+const TRUNC_CLOSE = /\x3c\/acp(?:\s[^<>]{0,32})?$/;
 const CLOSE_TAG = "\x3c/acp";
 const HOLD_LIMIT = 128;
 // Hold cap for a definite unterminated opening tail — far beyond any real tag

--- a/tests/tag-echo.test.ts
+++ b/tests/tag-echo.test.ts
@@ -124,6 +124,30 @@ test("stripAcpTags: short truncated close at end is still dropped (#644 bound)",
     assert.equal(stripAcpTags(`ref m00001 ${LT}/acp tokens`), "ref m00001 ");
 });
 
+// The actual #644 incident shape: whitespace right after the malformed
+// close. The unbounded close-side tails consumed content only through the
+// \s[^<>]* group, so the no-whitespace variants above never triggered the
+// bug on their own — this is the shape that ate the real prose.
+test("stripAcpTags: malformed close with trailing space does not eat following content (#644 incident shape)", () => {
+    const content = "这是真实的正文内容，不应被过滤器吃掉。".repeat(12);
+    const malformed = `${LT}acp tokens="245" type="text">m01998${LT}/acp ` + content;
+    const out = stripAcpTags(malformed);
+    assert.ok(out.includes(content), "real content survives the malformed close (not eaten)");
+    assert.ok(out.includes("m01998"), "the ref is preserved");
+    assert.notEqual(out, "m01998", "not stripped to the bare ref");
+});
+
+test("streaming filter matches stripAcpTags for the incident-shape malformed close at every split position (#644)", () => {
+    const content = "这是真实的正文内容，不应被过滤器吃掉。".repeat(12);
+    const full = `${LT}acp tokens="245" type="text">m01998${LT}/acp ` + content;
+    const expected = stripAcpTags(full);
+    for (let split = 0; split <= full.length; split++) {
+        const f = createTagEchoFilter();
+        const out = f.push(full.slice(0, split)) + f.push(full.slice(split)) + f.flush();
+        assert.equal(out, expected, `split=${split}`);
+    }
+});
+
 test("streaming filter matches stripAcpTags for every split position", () => {
     const cases = [
         `answer ${TAG("m00155")}${TAG("m00155", 44)} done`,

--- a/tests/tag-echo.test.ts
+++ b/tests/tag-echo.test.ts
@@ -91,6 +91,39 @@ test("stripAcpTags: long paired content keeps content, strips tags", () => {
     assert.equal(stripAcpTags(`${OPEN}t="1">${long}${CLOSE}`), long);
 });
 
+// #644: a malformed render-tag close (the echoed `</acp` is missing its closing
+// `>`) used to make the close-side tail regexes (TRUNC_CLOSE, PARTIAL_TAIL)
+// swallow the ENTIRE following real content — they were unbounded, so `</acp`
+// + 300 chars of prose was held/dropped and only the bare ref survived. Bounding
+// the close-side tail to {0,32} (aligned with LONE_CLOSE) releases an over-long
+// tail as content instead of holding/dropping it.
+test("stripAcpTags: malformed close (missing >) does not eat following content (#644)", () => {
+    const content = "这是真实的正文内容，不应被过滤器吃掉。".repeat(12);
+    const malformed = `${LT}acp tokens="245" type="text">m01998${LT}/acp` + content;
+    const out = stripAcpTags(malformed);
+    assert.ok(out.includes(content), "real content survives the malformed close (not eaten)");
+    assert.ok(out.includes("m01998"), "the ref is preserved");
+    assert.notEqual(out, "m01998", "not stripped to the bare ref");
+});
+
+test("streaming filter matches stripAcpTags for a malformed close at every split position (#644)", () => {
+    const content = "这是真实的正文内容，不应被过滤器吃掉。".repeat(12);
+    const full = `${LT}acp tokens="245" type="text">m01998${LT}/acp` + content;
+    const expected = stripAcpTags(full);
+    for (let split = 0; split <= full.length; split++) {
+        const f = createTagEchoFilter();
+        const out = f.push(full.slice(0, split)) + f.push(full.slice(split)) + f.flush();
+        assert.equal(out, expected, `split=${split}`);
+    }
+});
+
+// A genuinely short truncated close at end-of-stream (<= 32 chars) is still a
+// truncated imitation and is dropped — the bound must not over-release.
+test("stripAcpTags: short truncated close at end is still dropped (#644 bound)", () => {
+    assert.equal(stripAcpTags(`ref m00001 ${LT}/acp`), "ref m00001 ");
+    assert.equal(stripAcpTags(`ref m00001 ${LT}/acp tokens`), "ref m00001 ");
+});
+
 test("streaming filter matches stripAcpTags for every split position", () => {
     const cases = [
         `answer ${TAG("m00155")}${TAG("m00155", 44)} done`,


### PR DESCRIPTION
## What
A model-echoed render tag whose close is **malformed** (the echoed `</acp` is missing its closing `>`) used to make the close-side tail regexes swallow the **entire following real content**.

`TRUNC_CLOSE` and the `PARTIAL_TAIL` close branch were unbounded (`[^<>]*`), so at `flush()` / in the streaming hold, `</acp` + all following non-angle prose was held (up to `TAG_OPEN_CAP=4096`) then dropped, leaving only the bare ref. The client saw a marker-only turn and the agent stalled until a manual nudge.

## Root cause (verified against the recovered raw stream in #644)
Turn B's text block was `<acp tokens="245" type="text">m01998</acp` + ~324 chars of real prose (the close missing its `>`). Traced through the filter:
- `LONE_OPEN` removes the opening `<acp ...>`.
- `TRUNC_CLOSE = /<\/acp(?:\s[^<>]*)?$/` (unbounded) then matches `</acp` + the whole prose span to end-of-string and drops it.
- Result: only `m01998` survives — exactly the 6-char client result.

Reproduced offline: `stripAcpTags("<acp tokens=\"245\" type=\"text\">m01998</acp" + content)` → `m01998` before the fix.

## Fix
Bound the close-side tail to `{0,32}` (aligned with the existing `LONE_CLOSE` bound):
- `TRUNC_CLOSE`: `/<\/acp(?:\s[^<>]*)?$/` → `/<\/acp(?:\s[^<>]{0,32})?$/`
- `PARTIAL_TAIL` close branch: `\x3c\/acp(?:\s[^<>]*)?` → `\x3c\/acp(?:\s[^<>]{0,32})?`

An over-long tail is now **released as content** instead of held/dropped. Genuine short truncated closes (`</acp`, `</acp tokens` at stream end, ≤32 chars) still match and are dropped.

## Tests
- `stripAcpTags`: malformed close + content → content survives (not stripped to the bare ref).
- streaming filter matches `stripAcpTags` for the malformed close at **every split position** (the repo's core invariant).
- short truncated close at end is still dropped (the bound doesn't over-release).

## Pre-flight
- `npm run typecheck` — clean
- `npm test` — 1237 pass / 1 fail (the 1 fail is `resolveClientCommand: codex/claude resolve to themselves`, a pre-existing environment-dependent launcher test that also fails on clean master; unrelated to this change)
- `npm run build` — success

Fixes #644