### PR TITLE
fix: synthesize terminal/error sequence when plugin-mode streams end without one (#721)

### DIFF
--- a/src/exit-matrix.ts
+++ b/src/exit-matrix.ts
@@ -54,13 +54,13 @@ export const ERROR_DELIVERY: Record<WireExitId, ExitCell> = {
     },
     "plugin-chat-sse": {
         implementer: [pipePluginChatWithStrip],
-        contract: "byte-faithful passthrough: pre-stream fetch failure → JSON `{error: formatUpstreamError}` before any SSE byte; mid-stream cut → stream simply ends (no synthetic error event — the agent's tool loop must not see fabricated events)",
-        coveredBy: ["tests/issue411-abort-usage.test.ts", "tests/plugin-agent.test.ts"],
+        contract: "byte-faithful passthrough: pre-stream fetch failure → JSON `{error: formatUpstreamError}` before any SSE byte; upstream cut without terminal event → synthesized terminal byte when a finish reason was delivered, else protocol-native in-band error event (#721); client abort → clean end",
+        coveredBy: ["tests/issue411-abort-usage.test.ts", "tests/plugin-agent.test.ts", "tests/plugin-truncation-weak-overflow.test.ts"],
     },
     "plugin-responses-sse": {
         implementer: [pipePluginResponsesWithStrip],
         contract: "same as plugin-chat-sse, responses wire",
-        coveredBy: ["tests/issue411-abort-usage.test.ts"],
+        coveredBy: ["tests/issue411-abort-usage.test.ts", "tests/plugin-truncation-weak-overflow.test.ts"],
     },
     "plugin-json": {
         implementer: [pipePluginJson],

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -901,7 +901,17 @@ export async function pipePluginChatWithStrip(
             }
             if (res.destroyed || res.writableEnded) break;
         }
-        if (buf.length > 0 && !res.destroyed && !res.writableEnded) await write(buf);
+        // #721: upstream EOF without a terminal event must not close the
+        // stream bare — the agent would persist the partial turn as complete
+        // (the #719 chain). finished=true when a finish reason was delivered:
+        // only the trailing terminal byte ([DONE]/message_stop) is missing.
+        const truncated = !sawTerminal && !res.destroyed && !res.writableEnded;
+        // A dangling partial event left in buf by a mid-event cut would fuse
+        // with the next complete frame — SSE joins every data line inside one
+        // blank-line-delimited block — corrupting the truncation signal. Drop
+        // it when the signal follows: an unterminated event is unparseable by
+        // the client anyway (same as the pre-#721 bare end).
+        if (!truncated && buf.length > 0 && !res.destroyed && !res.writableEnded) await write(buf);
         const rest = flushTails();
         if (rest.length > 0 && !res.destroyed && !res.writableEnded) await write(rest);
         // Settle BEFORE res.end() in the finally below: the client can issue
@@ -911,11 +921,7 @@ export async function pipePluginChatWithStrip(
         settleUsage();
         maybeNoteTruncated();
         maybeWarnDegenerate();
-        // #721: upstream EOF without a terminal event must not close the
-        // stream bare — the agent would persist the partial turn as complete
-        // (the #719 chain). finished=true when a finish reason was delivered:
-        // only the trailing terminal byte ([DONE]/message_stop) is missing.
-        if (!sawTerminal && !res.destroyed && !res.writableEnded) {
+        if (truncated) {
             emitUpstreamTruncation(res, protocol, finalFinishReason !== undefined, log);
             return;
         }
@@ -929,9 +935,10 @@ export async function pipePluginChatWithStrip(
         // #721: upstream read failed while the client is still connected —
         // deliver the in-band truncation signal instead of rethrowing into
         // the top-level handler, which would close the stream bare. Flush
-        // held tag tails first so partial prose is never silently lost.
+        // held tag tails first so partial prose is never silently lost. The
+        // dangling partial event left in buf is dropped (see EOF path above):
+        // written raw it would fuse with the signal frame.
         try {
-            if (buf.length > 0) await write(buf);
             const rest = flushTails();
             if (rest.length > 0) await write(rest);
         } catch {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -10,6 +10,7 @@ import { executeProxyTool } from "./loop/core.js";
 import { normalizeSseLineEndings } from "./sse-util.js";
 import { containsRenderTagText, createTagEchoFilter, mayStartRenderTag, stripAnthropicText, stripOpenaiChatText, stripResponsesText, type TagEchoFilter } from "./loop/tag-echo-filter.js";
 import { log as loggerLog } from "./logger.js";
+import { emitUpstreamTruncation } from "./stream-error.js";
 import { degenerateTurnWarning } from "./degenerate-turn.js";
 import { noteWeakOverflow } from "./weak-overflow.js";
 import { warnCacheCollapse } from "./cache-warn.js";
@@ -910,6 +911,14 @@ export async function pipePluginChatWithStrip(
         settleUsage();
         maybeNoteTruncated();
         maybeWarnDegenerate();
+        // #721: upstream EOF without a terminal event must not close the
+        // stream bare — the agent would persist the partial turn as complete
+        // (the #719 chain). finished=true when a finish reason was delivered:
+        // only the trailing terminal byte ([DONE]/message_stop) is missing.
+        if (!sawTerminal && !res.destroyed && !res.writableEnded) {
+            emitUpstreamTruncation(res, protocol, finalFinishReason !== undefined, log);
+            return;
+        }
     } catch (e) {
         settleUsage();
         maybeNoteTruncated();
@@ -917,7 +926,20 @@ export async function pipePluginChatWithStrip(
             log?.("client aborted mid-stream");
             return;
         }
-        throw e;
+        // #721: upstream read failed while the client is still connected —
+        // deliver the in-band truncation signal instead of rethrowing into
+        // the top-level handler, which would close the stream bare. Flush
+        // held tag tails first so partial prose is never silently lost.
+        try {
+            if (buf.length > 0) await write(buf);
+            const rest = flushTails();
+            if (rest.length > 0) await write(rest);
+        } catch {
+            /* client half-gone; the emission below is best-effort too */
+        }
+        loggerLog("warn", `[plugin] upstream stream read failed (${protocol}): ${String(e instanceof Error ? e.message : e)} — emitting in-band truncation signal`);
+        emitUpstreamTruncation(res, protocol, finalFinishReason !== undefined, log);
+        return;
     } finally {
         reader.releaseLock();
         res.end();
@@ -1111,6 +1133,13 @@ export async function pipePluginResponsesWithStrip(
         maybeWarnDegenerate();
         settleUsage();
         maybeNoteTruncated();
+        // #721: same as the chat-pipe twin — never close bare on a missing
+        // done-family event. Responses has no separate finish-reason concept
+        // (terminal events carry the status), so this is always the error shape.
+        if (!sawTerminal && !res.destroyed && !res.writableEnded) {
+            emitUpstreamTruncation(res, "responses", false, log);
+            return;
+        }
     } catch (e) {
         settleUsage();
         maybeNoteTruncated();
@@ -1118,7 +1147,19 @@ export async function pipePluginResponsesWithStrip(
             log?.("client aborted mid-stream");
             return;
         }
-        throw e;
+        // #721: upstream read failed while the client is still connected —
+        // deliver the in-band truncation signal instead of rethrowing into
+        // the top-level handler, which would close the stream bare. Flush
+        // held tag tails first so partial prose is never silently lost.
+        try {
+            const rest = flushTail("");
+            if (rest.length > 0) await write(rest);
+        } catch {
+            /* client half-gone; the emission below is best-effort too */
+        }
+        loggerLog("warn", `[plugin] upstream stream read failed (responses): ${String(e instanceof Error ? e.message : e)} — emitting in-band truncation signal`);
+        emitUpstreamTruncation(res, "responses", false, log);
+        return;
     } finally {
         reader.releaseLock();
         res.end();

--- a/src/server.ts
+++ b/src/server.ts
@@ -3698,9 +3698,10 @@ async function forward(
     // opt-in #371 fake-completion backstop buffers + retries first, same as
     // proxy mode (#473).
     if (prepared?.pluginMode) {
-        // #411: clear the idle timer on the abort path too — the pipes rethrow
-        // when the client is still connected, and a client cancel throws from
-        // inside them; without a finally each abort leaked an idle timer.
+        // #411: clear the idle timer on every path — resolveFakeCompletion and
+        // other failures still escape these pipes; without a finally each one
+        // leaked a live idle timer. (#721: the SSE pipes themselves no longer
+        // rethrow an upstream cut — they emit an in-band truncation signal.)
         try {
             let pluginBody = upstream.body as ReadableStream<Uint8Array>;
             if (prepared.stream && maxFakeCompletionRetries() > 0) {

--- a/src/stream-error.ts
+++ b/src/stream-error.ts
@@ -72,6 +72,55 @@ export function emitStreamError(res: http.ServerResponse, protocol: Protocol, me
 }
 
 /**
+ * #721: the upstream stream ended without a terminal event — clean EOF with
+ * no [DONE] / message_stop / completed-family event, or a read failure while
+ * the client is still connected. Without intervention the client sees a bare
+ * cut-off SSE and persists the partial turn as complete (the #719 chain).
+ * Two shapes:
+ *  - finished=true: a finish reason WAS delivered (OpenAI finish_reason chunk
+ *    / Anthropic message_delta stop_reason); only the final terminal byte was
+ *    lost → synthesize just that byte (silent completion).
+ *  - finished=false: true mid-generation cut → protocol-native in-band error
+ *    event, same shapes as emitPreflightError (#568): openai top-level `error`
+ *    data frame + [DONE]; anthropic/responses `event: error`. A fabricated
+ *    response.failed lifecycle object is deliberately avoided — the pipe does
+ *    not track the full output-item list, and strict clients (codex) crash on
+ *    half-consistent terminal payloads (see emitStreamError). The responses
+ *    wire has no separate finish-reason concept (terminal events carry the
+ *    status), so !sawTerminal ⇒ finished=false always there.
+ * Never throws.
+ */
+export function emitUpstreamTruncation(res: http.ServerResponse, protocol: Protocol, finished: boolean, log?: (msg: string) => void): void {
+    const message = "upstream stream ended before a completion event; this turn may be incomplete";
+    log?.(`[acp-proxy: upstream stream truncated (${protocol})${finished ? " — finish reason seen, synthesizing missing terminal byte" : " — emitting in-band error"}]`);
+    try {
+        if (protocol === "openai") {
+            if (finished) {
+                safeWrite(res, "data: [DONE]\n\n");
+            } else {
+                safeWrite(res, `data: ${JSON.stringify({ error: { type: "server_error", code: "upstream_stream_truncated", message } })}\n\ndata: [DONE]\n\n`);
+            }
+        } else if (protocol === "responses") {
+            safeWrite(res, `event: error\ndata: ${JSON.stringify({ type: "error", code: "upstream_stream_truncated", message })}\n\n`);
+        } else {
+            if (finished) {
+                safeWrite(res, `event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`);
+            } else {
+                safeWrite(res, `event: error\ndata: ${JSON.stringify({ type: "error", error: { type: "server_error", code: "upstream_stream_truncated", message } })}\n\n`);
+            }
+        }
+    } catch {
+        /* best-effort */
+    } finally {
+        try {
+            res.end();
+        } catch {
+            /* already closed */
+        }
+    }
+}
+
+/**
  * #568: deliver a preflight fail-fast error IN-BAND, after the proxy already
  * committed `200` early to hold the client through a long compression (see
  * beginPreflightHold in server.ts). The status line can no longer change, so

--- a/tests/plugin-truncation-weak-overflow.test.ts
+++ b/tests/plugin-truncation-weak-overflow.test.ts
@@ -248,3 +248,43 @@ test("#721 chat pipe: no session (#460 non-injected branch) still gets the in-ba
     assert.ok(out.includes(TRUNC_MARKER));
     assert.ok(out.includes("data: [DONE]"));
 });
+
+// #721 review: a cut landing MID-EVENT leaves a dangling partial SSE line in
+// the pipe's buffer. SSE joins every `data:` line inside one blank-line-
+// delimited block, so writing that fragment before the synthesized signal
+// fuses the two into a single malformed frame (corrupting the signal). The
+// fragment must be dropped — matching the responses pipe, which never writes
+// raw buf. These assert every emitted data payload is standalone-parseable.
+function sseDataEvents(out: string): string[] {
+    return out.split("\n\n").filter((b) => b.trim().length > 0).map((block) =>
+        block.split("\n").filter((l) => l.startsWith("data:")).map((l) => l.slice(5).replace(/^ /, "")).join("\n"),
+    );
+}
+
+const PARTIAL_CHUNK = `data: ${JSON.stringify({ id: "c1", object: "chat.completion.chunk", created: 1, model: "qwen", choices: [{ index: 0, delta: { content: "tial" }, finish_reason: null }] })}`; // NO trailing \n\n
+
+test("#721 review (openai, EOF): mid-event cut drops the dangling fragment; signal stays well-formed", async () => {
+    const { res, chunks } = makeRes();
+    await pipePluginChatWithStrip(streamOf([chatChunk({ content: "par" }), PARTIAL_CHUNK]), res, "openai", makeSession());
+    const out = chunks.join("");
+    assert.ok(!out.includes("tial"), "dangling partial event must be dropped, not fused into the signal");
+    for (const ev of sseDataEvents(out)) {
+        if (ev === "[DONE]") continue;
+        JSON.parse(ev);
+    }
+    assert.ok(sseDataEvents(out).some((ev) => ev.includes(TRUNC_MARKER)), "error frame still delivered as its own event");
+});
+
+test("#721 review (openai, read failure): mid-event cut drops the dangling fragment; signal stays well-formed", async () => {
+    const { res, chunks } = makeRes();
+    await assert.doesNotReject(
+        pipePluginChatWithStrip(failingStream([chatChunk({ content: "par" }), PARTIAL_CHUNK], new Error("other side closed")), res, "openai", makeSession()),
+    );
+    const out = chunks.join("");
+    assert.ok(!out.includes("tial"), "dangling partial event must be dropped on the read-failure path too");
+    for (const ev of sseDataEvents(out)) {
+        if (ev === "[DONE]") continue;
+        JSON.parse(ev);
+    }
+    assert.ok(sseDataEvents(out).some((ev) => ev.includes(TRUNC_MARKER)), "error frame still delivered as its own event");
+});

--- a/tests/plugin-truncation-weak-overflow.test.ts
+++ b/tests/plugin-truncation-weak-overflow.test.ts
@@ -118,3 +118,133 @@ test("responses pipe: response.completed terminates, no signal", async () => {
     }
     assert.equal(learnedOf(session), undefined);
 });
+
+// #721: a plugin-mode stream that ends without a terminal event must hand the
+// client a well-formed end of stream (synthesized terminal byte or in-band
+// error event) instead of a bare cut-off SSE.
+
+const TRUNC_MARKER = "upstream_stream_truncated";
+
+function failingStream(chunks: string[], err: Error): ReadableStream<Uint8Array> {
+    const enc = new TextEncoder();
+    let i = 0;
+    return new ReadableStream<Uint8Array>({
+        pull(controller) {
+            if (i < chunks.length) {
+                controller.enqueue(enc.encode(chunks[i]));
+                i += 1;
+            } else {
+                controller.error(err);
+            }
+        },
+    });
+}
+
+test("#721 chat pipe (openai): mid-generation cut emits in-band error frame + [DONE]", async () => {
+    const { res, chunks } = makeRes();
+    await pipePluginChatWithStrip(streamOf([chatChunk({ content: "partial" })]), res, "openai", makeSession());
+    const out = chunks.join("");
+    assert.ok(out.includes('"content":"partial"'), "partial content still forwarded");
+    const errIdx = out.indexOf(TRUNC_MARKER);
+    const doneIdx = out.indexOf("data: [DONE]");
+    assert.ok(errIdx !== -1, "in-band error frame emitted");
+    assert.ok(doneIdx !== -1 && doneIdx > errIdx, "[DONE] terminates the stream after the error frame");
+    assert.ok(out.includes(`"type":"server_error"`), "error frame carries the server_error type");
+});
+
+test("#721 chat pipe (openai): finish_reason seen, [DONE] lost → bare [DONE] synthesized, no error", async () => {
+    const finish = `data: ${JSON.stringify({ id: "chatcmpl-1", object: "chat.completion.chunk", created: 1, model: "qwen", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] })}\n\n`;
+    const { res, chunks } = makeRes();
+    await pipePluginChatWithStrip(streamOf([chatChunk({ content: "done turn" }), finish]), res, "openai", makeSession());
+    const out = chunks.join("");
+    assert.ok(!out.includes(TRUNC_MARKER), "no error frame when a finish reason was delivered");
+    assert.ok(out.endsWith("data: [DONE]\n\n"), "missing terminal byte synthesized");
+});
+
+test("#721 chat pipe (anthropic): stop_reason seen, message_stop lost → message_stop synthesized, no error", async () => {
+    const start = `event: message_start\ndata: ${JSON.stringify({ type: "message_start", message: { usage: { input_tokens: 95000 } } })}\n\n`;
+    const mdelta = `event: message_delta\ndata: ${JSON.stringify({ type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 5 } })}\n\n`;
+    const { res, chunks } = makeRes();
+    await pipePluginChatWithStrip(streamOf([start, mdelta]), res, "anthropic", makeSession());
+    const out = chunks.join("");
+    assert.ok(!out.includes(TRUNC_MARKER), "no error event when stop_reason was delivered");
+    assert.ok(out.endsWith(`event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`), "missing message_stop synthesized");
+});
+
+test("#721 chat pipe (anthropic): cut before stop_reason → in-band error event", async () => {
+    const start = `event: message_start\ndata: ${JSON.stringify({ type: "message_start", message: { usage: { input_tokens: 95000 } } })}\n\n`;
+    const { res, chunks } = makeRes();
+    await pipePluginChatWithStrip(streamOf([start]), res, "anthropic", makeSession());
+    const out = chunks.join("");
+    const errIdx = out.indexOf(TRUNC_MARKER);
+    assert.ok(errIdx !== -1, "in-band error event emitted");
+    const evIdx = out.indexOf("event: error");
+    assert.ok(evIdx !== -1 && evIdx < errIdx, "delivered on the Anthropic error event channel");
+});
+
+test("#721 chat pipe (openai): upstream read failure emits in-band error instead of rethrowing", async () => {
+    const { res, chunks } = makeRes();
+    await assert.doesNotReject(
+        pipePluginChatWithStrip(failingStream([chatChunk({ content: "partial" })], new Error("other side closed")), res, "openai", makeSession()),
+    );
+    const out = chunks.join("");
+    assert.ok(out.includes('"content":"partial"'), "partial content still forwarded before the failure");
+    const errIdx = out.indexOf(TRUNC_MARKER);
+    const doneIdx = out.lastIndexOf("data: [DONE]");
+    assert.ok(errIdx !== -1, "in-band error frame emitted");
+    assert.ok(doneIdx > errIdx, "[DONE] terminates the stream after the error frame");
+});
+
+test("#721 chat pipe (openai): read failure AFTER finish_reason → bare [DONE], no error", async () => {
+    const finish = `data: ${JSON.stringify({ id: "chatcmpl-1", object: "chat.completion.chunk", created: 1, model: "qwen", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] })}\n\n`;
+    const { res, chunks } = makeRes();
+    await assert.doesNotReject(
+        pipePluginChatWithStrip(failingStream([chatChunk({ content: "x" }), finish], new Error("socket hang up")), res, "openai", makeSession()),
+    );
+    const out = chunks.join("");
+    assert.ok(!out.includes(TRUNC_MARKER));
+    assert.ok(out.endsWith("data: [DONE]\n\n"));
+});
+
+test("#721 responses pipe: mid-stream cut emits in-band error event instead of bare close", async () => {
+    const delta = `data: ${JSON.stringify({ type: "response.output_text.delta", delta: "hello" })}\n\n`;
+    const { res, chunks } = makeRes();
+    await pipePluginResponsesWithStrip(streamOf([delta]), res, makeSession());
+    const out = chunks.join("");
+    const errIdx = out.indexOf(TRUNC_MARKER);
+    assert.ok(errIdx !== -1, "in-band error event emitted");
+    const evIdx = out.indexOf("event: error");
+    assert.ok(evIdx !== -1 && evIdx < errIdx, "delivered on the Responses error event channel");
+});
+
+test("#721 responses pipe: upstream read failure emits in-band error instead of rethrowing", async () => {
+    const delta = `data: ${JSON.stringify({ type: "response.output_text.delta", delta: "hello" })}\n\n`;
+    const { res, chunks } = makeRes();
+    await assert.doesNotReject(pipePluginResponsesWithStrip(failingStream([delta], new Error("fetch failed")), res, makeSession()));
+    const out = chunks.join("");
+    assert.ok(out.includes('"delta":"hello"'));
+    assert.ok(out.indexOf(TRUNC_MARKER) !== -1);
+});
+
+test("#721 chat pipe: client abort suppresses the synthesized terminal/error", async () => {
+    const { res, chunks } = makeRes();
+    res.destroyed = true;
+    await pipePluginChatWithStrip(streamOf([chatChunk({ content: "x" })]), res, "openai", makeSession());
+    assert.ok(!chunks.join("").includes(TRUNC_MARKER), "no in-band error for a gone client");
+});
+
+test("#721 responses pipe: client abort suppresses the synthesized terminal/error", async () => {
+    const delta = `data: ${JSON.stringify({ type: "response.output_text.delta", delta: "hello" })}\n\n`;
+    const { res, chunks } = makeRes();
+    res.destroyed = true;
+    await pipePluginResponsesWithStrip(failingStream([delta], new Error("aborted")), res, makeSession());
+    assert.ok(!chunks.join("").includes(TRUNC_MARKER), "no in-band error for a gone client");
+});
+
+test("#721 chat pipe: no session (#460 non-injected branch) still gets the in-band error", async () => {
+    const { res, chunks } = makeRes();
+    await pipePluginChatWithStrip(streamOf([chatChunk({ content: "x" })]), res, "openai");
+    const out = chunks.join("");
+    assert.ok(out.includes(TRUNC_MARKER));
+    assert.ok(out.includes("data: [DONE]"));
+});


### PR DESCRIPTION
## Problem (#721)

In plugin mode (agent-owned compression: `bili dsh` / `bili omp` / ...), when the upstream model stream terminates abnormally mid-turn — clean EOF with no finish_reason/[DONE]/message_stop/done-family event, or an upstream read failure while the client is still connected — the proxy closed the response right after the last received chunk. The agent client received a bare cut-off SSE with NO completion or error event and persisted the partial turn as if it were complete (the chain that produced #719).

Two shapes, both verified on master f85553b:
- **Clean EOF without a terminal event**: `maybeNoteTruncated` only records server-side (`noteWeakOverflow`), then `finally { res.end() }` closes the stream. Nothing client-visible.
- **Upstream read throw** (RST/timeout/idle abort): the pipe rethrew; the plugin branch in `src/server.ts` has no catch; the top-level handler does a bare `res.end()` when headers are already sent.

## Fix

New `emitUpstreamTruncation(res, protocol, finished, log?)` in `src/stream-error.ts` (sibling of `emitStreamError`/`emitPreflightError`; best-effort, never throws, ends res). Both plugin pipes now call it before closing when `!sawTerminal` and the client is still connected:

- **Case A — finish reason delivered, final terminal byte lost** (OpenAI `finish_reason` chunk / Anthropic `message_delta.stop_reason` seen): synthesize ONLY the missing terminal byte (`data: [DONE]` / `event: message_stop`). Silent completion — the model genuinely finished.
- **Case B — true mid-generation cut** (no finish reason): protocol-native in-band error event, same shapes as `emitPreflightError` (#568): OpenAI top-level `error` data frame `{type:"server_error", code:"upstream_stream_truncated"}` + `[DONE]`; Anthropic/Responses `event: error`. Deliberately NOT a fabricated `response.failed` lifecycle object — the pipe does not track the full output-item list, and strict clients (codex) crash on half-consistent terminal payloads (see the `emitStreamError` comment). Responses always takes the error shape because its terminal events carry the status (no separate finish-reason concept).
- **Throw shape**: both pipes' `catch` now flushes held tag tails (partial prose is never silently lost) and emits the in-band signal instead of rethrowing into the top-level handler's bare close. Client-abort early-return unchanged. The stale rethrow-contract comment at the server.ts plugin branch is updated.

Free coverage: the #460 non-injected proxy-mode branches reuse these same pipes (`src/server.ts:3776`, `3800-3802`) and get the same protection; the `resetAfterSuccess` native-compaction branch now reaches its "rebase NOT scheduled" log path cleanly on truncation instead of throwing into the top level.

Semantics implemented per the recommendation posted in the #721 thread (error framing over silent-stop; no visible content marker). If a different semantic was intended, it is a small change confined to the single helper.

Known residual edge (out of scope): with the opt-in #371 fake-completion backstop enabled, plugin bodies buffer through `resolveFakeCompletion` first, and a read error there still escapes to the top-level bare close. Follow-up candidate: porting the #413 zero-content retry into the plugin pipes (needs re-fetch plumbing; separate PR per the thread discussion).

## Tests

Extended `tests/plugin-truncation-weak-overflow.test.ts` (+11 tests): per-protocol x per-case wire assertions (openai mid-cut → error frame + [DONE]; openai finish-seen → bare [DONE], no error; anthropic stop_reason-seen → message_stop synthesized; anthropic pre-stop cut → error event; responses mid-cut → error event), both throw shapes (mid-generation and post-finish-reason), client-abort suppression (both pipes), and the no-session #460 variant.

## Pre-flight

- `npm run typecheck` — clean
- `npm test` — 1382 pass / 0 fail / 2 skipped (e2e gate)
- `npm run build` — success; verified `upstream_stream_truncated` present in `dist/index.js`
- `E2E_CHECK=1` codex pre-flight — pass (codex binary present). Full `ACP_TEST_E2E` run not possible in this sandbox (no local upstream at 127.0.0.1:8199 — same constraint noted in #720); the changed paths are unit-covered per protocol x case, including both truncation shapes.

Pre-ship verification item from the issue thread: confirm each registered client's mid-stream error handling (pi / omp / opencode / dsh) against a real session before merge — dsh's behavior on OpenAI-wire error frames is the unknown one.

Fixes #721