### PR TITLE
test: add containerized real-codex E2E (docker) (#686)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+dist
+tmp
+artifacts
+*.log
+.env
+*.tgz
+.git

--- a/.github/workflows/ci-e2e-docker.yml
+++ b/.github/workflows/ci-e2e-docker.yml
@@ -1,0 +1,35 @@
+name: E2E (real codex, Docker)
+
+on:
+  workflow_dispatch:
+    inputs:
+      forge:
+        description: "run forge phase (needs BILI_CODEX_COMPACT support in master)"
+        type: boolean
+        default: false
+
+jobs:
+  e2e-docker:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - name: Preflight (in container)
+        run: bash scripts/e2e-docker/run.sh preflight
+        env:
+          E2E_UPSTREAM_URL: ${{ secrets.E2E_UPSTREAM_URL }}
+          E2E_UPSTREAM_KEY: ${{ secrets.E2E_UPSTREAM_KEY }}
+      - name: E2E suite (in container)
+        run: bash scripts/e2e-docker/run.sh full
+        env:
+          E2E_UPSTREAM_URL: ${{ secrets.E2E_UPSTREAM_URL }}
+          E2E_UPSTREAM_KEY: ${{ secrets.E2E_UPSTREAM_KEY }}
+          E2E_FORGE: ${{ inputs.forge && '1' || '' }}
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-docker-logs
+          path: tmp/docker-e2e/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "typecheck": "tsc --noEmit --project tsconfig.build.json",
     "test": "node --import tsx --test tests/*.test.ts",
     "start": "node dist/index.js",
-    "test:e2e": "node --import tsx --test tests/e2e/e2e-codex.test.ts"
+    "test:e2e": "node --import tsx --test tests/e2e/e2e-codex.test.ts",
+    "e2e:docker": "bash scripts/e2e-docker/run.sh full",
+    "e2e:docker:preflight": "bash scripts/e2e-docker/run.sh preflight"
   },
   "keywords": [
     "context",

--- a/scripts/e2e-docker/Dockerfile
+++ b/scripts/e2e-docker/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:22-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci --ignore-scripts --no-fund --no-audit
+
+COPY . .
+RUN npm run build
+
+RUN npm install -g @openai/codex@latest
+
+CMD ["bash", "-lc", "E2E_CHECK=1 node --import tsx --test tests/e2e/e2e-codex.test.ts"]

--- a/scripts/e2e-docker/run.sh
+++ b/scripts/e2e-docker/run.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$REPO_ROOT"
+
+IMAGE="${BILI_E2E_IMAGE:-billion-context-e2e:local}"
+NETWORK="${E2E_DOCKER_NETWORK:-bridge}"
+LOG_DIR="${BILI_E2E_LOG_DIR:-$REPO_ROOT/tmp/docker-e2e}"
+MODE="${1:-full}"
+
+case "$MODE" in
+  full | preflight) ;;
+  *) echo "usage: $0 [full|preflight]" >&2; exit 64 ;;
+esac
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "error: docker not found on PATH" >&2
+  exit 3
+fi
+
+echo ">> building image $IMAGE"
+docker build -f scripts/e2e-docker/Dockerfile -t "$IMAGE" .
+
+FORWARD=()
+for v in E2E_UPSTREAM_URL E2E_UPSTREAM_KEY E2E_MODEL E2E_FORGE E2E_TMO E2E_CODEX_BIN; do
+  if [ -n "${!v:-}" ]; then FORWARD+=(-e "$v=${!v}"); fi
+done
+
+mkdir -p "$LOG_DIR"
+
+# Default upstream is host loopback; in a bridge container that's the container
+# itself. Use E2E_DOCKER_NETWORK=host, or set E2E_UPSTREAM_URL reachable from the container.
+if [ "$MODE" = "preflight" ]; then
+  CMD="E2E_CHECK=1 node --import tsx --test tests/e2e/e2e-codex.test.ts"
+else
+  CMD="ACP_TEST_E2E=1 node --import tsx --test tests/e2e/e2e-codex.test.ts"
+fi
+
+echo ">> running e2e [$MODE] in container (network=$NETWORK, logs=$LOG_DIR)"
+exec docker run --rm \
+  --network "$NETWORK" \
+  -v "$LOG_DIR:/app/tmp" \
+  "${FORWARD[@]}" \
+  "$IMAGE" bash -lc "$CMD"


