### PR TITLE
test: add Windows codex overlay MCP-registration check (#686)

### DIFF
--- a/.github/workflows/ci-windows-codex.yml
+++ b/.github/workflows/ci-windows-codex.yml
@@ -25,6 +25,11 @@ jobs:
         run: |
           npm install --ignore-scripts --no-fund --no-audit
           npm run build
+      # Bare `bili` is not on the runner PATH after a local install; link the
+      # just-built package globally (dist is self-contained, so no extra fetch).
+      - name: Link locally-built bili onto PATH
+        shell: pwsh
+        run: npm install -g .
       - name: Install codex CLI
         shell: pwsh
         run: npm install -g @openai/codex

--- a/.github/workflows/ci-windows-codex.yml
+++ b/.github/workflows/ci-windows-codex.yml
@@ -1,0 +1,44 @@
+name: CI Windows codex overlay (#686)
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+# Real-machine layer for issue #686: on a hosted Windows runner, confirm codex
+# accepts the `<CODEX_HOME>-bili` overlay from `bili codex` and registers bili.
+# Headless and key-free because `codex mcp list` reads config.toml only and
+# never calls a model (the secret-backed ubuntu e2e still covers model round-trip).
+jobs:
+  windows-codex-overlay:
+    name: codex accepts CODEX_HOME overlay + registers bili MCP
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install deps + build
+        shell: pwsh
+        run: |
+          npm install --ignore-scripts --no-fund --no-audit
+          npm run build
+      - name: Install codex CLI
+        shell: pwsh
+        run: npm install -g @openai/codex
+      # Non-obvious on purpose: do NOT remove continue-on-error until one clean
+      # run proves codex boots unauthenticated on windows-latest. The transcript
+      # artifact shows what happened so this can then become a hard gate.
+      - name: Headless verify (codex reads overlay, registers bili)
+        continue-on-error: true
+        shell: pwsh
+        run: powershell -ExecutionPolicy Bypass -File scripts/windows-codex-mcp-check.ps1
+      - name: Upload transcript
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-codex-mcp-output
+          path: windows-codex-mcp-output.txt
+          if-no-files-found: ignore

--- a/scripts/windows-codex-mcp-check.ps1
+++ b/scripts/windows-codex-mcp-check.ps1
@@ -1,0 +1,69 @@
+#Requires -Version 5.1
+<#
+Headless verification for issue #686.
+
+Question answered: does `codex` accept the `<CODEX_HOME>-bili` overlay that
+`bili codex` produces, and register the `bili` MCP server from it?
+
+Why no model upstream / API key is needed:
+  `bili codex mcp list` starts the bili proxy, points CODEX_HOME at the generated
+  overlay (win32) or injects inline -c (posix), then forwards `mcp list` to codex.
+  `codex mcp list` only reads config.toml and enumerates MCP servers -- it never
+  calls a model, so no E2E_UPSTREAM_URL / E2E_UPSTREAM_KEY is required.
+
+Stream contract (verified against the built dist): bili writes ALL of its own
+status lines to STDERR (console.error); the child codex writes its `mcp list`
+result to STDOUT. We assert on STDOUT only, so bili's own "injecting native bili
+MCP tools" line cannot cause a false positive.
+
+Usage (Windows box):
+  npm i -g billion-context@latest @openai/codex
+  powershell -ExecutionPolicy Bypass -File scripts/windows-codex-mcp-check.ps1
+
+Exit codes: 0 = PASS (codex registered bili); 1 = FAIL; 2 = missing prerequisite.
+Writes a transcript to ./windows-codex-mcp-output.txt for reporting.
+#>
+$ErrorActionPreference = 'Stop'
+$transcript = 'windows-codex-mcp-output.txt'
+
+foreach ($cmd in @('bili', 'codex')) {
+    if (-not (Get-Command $cmd -ErrorAction SilentlyContinue)) {
+        Write-Host "MISSING: '$cmd' not found on PATH. Install with: npm i -g billion-context@latest @openai/codex"
+        exit 2
+    }
+}
+
+$env:BILI_LAUNCHER_PLUGIN = '1'
+$sb = New-Object System.Text.StringBuilder
+
+Write-Host "=== [1/2] bili codex mcp list (asserting on codex STDOUT only) ==="
+$list = (& bili codex mcp list 2>$null | Out-String)
+[void]$sb.AppendLine("--- codex mcp list (stdout) ---")
+[void]$sb.AppendLine($list)
+Write-Host $list
+
+Write-Host "=== [2/2] bili codex mcp get bili (soft check) ==="
+$get = (& bili codex mcp get bili 2>$null | Out-String)
+[void]$sb.AppendLine("--- codex mcp get bili (stdout) ---")
+[void]$sb.AppendLine($get)
+Write-Host $get
+
+Set-Content -Path $transcript -Value $sb.ToString()
+Write-Host "Transcript saved to: $transcript"
+
+$failures = New-Object System.Collections.Generic.List[string]
+if ($list -notmatch 'bili') {
+    $failures.Add("'codex mcp list' did not show a 'bili' server -> codex likely rejected the CODEX_HOME overlay")
+}
+if ($get -notmatch 'BILI_MCP_PROXY') {
+    Write-Warning "'codex mcp get bili' did not show BILI_MCP_PROXY (soft check; some codex versions lack this subcommand)"
+}
+
+if ($failures.Count -gt 0) {
+    foreach ($f in $failures) { Write-Host "FAIL: $f" }
+    Write-Host "Capture the transcript above and report back in #686."
+    exit 1
+}
+
+Write-Host "PASS: codex accepted the CODEX_HOME overlay and registered the bili MCP server."
+exit 0


### PR DESCRIPTION
## What
Adds a `windows-latest` CI job + `scripts/windows-codex-mcp-check.ps1` that closes the **real-machine gap** in #686: it confirms that `codex` accepts the `<CODEX_HOME>-bili` overlay produced by `bili codex` and registers the `bili` MCP server from it.

## Why headless / key-free
`bili codex mcp list` starts the proxy, points `CODEX_HOME` at the generated overlay (win32), and forwards `mcp list` to codex. `codex mcp list` only reads `config.toml` and enumerates MCP servers -- it never calls a model -- so **no `E2E_UPSTREAM_*` secrets are required**. The existing secret-backed ubuntu e2e (`ci-e2e.yml`) still covers the full model round-trip; this adds the Windows MCP-registration layer for free.

## How the script verifies
- Asserts on **codex stdout only** (`2>$null` drops bili's own stderr log lines), so bili's own "injecting native bili MCP tools" line cannot cause a false positive.
- Hard pass = `mcp list` shows `bili`; soft check = `mcp get bili` shows `BILI_MCP_PROXY`.
- Writes a transcript artifact for reporting.

## Pre-flight (run here, on Linux)
- `typecheck` clean, `build` success, `tests/launcher.test.ts` **109/109 pass** (includes #683's overlay tests).
- Confirmed **#679 is intact** alongside #683 (`planClientSpawn`/`quoteWinToken`/`buildWindowsCommandLine` all present in `src/launcher.ts`).
- A fake-`codex` harness proved `bili codex mcp list` **boots the proxy with no upstream/key**, forwards `mcp list`, and sets `HTTPS_PROXY`; the win32 `CODEX_HOME=<overlay>` env-patch was proven separately by driving the real `prepareCodexHome`.
- Python `tomllib` confirmed the delivered `config.toml` is **valid TOML even for a spaced `C:\Program Files\...` node path** (the #681 crux) with exactly one `[mcp_servers.bili]` block.

## Review note
The verify step uses `continue-on-error: true` **deliberately** until one clean run proves codex boots unauthenticated on `windows-latest` (this agent runs on Linux and could not drive real Windows/codex). The transcript artifact shows exactly what happened so it can be flipped to a hard gate with confidence. This does **not** close #686 -- the interactive/compress-tool + concurrent-window acceptance items still need a human on a real box (step-by-step instructions posted in the issue thread).

Refs #686

---
中文摘要：新增一个 `windows-latest` 的无密钥 CI job（用 `codex mcp list`，只读配置、不调模型）来自动化验证"真机 codex 接受 CODEX_HOME overlay 并注册 bili MCP server"这一 #686 缺口；本机已验证 typecheck/build/launcher 测试全绿、空格路径产出合法 TOML、无需上游即可启动代理并转发 `mcp list`；verify 步骤暂设 `continue-on-error`，待一次干净运行后转硬门禁，供你评审拍板。