### PR TITLE
deps: bump acp-kernel 0.0.60 (fixes #658 via kernel #230/#232)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.94",
+  "version": "0.1.96",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.94",
+      "version": "0.1.96",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@types/node": "^22.0.0",
         "@types/node-forge": "^1.3.14",
-        "acp-kernel": "0.0.59",
+        "acp-kernel": "0.0.60",
         "fzstd": "0.1.1",
         "node-forge": "^1.4.0",
         "tar": "^7.5.22",
@@ -988,9 +988,9 @@
       }
     },
     "node_modules/acp-kernel": {
-      "version": "0.0.59",
-      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.59.tgz",
-      "integrity": "sha512-CegmdDbyM6hMlsPFDzDJrbBAUaAvZZfv2SG8pojho/8cC4tRq5qrKLHY1yf7jp8eAwyY2x4YdBEQvspv0AwHUg==",
+      "version": "0.0.60",
+      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.60.tgz",
+      "integrity": "sha512-AdvQ5hVsupmspjFJrmtD3sWBShKmd2I/ZzglO+0Z2djJI5f1T/4Cp7WDhhl3E7qqft7rExBr4qTxWiOSCj1BFw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/node-forge": "^1.3.14",
-    "acp-kernel": "0.0.59",
+    "acp-kernel": "0.0.60",
     "fzstd": "0.1.1",
     "node-forge": "^1.4.0",
     "tar": "^7.5.22",


### PR DESCRIPTION
Fixes #658

## ⛔ BLOCKED:等 acp-kernel v0.0.60 发版

acp-kernel v0.0.60 尚未发布(需先人工合并 [acp-kernel#232](https://github.com/ranxianglei/acp-kernel/pull/232) 并走其发版流程)。在此之前 CI 的 `npm ci` 会因版本不存在而失败,lockfile 也无法刷新——均为预期。

## 转正步骤(kernel v0.0.60 上线后)

1. `npm install`(刷新 package-lock.json,应只含 acp-kernel 0.0.59→0.0.60)
2. `npm test && npm run build` 确认绿
3. commit lockfile,push,CI 绿后转 ready,人工合并

## 内容

- `devDependencies.acp-kernel` `0.0.59` → `0.0.60`
- 修复收益:hide-consumed 对字符串形态 `content`(qwen/glm 等非严格 provider 100% 触发)与带前缀调用文本的解析修复,compress 锚点 args 复写本瘦身生效(风暴会话实测单条 924→278 chars,合计 ~22K tokens 回收)。详见 #658。