### PR TITLE
fix: keep content-encoding when forwarding undecoded passthrough bodies

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -212,10 +212,6 @@ const UPSTREAM_HOP_HEADERS = new Set([
     "connection",
     "keep-alive",
     "transfer-encoding",
-    // Node's fetch transparently decodes compressed responses. Do not
-    // forward the upstream encoding marker when the body is rewritten or
-    // streamed from fetch, otherwise clients try to decompress plain bytes.
-    "content-encoding",
     // RFC 7230 §6.1 hop-by-hop headers. proxy-authorization in particular
     // carries client→proxy credentials that must never reach the model
     // endpoint. (#80)
@@ -226,6 +222,18 @@ const UPSTREAM_HOP_HEADERS = new Set([
     "trailer",
     "upgrade",
 ]);
+
+// content-encoding is end-to-end (RFC 9110 §7.2), NOT hop-by-hop — but the two
+// directions need opposite treatment. RESPONSES: Node's fetch transparently
+// decodes compressed bodies, so the upstream's encoding marker must not reach
+// the client (it would try to decompress already-plain bytes) — stripped at
+// the response-forward sites below. REQUESTS: the marker describes exactly the
+// bytes bili forwards — decoded/rebuilt bodies have it dropped at decode time
+// (handle()), while verbatim passthrough bodies (#619 undecodable encodings,
+// unknown paths) MUST keep it so upstream applies its own decode; forwarding
+// encoded request bytes without the marker made upstream reject undeclared
+// binary bodies (#677).
+const RESPONSE_ONLY_STRIP_HEADERS = new Set(["content-encoding"]);
 
 // RFC 7230 §6.1: the Connection header names additional hop-by-hop headers
 // that must be stripped per-message. Returns their lowercased names.
@@ -3448,14 +3456,14 @@ async function forward(
     const respConnNamed = connectionNamedHeaders(upstream.headers.get("connection") ?? undefined);
     upstream.headers.forEach((v, k) => {
         const lower = k.toLowerCase();
-        if (UPSTREAM_HOP_HEADERS.has(lower) || respConnNamed.has(lower)) return;
+        if (UPSTREAM_HOP_HEADERS.has(lower) || RESPONSE_ONLY_STRIP_HEADERS.has(lower) || respConnNamed.has(lower)) return;
         respHeaders[k] = v;
     });
     if (opts.debug) {
         const respLog: Record<string, string> = {};
         upstream.headers.forEach((v, k) => {
             const lower = k.toLowerCase();
-            if (UPSTREAM_HOP_HEADERS.has(lower) || respConnNamed.has(lower)) return;
+            if (UPSTREAM_HOP_HEADERS.has(lower) || RESPONSE_ONLY_STRIP_HEADERS.has(lower) || respConnNamed.has(lower)) return;
             const masked = maskHeaderForLog(k, v);
             respLog[k] = masked.length > 300 ? masked.slice(0, 300) + "..." : masked;
         });

--- a/tests/decode-fail-passthrough.test.ts
+++ b/tests/decode-fail-passthrough.test.ts
@@ -75,6 +75,8 @@ test("undecodable content-encoding body is forwarded verbatim instead of 400", a
         await res.arrayBuffer();
         assert.equal(captured.length, 1);
         assert.deepEqual(captured[0].body, badBody);
+        // #677: verbatim bytes must reach upstream with their encoding declared.
+        assert.equal(captured[0].headers["content-encoding"], "gzip");
     } finally {
         await close(proxy);
         await close(upstream);
@@ -137,6 +139,119 @@ test("oversized decompressed body is rejected 413 and not forwarded", async () =
         assert.equal(res.status, 413);
         await res.arrayBuffer();
         assert.equal(captured.length, 0);
+    } finally {
+        await close(proxy);
+        await close(upstream);
+    }
+});
+
+// #677: unknown paths never attempt a decode, so their encoded bodies hit the
+// same verbatim passthrough - the encoding marker must survive the forward too.
+test("unknown-path passthrough keeps content-encoding on the forwarded request", async () => {
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    setRegistryForTest({});
+    const captured: Captured[] = [];
+    const upstream = http.createServer((req, res) => {
+        const chunks: Buffer[] = [];
+        req.on("data", (chunk: Buffer) => chunks.push(chunk));
+        req.on("end", () => {
+            captured.push({ url: req.url ?? "", headers: req.headers, body: Buffer.concat(chunks) });
+            res.writeHead(200, { "content-type": "application/json" });
+            res.end(JSON.stringify({ ok: true }));
+        });
+    });
+    upstream.listen(0, "127.0.0.1");
+    await listen(upstream);
+    const upstreamPort = (upstream.address() as { port: number }).port;
+    const opts: ProxyOptions = {
+        port: 0,
+        host: "127.0.0.1",
+        upstream: "http://127.0.0.1",
+        routes: {
+            [`http://127.0.0.1:${upstreamPort}`]: { models: { "gpt-5": { context: 400_000 } } },
+        },
+        modelContextLimit: 400_000,
+        kernelConfig: defaultConfig(400_000),
+        compress: { injectTool: true, injectNudge: true },
+        compat: { roles: {} },
+        passthroughSource: null,
+        promptCache: { routing: "auto" },
+        sessionHeader: "x-acp-session",
+        log: false,
+        debug: false,
+        passthrough: false,
+        autoUpdate: false,
+        mitm: { enabled: false, domains: [] },
+    };
+    const proxy = await startServer(opts);
+    await listen(proxy);
+    const proxyPort = (proxy.address() as { port: number }).port;
+    const base = `http://127.0.0.1:${proxyPort}/bili/http://127.0.0.1:${upstreamPort}`;
+    const { gzipSync } = await import("node:zlib");
+    const wireBody = gzipSync(Buffer.from(JSON.stringify({ input: ["hi"] }), "utf8"));
+    try {
+        const res = await fetch(`${base}/v1/embeddings`, {
+            method: "POST",
+            headers: {
+                "content-encoding": "gzip",
+                "content-type": "application/json",
+            },
+            body: wireBody,
+        });
+        assert.equal(res.status, 200);
+        await res.arrayBuffer();
+        assert.equal(captured.length, 1);
+        assert.deepEqual(captured[0].body, wireBody);
+        assert.equal(captured[0].headers["content-encoding"], "gzip");
+    } finally {
+        await close(proxy);
+        await close(upstream);
+    }
+});
+
+// #677: the strip stays direction-specific - upstream RESPONSE encodings are
+// still removed (Node fetch already decoded them) while requests pass through.
+test("response content-encoding is stripped when forwarding upstream responses", async () => {
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    setRegistryForTest({});
+    const { gzipSync } = await import("node:zlib");
+    const upstream = http.createServer((req, res) => {
+        req.resume();
+        res.writeHead(200, { "content-type": "application/json", "content-encoding": "gzip" });
+        res.end(gzipSync(Buffer.from(JSON.stringify({ ok: true }), "utf8")));
+    });
+    upstream.listen(0, "127.0.0.1");
+    await listen(upstream);
+    const upstreamPort = (upstream.address() as { port: number }).port;
+    const opts: ProxyOptions = {
+        port: 0,
+        host: "127.0.0.1",
+        upstream: "http://127.0.0.1",
+        routes: {
+            [`http://127.0.0.1:${upstreamPort}`]: { models: { "gpt-5": { context: 400_000 } } },
+        },
+        modelContextLimit: 400_000,
+        kernelConfig: defaultConfig(400_000),
+        compress: { injectTool: true, injectNudge: true },
+        compat: { roles: {} },
+        passthroughSource: null,
+        promptCache: { routing: "auto" },
+        sessionHeader: "x-acp-session",
+        log: false,
+        debug: false,
+        passthrough: false,
+        autoUpdate: false,
+        mitm: { enabled: false, domains: [] },
+    };
+    const proxy = await startServer(opts);
+    await listen(proxy);
+    const proxyPort = (proxy.address() as { port: number }).port;
+    const base = `http://127.0.0.1:${proxyPort}/bili/http://127.0.0.1:${upstreamPort}`;
+    try {
+        const res = await fetch(`${base}/v1/embeddings`, { method: "POST", body: "{}" });
+        assert.equal(res.status, 200);
+        assert.equal(res.headers.get("content-encoding"), null);
+        assert.deepEqual(JSON.parse(await res.text()), { ok: true });
     } finally {
         await close(proxy);
         await close(upstream);


### PR DESCRIPTION
## Problem (#677)

`content-encoding` is an **end-to-end** header (RFC 9110 §7.2), not hop-by-hop, but it lived in `UPSTREAM_HOP_HEADERS` — a single strip set shared by both forwarding directions. That is correct for **responses** (Node's fetch transparently decodes upstream bodies, so the marker must not reach the client) but wrong for **requests** on any path where bili forwards bytes it did not decode:

- #619 undecodable-encoding passthrough (`src/server.ts`, protocol dropped → verbatim relay of still-encoded bytes) — header stripped at forward, upstream receives undeclared binary bytes → 400-class failures;
- unknown-path requests (e.g. `POST /v1/embeddings`) where no decode is ever attempted.

The comment near the #619 catch block ("the content-encoding header stays intact") also contradicted actual behavior; after this change it is true again.

## Fix

Split the strip set by direction:

- `content-encoding` removed from `UPSTREAM_HOP_HEADERS` (request side now forwards it);
- new `RESPONSE_ONLY_STRIP_HEADERS = new Set(["content-encoding"])` applied at the two response-forward sites (`forward()`, normal + debug log copy), preserving today's client-facing behavior exactly.

Safe because every *processed* request already drops the header at decode time (`if (decoded.decoded) delete req.headers["content-encoding"]`) before forwarding — only byte-identical passthrough bodies carry it to the forward, and there the marker describes exactly the bytes being sent.

## Tests (`tests/decode-fail-passthrough.test.ts`)

- decode-failure passthrough test now asserts `content-encoding: gzip` reaches the upstream;
- new: unknown-path passthrough keeps `content-encoding` on a valid gzip body;
- new: response-side strip still works (upstream gzip response → client gets plain JSON, no `content-encoding` header) — pins the direction asymmetry;
- canary: `tests/codex-official.test.ts` valid-gzip decoded path still asserts the header is absent upstream (unchanged behavior).

## Pre-flight

- `npm run typecheck` ✅
- `npm test` — 1272/1272 ✅
- `npm run build` ✅

Fixes #677