### PR TITLE
fix: dsh launcher sets NODE_EXTRA_CA_CERTS so Windows Node trusts the MITM CA (#710)

### DIFF
--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -2150,25 +2150,31 @@ export async function runLaunch(params: RunLaunchParams, deps: LauncherDeps = {}
     } else if (base === "dsh") {
         // #535 phase 4: split by destination (see discoverRoutes). Non-loopback
         // upstreams ride the proxy envs — https via CONNECT + cert MITM
-        // (HTTPS_PROXY + SSL_CERT_FILE), plain-http via absolute-form forward-
-        // proxy requests (HTTP_PROXY). SSL_CERT_FILE gets the COMBINED bundle
-        // because it REPLACES dsh's trust store — system roots must survive for
-        // blind-tunneled hosts (same pattern as codex). The built-in
-        // deepseek-official route stays captured through $DEEPSEEK_BASE_URL
-        // (resolution order: settings baseURL ?? env ?? default, so a user
-        // setting wins and this env is the no-settings fallback). ONLY loopback
-        // destinations take the settings.yaml /bili/ rewrite below (persistent
-        // overlay DSH_HOME ~/.dsh-bili; real ~/.dsh never touched) — dsh
-        // bypasses proxy envs for loopback unconditionally. Proxy envs are set
-        // only when something actually routes through them, so a launch with
-        // no non-loopback custom providers behaves exactly as before.
+        // (HTTPS_PROXY + CA), plain-http via absolute-form forward-proxy
+        // requests (HTTP_PROXY). The COMBINED bundle goes to BOTH SSL_CERT_FILE
+        // (OpenSSL replace-semantics readers) and NODE_EXTRA_CA_CERTS (Node
+        // append-semantics readers): dsh is a Node program, but Windows' official
+        // Node ignores SSL_CERT_FILE and trusts only NODE_EXTRA_CA_CERTS (#710),
+        // so both must be set for the MITM CA to be trusted cross-platform. The
+        // combined bundle carries system roots, so blind-tunneled hosts still
+        // validate under either mechanism. The built-in deepseek-official route
+        // stays captured through $DEEPSEEK_BASE_URL (resolution order: settings
+        // baseURL ?? env ?? default, so a user setting wins and this env is the
+        // no-settings fallback). ONLY loopback destinations take the settings.yaml
+        // /bili/ rewrite below (persistent overlay DSH_HOME ~/.dsh-bili; real
+        // ~/.dsh never touched) — dsh bypasses proxy envs for loopback
+        // unconditionally. Proxy envs are set only when something actually routes
+        // through them, so a launch with no non-loopback custom providers behaves
+        // exactly as before.
         const usesProxyEnv = routes.httpsDomains.length > 0 || routes.httpEnvRoutes.length > 0;
         env = usesProxyEnv ? stripInheritedProxy(process.env) : { ...process.env };
         env.BILLION_CONTEXT_PROXY = origin;
         env.DEEPSEEK_BASE_URL = wrapUpstream(origin, "https://api.deepseek.com");
         if (usesProxyEnv) {
+            const caBundle = resolveCombinedCaPath(process.env);
             env.HTTPS_PROXY = origin;
-            env.SSL_CERT_FILE = resolveCombinedCaPath(process.env);
+            env.SSL_CERT_FILE = caBundle;
+            env.NODE_EXTRA_CA_CERTS = caBundle;
         }
         if (routes.httpEnvRoutes.length > 0) env.HTTP_PROXY = origin;
         // Session identity for the proxy: dsh's pi-ai stack keys its

--- a/tests/launcher.test.ts
+++ b/tests/launcher.test.ts
@@ -1959,6 +1959,9 @@ test("runLaunch dsh: non-loopback upstreams ride proxy envs, loopback keeps the 
         // exclusion comes from its built-in policy, not from NO_PROXY.
         assert.equal(seenEnv.HTTPS_PROXY, origin);
         assert.ok(String(seenEnv.SSL_CERT_FILE).endsWith(path.join("billion-context", "ca", "combined-ca.pem")));
+        // #710: Windows official Node ignores SSL_CERT_FILE and reads only
+        // NODE_EXTRA_CA_CERTS — both must carry the combined bundle.
+        assert.ok(String(seenEnv.NODE_EXTRA_CA_CERTS).endsWith(path.join("billion-context", "ca", "combined-ca.pem")));
         assert.equal(seenEnv.HTTP_PROXY, undefined);
         assert.equal(seenEnv.NO_PROXY, undefined);
         // Loopback sglang stays on the /bili/ rewrite path via the persistent


### PR DESCRIPTION
## What changed

The `bili dsh` launch branch now exports **both** `SSL_CERT_FILE` and `NODE_EXTRA_CA_CERTS`, pointing at the combined CA bundle (`src/launcher.ts`, dsh branch):

    const caBundle = resolveCombinedCaPath(process.env);
    env.HTTPS_PROXY = origin;
    env.SSL_CERT_FILE = caBundle;
    env.NODE_EXTRA_CA_CERTS = caBundle;   // added

## Why

dsh (`@deepseek-ai/dsh`) is a **Node** program, but its launch branch only exported `SSL_CERT_FILE` — the pattern used for non-Node clients (codex/trae are Go/Rust binaries that read OpenSSL env vars). The official Windows Node build does **not** read `SSL_CERT_FILE`; it trusts extra CAs only through `NODE_EXTRA_CA_CERTS`. As a result, bili's MITM root was never trusted on Windows and every proxied model request (including the wrapped built-in DeepSeek route via `DEEPSEEK_BASE_URL`) failed at the TLS handshake. macOS/Linux were unaffected because their Node honors `SSL_CERT_FILE`.

Pointing `NODE_EXTRA_CA_CERTS` at the same **combined** bundle is correct under both semantics: `SSL_CERT_FILE` *replaces* the trust store while `NODE_EXTRA_CA_CERTS` *appends* to it, and `combined-ca.pem` already always merges system roots + Node's Mozilla root set + the MITM root (`src/ca.ts` `writeCombinedBundle`), so blind-tunneled (non-MITM) hosts still validate either way. This matches how every other Node-based client here (pi/opencode/claude/qoder/codebuddy) already exports the CA; codex/trae stay `SSL_CERT_FILE`-only.

## Pre-flight

- `npm run typecheck` — clean
- `node --import tsx --test tests/*.test.ts` — 1367 pass / 0 fail / 2 skipped (e2e-gated, skipped by design)
- `npm run build` — success

Test: the `runLaunch dsh: non-loopback upstreams…` case now asserts both `SSL_CERT_FILE` and `NODE_EXTRA_CA_CERTS` carry the combined bundle.

Fixes #710
