### PR TITLE
release v0.1.106

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.105",
+  "version": "0.1.106",
   "description": "Context-compression proxy that lets AI coding agents run for days — billions of tokens through one context window. Sits between any agent (Claude Code, Codex, Cursor, Aider, …) and its model API, folding consumed conversation into reversible, prefix-cache-friendly summaries. Zero per-agent code: just point your base URL at the proxy.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Changes since v0.1.105

- **#678 / #677** — request `content-encoding` fixed (PR #678): it is an end-to-end header (RFC 9110 §7.2), not hop-by-op — removed from the shared hop-by-hop set; now dropped only where bili decoded+rebuilt the body or when forwarding upstream RESPONSES (Node fetch already undecoded them). Undecodable/unknown-path passthrough keeps raw bytes WITH the marker so upstream decodes — fixes codex `gzip, charset=latin1` requests being rejected as undeclared binary.
- **#691 / #660** — host usage reporting redesigned: post-fold provider-measured usage is forwarded verbatim to EVERY client; the #408 uncompressed-baseline backfill (virtual number the model never receives) and its entire exemption ladder (pi/omp/codex-UA/ZCode switch) removed (-379 lines). The removed option's config key/env are now inert.
- **#709 / #707** — cross-process startup-window race fixed: concurrent launcher invocations no longer double-spawn proxies (O_EXCL `<state>/proxy-starting` marker + token-checked wait/claim; closes the read→claim TOCTOU per review).
- **#712 / #710** — dsh launcher sets `NODE_EXTRA_CA_CERTS` on Windows so Node trusts the lazily-generated MITM root CA.
- **Docs** — logo.svg restored (#703); QQ community group added to README EN+ZH (#704/#705); hostUsageCredit marked removed in CONFIGURATION.md / .zh-CN.md (part of #691).

## Pre-flight (local)

- `npm run typecheck` — clean
- `npm test` — 1373 files, 1371 pass, 0 fail (2 skipped = e2e-gated)
- `npm run build` — dist/index.js 2.8MB self-contained bundle