### PR TITLE
feat: per-route passthrough option for providers (#661)

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -126,7 +126,7 @@ Top-level keys that control how the proxy listens and behaves globally.
 
 ## Providers
 
-The `providers` block maps **upstream URLs** to per-provider configuration. Each key is a URL prefix; each value can declare model context windows, a per-provider proxy, a compression protocol, and compression overrides.
+The `providers` block maps **upstream URLs** to per-provider configuration. Each key is a URL prefix; each value can declare model context windows, a per-provider proxy, a compression protocol, compression overrides, and a per-route passthrough.
 
 ```jsonc
 {
@@ -185,6 +185,21 @@ A shallow key (`https://open.bigmodel.cn`) matches every path on that host. A de
 - **Default:** `{}` (disabled)
 - **Status:** ACTIVE
 - **Description:** Per-provider wire-compat overrides. `roles` maps message roles to the role name this upstream accepts, e.g. `{"developer": "system"}` for upstreams that reject the `developer` role newer codex clients send (#552). Applied to the final forwarded `openai`/`responses` body — client-sent roles and bili's own injected prompt alike — and to every body the compress-retry loops re-send. Wins per key over the global `compat` block (see [Server Settings](#server-settings)). Default `{}` forwards byte-for-byte unchanged.
+
+### `passthrough`
+
+- **Type:** `boolean`
+- **Default:** *(none — compression active)*
+- **Status:** ACTIVE
+- **Description:** Per-route override of the global [`passthrough`](#passthrough) setting. When `true`, every request matching this route is forwarded **byte-for-byte**: no kernel round-trip (no message re-serialization, no ACP render tags, no `prompt_cache_key` removal), the response is piped through untouched, and no session state is created for that route. Use this for upstreams whose anti-fraud fingerprinting rejects bili's rewritten bodies — e.g. ZCode's `405 / 3012` ("request has been blocked due to unusual activity") on the kernel-rebuilt `messages` body (#661). A `mitm://` key targets only the MITM (login-client) traffic of that host, while a plain `https://` key covers both MITM and `/bili/` (API-key) traffic:
+
+  ```jsonc
+  {
+    "providers": {
+      "mitm://zcode.z.ai": { "passthrough": true }
+    }
+  }
+  ```
 
 ---
 

--- a/CONFIGURATION.zh-CN.md
+++ b/CONFIGURATION.zh-CN.md
@@ -126,7 +126,7 @@
 
 ## Providers
 
-`providers` 块将**上游 URL** 映射到按 provider 的配置。每个键是一个 URL 前缀；每个值可以声明模型上下文窗口、按 provider 的代理、压缩协议以及压缩覆盖项。
+`providers` 块将**上游 URL** 映射到按 provider 的配置。每个键是一个 URL 前缀；每个值可以声明模型上下文窗口、按 provider 的代理、压缩协议、压缩覆盖项，以及按路由的透传开关。
 
 ```jsonc
 {
@@ -183,6 +183,21 @@
 - **默认值：** `{}`（禁用）
 - **状态：** ACTIVE
 - **说明：** 按 provider 的线上兼容覆盖。`roles` 把消息角色映射为该上游接受的角色名，例如 `{"developer": "system"}` —— 用于拒绝 `developer` 角色的上游（#552，新版 codex 客户端会发这个角色）。作用于最终转发的 `openai`/`responses` 请求体 —— 客户端发送的角色和 bili 自己注入的提示一视同仁 —— 压缩重试循环重发的请求体同样携带该改写。按键覆盖全局 `compat` 块（见[服务端设置](#服务端设置)）。默认 `{}` 逐字节透明转发。
+
+### `passthrough`
+
+- **类型：** `boolean`
+- **默认值：** *（无 —— 压缩开启）*
+- **状态：** ACTIVE
+- **说明：** 按路由覆盖全局 [`passthrough`](#passthrough) 设置。设为 `true` 时，匹配该路由的所有请求**逐字节转发**：不走 kernel 往返（不重序列化 messages、不注入 ACP 渲染标签、不删除 `prompt_cache_key`），响应原样 pipe，该路由不建立 session 状态。用于上游反作弊会拒绝 bili 改写后请求体的场景 —— 例如 ZCode 对 kernel 重建的 `messages` 请求体返回 `405 / 3012`（"request has been blocked due to unusual activity"，#661）。`mitm://` 键只命中该 host 的 MITM（登录态客户端）流量，普通 `https://` 键则同时覆盖 MITM 与 `/bili/`（API key）流量：
+
+  ```jsonc
+  {
+    "providers": {
+      "mitm://zcode.z.ai": { "passthrough": true }
+    }
+  }
+  ```
 
 ---
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -49,6 +49,13 @@ export type ProviderRoute = {
      *  client-sent roles and bili's own injected prompt alike (#552). Wins
      *  per key over the global `compat` block. */
     compat?: { roles?: Record<string, string> };
+    /** Route-scoped passthrough (#661): same semantics as the global
+     *  `passthrough` flag, but only for requests whose upstream URL matches
+     *  this route — request body forwarded byte-for-byte (no kernel
+     *  round-trip, no render tags, no re-serialization), response piped
+     *  verbatim, no session state. For upstreams whose anti-cheat fingerprints
+     *  the request body (e.g. ZCode 405/3012). */
+    passthrough?: boolean;
 };
 export type ProviderRoutes = Record<string, ProviderRoute>; // key = upstream URL prefix (the /bili/<this> string)
 
@@ -579,13 +586,14 @@ export function parseRouteEntry(v: unknown): ProviderRoute | undefined {
     // is the KEY in the providers map (identical to the /bili/<url> string),
     // so it is NOT repeated inside the value.
     if (v && typeof v === "object" && !Array.isArray(v)) {
-        const obj = v as { models?: Record<string, ModelEntry>; proxy?: string; compressProtocol?: string; compress?: CompressSettings; compat?: { roles?: unknown } };
+        const obj = v as { models?: Record<string, ModelEntry>; proxy?: string; compressProtocol?: string; compress?: CompressSettings; compat?: { roles?: unknown }; passthrough?: boolean };
         const route: ProviderRoute = { models: obj.models };
         if (typeof obj.proxy === "string") route.proxy = obj.proxy;
         if (obj.compressProtocol === "marker" || obj.compressProtocol === "tools") route.compressProtocol = obj.compressProtocol;
         if (obj.compress) route.compress = obj.compress;
         const compatRoles = parseCompatRoles(obj.compat?.roles);
         if (compatRoles) route.compat = { roles: compatRoles };
+        if (typeof obj.passthrough === "boolean") route.passthrough = obj.passthrough;
         return route;
     }
     // A bare value (e.g. null) means "this upstream exists, no overrides".

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,7 +8,7 @@ import { DEFAULT_STRIP_IMAGES_KEEP_RECENT, stripHistoricalImages } from "./strip
 import type { ProxyOptions } from "./config.js";
 import { loadOptions, loadRoutes } from "./config.js";
 import { resetProxyCache } from "./upstream-proxy.js";
-import { FALLBACK_EFFECTIVE_WINDOW_FLOOR, lookupContextLimit, resolveConfiguredContextLimit, resolveCompressProtocol } from "./config.js";
+import { FALLBACK_EFFECTIVE_WINDOW_FLOOR, findRoute, lookupContextLimit, resolveConfiguredContextLimit, resolveCompressProtocol } from "./config.js";
 import { contextFromRegistry, loadRegistry, peekRegistryContext } from "./registry.js";
 import { codexAlignedWindow } from "./codex-models.js";
 import { fetchWithTimeout, MAX_REQUEST_BYTES } from "./fetch-util.js";
@@ -1165,10 +1165,17 @@ async function handle(
         }
     }
     let prepared: Prepared | null = null;
+    // #661: route-scoped passthrough — the global flag's semantics, limited to
+    // requests whose upstream URL matches a provider route with
+    // `passthrough: true` (upstreams that fingerprint the request body).
+    const routePassthrough = !opts.passthrough && findRoute(opts.routes, route?.rewrittenUrl)?.passthrough === true;
+    if (routePassthrough && hopMarker === undefined && protocol && parsed) {
+        log("info", `[route-passthrough] ${maskUrlsInText(route?.rewrittenUrl ?? "")} matches a passthrough route — forwarding verbatim, kernel bypassed`);
+    }
     // #300: `hopMarker !== undefined` means an upstream bili already processed
     // this request — skip the whole pipeline (prepared stays null) so the
     // passthrough path below forwards it verbatim.
-    if (!opts.passthrough && hopMarker === undefined && protocol && parsed && typeof parsed === "object") {
+    if (!opts.passthrough && !routePassthrough && hopMarker === undefined && protocol && parsed && typeof parsed === "object") {
         const sessionHeader = headerValue(req, opts.sessionHeader);
         // Plugin mode (issue #1, "内外呼应"): a cooperative agent-side plugin
         // announces itself with x-bili-plugin. The proxy then treats the
@@ -1684,7 +1691,7 @@ async function handle(
         }
     }
     if (!prepared) {
-        if (protocol === null && !opts.passthrough && !isModelDiscoveryPath(urlPath)) {
+        if (protocol === null && !opts.passthrough && !routePassthrough && !isModelDiscoveryPath(urlPath)) {
             logUnrecognizedPath(log, req.url ?? "");
         }
         await forward(req, res, opts, bodyBuffer, null, core, reqConfig, log, route, instanceId, undefined);

--- a/tests/route-passthrough.test.ts
+++ b/tests/route-passthrough.test.ts
@@ -1,0 +1,222 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import { once } from "node:events";
+import { defaultConfig } from "acp-kernel";
+import { startServer } from "../src/server.ts";
+import { SessionStore, _setStoreForTest } from "../src/persist.ts";
+import { findRoute, parseRouteEntry } from "../src/config.ts";
+import type { ProxyOptions } from "../src/config.ts";
+import { _setForTest as setRegistryForTest } from "../src/registry.ts";
+
+// #661: per-route `passthrough` — upstreams that fingerprint the request body
+// (ZCode 405/3012) must get byte-verbatim forwarding without a global flag.
+
+function listen(server: http.Server): Promise<void> {
+    if (server.listening) return Promise.resolve();
+    return once(server, "listening").then(() => undefined);
+}
+
+function close(server: http.Server): Promise<void> {
+    return new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+}
+
+test("parseRouteEntry: passthrough boolean round-trips, non-boolean ignored", () => {
+    assert.equal(parseRouteEntry({ passthrough: true })?.passthrough, true);
+    assert.equal(parseRouteEntry({ passthrough: false })?.passthrough, false);
+    assert.equal(parseRouteEntry({ passthrough: "yes" })?.passthrough, undefined, "non-boolean must be ignored");
+    assert.equal(parseRouteEntry({ passthrough: 1 })?.passthrough, undefined, "non-boolean must be ignored");
+    assert.deepEqual(parseRouteEntry(null), {});
+    assert.equal(parseRouteEntry({ models: { m1: { context: 100 } }, passthrough: true })?.passthrough, true, "coexists with models");
+});
+
+test("findRoute: mitm:// key matches only MITM traffic to that host (ZCode case)", () => {
+    const routes = { "mitm://zcode.z.ai": { passthrough: true } };
+    const mitmHit = findRoute(routes, "mitm://zcode.z.ai/api/v1/zcode-plan/anthropic/v1/messages");
+    assert.equal(mitmHit?.passthrough, true, "MITM traffic to zcode.z.ai matches the mitm:// key");
+    assert.equal(findRoute(routes, "https://zcode.z.ai/api/v1/zcode-plan/anthropic/v1/messages"), undefined, "https:// (API-key /bili/) traffic must NOT match a mitm:// key");
+    assert.equal(findRoute(routes, "mitm://zcode.z.ai.evil/"), undefined, "host boundary: sibling host must not match");
+});
+
+test("findRoute: shallow host key matches all paths on the host", () => {
+    const routes = { "https://open.bigmodel.cn": { passthrough: true } };
+    assert.equal(findRoute(routes, "https://open.bigmodel.cn/api/anthropic/v1/messages")?.passthrough, true);
+    assert.equal(findRoute(routes, "https://open.bigmodel.cn")?.passthrough, true, "exact key match");
+});
+
+// max_tokens must exceed SIDE_REQUEST_MAX_TOKENS (200) or the control case
+// takes the side-request passthrough instead of the kernel round-trip.
+const ANTHROPIC_BODY = '{\n  "prompt_cache_key": "keep-me-please",\n  "model": "claude-test",\n  "max_tokens": 4096,\n  "messages": [\n    {\n      "role": "user",\n      "content": [\n        { "type": "text", "text": "hi there" }\n      ]\n    }\n  ]\n}';
+
+const ANTHROPIC_RESPONSE = JSON.stringify({
+    id: "msg_test_1",
+    type: "message",
+    role: "assistant",
+    model: "claude-test",
+    content: [{ type: "text", "text": "hello back" }],
+    stop_reason: "end_turn",
+    stop_sequence: null,
+    usage: { input_tokens: 10, output_tokens: 5 },
+});
+
+function makeUpstream(capture: { url: string; body: string }, respond: (res: http.ServerResponse) => void): http.Server {
+    const upstream = http.createServer((req, res) => {
+        const chunks: Buffer[] = [];
+        req.on("data", (c: Buffer) => chunks.push(c));
+        req.on("end", () => {
+            capture.url = req.url ?? "";
+            capture.body = Buffer.concat(chunks).toString("utf8");
+            respond(res);
+        });
+    });
+    return upstream;
+}
+
+function makeOpts(routes: Record<string, { passthrough?: boolean }>, upstream: string): ProxyOptions {
+    return {
+        port: 0,
+        host: "127.0.0.1",
+        upstream,
+        routes,
+        modelContextLimit: 400_000,
+        kernelConfig: defaultConfig(400_000),
+        compress: { injectTool: true, injectNudge: true },
+        promptCache: { routing: "auto" },
+        sessionHeader: "x-acp-session",
+        log: false,
+        debug: false,
+        passthrough: false,
+        autoUpdate: false,
+        mitm: { enabled: false, domains: [] },
+    };
+}
+
+async function postMessages(proxyPort: number, upstreamHost: string, sessionId: string): Promise<{ status: number; body: string }> {
+    return await new Promise((resolve, reject) => {
+        const req = http.request(
+            {
+                host: "127.0.0.1",
+                port: proxyPort,
+                method: "POST",
+                path: `/bili/http://${upstreamHost}/v1/messages`,
+                headers: {
+                    "content-type": "application/json",
+                    host: upstreamHost,
+                    "x-acp-session": sessionId,
+                    "content-length": String(Buffer.byteLength(ANTHROPIC_BODY)),
+                },
+            },
+            (res) => {
+                const chunks: Buffer[] = [];
+                res.on("data", (c) => chunks.push(c));
+                res.on("end", () => resolve({ status: res.statusCode ?? 0, body: Buffer.concat(chunks).toString("utf8") }));
+            },
+        );
+        req.on("error", reject);
+        req.write(ANTHROPIC_BODY);
+        req.end();
+    });
+}
+
+test("route passthrough: body forwarded byte-for-byte, response piped verbatim, kernel bypassed", async () => {
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    setRegistryForTest({});
+
+    const capture = { url: "", body: "" };
+    const upstream = makeUpstream(capture, (res) => {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(ANTHROPIC_RESPONSE);
+    });
+    upstream.listen(0, "127.0.0.1");
+    await listen(upstream);
+    const upstreamPort = (upstream.address() as { port: number }).port;
+    const upstreamHost = `127.0.0.1:${upstreamPort}`;
+
+    const opts = makeOpts({ [`http://${upstreamHost}`]: { passthrough: true } }, `https://${upstreamHost}`);
+    const proxy = await startServer(opts);
+    await listen(proxy);
+    const proxyPort = (proxy.address() as { port: number }).port;
+
+    try {
+        const out = await postMessages(proxyPort, upstreamHost, "route-passthrough-test");
+        assert.equal(out.status, 200, `client must see the upstream 200; got ${out.status}: ${out.body}`);
+        assert.equal(capture.body, ANTHROPIC_BODY, "upstream must receive the EXACT client bytes (no re-serialization, field order + whitespace intact)");
+        assert.ok(capture.body.includes("prompt_cache_key"), "prompt_cache_key must survive (kernel rebuild deletes it)");
+        assert.ok(!capture.body.includes("\x3cacp "), "no ACP render tags may be injected");
+        assert.equal(out.body, ANTHROPIC_RESPONSE, "response must be piped verbatim to the client");
+    } finally {
+        await close(proxy);
+        await close(upstream);
+    }
+});
+
+test("control: same request WITHOUT a passthrough route goes through the kernel round-trip", async () => {
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    setRegistryForTest({});
+
+    const capture = { url: "", body: "" };
+    const upstream = makeUpstream(capture, (res) => {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(ANTHROPIC_RESPONSE);
+    });
+    upstream.listen(0, "127.0.0.1");
+    await listen(upstream);
+    const upstreamPort = (upstream.address() as { port: number }).port;
+    const upstreamHost = `127.0.0.1:${upstreamPort}`;
+
+    const opts = makeOpts({}, `https://${upstreamHost}`);
+    const proxy = await startServer(opts);
+    await listen(proxy);
+    const proxyPort = (proxy.address() as { port: number }).port;
+
+    try {
+        const out = await postMessages(proxyPort, upstreamHost, "route-passthrough-control");
+        assert.equal(out.status, 200, `client must see the upstream 200; got ${out.status}: ${out.body}`);
+        assert.notEqual(capture.body, ANTHROPIC_BODY, "kernel round-trip must re-serialize the body");
+        assert.ok(!capture.body.includes("prompt_cache_key"), "kernel rebuild deletes prompt_cache_key");
+        assert.ok(capture.body.includes("\x3cacp "), "kernel round-trip injects ACP render tags");
+    } finally {
+        await close(proxy);
+        await close(upstream);
+    }
+});
+
+test("route passthrough: global passthrough=false still compresses OTHER routes", async () => {
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    setRegistryForTest({});
+
+    const bypassCapture = { url: "", body: "" };
+    const normalCapture = { url: "", body: "" };
+    const respondJson = (res: http.ServerResponse) => {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(ANTHROPIC_RESPONSE);
+    };
+    const bypassUpstream = makeUpstream(bypassCapture, respondJson);
+    const normalUpstream = makeUpstream(normalCapture, respondJson);
+    bypassUpstream.listen(0, "127.0.0.1");
+    normalUpstream.listen(0, "127.0.0.1");
+    await listen(bypassUpstream);
+    await listen(normalUpstream);
+    const bypassHost = `127.0.0.1:${(bypassUpstream.address() as { port: number }).port}`;
+    const normalHost = `127.0.0.1:${(normalUpstream.address() as { port: number }).port}`;
+
+    const opts = makeOpts({ [`http://${bypassHost}`]: { passthrough: true } }, `http://${normalHost}`);
+    const proxy = await startServer(opts);
+    await listen(proxy);
+    const proxyPort = (proxy.address() as { port: number }).port;
+
+    try {
+        const outBypass = await postMessages(proxyPort, bypassHost, "route-passthrough-mixed-1");
+        const outNormal = await postMessages(proxyPort, normalHost, "route-passthrough-mixed-2");
+        assert.equal(outBypass.status, 200);
+        assert.equal(outNormal.status, 200);
+        assert.equal(bypassCapture.body, ANTHROPIC_BODY, "bypassed route: byte-identical");
+        assert.notEqual(normalCapture.body, ANTHROPIC_BODY, "non-bypassed route: kernel round-trip still active");
+        assert.ok(!bypassCapture.body.includes("\x3cacp "), "bypassed route: no tags");
+        assert.ok(normalCapture.body.includes("\x3cacp "), "non-bypassed route: tags injected");
+    } finally {
+        await close(proxy);
+        await close(bypassUpstream);
+        await close(normalUpstream);
+    }
+});


### PR DESCRIPTION
## What

New per-route option `passthrough: true` on `providers` entries — the scoped sibling of the global `passthrough` setting:

```jsonc
{ "providers": { "mitm://zcode.z.ai": { "passthrough": true } } }
```

Matching requests are forwarded **byte-for-byte**: no kernel round-trip (no message re-serialization, no ACP render tags, no `prompt_cache_key` removal), response piped verbatim, no session state for that route. `mitm://` keys target only MITM (login-client) traffic; a plain `https://` host key covers both MITM and `/bili/` traffic.

## Why

#661: ZCode's upstream anti-fraud returns `405 / 3012` on the kernel-rebuilt `messages` body (field order/whitespace/`prompt_cache_key` + injected render tags), even with `injectTool=false`/`injectNudge=false`. The user's evidence (same MITM TLS chain: un-rewritten paths 200, rewritten path 405) isolates the body fingerprint as the trigger. Per-route passthrough is the shape of the user's proposal A, built on the existing route table instead of a new top-level `bypassHosts` list: zero new matching mechanism (reuses `findRoute` longest-prefix), exact MITM-vs-/bili/ targeting via the existing `mitm://` scheme, discoverable in the existing providers config surface and web UI.

Not proposal B (skip `processTurn` when no active blocks): the first compress call arrives with zero active blocks, and in plugin mode `processTurn` also materializes the agent's compress tool calls, runs orphan GC, and maintains compaction archive + preflight token tracking — skipping it breaks first compression and state maintenance.

Not proposal C (blind tunnel): body-fingerprint evidence makes kernel bypass sufficient; blind tunnel changes the TLS path and stays as a fallback if 405 persists after this.

## Changes

- `src/config.ts` — `ProviderRoute.passthrough?: boolean` + parsing in `parseRouteEntry` (boolean only, non-boolean values ignored)
- `src/server.ts` — `routePassthrough = findRoute(opts.routes, route?.rewrittenUrl)?.passthrough === true`; added to the pipeline gate and the `logUnrecognizedPath` condition; info log when the bypass fires
- `tests/route-passthrough.test.ts` — 6 tests: config round-trip, `mitm://` key matching (incl. lookalike-host negative), e2e byte-identical forward (incl. `prompt_cache_key` + whitespace), e2e control (no-route still kernel-processed: re-serialized, tags, `prompt_cache_key` removed), e2e mixed (both behaviours in one server)
- `CONFIGURATION.md` / `CONFIGURATION.zh-CN.md` — per-route `passthrough` documented under Providers

## Pre-flight

- `npm run typecheck` — pass
- `npm test` — 1240/1241 pass; the single failure (`launcher.test.ts resolveClientCommand: codex/claude resolve to themselves`) fails identically on clean master in this environment (expects bare `codex`, this box resolves `/usr/bin/codex`) — pre-existing, unrelated
- `npm run build` — pass
- E2E regression (`tests/e2e/e2e-codex.test.ts`, `ACP_TEST_E2E=1`) not run here: needs a reachable Responses-compatible upstream (local sglang or `E2E_UPSTREAM_URL`), unavailable in this environment. The change is additive (new option, default off; non-matching routes take the exact previous path — covered by the control test), so regression risk on existing routes is low.

Fixes #661