### PR TITLE
release v0.1.103

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.102",
+  "version": "0.1.103",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.102",
+      "version": "0.1.103",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.102",
+  "version": "0.1.103",
   "description": "Universal context-compression proxy for AI coding agents. Sits between any agent and its model API, rewriting Anthropic/OpenAI streams with acp-kernel compression. Any agent that can set a base URL (Claude Code, Codex, Cursor, Aider) works out of the box.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Version bump only (`0.1.102` → `0.1.103`). CI publishes on merge.

## Changes since v0.1.102

v0.1.102 shipped before the client batch landed; this is the first release containing it:

- **feat(#640,#653,#655): client support batch** (PR #693) — `bili codebuddy` (`CODEBUDDY_BASE_URL` `/bili/` rewrite, OpenAI chat-completions wire), `bili qoder` (cert-MITM, hardcoded-https model hosts whitelisted, CN-site detection), `bili trae` (Go binary, `SSL_CERT_FILE` combined bundle, `/llm_raw_chat` OpenAI sniffing)
- docs unified across README(.zh-CN) and CONFIGURATION(.zh-CN)
- fix(#679): `.exe`-suffix the new fake client bins so win32 CI spawn stubs match

## Pre-flight (identical to what CI runs)

- `npm run typecheck` — clean
- full test suite — failure set identical to master baseline (only the two pre-existing sandbox-env failures in tests/plugin-agent.test.ts)
- `npm run build` — clean, dist/index.js 2.88MB