### PR TITLE
docs: add QQ community group to README (EN + ZH)

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,6 +466,10 @@ Early. Protocol handling and compression work against mock tests (500+ passing).
 
 Client-side plugins for pi / omp / opencode ship inside `billion-context` (`dist/agent/*.js`) for the cooperative-proxy path. See the **"Which do I need?"** section above for how `billion-context`, the standalone `billion-context-pi`, and `opencode-acp` relate.
 
+## Community
+
+QQ group — one shared group for all three projects ([`billion-context`](https://github.com/ranxianglei/billion-context), [`billion-context-pi`](https://github.com/ranxianglei/billion-context-pi), [`opencode-acp`](https://github.com/ranxianglei/opencode-acp)): **1056132097**
+
 ## License
 
 MIT

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -287,6 +287,10 @@ Windows 下会自动发现常见 Clash/Mihomo 静态系统代理;Web UI 会显�
 
 针对 pi / omp / opencode 的客户端插件随 `billion-context` 一起发布(`dist/agent/*.js`),用于协作代理路径。三者(`billion-context`、独立的 `billion-context-pi`、`opencode-acp`)如何取舍,见上文「该选哪个?」一节。
 
+## 社区
+
+QQ 群 —— 三个项目共用一个群（[`billion-context`](https://github.com/ranxianglei/billion-context)、[`billion-context-pi`](https://github.com/ranxianglei/billion-context-pi)、[`opencode-acp`](https://github.com/ranxianglei/opencode-acp)）：**1056132097**
+
 ## 许可证
 
 MIT


### PR DESCRIPTION
Adds a shared QQ community group (**1056132097**) to both READMEs, per #704.

- `README.md`: new `## Community` section before `## License`
- `README.zh-CN.md`: new `## 社区` section before `## 许可证`

One shared group covers all three projects: `billion-context`, `billion-context-pi`, `opencode-acp` — each linked in the section.

Docs-only; no version bump. No code changes, so no typecheck/test/build needed.