### PR TITLE
fix: harden rebuilt assistant content against null for OpenAI-compatible backends (#719)

### DIFF
--- a/src/loop/adapter-openai.ts
+++ b/src/loop/adapter-openai.ts
@@ -4,7 +4,7 @@ import { buildVisibilityMarker } from "../compress-loop.js";
 import { createTagEchoFilter } from "./tag-echo-filter.js";
 import { degenerateTurnWarning } from "../degenerate-turn.js";
 import { log as loggerLog } from "../logger.js";
-import { systemToUser } from "../util.js";
+import { hardenOpenaiAssistantContent, systemToUser } from "../util.js";
 
 import type {
     CompressLoopAdapter,
@@ -191,7 +191,7 @@ export function createOpenaiAdapter(requestBody: Record<string, unknown>, client
             // runtime state), so coreMessages no longer carries it — re-inject
             // the CLIENT's original system ahead of the compress prompt,
             // mirroring the anthropic adapter's anthropicSystem path.
-            const messages = systemToUser(coreToOpenai(coreMessages));
+            const messages = systemToUser(hardenOpenaiAssistantContent(coreToOpenai(coreMessages)));
             const withSys = injectOpenaiSystem(messages, [clientSystem, systemPrompt].filter((p): p is string => typeof p === "string" && p.length > 0));
             return { ...body, messages: withSys };
         },

--- a/src/server.ts
+++ b/src/server.ts
@@ -73,7 +73,7 @@ import { flushPrefixAffinity, hydratePrefixAffinity, scheduleAffinityPersist } f
 import { consumePluginRegisterFor, flushConversations, handlePluginCompact, handlePluginManifest, handlePluginRegister, handlePluginStatus, handlePluginTool, loadConversations, pipePluginChatWithStrip, pipePluginJson, pipePluginResponsesWithStrip, pluginAgentHeader, pluginConversationHeader, pluginReportedContextWindow, recordPluginSession, rememberPluginMessages, takePendingPluginRegister } from "./plugin.js";
 import { setupMitm, readMitmUpstream } from "./mitm.js";
 import type { BiliMessage } from "acp-kernel/wire";
-import { isLoopbackAddress, inspectContextOverflow, reserveOutputHeadroom, shouldReserveOutputHeadroom, systemToUser, usageTotals, type WireProtocol } from "./util.js";
+import { hardenOpenaiAssistantContent, isLoopbackAddress, inspectContextOverflow, reserveOutputHeadroom, shouldReserveOutputHeadroom, systemToUser, usageTotals, type WireProtocol } from "./util.js";
 import { resolveConfirmedLimit, resolveLearnedLimit, resolveSpeculativeLimit, retractStaleLearnedLimits } from "./weak-overflow.js";
 import { BILI_TUNNEL_HEADER, checkTunnelDestination, tunnelAllowlistFromEnv } from "./tunnel-guard.js";
 
@@ -2256,7 +2256,7 @@ function prepareOpenai(
         processedMessages = stripReasoning(stripKernelSummaries(turn.messages, turn.state));
         applyCompactionArchive(session, activeBefore, new Set(msgs.map((m) => m.id)), log);
         reapOrphanBlocks(session, msgs, deactivateBlock);
-        rebuiltMessages = systemToUser(coreToOpenai(processedMessages as BiliMessage[]));
+        rebuiltMessages = systemToUser(hardenOpenaiAssistantContent(coreToOpenai(processedMessages as BiliMessage[])));
 
         // ONLY the static compress prompt goes into the system message — the
         // system prompt is the prefix-cache anchor and must be byte-stable

--- a/src/util.ts
+++ b/src/util.ts
@@ -241,6 +241,25 @@ export function systemToUser<T extends { role: string }>(messages: T[]): T[] {
     );
 }
 
+/** #719: Some OpenAI-compatible backends (DeepSeek) reject assistant messages
+ * whose `content` is null — they require a string content (possibly "") or
+ * tool_calls ("Invalid assistant message: content or tool_calls must be set").
+ * coreToOpenai emits `content: null` for reasoning-only assistant turns (an
+ * upstream stream truncated before any completion event leaves 0 text chars +
+ * N reasoning chars; openaiToCore drops empty text, so both `content:""` and
+ * `content:null` inputs rebuild as null). Force an empty string so the rebuilt
+ * wire payload is always accepted; no-op when content is already a string or
+ * an array of parts. Deterministic across turns → prefix-cache stable.
+ */
+export function hardenOpenaiAssistantContent<T extends { role: string }>(messages: T[]): T[] {
+    return messages.map((m) => {
+        if (m.role !== "assistant") return m;
+        const c = (m as { content?: unknown }).content;
+        if (c === null || c === undefined) return { ...m, content: "" } as T;
+        return m;
+    });
+}
+
 /**
  * Whether the OUTPUT budget should be reserved from the context window at all.
  * Anthropic's Messages API enforces the input limit INDEPENDENTLY of

--- a/tests/openai-assistant-content-harden.test.ts
+++ b/tests/openai-assistant-content-harden.test.ts
@@ -1,0 +1,105 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { openaiToCore, coreToOpenai } from "acp-kernel/wire";
+import type { OpenAIRequestBody } from "acp-kernel/wire";
+import { hardenOpenaiAssistantContent } from "../src/util.ts";
+import { createOpenaiAdapter } from "../src/loop/index.ts";
+
+// #719: a reasoning-only assistant turn (upstream stream truncated before any
+// completion event) rebuilds as content:null via coreToOpenai; DeepSeek rejects
+// that with 400 "Invalid assistant message: content or tool_calls must be set".
+// hardenOpenaiAssistantContent normalizes it to "" at the proxy forward boundary.
+
+test("harden: reasoning-only assistant turn becomes content '' (issue #719 repro)", () => {
+    const body: OpenAIRequestBody = {
+        messages: [
+            { role: "user", content: "hi" },
+            { role: "assistant", content: "", reasoning_content: "let me think about this..." },
+            { role: "user", content: "say ok" },
+        ],
+    };
+    const { msgs } = openaiToCore(body);
+    const raw = coreToOpenai(msgs);
+    const rawAsst = raw.find((m) => m.role === "assistant");
+    assert.equal(rawAsst?.content, null, "kernel emits content:null for reasoning-only turns");
+
+    const out = hardenOpenaiAssistantContent(raw);
+    const asst = out.find((m) => m.role === "assistant");
+    assert.equal(asst?.content, "", "null normalized to empty string");
+    assert.equal(asst?.reasoning_content, "let me think about this...", "reasoning preserved");
+    const users = out.filter((m) => m.role === "user").map((u) => u.content);
+    assert.deepEqual(users, ["hi", "say ok"], "user messages untouched");
+});
+
+test("harden: content:null input (vs '') also rebuilds to ''", () => {
+    const body: OpenAIRequestBody = {
+        messages: [{ role: "assistant", content: null, reasoning_content: "just thinking" }],
+    };
+    const { msgs } = openaiToCore(body);
+    const out = hardenOpenaiAssistantContent(coreToOpenai(msgs));
+    assert.equal(out.length, 1);
+    assert.equal(out[0]?.role, "assistant");
+    assert.equal(out[0]?.content, "");
+    assert.equal(out[0]?.reasoning_content, "just thinking");
+});
+
+test("harden: tool_calls branch null content normalized too, tool_calls preserved", () => {
+    const body: OpenAIRequestBody = {
+        messages: [
+            {
+                role: "assistant",
+                content: null,
+                reasoning_content: "thinking about tools",
+                tool_calls: [
+                    { id: "call_1", type: "function", function: { name: "get_weather", arguments: '{"city":"SF"}' } },
+                ],
+            },
+        ],
+    };
+    const { msgs } = openaiToCore(body);
+    const out = hardenOpenaiAssistantContent(coreToOpenai(msgs));
+    assert.equal(out.length, 1);
+    assert.equal(out[0]?.content, "", "null -> '' even when tool_calls present");
+    assert.equal(out[0]?.tool_calls?.length, 1);
+    assert.equal(out[0]?.tool_calls?.[0]?.function?.name, "get_weather");
+    assert.equal(out[0]?.tool_calls?.[0]?.function?.arguments, '{"city":"SF"}');
+    assert.equal(out[0]?.reasoning_content, "thinking about tools");
+});
+
+test("harden: no-op (same object identity) for string/array content and non-assistant roles", () => {
+    const msgs = [
+        { role: "user" as const, content: "hello" },
+        { role: "assistant" as const, content: "plain answer" },
+        { role: "assistant" as const, content: [{ type: "text", text: "parted" }] },
+        { role: "tool" as const, content: "tool result", tool_call_id: "call_1" },
+    ];
+    const out = hardenOpenaiAssistantContent(msgs);
+    assert.equal(out[0], msgs[0], "user untouched");
+    assert.equal(out[1], msgs[1], "string assistant untouched");
+    assert.equal(out[2], msgs[2], "array assistant untouched");
+    assert.equal(out[3], msgs[3], "tool untouched");
+});
+
+test("harden: empty list stays empty", () => {
+    assert.deepEqual(hardenOpenaiAssistantContent([]), []);
+});
+
+test("adapter.buildRequest: every rebuilt assistant message carries string content end-to-end", () => {
+    const body: OpenAIRequestBody = {
+        messages: [
+            { role: "system", content: "you are helpful" },
+            { role: "user", content: "hi" },
+            { role: "assistant", content: "", reasoning_content: "truncated reasoning..." },
+            { role: "user", content: "continue" },
+        ],
+    };
+    const { msgs } = openaiToCore(body);
+    const adapter = createOpenaiAdapter({ model: "gpt" });
+    const req = adapter.buildRequest(msgs, "", { model: "gpt" });
+    const messages = req.messages as Array<{ role: string; content?: unknown; reasoning_content?: string }>;
+    const asst = messages.filter((m) => m.role === "assistant");
+    assert.equal(asst.length, 1, "reasoning-only turn not dropped");
+    assert.equal(typeof asst[0]?.content, "string", "assistant content is a string on the wire");
+    assert.equal(asst[0]?.content, "");
+    assert.equal(asst[0]?.reasoning_content, "truncated reasoning...");
+});


### PR DESCRIPTION
## Problem (#719)

DSH plan mode, round 2+: upstream rejects with `400 Invalid assistant message: content or tool_calls must be set` (DeepSeek).

Verified root cause: when an upstream stream is truncated mid-reasoning (no completion event), the assistant turn ends up reasoning-only. `openaiToCore` drops empty text (`if (text)` is falsy for `""`), so BOTH `content:""` and `content:null` inputs rebuild as a reasoning-only core message — and `coreToOpenai` (acp-kernel 0.0.63) emits `content: null` for those turns (`dist/wire/index.js` flush(): `content: pending.text ?? null` / reasoning-only branch `content: null`). DeepSeek requires string content (possibly `""`) or tool_calls for assistant messages; the user empirically confirmed `content:""` + `reasoning_content` → 200 direct.

## Fix

Normalize at the proxy's outbound boundary instead of waiting on an acp-kernel release: new `hardenOpenaiAssistantContent()` in `src/util.ts` maps any assistant message whose `content` is `null`/`undefined` to `{...m, content: ""}` (identity no-op otherwise). Applied at both `coreToOpenai` call sites:

- `src/server.ts` `prepareOpenai` — main request pipeline
- `src/loop/adapter-openai.ts` `buildRequest` — proxy-side compress-loop rounds

Mode-neutral (plugin/proxy): pure outbound normalization after wire rebuild. Deterministic across turns → prefix-cache stable. These messages previously always 400'd on DeepSeek, so nothing working changes shape.

Note: the kernel-side equivalent (flush() emitting `""` instead of `null`) remains worth doing upstream; this PR makes the proxy robust regardless of kernel version.

## Tests

New `tests/openai-assistant-content-harden.test.ts` (6 tests): #719 repro asserting raw kernel output is `content:null` and hardened output is `""`; `content:null` input variant; tool_calls branch normalization with tool_calls preserved; identity no-ops; empty list; end-to-end `adapter.buildRequest` wire check.

## Pre-flight

- `npm run typecheck` — clean
- `npm test` — 1377 pass / 0 fail / 2 skipped (e2e gate)
- `npm run build` — success

Fixes #719