### PR TITLE
fix: stop truncating Windows launches at spaced paths (#679)

### DIFF
--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -103,7 +103,7 @@ export interface SpawnChild {
 export type SpawnFn = (
     command: string,
     args: readonly string[],
-    options: { detached?: boolean; stdio?: StdioOptions; env?: NodeJS.ProcessEnv; shell?: boolean },
+    options: { detached?: boolean; stdio?: StdioOptions; env?: NodeJS.ProcessEnv; shell?: boolean; windowsVerbatimArguments?: boolean },
 ) => SpawnChild;
 
 export interface LaunchOptions {
@@ -1597,15 +1597,62 @@ export function stopProxy(handle: ProxyHandle): void {
     } catch {}
 }
 
+/** #679: quote one token for cmd.exe's line parser. Only whitespace-bearing
+ *  tokens get wrapped in double quotes, so a space-free launch produces a
+ *  byte-identical line to the old shell:true form. A token containing an
+ *  embedded double quote stays bare: cmd.exe has no escape mechanism for
+ *  quotes, so wrapping would only change how it is mangled (today's behavior
+ *  preserved). */
+export function quoteWinToken(token: string): string {
+    if (!/\s/.test(token) || token.includes('"')) return token;
+    return `"${token}"`;
+}
+
+/** #679: full command line for `comspec /d /s /c <line>` — tokens quoted as
+ *  needed, wrapped in one extra outer pair that cmd's /s strips before
+ *  parsing the inner tokens with their own quoting intact (the documented /s
+ *  form; same trick cross-spawn uses). */
+export function buildWindowsCommandLine(cmd: string, args: readonly string[]): string {
+    return `"${[cmd, ...args].map(quoteWinToken).join(" ")}"`;
+}
+
+/** #679: which spawn form a resolved client needs on Windows. Only .cmd/.bat
+ *  shims and unresolved bare names need cmd.exe — CreateProcess cannot
+ *  execute a batch file, and an extensionless name needs cmd's PATHEXT
+ *  resolution. Everything else (.exe, node, an existing path with an
+ *  extension) spawns directly and the OS quotes the executable and argv
+ *  itself, spaces included. shell:true is never used anymore: no DEP0190, no
+ *  cmd.exe re-splitting of spaced paths at their first space (which truncated
+ *  both the command and its args). */
+export function planClientSpawn(
+    cmd: string,
+    args: readonly string[],
+    env: NodeJS.ProcessEnv,
+    platform: NodeJS.Platform = process.platform,
+): { command: string; args: string[]; windowsVerbatimArguments?: boolean } {
+    if (platform !== "win32") return { command: cmd, args: [...args] };
+    const lower = cmd.toLowerCase();
+    const base = cmd.slice(Math.max(cmd.lastIndexOf("/"), cmd.lastIndexOf("\\")) + 1);
+    const needsCmd = lower.endsWith(".cmd") || lower.endsWith(".bat") || !path.extname(base);
+    if (!needsCmd) return { command: cmd, args: [...args] };
+    const comspec = nonEmpty(env.COMSPEC) ? env.COMSPEC : "cmd.exe";
+    return {
+        command: comspec,
+        args: ["/d", "/s", "/c", buildWindowsCommandLine(cmd, args)],
+        windowsVerbatimArguments: true,
+    };
+}
+
 export function runClient(
     cmd: string,
     args: string[],
     env: NodeJS.ProcessEnv,
-    deps?: { spawnImpl?: SpawnFn },
+    deps?: { spawnImpl?: SpawnFn; platform?: NodeJS.Platform },
 ): Promise<number> {
     const spawnImpl = deps?.spawnImpl ?? (spawn as SpawnFn);
+    const plan = planClientSpawn(cmd, args, env, deps?.platform);
     return new Promise((resolve, reject) => {
-        const child = spawnImpl(cmd, args, { stdio: "inherit", env, shell: process.platform === "win32" });
+        const child = spawnImpl(plan.command, plan.args, { stdio: "inherit", env, windowsVerbatimArguments: plan.windowsVerbatimArguments });
         child.on?.("error", (...rest: unknown[]) => reject(rest[0]));
         child.on?.("exit", (...rest: unknown[]) => {
             const code = rest[0];

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -1649,6 +1649,9 @@ export function runClient(
     env: NodeJS.ProcessEnv,
     deps?: { spawnImpl?: SpawnFn; platform?: NodeJS.Platform },
 ): Promise<number> {
+    // #679: never shell:true — besides DEP0190, cmd.exe re-splits the unquoted
+    // line on whitespace and truncated spaced client/-e paths at their first
+    // space; planClientSpawn picks the direct-vs-comspec form instead.
     const spawnImpl = deps?.spawnImpl ?? (spawn as SpawnFn);
     const plan = planClientSpawn(cmd, args, env, deps?.platform);
     return new Promise((resolve, reject) => {

--- a/tests/fix-679-windows-launch.test.ts
+++ b/tests/fix-679-windows-launch.test.ts
@@ -60,6 +60,10 @@ test("planClientSpawn win32: .exe spawns directly even when spaced — the OS qu
         planClientSpawn("C:\\Program Files\\nodejs\\node.exe", ["C:\\Users\\John Doe\\cli.js"], WIN_ENV, "win32"),
         { command: "C:\\Program Files\\nodejs\\node.exe", args: ["C:\\Users\\John Doe\\cli.js"] },
     );
+    assert.deepEqual(
+        planClientSpawn("C:\\TOOLS\\NODE.EXE", [], WIN_ENV, "win32"),
+        { command: "C:\\TOOLS\\NODE.EXE", args: [] },
+    );
 });
 
 test("planClientSpawn win32: .cmd/.bat shims route through comspec /d /s /c with verbatim quoting", () => {
@@ -78,8 +82,14 @@ test("planClientSpawn win32: unset COMSPEC falls back to cmd.exe", () => {
     assert.equal(p.windowsVerbatimArguments, true);
 });
 
+test("planClientSpawn win32: a COMSPEC with spaces is used verbatim as the program", () => {
+    const p = planClientSpawn("tool.cmd", [], { COMSPEC: "C:\\My Tools\\cmd.exe" }, "win32");
+    assert.equal(p.command, "C:\\My Tools\\cmd.exe");
+    assert.deepEqual(p.args.slice(0, 3), ["/d", "/s", "/c"]);
+});
+
 test("planClientSpawn win32: unresolved bare names and extensionless paths keep cmd's PATHEXT resolution", () => {
-    for (const c of ["codex", "C:\\tools\\extensionless"]) {
+    for (const c of ["codex", "C:\\tools\\extensionless", "C:\\tools\\.hidden"]) {
         const p = planClientSpawn(c, [], WIN_ENV, "win32");
         assert.equal(p.command, "C:\\Windows\\System32\\cmd.exe");
         assert.equal(p.windowsVerbatimArguments, true);

--- a/tests/fix-679-windows-launch.test.ts
+++ b/tests/fix-679-windows-launch.test.ts
@@ -1,0 +1,207 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+    buildWindowsCommandLine,
+    planClientSpawn,
+    quoteWinToken,
+    runClient,
+    type SpawnChild,
+    type SpawnFn,
+} from "../src/launcher.ts";
+
+// #679: on Windows the launcher spawned with shell:true and unquoted args, so
+// cmd.exe re-split the line on whitespace — a space in the resolved client or
+// -e path truncated the launch (loud) or the extension path (silent: the
+// extension never loads, compression never activates).
+
+test("quoteWinToken: space-free tokens stay bare (byte-identical to the old shell:true line)", () => {
+    assert.equal(quoteWinToken("C:\\bin\\code.cmd"), "C:\\bin\\code.cmd");
+    assert.equal(quoteWinToken("-e"), "-e");
+    assert.equal(quoteWinToken(""), "");
+});
+
+test("quoteWinToken: whitespace-bearing tokens get wrapped in double quotes", () => {
+    assert.equal(quoteWinToken("C:\\Program Files\\nodejs\\node.exe"), '"C:\\Program Files\\nodejs\\node.exe"');
+    assert.equal(quoteWinToken("C:\\My Docs\\a.txt"), '"C:\\My Docs\\a.txt"');
+    assert.equal(quoteWinToken("a\tb"), '"a\tb"');
+});
+
+test("quoteWinToken: embedded double quotes stay bare (cmd.exe has no quote escape — today's behavior preserved)", () => {
+    assert.equal(quoteWinToken('key="value"'), 'key="value"');
+    assert.equal(quoteWinToken('C:\\x "q" y'), 'C:\\x "q" y');
+});
+
+test("buildWindowsCommandLine: outer pair for cmd /s, inner tokens quoted only when needed", () => {
+    assert.equal(buildWindowsCommandLine("pi", ["-e", "/ext.js"]), '"pi -e /ext.js"');
+    assert.equal(
+        buildWindowsCommandLine("C:\\Users\\John Doe\\omp\\omp.exe", ["-e", "C:\\Users\\John Doe\\ext.js"]),
+        '""C:\\Users\\John Doe\\omp\\omp.exe" -e "C:\\Users\\John Doe\\ext.js""',
+    );
+    assert.equal(
+        buildWindowsCommandLine("C:\\bin\\code.cmd", ["--file", "C:\\My Docs\\a.txt"]),
+        '"C:\\bin\\code.cmd --file "C:\\My Docs\\a.txt""',
+    );
+});
+
+const WIN_ENV: NodeJS.ProcessEnv = { COMSPEC: "C:\\Windows\\System32\\cmd.exe" };
+
+test("planClientSpawn: non-win32 always spawns directly, untouched", () => {
+    assert.deepEqual(planClientSpawn("/usr/bin/codex", ["--foo"], {}, "linux"), {
+        command: "/usr/bin/codex",
+        args: ["--foo"],
+    });
+});
+
+test("planClientSpawn win32: .exe spawns directly even when spaced — the OS quotes the executable and argv itself", () => {
+    assert.deepEqual(
+        planClientSpawn("C:\\Program Files\\nodejs\\node.exe", ["C:\\Users\\John Doe\\cli.js"], WIN_ENV, "win32"),
+        { command: "C:\\Program Files\\nodejs\\node.exe", args: ["C:\\Users\\John Doe\\cli.js"] },
+    );
+});
+
+test("planClientSpawn win32: .cmd/.bat shims route through comspec /d /s /c with verbatim quoting", () => {
+    for (const shim of ["C:\\npm\\codex.cmd", "C:\\npm\\claude.BAT"]) {
+        const p = planClientSpawn(shim, ["-e", "C:\\John Doe\\ext.js"], WIN_ENV, "win32");
+        assert.equal(p.command, "C:\\Windows\\System32\\cmd.exe");
+        assert.deepEqual(p.args.slice(0, 3), ["/d", "/s", "/c"]);
+        assert.equal(p.args[3], buildWindowsCommandLine(shim, ["-e", "C:\\John Doe\\ext.js"]));
+        assert.equal(p.windowsVerbatimArguments, true);
+    }
+});
+
+test("planClientSpawn win32: unset COMSPEC falls back to cmd.exe", () => {
+    const p = planClientSpawn("tool.cmd", [], {}, "win32");
+    assert.equal(p.command, "cmd.exe");
+    assert.equal(p.windowsVerbatimArguments, true);
+});
+
+test("planClientSpawn win32: unresolved bare names and extensionless paths keep cmd's PATHEXT resolution", () => {
+    for (const c of ["codex", "C:\\tools\\extensionless"]) {
+        const p = planClientSpawn(c, [], WIN_ENV, "win32");
+        assert.equal(p.command, "C:\\Windows\\System32\\cmd.exe");
+        assert.equal(p.windowsVerbatimArguments, true);
+    }
+});
+
+function fakeChild(exitCode = 0, signal: string | null = null): SpawnChild {
+    return {
+        pid: 42424,
+        unref() {},
+        kill() {
+            return true;
+        },
+        on(event, listener) {
+            if (event === "exit") setImmediate(() => listener(exitCode, signal));
+            return undefined;
+        },
+    };
+}
+
+interface CapturedSpawn {
+    cmd?: string;
+    args?: readonly string[];
+    options?: { shell?: boolean; windowsVerbatimArguments?: boolean };
+}
+
+function captureSpawn(): { captured: CapturedSpawn; spawnImpl: SpawnFn } {
+    const captured: CapturedSpawn = {};
+    const spawnImpl: SpawnFn = (cmd, args, options) => {
+        captured.cmd = cmd;
+        captured.args = [...args];
+        captured.options = options;
+        return fakeChild();
+    };
+    return { captured, spawnImpl };
+}
+
+test("runClient win32: .cmd shim → comspec spawn, verbatim on, NO shell option (DEP0190 gone)", async () => {
+    const { captured, spawnImpl } = captureSpawn();
+    const shim = "C:\\Users\\John Doe\\AppData\\npm\\omp.cmd";
+    const extArg = "C:\\Users\\John Doe\\ext.js";
+    const code = await runClient(shim, ["-e", extArg], WIN_ENV, {
+        spawnImpl,
+        platform: "win32",
+    });
+    assert.equal(code, 0);
+    assert.equal(captured.cmd, "C:\\Windows\\System32\\cmd.exe");
+    assert.deepEqual(captured.args?.slice(0, 3), ["/d", "/s", "/c"]);
+    assert.equal(captured.args?.[3], '""C:\\Users\\John Doe\\AppData\\npm\\omp.cmd" -e "C:\\Users\\John Doe\\ext.js""');
+    assert.equal(captured.options?.shell, undefined, "shell:true must be gone");
+    assert.equal(captured.options?.windowsVerbatimArguments, true);
+});
+
+test("runClient win32: spaced .exe → direct spawn, args passed through intact", async () => {
+    const { captured, spawnImpl } = captureSpawn();
+    const exe = "C:\\Users\\John Doe\\AppData\\Local\\omp\\omp.exe";
+    const ext = "C:\\Users\\John Doe\\ext.js";
+    const code = await runClient(exe, ["-e", ext], {}, { spawnImpl, platform: "win32" });
+    assert.equal(code, 0);
+    assert.equal(captured.cmd, exe);
+    assert.deepEqual(captured.args, ["-e", ext]);
+    assert.equal(captured.options?.shell, undefined);
+    assert.equal(captured.options?.windowsVerbatimArguments, undefined);
+});
+
+test("runClient posix: passthrough unchanged, exit code propagates", async () => {
+    const { captured, spawnImpl } = captureSpawn();
+    const code = await runClient("/usr/local/bin/pi", ["-e", "/x/y.js"], { PATH: "/usr/bin" }, {
+        spawnImpl,
+        platform: "linux",
+    });
+    assert.equal(code, 0);
+    assert.equal(captured.cmd, "/usr/local/bin/pi");
+    assert.deepEqual(captured.args, ["-e", "/x/y.js"]);
+    assert.equal(captured.options?.shell, undefined);
+});
+
+test("runClient: exit code and signal mapping unchanged", async () => {
+    const codeOf = (exitCode: number, signal: string | null) =>
+        new Promise<number>((resolve, reject) => {
+            const impl: SpawnFn = () => fakeChild(exitCode, signal);
+            runClient("/bin/x", [], {}, { spawnImpl: impl }).then(resolve, reject);
+        });
+    assert.equal(await codeOf(7, null), 7);
+    assert.equal(await codeOf(0, "SIGINT"), 130);
+});
+
+// Real launches — only meaningful on Windows, skipped everywhere else.
+
+test("#679 real win32: spaced .cmd shim receives its spaced args intact", { skip: process.platform !== "win32" }, async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "bili-679-"));
+    try {
+        const clientDir = path.join(root, "client dir");
+        fs.mkdirSync(clientDir, { recursive: true });
+        const client = path.join(clientDir, "client.cmd");
+        fs.writeFileSync(client, '@echo off\r\n> "%~dp0argv.txt" echo(%*\r\n');
+        const argPath = path.join(root, "my docs", "ext file.js");
+        const code = await runClient(client, ["-e", argPath], process.env);
+        assert.equal(code, 0);
+        const seen = fs.readFileSync(path.join(clientDir, "argv.txt"), "utf8");
+        assert.ok(seen.includes(argPath), `shim saw "${seen}" — spaced arg must survive intact`);
+        assert.ok(seen.includes("-e"), "flag survives too");
+    } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+});
+
+test("#679 real win32: spaced .exe spawns directly with spaced argv", { skip: process.platform !== "win32" }, async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "bili-679-"));
+    try {
+        const outDir = path.join(root, "out dir");
+        fs.mkdirSync(outDir, { recursive: true });
+        const outFile = path.join(outDir, "argv.json");
+        const script = `require("fs").writeFileSync(${JSON.stringify(outFile)}, JSON.stringify(process.argv))`;
+        const code = await runClient(process.execPath, ["-e", script], process.env);
+        assert.equal(code, 0);
+        const argv = JSON.parse(fs.readFileSync(outFile, "utf8")) as string[];
+        assert.equal(argv.length, 3);
+        assert.equal(argv[0], process.execPath);
+        assert.equal(argv[1], "-e");
+        assert.equal(argv[2], script, "arg with spaces AND embedded quotes must round-trip");
+    } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+});

--- a/tests/fix-679-windows-launch.test.ts
+++ b/tests/fix-679-windows-launch.test.ts
@@ -204,13 +204,16 @@ test("#679 real win32: spaced .exe spawns directly with spaced argv", { skip: pr
         fs.mkdirSync(outDir, { recursive: true });
         const outFile = path.join(outDir, "argv.json");
         const script = `require("fs").writeFileSync(${JSON.stringify(outFile)}, JSON.stringify(process.argv))`;
-        const code = await runClient(process.execPath, ["-e", script], process.env);
+        // node -e consumes the script string (it never lands in process.argv); a
+        // trailing arg does. The marker carries spaces AND quotes, so surviving
+        // the round-trip proves direct-spawn quoting on win32.
+        const marker = 'MARK spaced "quoted" arg';
+        const code = await runClient(process.execPath, ["-e", script, marker], process.env);
         assert.equal(code, 0);
         const argv = JSON.parse(fs.readFileSync(outFile, "utf8")) as string[];
-        assert.equal(argv.length, 3);
+        assert.equal(argv.length, 2);
         assert.equal(argv[0], process.execPath);
-        assert.equal(argv[1], "-e");
-        assert.equal(argv[2], script, "arg with spaces AND embedded quotes must round-trip");
+        assert.equal(argv[1], marker, "spaced+quoted arg must round-trip intact");
     } finally {
         fs.rmSync(root, { recursive: true, force: true });
     }

--- a/tests/launcher.test.ts
+++ b/tests/launcher.test.ts
@@ -1762,7 +1762,7 @@ test("runLaunch dsh: non-loopback upstreams ride proxy envs, loopback keeps the 
     );
     fs.mkdirSync(path.join(dshHome, "profiles"));
     const original = fs.readFileSync(path.join(dshHome, "settings.yaml"), "utf8");
-    const fakeDsh = path.join(home, "fake-dsh");
+    const fakeDsh = path.join(home, process.platform === "win32" ? "fake-dsh.exe" : "fake-dsh");
     fs.writeFileSync(fakeDsh, "");
     process.env.BILI_CLIENT_BIN = fakeDsh;
     process.env.DSH_HOME = dshHome;
@@ -1867,7 +1867,7 @@ test("runLaunch dsh: no loopback custom providers — no DSH_HOME overlay (#535 
             "      baseURL: https://api.anthropic.com",
         ].join("\n"),
     );
-    const fakeDsh = path.join(home, "fake-dsh");
+    const fakeDsh = path.join(home, process.platform === "win32" ? "fake-dsh.exe" : "fake-dsh");
     fs.writeFileSync(fakeDsh, "");
     process.env.BILI_CLIENT_BIN = fakeDsh;
     process.env.DSH_HOME = dshHome;

--- a/tests/launcher.test.ts
+++ b/tests/launcher.test.ts
@@ -298,7 +298,7 @@ test("runLaunch pi: native -e plugin injected only when not installed", async ()
     // home and the second assertion fails.
     if (prevUserProfile !== undefined) process.env.USERPROFILE = home;
     delete process.env.PI_CODING_AGENT_DIR;
-    const fakePi = path.join(home, "fake-pi");
+    const fakePi = path.join(home, process.platform === "win32" ? "fake-pi.exe" : "fake-pi");
     fs.writeFileSync(fakePi, "");
     process.env.PI_BIN = fakePi;
     const piHome = path.join(home, ".pi/agent");
@@ -414,7 +414,7 @@ test("runLaunch pi #535: refuses launch when http rewrites needed and extension 
     const distExisted = fs.existsSync(distAgent);
     if (distExisted) fs.renameSync(distAgent, distBackup);
 
-    const fakePi = path.join(home, "fake-pi");
+    const fakePi = path.join(home, process.platform === "win32" ? "fake-pi.exe" : "fake-pi");
     fs.writeFileSync(fakePi, "");
     const prevPiBin = process.env.PI_BIN;
     process.env.PI_BIN = fakePi;
@@ -483,7 +483,7 @@ test("runLaunch omp #535: refuses launch when http rewrites needed and extension
     process.env.HOME = home;
     if (prevUserProfile !== undefined) process.env.USERPROFILE = home;
     delete process.env.PI_CODING_AGENT_DIR;
-    process.env.BILI_CLIENT_BIN = path.join(home, "fake-omp");
+    process.env.BILI_CLIENT_BIN = path.join(home, process.platform === "win32" ? "fake-omp.exe" : "fake-omp");
     fs.writeFileSync(process.env.BILI_CLIENT_BIN, "");
     const ompHome = path.join(home, ".omp", "agent");
     fs.mkdirSync(ompHome, { recursive: true });
@@ -563,7 +563,7 @@ test("runLaunch hermes #535: proxy env routing, no HERMES_HOME overlay, real con
     process.env.HOME = home;
     if (prevUserProfile !== undefined) process.env.USERPROFILE = home;
     delete process.env.HTTPS_PROXY;
-    const fakeHermes = path.join(home, "fake-hermes");
+    const fakeHermes = path.join(home, process.platform === "win32" ? "fake-hermes.exe" : "fake-hermes");
     fs.writeFileSync(fakeHermes, "");
     process.env.BILI_CLIENT_BIN = fakeHermes;
     const hermesHome = path.join(home, ".hermes");
@@ -674,7 +674,7 @@ test("runLaunch omp: native -e plugin injected only when no loadable config entr
     process.env.HOME = home;
     if (prevUserProfile !== undefined) process.env.USERPROFILE = home;
     delete process.env.PI_CODING_AGENT_DIR;
-    const fakeOmp = path.join(home, "fake-omp");
+    const fakeOmp = path.join(home, process.platform === "win32" ? "fake-omp.exe" : "fake-omp");
     fs.writeFileSync(fakeOmp, "");
     process.env.BILI_CLIENT_BIN = fakeOmp;
     const ompHome = path.join(home, ".omp", "agent");
@@ -1930,7 +1930,7 @@ test("runLaunch omp: launcher hands per-model windows to the spawned proxy", asy
     process.env.HOME = home;
     if (prevUserProfile !== undefined) process.env.USERPROFILE = home;
     delete process.env.PI_CODING_AGENT_DIR;
-    const fakeOmp = path.join(home, "fake-omp");
+    const fakeOmp = path.join(home, process.platform === "win32" ? "fake-omp.exe" : "fake-omp");
     fs.writeFileSync(fakeOmp, "");
     process.env.BILI_CLIENT_BIN = fakeOmp;
     const ompHome = path.join(home, ".omp", "agent");
@@ -2175,7 +2175,7 @@ test("runLaunch codex: budget args injected for MITM mode (built-in table window
     if (prevUserProfile !== undefined) process.env.USERPROFILE = home;
     delete process.env.ANTHROPIC_MODEL;
     delete process.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW;
-    const fakeCodex = path.join(home, "fake-codex");
+    const fakeCodex = path.join(home, process.platform === "win32" ? "fake-codex.exe" : "fake-codex");
     fs.writeFileSync(fakeCodex, "");
     process.env.BILI_CLIENT_BIN = fakeCodex;
     const codexHome = path.join(home, ".codex");
@@ -2260,7 +2260,7 @@ test("runLaunch claude: CLAUDE_CODE_AUTO_COMPACT_WINDOW injected (built-in table
     if (prevUserProfile !== undefined) process.env.USERPROFILE = home;
     delete process.env.ANTHROPIC_MODEL;
     delete process.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW;
-    const fakeClaude = path.join(home, "fake-claude");
+    const fakeClaude = path.join(home, process.platform === "win32" ? "fake-claude.exe" : "fake-claude");
     fs.writeFileSync(fakeClaude, "");
     process.env.BILI_CLIENT_BIN = fakeClaude;
     const claudeDir = path.join(home, ".claude");


### PR DESCRIPTION
## What

On Windows every launcher (`bili pi/codex/claude/omp/opencode/hermes/dsh`) spawned the client with `shell: true` and unquoted args, so cmd.exe re-split the line on whitespace:

- space in the **resolved client** path → launch fails outright (`'C:\Users\John' is not recognized...`)
- space in the **`-e` extension path** → process starts but the arg is cut at its first space; the extension never loads and compression silently never activates (the failure class behind the CHANGELOG's "92% context, zero compressions" omp session)
- plus a `DEP0190` deprecation warning on every Windows launch

## Fix (src/launcher.ts — runClient)

- `.exe`, node, and any existing path with an extension now spawn **directly** (no shell): CreateProcess/libuv quote the executable and argv itself, spaces included. Covers the reported omp case and the `pi` fallback under `C:\Program Files\nodejs\`.
- `.cmd`/`.bat` shims (npm-installed CLIs) and unresolved bare names route through an explicit `comspec /d /s /c "<line>"` with `windowsVerbatimArguments: true`: each token quoted only when it contains whitespace, wrapped in one extra outer quote pair that cmd's `/s` strips before parsing — the documented `/s` form, same trick cross-spawn uses. A space-free launch produces a byte-identical line to today's.
- `shell: true` is gone entirely → no more DEP0190.
- POSIX behaviour untouched (branch gated on `platform === "win32"`); the proxy child spawn (`ensureProxyRunning`) was already shell-less.

Pure helpers exported for testability: `quoteWinToken`, `buildWindowsCommandLine`, `planClientSpawn(cmd, args, env, platform?)`.

## Tests (tests/fix-679-windows-launch.test.ts)

- Platform-independent: token quoting rules, command-line construction, spawn planning (.cmd/.BAT/.exe/bare-name/extensionless × posix/win32 × COMSPEC set/unset), runClient plumbing (comspec argv shape, verbatim flag, no shell option, exit-code/signal mapping unchanged).
- Real-launch regressions gated to win32 (skipped elsewhere): a `.cmd` shim in a temp dir whose name contains spaces must receive its spaced `-e` arg intact; a spaced-argv direct spawn through `process.execPath` must round-trip including an arg with embedded quotes.

## Known limitation (pre-existing, out of scope)

cmd.exe has no escape mechanism for embedded double quotes, so tokens containing BOTH quotes and whitespace cannot be transmitted through a `.cmd` shim by any quoting scheme. Such tokens keep today's exact behaviour. This bites one real case — codex MCP injection's inline `-c mcp_servers.bili.command=<JSON>` value when node lives under a spaced dir (broken before this change too): https://github.com/ranxianglei/billion-context/issues/681

## Pre-flight

- `npm run typecheck` — clean
- `npm test` — 1299 tests, 0 fail, 2 skipped (the win32-gated real launches)
- `npm run build` — ok

Fixes #679