### PR DESCRIPTION
## What
Containerized **real** end-to-end for codex, per the ask in #686 (“需要真的端到端…docker 起 codex 的那种”). It wraps the existing `tests/e2e/e2e-codex.test.ts` suite -- real `codex` CLI → bili proxy → real Responses upstream → full warmup / load-growth / ACP-compress / purity(/forge) lifecycle -- inside a reproducible Docker image, following the containerized-e2e pattern from Tyan66666/billion-context-dsh#128.

This is "real" in the sense #686 wants: actual model round-trips and compression through the proxy, not just the headless `mcp list` config check from PR #688. The two are complementary (#688 = Windows MCP-registration layer; this = full lifecycle in an isolated container).

## Files
- `scripts/e2e-docker/Dockerfile` -- `node:22-slim` + `npm ci` + `npm run build` + `@openai/codex`; runtime baked into the image, host needs no node/codex.
- `scripts/e2e-docker/run.sh` -- host orchestrator: build image → run the suite in-container, forwarding `E2E_UPSTREAM_URL/KEY/MODEL/FORGE/TMO/CODEX_BIN`, mounting `tmp/docker-e2e` for persistent logs.
- `.dockerignore` -- keeps host `node_modules`/`dist` out of the build context.
- `.github/workflows/ci-e2e-docker.yml` -- `workflow_dispatch` job mirroring `ci-e2e.yml` (secrets-backed upstream); runs preflight then full.
- `package.json` -- `npm run e2e:docker` / `e2e:docker:preflight`.

## Local usage
```bash
# zero-token smoke (boots container, prints codex version + dist + upstream probe)
E2E_UPSTREAM_URL=http://host.docker.internal:8199/v1 E2E_UPSTREAM_KEY=... npm run e2e:docker:preflight
# full lifecycle
E2E_UPSTREAM_URL=... E2E_UPSTREAM_KEY=... npm run e2e:docker
# if the upstream is on the host loopback, share the host netns instead:
E2E_DOCKER_NETWORK=host E2E_UPSTREAM_URL=http://127.0.0.1:8199/v1 npm run e2e:docker
```

## Validation done here (Linux sandbox)
- `bash -n scripts/e2e-docker/run.sh` clean; workflow YAML parses; `package.json` valid JSON, **version untouched**.
- Confirmed the suite's work dir is `process.cwd()/tmp` (`tests/e2e/e2e-codex.test.ts:18`), so the `-v <log>:/app/tmp` mount captures logs exactly where CI uploads them.
- ⚠️ **Docker is not available in this agent's sandbox**, so I could NOT build the image or run the container here. The image build + first in-container run must happen on a docker host or via the `workflow_dispatch` job. That is why the CI job is manual-dispatch (zero risk to other PRs until triggered).

## Review note
Reuses the proven host e2e unchanged -- the only new surface is "does `@openai/codex` install & run inside `node:22-slim`" plus container→upstream networking (documented in `run.sh`). Suggest one `workflow_dispatch` run to confirm before treating it as a standing gate.

Refs #686

---
中文摘要：按你"要真·端到端、用 docker 起 codex"的要求，把现有真实 codex e2e 套件封装成可复现的 Docker 镜像（node:22-slim + bili dist + codex），照 billion-context-dsh#128 的容器化模式做了 `run.sh` 编排 + 手动触发的 CI job + `npm run e2e:docker`；本机已验证脚本/YAML/JSON 语法与日志挂载路径，但本沙箱没有 docker，无法实际构建/运行容器，需在有 docker 的主机或 dispatch job 上跑首次确认。