### PR TITLE
fix(ci): skip npm publish on fork PRs in PR artifact workflow

### DIFF
--- a/.github/workflows/pr-artifact.yml
+++ b/.github/workflows/pr-artifact.yml
@@ -25,6 +25,9 @@ jobs:
             - run: npm run build
 
             - name: Publish to npm with PR tag
+              # Repository secrets (NPM_TOKEN) are not available to workflows
+              # triggered by fork PRs — publishing would fail with ENEEDAUTH (#670).
+              if: github.event.pull_request.head.repo.full_name == github.repository
               run: |
                   PR_NUMBER="${{ github.event.pull_request.number }}"
                   RUN_NUMBER="${{ github.run_number }}"
@@ -65,12 +68,17 @@ jobs:
                       const sha = context.payload.pull_request.head.sha.slice(0, 7);
                       const branch = context.payload.pull_request.head.ref;
                       const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+                      const isFork = context.payload.pull_request.head.repo.full_name !== context.payload.repository.full_name;
 
                       const body = [
                           '## 📦 Built Package Artifact',
                           '',
                           `**Branch:** \`${branch}\` (${sha})`,
                           '',
+                          ...(isFork ? [
+                              '> Fork PR: the npm PR-tag publish is skipped (repository secrets are not shared with fork workflows).',
+                              '',
+                          ] : [
                           '### Option A — Install from npm PR tag (recommended)',
                           '',
                           '```bash',
@@ -79,7 +87,8 @@ jobs:
                           '',
                           'Each push to this PR publishes a new version under the `pr-' + prNumber + '` npm tag.',
                           '',
-                          '### Option B — Download artifact',
+                          ]),
+                          ...(isFork ? ['### Install from artifact'] : ['### Option B — Download artifact']),
                           '',
                           `1. Download the artifact from the [Actions run](${runUrl})`,
                           '2. Extract the tarball and install:',


### PR DESCRIPTION
Fixes #670

## Problem

The `PR Build Artifact` workflow triggers on every `pull_request` to master, including fork PRs. Its "Publish to npm with PR tag" step authenticates with `secrets.NPM_TOKEN`, but GitHub does not pass repository secrets to workflows triggered by fork PRs — so on fork PRs the token is empty and `npm publish` fails with `ENEEDAUTH`, failing the job and skipping all subsequent steps (tarball, artifact upload, PR comment).

Observed on #668 (run 34380059571): build succeeded, publish failed with ENEEDAUTH (`NODE_AUTH_TOKEN:` empty in the publish step), tarball/upload/comment steps skipped. Also affects other fork PRs (e.g. #657, run 34376788600).

## Fix

- Gate the publish step to non-fork PRs:
  `if: github.event.pull_request.head.repo.full_name == github.repository`
- The "Comment on PR" step now detects fork PRs and drops the "Option A — Install from npm PR tag" section (replaced with a note that the npm publish was skipped), so the comment no longer advertises a tag that was never published.
- Tarball creation, artifact upload, and the PR comment still run for fork PRs — fork authors keep the artifact download path.

No credential or workflow permission changes; this is pure workflow gating.

## Verification

- YAML parses (pyyaml); embedded github-script JS passes `node --check`.
- Simulated the comment step with stubbed `context`/`github` for both cases: non-fork output is byte-identical to the previous comment format; fork output contains only the skip notice + artifact install instructions (no phantom npm tag).
- Workflow-only change: no typecheck/test/build impact.