### PR TITLE
fix: search_context with zero blocks reports empty state, not a failure (#714)

### DIFF
--- a/src/compress-loop-responses.ts
+++ b/src/compress-loop-responses.ts
@@ -8,7 +8,7 @@ import { lastCompressSuffix, type Session } from "./session.js";
 import { parseCompressInput, PROXY_TOOL_NAMES, MUTATING_PROXY_TOOLS, COMPRESS_TOOL_NAME, ACP_TEXT_OPEN, ACP_TEXT_CLOSE } from "./compress-tool.js";
 import { log as loggerLog } from "./logger.js";
 import { applyRanges } from "./stream.js";
-import { resolveDecompress } from "./decompress-shared.js";
+import { executeSearchContext, resolveDecompress } from "./decompress-shared.js";
 import { buildVisibilityMarker } from "./compress-loop.js";
 import { MAX_LOOP_ROUNDS } from "./loop/index.js";
 import { stripResponsesText } from "./loop/tag-echo-filter.js";
@@ -91,17 +91,7 @@ function executeProxyTool(
         return resolveDecompress(args, ctx);
     }
     if (toolName === "search_context") {
-        const query = typeof args.query === "string" ? args.query : "";
-        if (query.length === 0) return "[search_context FAILED: query is required]";
-        const limit = typeof args.limit === "number" && args.limit > 0 ? Math.floor(args.limit) : 5;
-        const blocks = ctx.core.search(query, ctx.session.state).slice(0, limit);
-        if (blocks.length === 0) return `[No blocks matched "${query}"]`;
-        const lines = blocks.map((b) => {
-            const topic = b.topic ?? "(no topic)";
-            const preview = b.summary.length > 200 ? b.summary.slice(0, 200) + "..." : b.summary;
-            return `${b.blockId} (T${b.tier}) "${topic}"\n  ${preview}`;
-        });
-        return `Found ${blocks.length} block(s) for "${query}":\n\n${lines.join("\n\n")}`;
+        return executeSearchContext(args, ctx.core, ctx.session.state);
     }
     if (toolName === "acp_status") {
         return handleAcpStatus(args, ctx);

--- a/src/compress-loop.ts
+++ b/src/compress-loop.ts
@@ -4,7 +4,6 @@ export function buildVisibilityMarker(toolName: string, result: string): string 
         l.includes("FAILED")
         || l.includes("not found")
         || l.includes("is required")
-        || l.includes("No blocks matched")
     );
     const icons: Record<string, string> = {
         compress: "📦",

--- a/src/decompress-shared.ts
+++ b/src/decompress-shared.ts
@@ -1,6 +1,7 @@
 import {
     collectBlockContent,
     type CompressionCore,
+    type CompressionState,
     type Config,
     type CoreMessage,
 } from "acp-kernel";
@@ -117,4 +118,29 @@ export function resolveDecompress(
         }
     }
     return `${header}\n${body}`;
+}
+
+/** Shared search_context execution for all wire paths. Distinguishes "no active
+ *  blocks at all" (searching is pointless until compress runs — an explicit
+ *  message stops premature-search retry loops, #714) from "blocks exist but none
+ *  matched". */
+export function executeSearchContext(
+    args: Record<string, unknown>,
+    core: CompressionCore,
+    state: CompressionState,
+): string {
+    const query = typeof args.query === "string" ? args.query : "";
+    if (query.length === 0) return "[search_context FAILED: query is required]";
+    const limit = typeof args.limit === "number" && args.limit > 0 ? Math.floor(args.limit) : 5;
+    const blocks = core.search(query, state).slice(0, limit);
+    if (blocks.length === 0) {
+        if (!state.blocks.some((b) => b.active)) return "[No compressed blocks exist yet — nothing to search.]";
+        return `[No blocks matched "${query}"]`;
+    }
+    const lines = blocks.map((b) => {
+        const topic = b.topic ?? "(no topic)";
+        const preview = b.summary.length > 200 ? b.summary.slice(0, 200) + "..." : b.summary;
+        return `${b.blockId} (T${b.tier}) "${topic}"\n  ${preview}`;
+    });
+    return `Found ${blocks.length} block(s) for "${query}":\n\n${lines.join("\n\n")}`;
 }

