### PR TITLE
release v0.1.104

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.103",
+  "version": "0.1.104",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.103",
+      "version": "0.1.104",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.103",
+  "version": "0.1.104",
   "description": "Context-compression proxy that lets AI coding agents run for days — billions of tokens through one context window. Sits between any agent (Claude Code, Codex, Cursor, Aider, …) and its model API, folding consumed conversation into reversible, prefix-cache-friendly summaries. Zero per-agent code: just point your base URL at the proxy.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## release v0.1.104

Version bump only — `package.json` plus the two root-version fields in `package-lock.json`. Ships everything merged to master since **v0.1.103**.

### Changes since v0.1.103
- **pi.dev listing** (#699 / #698): added `pi.image` so billion-context gets a preview/avatar card on pi.dev/packages/billion-context, plus a value-first rewrite of the package description. Logo committed to `docs/logo.svg` (+ raster `docs/logo.png`).
- **obs plugin** (#696 / #695): per-request `[acp-usage]` on the plugin path + fold-materialization anchor ceiling.

### Pre-flight (local, same checks CI runs)
- typecheck: clean
- test: 1367 pass / 0 fail (2 skipped, e2e-gated)
- build: success

No dependency changes; the lockfile diff is limited to the two root-version fields. CI publishes to npm on merge and creates tag `v0.1.104`.
