### PR TITLE
fix: restore docs/logo.svg so cached pi.dev preview reference resolves

### DIFF
--- a/docs/logo.svg
+++ b/docs/logo.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="1000" viewBox="0 0 1600 1000" role="img" aria-label="billion-context">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0b1020"/>
+      <stop offset="1" stop-color="#0e1626"/>
+    </linearGradient>
+    <radialGradient id="glow" cx="0.5" cy="0.34" r="0.62">
+      <stop offset="0" stop-color="#22d3ee" stop-opacity="0.30"/>
+      <stop offset="0.5" stop-color="#6366f1" stop-opacity="0.08"/>
+      <stop offset="1" stop-color="#6366f1" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="tile" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#22d3ee"/>
+      <stop offset="1" stop-color="#6366f1"/>
+    </linearGradient>
+    <linearGradient id="word" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#22d3ee"/>
+      <stop offset="1" stop-color="#818cf8"/>
+    </linearGradient>
+  </defs>
+
+  <rect x="0" y="0" width="1600" height="1000" fill="url(#bg)"/>
+  <rect x="0" y="0" width="1600" height="1000" fill="url(#glow)"/>
+
+  <g>
+    <rect x="640" y="100" width="320" height="320" rx="80" fill="url(#tile)"/>
+    <rect x="730" y="224" width="140" height="72" rx="36" fill="#ffffff"/>
+    <path d="M690 222 L726 260 L690 298" fill="none" stroke="#ffffff" stroke-width="24" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M910 222 L874 260 L910 298" fill="none" stroke="#ffffff" stroke-width="24" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+
+  <text x="800" y="650" text-anchor="middle" font-family="system-ui,-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif" font-size="300" font-weight="800" fill="#ffffff">billion</text>
+  <text x="800" y="890" text-anchor="middle" font-family="system-ui,-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif" font-size="300" font-weight="800" fill="url(#word)">context</text>
+</svg>


### PR DESCRIPTION
Fixes the broken image on https://pi.dev/packages/billion-context (图片加载失败).

**Root cause** (verified):
- npm is correct & live: published **0.1.105**, `pi.image` -> `docs/logo.png`, and that PNG returns HTTP 200 (image/png, 1055148 B).
- pi.dev's stored record still points at `docs/logo.svg` (the value from v0.1.104), but **#701 deleted that file -> 404 -> broken image**. pi.dev has not re-indexed to 0.1.105 yet and exposes no self-serve re-index button; its preview-media edge cache is only `max-age=300`.

**Fix**: restore `docs/logo.svg` so the currently-cached reference resolves immediately. No new publish needed — raw.githubusercontent.com serves master directly, so within ~5 min the broken image becomes the (older) SVG, and it flips to the hero PNG automatically once pi.dev re-indexes 0.1.105.

Content change, no version bump.