### PR TITLE
release v0.1.100

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.99",
+  "version": "0.1.100",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.99",
+      "version": "0.1.100",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.99",
+  "version": "0.1.100",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Release commit bumps `0.1.99 → 0.1.100` (package.json + package-lock.json only).

Ships since v0.1.99:
- #649 — `hostUsageCredit` switch ("auto" | "off", env `BILI_HOST_USAGE_CREDIT`) lets plain proxy clients (ZCode, #648) opt out of the #408 uncompressed-baseline usage backfill; default `auto` = no behavior change. 1270 tests / typecheck / build green.

Merge → CI publishes 0.1.100.