### PR TITLE
release v0.1.97

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.96",
+  "version": "0.1.97",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.96",
+      "version": "0.1.97",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@types/node": "^22.0.0",
         "@types/node-forge": "^1.3.14",
-        "acp-kernel": "0.0.60",
+        "acp-kernel": "0.0.61",
         "fzstd": "0.1.1",
         "node-forge": "^1.4.0",
         "tar": "^7.5.22",
@@ -988,9 +988,9 @@
       }
     },
     "node_modules/acp-kernel": {
-      "version": "0.0.60",
-      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.60.tgz",
-      "integrity": "sha512-AdvQ5hVsupmspjFJrmtD3sWBShKmd2I/ZzglO+0Z2djJI5f1T/4Cp7WDhhl3E7qqft7rExBr4qTxWiOSCj1BFw==",
+      "version": "0.0.61",
+      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.61.tgz",
+      "integrity": "sha512-Csu6LEP3PPEcaNsNq4NUZlr8BAIiPMrcv7OB4A7urrP9bGwbA0A+rwdB3JsyyqTN+JOqgGfvIh76nM7M7By+kQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.96",
+  "version": "0.1.97",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/node-forge": "^1.3.14",
-    "acp-kernel": "0.0.60",
+    "acp-kernel": "0.0.61",
     "fzstd": "0.1.1",
     "node-forge": "^1.4.0",
     "tar": "^7.5.22",


### PR DESCRIPTION
## 发版内容(自 v0.1.96)

- acp-kernel pin **0.0.60 → 0.0.61**(fixes #658:锚点 args 复写本瘦身终于对 qwen/glm 字符串形态生效——kernel #230 字符串形态解析 + #232 hide-consumed 补强,v0.0.60 已带;本版新增 #238 计数型 tier nudge 使用率门槛)
- 无其它代码变更(自 #659 后 master 仅此一依赖提交)

## 校验

- npm ci ✅ / tests 1246/1246 ✅ / build ✅(kernel 0.0.61 dist 本地覆盖预验证同套)
- acp-kernel 0.0.61 已在 npm(发布顺序满足)

合并后 CI 自动发布。