### PR TITLE
release v0.1.107

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "billion-context",
-  "version": "0.1.106",
+  "version": "0.1.107",
   "description": "Context-compression proxy that lets AI coding agents run for days — billions of tokens through one context window. Sits between any agent (Claude Code, Codex, Cursor, Aider, …) and its model API, folding consumed conversation into reversible, prefix-cache-friendly summaries. Zero per-agent code: just point your base URL at the proxy.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## v0.1.107

Version bump only. Changes since v0.1.106:

- **fix(#721) #722**: synthesize protocol-native terminal/error sequence when plugin-mode upstream streams end without a terminal event — client no longer receives a bare cut-off SSE and persists partial turns as complete (root of the #719/#720 chain)
- **fix(#719) #720**: harden rebuilt assistant `content` null→"" for OpenAI-compatible backends so persisted reasoning-only turns re-send cleanly instead of 400ing
- **fix(#717) #718**: strip model-forged ACP confirmation markers on every model-output path + state the marker contract in all nudges/injected compress prompts (self-receipt hallucination)
- **fix(#714) #716**: search_context with zero active blocks reports an explicit empty state (🔍, not ❌ failure); shared executeSearchContext dedups three wire handlers
- **chore(#723) #724**: pin acp-kernel 0.0.64

## Pre-flight (local, matches CI)

- typecheck: clean
- test: 1421 files / 1419 pass / 0 fail (2 skipped = e2e gate)
- build: dist/index.js self-contained, success