### PR TITLE
release v0.1.96

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Changes since v0.1.95

| PR | Issue | What |
|----|-------|------|
| #646 | #644 | fix: bound close-side tag-echo tail so a malformed `</acp` can't eat following content (+ incident-shape test) |
| #643 | #642 | test: make resolveClientCommand codex/claude tests hermetic |

Pure version bump otherwise.

Pre-flight: typecheck ✓ · **1244/1246** tests (2 known env fails in plugin-agent.test.ts) · build ✓