--- a/src/loop/core.ts
+++ b/src/loop/core.ts
@@ -13,7 +13,7 @@ import {
 } from "../compress-tool.js";
 import { effectiveAbsorbConfig, executeAbsorb, isProxyToolFor } from "../absorb.js";
 import { applyRanges } from "../stream.js";
-import { resolveDecompress } from "../decompress-shared.js";
+import { executeSearchContext, resolveDecompress } from "../decompress-shared.js";
 import { buildVisibilityMarker } from "../compress-loop.js";
 import { fetchWithRetry, UpstreamHttpError } from "../fetch-util.js";
 import { proxyDispatcher } from "../upstream-proxy.js";
@@ -141,17 +141,7 @@ export function executeProxyTool(
         return resolveDecompress(args, ctx);
     }
     if (toolName === "search_context") {
-        const query = typeof args.query === "string" ? args.query : "";
-        if (query.length === 0) return "[search_context FAILED: query is required]";
-        const limit = typeof args.limit === "number" && args.limit > 0 ? Math.floor(args.limit) : 5;
-        const blocks = ctx.core.search(query, ctx.session.state).slice(0, limit);
-        if (blocks.length === 0) return `[No blocks matched "${query}"]`;
-        const lines = blocks.map((b) => {
-            const topic = b.topic ?? "(no topic)";
-            const preview = b.summary.length > 200 ? b.summary.slice(0, 200) + "..." : b.summary;
-            return `${b.blockId} (T${b.tier}) "${topic}"\n  ${preview}`;
-        });
-        return `Found ${blocks.length} block(s) for "${query}":\n\n${lines.join("\n\n")}`;
+        return executeSearchContext(args, ctx.core, ctx.session.state);
     }
     if (toolName === "acp_status") {
         return handleAcpStatus(args, ctx);

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -3,7 +3,7 @@ import { handleAcpStatus } from "./acp-status.js";
 import { type Session, cacheBlockContent } from "./session.js";
 import { COMPRESS_TOOL_NAME, parseCompressInput, ABSORB_TOOL_NAME } from "./compress-tool.js";
 import { effectiveAbsorbConfig, executeAbsorb, isProxyToolFor } from "./absorb.js";
-import { resolveDecompress } from "./decompress-shared.js";
+import { executeSearchContext, resolveDecompress } from "./decompress-shared.js";
 import { containsRenderTagText, stripAcpTags } from "./loop/tag-echo-filter.js";
 import { maxShrinkPerCompress } from "./fetch-util.js";
 
@@ -32,17 +32,7 @@ function executeAnthropicProxyTool(toolName: string, args: Record<string, unknow
         return resolveDecompress(args, ctx);
     }
     if (toolName === "search_context") {
-        const query = typeof args.query === "string" ? args.query : "";
-        if (query.length === 0) return "[search_context FAILED: query is required]";
-        const limit = typeof args.limit === "number" && args.limit > 0 ? Math.floor(args.limit) : 5;
-        const blocks = ctx.core.search(query, ctx.session.state).slice(0, limit);
-        if (blocks.length === 0) return `[No blocks matched "${query}"]`;
-        const lines = blocks.map((b) => {
-            const topic = b.topic ?? "(no topic)";
-            const preview = b.summary.length > 200 ? b.summary.slice(0, 200) + "..." : b.summary;
-            return `${b.blockId} (T${b.tier}) "${topic}"\n  ${preview}`;
-        });
-        return `Found ${blocks.length} block(s) for "${query}":\n\n${lines.join("\n\n")}`;
+        return executeSearchContext(args, ctx.core, ctx.session.state);
     }
     if (toolName === "acp_status") {
         return handleAcpStatus(args, ctx);

--- a/tests/loop-core.test.ts
+++ b/tests/loop-core.test.ts
@@ -117,6 +117,35 @@ test("loop #2: search_context-only round → marker surfaced + re-request", asyn
     }
 });
 
