### PR TITLE
obs: per-request [acp-usage] on the plugin path + fold-materialization anchor ceiling

### DIFF
--- a/src/loop/core.ts
+++ b/src/loop/core.ts
@@ -188,8 +188,10 @@ function recordUsage(
     const hitPct =
         typeof cached === "number" && total > 0 ? Math.round((cached / total) * 100) : 0;
     warnCacheCollapse(ctx.session, total, cached ?? 0);
+    const foldNew = ctx.session.stats.pendingFoldUsage === true;
+    if (foldNew) ctx.session.stats.pendingFoldUsage = false;
     ctx.log(
-        `[acp-usage] round ${round} input=${total} cached=${cached ?? 0} (cache hit ${hitPct}%)`,
+        `[acp-usage] round ${round} input=${total} cached=${cached ?? 0} (cache hit ${hitPct}%)${foldNew ? " fold=new" : ""}`,
     );
 }
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -609,7 +609,7 @@ function usageFromSseEvent(obj: Record<string, unknown>): UsageSample | undefine
     return undefined;
 }
 
-function applyUsageSample(session: Session, sample: UsageSample, protocol?: WireProtocol): void {
+export function applyUsageSample(session: Session, sample: UsageSample, protocol?: WireProtocol): void {
     // inputTokens is protocol-native: Anthropic reports it NEW-only (cached
     // separate); OpenAI/Responses report the TOTAL (cached already included).
     // promptInputTotal adds the cached segment back when it is not part of
@@ -628,6 +628,12 @@ function applyUsageSample(session: Session, sample: UsageSample, protocol?: Wire
         warnCacheCollapse(session, total, sample.cachedTokens ?? 0);
         // #408: host-facing baseline = this report + prepare-time fold credit.
         session.hostContextTokens = total + (session.hostCreditTokens ?? 0);
+        // #695: per-request parity with the wire path's [acp-usage] — without
+        // this, post-fold cache cliffs cannot be attributed from logs.
+        const hit = sample.cachedTokens === undefined || total <= 0 ? undefined : Math.round((100 * (sample.cachedTokens ?? 0)) / total);
+        const foldNew = session.stats.pendingFoldUsage === true;
+        if (foldNew) session.stats.pendingFoldUsage = false;
+        loggerLog("info", `[${session.id}] [plugin] [acp-usage] input=${total} cached=${sample.cachedTokens ?? "n/a"}${hit === undefined ? "" : ` (cache hit ${hit}%)`} ctx=${session.hostContextTokens}${foldNew ? " fold=new" : ""}`);
     }
     if (sample.outputTokens !== undefined) session.stats.outputTokens += sample.outputTokens;
 }

--- a/src/session.ts
+++ b/src/session.ts
@@ -84,6 +84,10 @@ export type Session = {
          *  lastInputTokens; the next prepare() — where the fold actually
          *  happens — clears it. In-memory only. */
         compressCreditTokens: number;
+        /** True from compress execution until the next upstream usage report
+         *  lands — marks THE request whose prompt first materialized the fold
+         *  (the one whose prefix-cache hit is expected to cliff). #695. */
+        pendingFoldUsage?: boolean;
         /** Current in-context (uncompressed) token count at last processTurn. */
         contextTokens: number;
     };

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -121,7 +121,16 @@ export function applyRanges(parsed: ReturnType<typeof parseCompressInput>, ctx: 
         const shrinkRatio = preContext > 0 ? r.tokensCompressed / preContext : 0;
         const foldPoint = [...ranges].sort((a, b) => refNum(a.startRef) - refNum(b.startRef))[0]?.startRef ?? "unknown";
         ctx.session.lastCompress = { at: Date.now(), shrinkRatio, foldPoint, blocks: r.blocksCreated, tokensCompressed: r.tokensCompressed };
-        ctx.log(`[acp-compress-obs] shrink ${Math.round(shrinkRatio * 100)}% (~${r.tokensCompressed}/${preContext} tok) foldPoint=${foldPoint} blocks=${r.blocksCreated}`);
+        ctx.session.stats.pendingFoldUsage = true;
+        // #695: the next request materializes this fold — its prefix-cache hit
+        // ceiling ≈ anchor / postFoldContext. sys length is unknown here, so
+        // anchor (active block summaries) is a LOWER bound; the fold=new
+        // [acp-usage] line reports the real cached, separating physics from
+        // upstream eviction.
+        const anchorTok = res.state.blocks.reduce((n, b) => n + (b.active ? Math.ceil(b.summary.length / 4) : 0), 0);
+        const postCtx = Math.max(0, preContext - r.tokensCompressed);
+        const ceiling = postCtx > 0 ? Math.floor((100 * anchorTok) / postCtx) : 0;
+        ctx.log(`[acp-compress-obs] shrink ${Math.round(shrinkRatio * 100)}% (~${r.tokensCompressed}/${preContext} tok) foldPoint=${foldPoint} blocks=${r.blocksCreated} anchor≈${anchorTok} tok (${res.state.blocks.filter((b) => b.active).length} active blocks, sys excluded) postCtx≈${postCtx} → next-request cache ceiling ≥${ceiling}%`);
 
         const warn = r.warnings.length > 0 ? ` ${r.warnings.join("; ")}` : "";
         let msg = `[Compressed ${detail} → ${r.blocksCreated} block(s), ~${r.tokensCompressed} tokens saved.${warn}]`;

--- a/tests/usage-observability.test.ts
+++ b/tests/usage-observability.test.ts
@@ -1,0 +1,113 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createCore, createInitialState, assignRefs, emptyRefMap, defaultConfig } from "acp-kernel";
+import type { CoreMessage } from "acp-kernel";
+import type { Session } from "../src/session.ts";
+import { applyRanges, type RewriteCtx } from "../src/stream.ts";
+import { parseCompressInput } from "../src/compress-tool.ts";
+import { applyUsageSample } from "../src/plugin.ts";
+import { setLogCapture } from "../src/logger.ts";
+
+type Ctx = Omit<RewriteCtx, "log"> & { log: (m: string) => void; logs: string[] };
+
+function makeSession(): Session {
+    return {
+        id: "usage-obs-test",
+        meta: {},
+        stats: { requests: 0, tokensSaved: 0, inputTokens: 0, cachedTokens: 0, outputTokens: 0, cacheSamples: 0, lastInputTokens: 0, compressCreditTokens: 0, contextTokens: 0 },
+        metadata: {},
+        state: createInitialState(),
+        createdAt: Date.now(),
+        lastSeen: Date.now(),
+        blockContents: new Map(),
+        inFlight: 0,
+        persisted: false,
+    };
+}
+
+function makeCtx(messages: CoreMessage[]): Ctx {
+    const logs: string[] = [];
+    const res = assignRefs(messages, { existing: emptyRefMap(), nextIndex: 0 });
+    const session = makeSession();
+    session.state.messageRefs = res.map;
+    return {
+        core: createCore(),
+        config: defaultConfig(200000),
+        messages,
+        session,
+        log: (m: string) => { logs.push(m); },
+        logs,
+    };
+}
+
+function textMsg(id: string, role: "user" | "assistant", text: string): CoreMessage {
+    return { id, role, contentType: "text", text };
+}
+
+const COMPRESS_ARGS = { content: [{ startId: "m00001", endId: "m00002", summary: "USAGE-OBS-TEST-SUMMARY-PAYLOAD-LONG-ENOUGH-FOR-THE-KERNEL-MIN-LENGTH-CHECK" }] };
+
+function captureLogs<T>(fn: () => T): { lines: string[]; result: T } {
+    const lines: string[] = [];
+    setLogCapture((_level, msg) => { lines.push(msg); });
+    try {
+        const result = fn();
+        return { lines, result };
+    } finally {
+        setLogCapture(null);
+    }
+}
+
+test("#695: applyRanges marks the next request as fold-materializing and logs the anchor ceiling", () => {
+    const ctx = makeCtx([
+        textMsg("raw_1", "user", "x".repeat(20000)),
+        textMsg("raw_2", "assistant", "x".repeat(20000)),
+        textMsg("raw_3", "user", "x".repeat(5000)),
+        textMsg("raw_4", "assistant", "x".repeat(5000)),
+        textMsg("raw_5", "user", "x".repeat(5000)),
+        textMsg("raw_6", "assistant", "x".repeat(5000)),
+        textMsg("raw_7", "user", "x".repeat(5000)),
+    ]);
+    ctx.session.stats.lastInputTokens = 100000;
+    const out = applyRanges(parseCompressInput(COMPRESS_ARGS), ctx);
+    assert.ok(out.startsWith("[Compressed"), `expected success, got: ${out}`);
+    assert.equal(ctx.session.stats.pendingFoldUsage, true, "flag set for the fold-materializing request");
+    const obs = ctx.logs.find((l) => l.includes("[acp-compress-obs]"));
+    assert.ok(obs, "observability line logged");
+    assert.ok(obs!.includes("anchor≈"), `anchor estimate present: ${obs}`);
+    assert.ok(obs!.includes("active blocks"), `block count present: ${obs}`);
+    assert.ok(obs!.includes("postCtx≈"), `post-fold context present: ${obs}`);
+    assert.ok(obs!.includes("ceiling ≥"), `cache ceiling present: ${obs}`);
+});
+
+test("#695: applyUsageSample logs a per-request [acp-usage] line and consumes the fold flag", () => {
+    const session = makeSession();
+    session.stats.pendingFoldUsage = true;
+    const { lines } = captureLogs(() => applyUsageSample(session, { inputTokens: 50000, cachedTokens: 8000, outputTokens: 100 }, "openai"));
+    const line = lines.find((l) => l.includes("[acp-usage]"));
+    assert.ok(line, `[acp-usage] logged: ${lines}`);
+    assert.ok(line!.includes("input=50000"), `input present: ${line}`);
+    assert.ok(line!.includes("cached=8000"), `cached present: ${line}`);
+    assert.ok(line!.includes("(cache hit 16%)"), `hit pct present: ${line}`);
+    assert.ok(line!.includes("fold=new"), `fold marker on the materializing request: ${line}`);
+    assert.equal(session.stats.pendingFoldUsage, false, "flag consumed after the report");
+});
+
+test("#695: subsequent usage lines carry no fold marker", () => {
+    const session = makeSession();
+    const { lines } = captureLogs(() => {
+        applyUsageSample(session, { inputTokens: 50000, cachedTokens: 8000, outputTokens: 100 }, "openai");
+        applyUsageSample(session, { inputTokens: 52000, cachedTokens: 51000, outputTokens: 100 }, "openai");
+    });
+    const line = lines.filter((l) => l.includes("[acp-usage]"));
+    assert.equal(line.length, 2, `two lines: ${lines}`);
+    assert.ok(!line[1].includes("fold=new"), `no stale marker: ${line[1]}`);
+});
+
+test("#695: missing cached field logs n/a without a hit percentage", () => {
+    const session = makeSession();
+    const { lines } = captureLogs(() => applyUsageSample(session, { inputTokens: 50000, outputTokens: 100 }, "openai"));
+    const line = lines.find((l) => l.includes("[acp-usage]"));
+    assert.ok(line, `logged: ${lines}`);
+    assert.ok(line!.includes("cached=n/a"), `n/a present: ${line}`);
+    assert.ok(!line!.includes("cache hit"), `no hit pct when cached unknown: ${line}`);
+});


### PR DESCRIPTION
Fixes #695

## 背景

用户报告 plugin 会话「压缩后缓存掉 0」。现场调查(见 issue)只能给出理论上限 ≈15–18%(系统提示+块摘要),无法区分**折叠物理**与**上游逐出**,因为 plugin 路径没有任何 per-request 日志(wire 路径有 `[acp-usage]`,plugin 路径静默更新内存)。

## 改动(纯观测,零行为变化)

1. **plugin 路径 per-request `[acp-usage]`**(src/plugin.ts applyUsageSample,现导出供测试):
   `[<sid>] [plugin] [acp-usage] input=50000 cached=8000 (cache hit 16%) ctx=51200 fold=new`
   - `fold=new` 精确标出折叠落地的那一个请求(applyRanges 置位 → 首个 usage 报告消费)
   - cached 缺失时打 `cached=n/a`,不算命中率
2. **`[acp-compress-obs]` 扩展锚点估计**(src/stream.ts):
   `... anchor≈1234 tok (3 active blocks, sys excluded) postCtx≈31000 → next-request cache ceiling ≥3%`
   - anchor = Σ active 块 summary chars/4(下界,sys 未知)
   - 下一请求真实 cached ≈ ceiling → 物理保留;≪ ceiling → 上游逐出/争用
3. **wire 路径同标 fold=new**(src/loop/core.ts)保持两条路径对称。
4. `Session.stats.pendingFoldUsage?: boolean`(src/session.ts),内存态,不落盘。

## 验证

- 新增 tests/usage-observability.test.ts 4 项:置位/锚点行字段、usage 行格式+fold 消费、无残留标记、cached=n/a
- 全套 1322 pass / 0 fail(2 skip),tsc + build 绿