### PR TITLE
fix(#638): codex plugin install self-heals malformed blocks instead of short-circuiting on the origin line

### DIFF
--- a/src/plugin-install.ts
+++ b/src/plugin-install.ts
@@ -369,17 +369,23 @@ function codexBlock(): string {
     return `\n[mcp_servers.bili]\ncommand = ${JSON.stringify(process.execPath)}\nargs = [${JSON.stringify(path.join(selfPackageRoot(), "dist", "mcp.js"))}]\nenv = { BILI_MCP_PROXY = ${JSON.stringify(proxyOriginForInstall())} }\n`;
 }
 
+function malformedCodexArgs(block: string): boolean {
+    return /^[ \t]*args[ \t]*=[ \t]*["']/m.test(block);
+}
+
 function codexInstall(): string {
     const file = codexToml();
     const text = fs.existsSync(file) ? fs.readFileSync(file, "utf8") : "";
     const existing = /^[ \t]*\[mcp_servers\.bili\][ \t]*$/m.exec(text);
     if (existing !== null) {
         const block = text.slice(existing.index, text.indexOf("\n[", existing.index + 1) === -1 ? undefined : text.indexOf("\n[", existing.index + 1));
-        if (block.includes(`BILI_MCP_PROXY = ${JSON.stringify(proxyOriginForInstall())}`)) return `codex: already installed (${file})`;
-        const refreshed = text.slice(0, existing.index) + codexBlock().replace(/^\n/, "") + text.slice(existing.index + block.length);
+        const canonical = codexBlock().replace(/^\n/, "");
+        if (block.trimEnd() === canonical.trimEnd()) return `codex: already installed (${file})`;
+        const refreshed = text.slice(0, existing.index) + canonical + text.slice(existing.index + block.length);
         backupOnce(file);
         fs.writeFileSync(file, refreshed);
-        return `codex: refreshed proxy origin -> ${file} [mcp_servers.bili]`;
+        const healed = malformedCodexArgs(block) ? " (repaired args: was not an array)" : "";
+        return `codex: refreshed [mcp_servers.bili] -> ${file}${healed}`;
     }
     fs.mkdirSync(path.dirname(file), { recursive: true });
     backupOnce(file);

--- a/tests/plugin-agent.test.ts
+++ b/tests/plugin-agent.test.ts
@@ -807,6 +807,22 @@ test("plugin install/remove roundtrips for pi/omp/codex/opencode under a fake HO
         assert.doesNotMatch(tomlEdge, /mcp_servers\.bili/);
         assert.match(tomlEdge, /\[mcp_servers\.other\]\ncommand = "x"\n/);
 
+        // #638: a malformed block (args as string - legal TOML, invalid codex
+        // schema) with a matching origin must NOT short-circuit to "already
+        // installed"; reinstall must self-heal it to the canonical block.
+        const selfRoot = path.dirname(path.dirname(path.resolve("src/plugin-install.ts")));
+        const malformed = `[mcp_servers.other]\ncommand = "x"\n[mcp_servers.bili]\ncommand = "node"\nargs = '[\"${path.join(selfRoot, "dist", "mcp.js")}\"]'\nenv = { BILI_MCP_PROXY = "http://127.0.0.1:8787" }\n`;
+        fs.writeFileSync(path.join(home, "config.toml"), malformed);
+        const healedMsg = pluginInstall("codex");
+        assert.match(healedMsg, /repaired args: was not an array/);
+        const tomlHealed = fs.readFileSync(path.join(home, "config.toml"), "utf8");
+        assert.match(tomlHealed, /args = \[/);
+        assert.doesNotMatch(tomlHealed, /args = '\[/);
+        assert.match(tomlHealed, /\[mcp_servers\.other\]\ncommand = "x"\n/);
+        // A now-canonical block stays "already installed" on rerun.
+        assert.match(pluginInstall("codex"), /already installed/);
+        assert.match(pluginRemove("codex"), /removed/);
+
         assert.match(pluginInstall("opencode"), /installed/);
         const oc = JSON.parse(fs.readFileSync(path.join(home, ".config/opencode/opencode.json"), "utf8")) as { mcp: Record<string, { command: string[]; environment?: Record<string, string> }> };
         assert.equal(oc.mcp.bili.command[1]!.endsWith(path.join("dist", "mcp.js")), true);


### PR DESCRIPTION
Fixes #638

## 问题

`codexInstall()`(v0.1.95)在 `[mcp_servers.bili]` 块已存在时,只比对 `BILI_MCP_PROXY` 那一行判断「已安装」。当块畸形(典型:`args` 被写成字符串 — 合法 TOML 但 codex schema 要求数组)且 origin 行恰好匹配时,重装直接返回 `already installed`,畸形 `args` 原样保留 → codex 持续报 `expected a sequence`,升级/重装这条最自然的自愈路径失效。

## 修复

- 「已安装」判定从「只比对 origin 行」改为**整块与 `codexBlock()` 规范块比对**(两侧 `trimEnd()` 归一,容忍尾部换行差异)
- 不一致 → 一律用规范块原位重写(自愈 `args` / `command` / 路径 / 格式)
- `args` 为字符串的畸形块额外提示:`codex: refreshed [mcp_servers.bili] -> … (repaired args: was not an array)`,不再让用户去啃 codex 的 serde 报错
- 字节一致 → 保留 `already installed` 文案(幂等,重跑不重写文件)

## 测试

tests/plugin-agent.test.ts 新增 #638 回归:
1. 畸形块(origin 匹配 + args 字符串)+ `pluginInstall("codex")` → 输出含 `repaired args: was not an array`,`args = [` 数组形态,相邻 `[mcp_servers.other]` 表不受影响
2. 治愈后的规范块重跑 → `already installed`(不再反复重写)
3. 既有用例(origin 变更 → `refreshed`、追加表后 `already installed`、header-only 边缘删除)全部保持

全套 1298/1298 通过,typecheck / build ✓。