+// #714: search_context before any compress used to surface "No blocks matched"
+// with a ❌ failure icon, driving premature-search retry loops. Zero active
+// blocks must render as a non-failure empty-state message instead.
+test("loop #714: search_context with zero blocks → empty-state marker, NOT ❌", async () => {
+    const round1 = [
+        sse("response.created", { response: { id: "resp_1", status: "in_progress" } }),
+        fcEvents(0, "call_search", "search_context", JSON.stringify({ query: "anything" })),
+        COMPLETED,
+    ].join("");
+    const round2 = COMPLETED;
+    let fetchCalls = 0;
+    const orig = globalThis.fetch;
+    globalThis.fetch = (async () => { fetchCalls++; return new Response(round2, { status: 200 }); }) as typeof fetch;
+    try {
+        const out = await drain(
+            new Response(round1, { status: 200 }).body!,
+            makeCtx(),
+            { model: "gpt-4o", input: [], stream: true },
+            { url: "http://mock", headers: {} },
+        );
+        assert.ok(out.includes("No compressed blocks exist yet"), "empty-state message surfaced");
+        assert.ok(out.includes("🔍"), "search icon, not failure");
+        assert.ok(!out.includes("❌"), "NOT rendered as a failure");
+        assert.equal(fetchCalls, 1, "re-request so model can continue");
+    } finally {
+        globalThis.fetch = orig;
+    }
+});
+
 test("loop #8: real-tool passthrough → emitted to client, loop ends (no re-request)", async () => {
     const round1 = [
         sse("response.created", { response: { id: "resp_1", status: "in_progress" } }),

--- a/tests/search-context.test.ts
+++ b/tests/search-context.test.ts
@@ -1,0 +1,94 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createCore, createInitialState, defaultConfig, type CompressionState } from "acp-kernel";
+import { anthropicToCore, type AnthropicRequestBody } from "acp-kernel/wire";
+import type { Session } from "../src/session.ts";
+import { buildVisibilityMarker } from "../src/compress-loop.ts";
+import { executeSearchContext } from "../src/decompress-shared.ts";
+
+function makeSession(): Session {
+    return {
+        id: `sc-${Math.random().toString(36).slice(2)}`,
+        meta: {},
+        stats: { requests: 0, tokensSaved: 0, inputTokens: 0, cachedTokens: 0, outputTokens: 0, cacheSamples: 0, lastInputTokens: 0, contextTokens: 0 },
+        metadata: {},
+        state: createInitialState(),
+        createdAt: Date.now(),
+        lastSeen: Date.now(),
+        blockContents: new Map(),
+        inFlight: 0,
+        persisted: false,
+    };
+}
+
+function makeSessionWithBlock(): { core: ReturnType<typeof createCore>; state: CompressionState } {
+    const session = makeSession();
+    const core = createCore();
+    const config = defaultConfig(200000);
+    const body: AnthropicRequestBody = { model: "claude-test", messages: [] };
+    for (let i = 0; i < 40; i++) {
+        body.messages.push({ role: i % 2 === 0 ? "user" : "assistant", content: `auth token flow message ${i} ${"y".repeat(2000)}` });
+    }
+    const { msgs } = anthropicToCore(body);
+    const turn = core.processTurn({ messages: msgs, state: session.state, config, tokenCount: 9999, renderTags: "text-only" });
+    const res = core.applyCompression({
+        ranges: [{ startRef: "m00001", endRef: "m00015", summary: "auth token exchange and refresh design decisions".repeat(3) }],
+        state: turn.state,
+        config,
+        messages: turn.messages,
+    });
+    assert.equal(res.result.blocksCreated, 1, "compression block should be created");
+    return { core, state: res.state };
+}
+
+test("buildVisibilityMarker: zero-blocks search result is NOT a failure (#714)", () => {
+    const marker = buildVisibilityMarker("search_context", "[No compressed blocks exist yet — nothing to search.]");
+    assert.ok(marker.includes("🔍"), "search icon kept");
+    assert.ok(!marker.includes("❌"), "no failure icon");
+    assert.ok(marker.includes("No compressed blocks exist yet"), "message surfaced to client");
+});
+
+test("buildVisibilityMarker: no-match search result is NOT a failure (#714)", () => {
+    const marker = buildVisibilityMarker("search_context", '[No blocks matched "quantum flux"]');
+    assert.ok(marker.includes("🔍"), "search icon kept");
+    assert.ok(!marker.includes("❌"), "no failure icon");
+    assert.ok(marker.includes('No blocks matched "quantum flux"'), "query echoed back");
+});
+
+test("buildVisibilityMarker: hits still render normally", () => {
+    const marker = buildVisibilityMarker("search_context", 'Found 1 block(s) for "auth":\n\nb0 (T1) "(no topic)"\n  auth token exchange');
+    assert.ok(marker.includes("🔍"));
+    assert.ok(!marker.includes("❌"));
+    assert.ok(marker.includes('Found 1 block(s) for "auth"'));
+});
+
+test("buildVisibilityMarker: real failures still ❌", () => {
+    assert.ok(buildVisibilityMarker("search_context", "[search_context FAILED: query is required]").includes("❌"), "missing query is a failure");
+    assert.ok(buildVisibilityMarker("decompress", "[Block b9 not found]").includes("❌"), "not-found decompress is a failure");
+});
+
+test("executeSearchContext: missing query → FAILED string", () => {
+    const core = createCore();
+    const state = createInitialState();
+    assert.equal(executeSearchContext({}, core, state), "[search_context FAILED: query is required]");
+    assert.equal(executeSearchContext({ query: "" }, core, state), "[search_context FAILED: query is required]");
+});
+
+test("executeSearchContext: zero active blocks → explicit empty-state message (#714)", () => {
+    const core = createCore();
+    const state = createInitialState();
+    assert.equal(executeSearchContext({ query: "anything" }, core, state), "[No compressed blocks exist yet — nothing to search.]");
+});
+
+test("executeSearchContext: active block exists but none match → no-match string", () => {
+    const { core, state } = makeSessionWithBlock();
+    assert.match(executeSearchContext({ query: "zzz-no-such-topic" }, core, state), /^\[No blocks matched "zzz-no-such-topic"\]$/);
+});
+
+test("executeSearchContext: matching block → Found listing with id/topic/preview", () => {
+    const { core, state } = makeSessionWithBlock();
+    const out = executeSearchContext({ query: "auth token" }, core, state);
+    assert.match(out, /^Found \d+ block\(s\) for "auth token":/);
+    assert.ok(out.includes("(T"), "tier present");
+    assert.ok(out.includes("auth token exchange"), "summary preview present");
+});


### PR DESCRIPTION
## Problem (#714)

Before any compress runs, `search_context` returns `[No blocks matched "<query>"]`, and `buildVisibilityMarker` classifies that string as a **failure** (`❌ [ACP] No blocks matched ...`). In the reporter's session the model saw repeated ❌ errors while every `acp_status` showed 'No compressed blocks' — and retried the same searches ~8 times. Empty results are being presented as hard errors, driving premature-search retry loops.

## Fix

- **New shared helper** `executeSearchContext(args, core, state)` in `src/decompress-shared.ts` (the existing home of `resolveDecompress` + `ProxyToolCtx`), replacing the three duplicated handlers in `src/loop/core.ts`, `src/stream.ts`, `src/compress-loop-responses.ts`.
- Distinguishes the two empty cases:
  - **zero active blocks** → `[No compressed blocks exist yet — nothing to search.]` (searching is pointless until compress runs)
  - **blocks exist, none matched** → `[No blocks matched "<query>"]` (unchanged wording)
- `buildVisibilityMarker` no longer treats `"No blocks matched"` as a failure: empty results now render with the 🔍 search icon instead of ❌. Real failures (`FAILED` / `not found` / `is required`) still render ❌.

Proxy-mode only by design: plugin-mode agents execute tools in their own process (separate repos); this is where the reported rendering comes from.

## Pre-flight

- `npm run typecheck` ✅
- `npm test`: 1243/1244 pass — the single failure (`launcher.test.ts resolveClientCommand`) is environmental (sandbox has `/usr/bin/codex` installed) and fails identically on clean master
- `npm run build` ✅
- New tests: `tests/search-context.test.ts` (marker icon matrix + helper: missing query / zero blocks / no-match / match) and `tests/loop-core.test.ts` `loop #714` integration test (zero-block round surfaces 🔍 empty-state marker, never ❌)