### PR TITLE
release v0.1.102

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.101",
+  "version": "0.1.102",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.101",
+      "version": "0.1.102",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.101",
+  "version": "0.1.102",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Releases #690 (Fixes #689 / #684): strict-echo reasoning gate + learn-on-400 + split-turn sentinels + acp-kernel pin 0.0.63 (turn integrity, #244/#245/#247). Only change since v0.1.101. 1327/0 green, build clean.

Merge is human-only. After merge, CI publishes to npm.