### PR TITLE
release v0.1.99

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.98",
+  "version": "0.1.99",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.98",
+      "version": "0.1.99",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.98",
+  "version": "0.1.99",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Release v0.1.99 — ships the fork-PR ENEEDAUTH CI fix (#670, PR #671: publish step gated to same-repo PRs; fork PRs keep tarball/artifact/comment without the npm-tag section). No runtime code change vs v0.1.98; acp-kernel stays 0.0.61.