### PR TITLE
docs: add QQ community group to README (EN + ZH)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ Any agent that can set a base URL — <em>zero per-agent adapter code</em>.
 
 `billion-context` sits between **any** agent and its model API, rewriting Anthropic/OpenAI streams with [acp-kernel](https://github.com/ranxianglei/acp-kernel) compression. The model decides **when** and **what** to compress into high-fidelity summaries — not a hard truncation limit.
 
+## Community
+
+Discussion, help, and updates on QQ — one group covers all three projects (`billion-context`, `billion-context-pi`, `opencode-acp`):
+
+**QQ Group: 1056132097**
+
 ## Why
 
 Long coding sessions blow up context. Each provider charges per token, and once you pass the context window the session degrades or dies. `billion-context` compresses consumed conversation into layered summaries so you can run a single session for days — billions of tokens through one context window.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -24,6 +24,12 @@ AI 编程助手的<strong>通用上下文压缩代理</strong>
 
 `billion-context` 架在**任意**编程助手与其模型 API 之间,用 [acp-kernel](https://github.com/ranxianglei/acp-kernel) 压缩重写 Anthropic/OpenAI 流。何时压缩、压缩什么 —— <strong>由模型决定</strong>,而非硬截断。
 
+## 社区
+
+交流、求助与更新都在 QQ——同一个群覆盖三个项目(`billion-context`、`billion-context-pi`、`opencode-acp`):
+
+**QQ 群:1056132097**
+
 ## 为什么
 
 长编程会话会把上下文撑爆。各家 provider 按 token 计费,一旦超过上下文窗口,会话质量下降甚至崩掉。`billion-context` 把已消耗的对话压缩成分层摘要,让你**一个会话连跑数天** —— 海量 token 穿过同一个上下文窗口。


### PR DESCRIPTION
Add a QQ community group (**1056132097**) to the README in both English and Chinese.

One shared group covers all three projects: `billion-context`, `billion-context-pi`, `opencode-acp`.

- `README.md`: new `## Community` section before `## License`
- `README.zh-CN.md`: new `## 社区` section before `## 许可证`

Docs-only; no version bump.