### PR TITLE
release v0.1.105

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.104",
+  "version": "0.1.105",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.104",
+      "version": "0.1.105",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.104",
+  "version": "0.1.105",
   "description": "Context-compression proxy that lets AI coding agents run for days — billions of tokens through one context window. Sits between any agent (Claude Code, Codex, Cursor, Aider, …) and its model API, folding consumed conversation into reversible, prefix-cache-friendly summaries. Zero per-agent code: just point your base URL at the proxy.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Release v0.1.105.

Changes since v0.1.104:
- #701 (#698): use the provided hero artwork as the pi.dev listing preview image (`docs/logo.png`, 16:10); drop the superseded generated `logo.svg`; point `pi.image` at the raster PNG (consistent with other listed packages).

Version bump only (`package.json` + matching root entries in `package-lock.json`). Pre-flight green: typecheck clean, 1367 tests pass / 0 fail / 2 skipped, build success.