### PR TITLE
chore(#723): pin acp-kernel 0.0.64

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.105",
+  "version": "0.1.106",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.105",
+      "version": "0.1.106",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@types/node": "^22.0.0",
         "@types/node-forge": "^1.3.14",
-        "acp-kernel": "0.0.63",
+        "acp-kernel": "0.0.64",
         "fzstd": "0.1.1",
         "node-forge": "^1.4.0",
         "tar": "^7.5.22",
@@ -546,9 +546,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -650,9 +647,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -667,9 +661,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -684,9 +675,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -701,9 +689,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -718,9 +703,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -735,9 +717,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -752,9 +731,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -769,9 +745,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -786,9 +759,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -803,9 +773,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -820,9 +787,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -837,9 +801,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -854,9 +815,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -988,9 +946,9 @@
       }
     },
     "node_modules/acp-kernel": {
-      "version": "0.0.63",
-      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.63.tgz",
-      "integrity": "sha512-hM437yJ+iDeYzXMRZ6pIO37o+qS9i27GPO24xGDcEWKjFIb2GPJOQkqURI7rtdiouPnDX1bWojUjPyLghz0jDQ==",
+      "version": "0.0.64",
+      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.64.tgz",
+      "integrity": "sha512-zmxYKbK2qBD6sq321Y+FwuVAwNWAEgOaiL0lFAAH3pHD6iXGRhlvcFUiHuGCDfAMTfo3v8WnEFZ+PICwYa6Lsw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/node-forge": "^1.3.14",
-    "acp-kernel": "0.0.63",
+    "acp-kernel": "0.0.64",
     "fzstd": "0.1.1",
     "node-forge": "^1.4.0",
     "tar": "^7.5.22",


### PR DESCRIPTION
Version bump only: acp-kernel 0.0.63 → 0.0.64 (+ lockfile).

0.0.64 ships the #375 fix on the kernel side (acp-kernel#253): the efficiency/emergency nudge now carries the active block map (`Active blocks (N): b1=m00001–m00009 · b2=...`, non-tier-1 suffixed `tN`, oldest collapsed beyond 8) plus per-range user-message counts (`· N user msgs`). Nudge text is rendered by the kernel (`renderNudgeText`), so the proxy needs zero code changes.

Verified on this branch: typecheck clean, 1371/1371 tests pass (2 skipped), build OK.

Fixes #723