### PR TITLE
fix: recover preflight from empty SSE summaries + dead-end cooldown (#726)

### DIFF
--- a/src/preflight.ts
+++ b/src/preflight.ts
@@ -70,6 +70,13 @@ export interface PreflightFailure {
     detail: string;
 }
 
+// #726: a summarization call can return HTTP 200 yet carry no usable summary
+// text (in-stream error event, truncated stream, empty completion). The
+// unusable branch carries a diagnosis of what the body actually contained so
+// it is logged and surfaced in the fail-fast message instead of the generic
+// "summary too short".
+type SummaryOutcome = { summary: string } | { unusable: string };
+
 export interface PreflightResult {
     compressedRanges: number;
     savedTokens: number;
@@ -165,6 +172,14 @@ function rangeChars(messages: CoreMessage[], startIdx: number, endIdx: number): 
         chars += (messages[i].text ?? "").length;
     }
     return chars;
+}
+
+function spanUnitsOf(messages: CoreMessage[], startIdx: number, endIdx: number, countText: (text: string) => number): number {
+    let units = 0;
+    for (let i = startIdx; i <= endIdx && i < messages.length; i++) {
+        units += countText(messages[i].text ?? "");
+    }
+    return units;
 }
 
 function renderRange(messages: CoreMessage[], startIdx: number, endIdx: number): string {
@@ -359,7 +374,78 @@ function extractSummaryText(protocol: PreflightProtocol, json: Record<string, un
         .join("");
 }
 
-async function summarizeRange(deps: PreflightDeps, content: string, startRef: string, endRef: string): Promise<string | null> {
+// #726: an HTTP-200 summarization body can still be a rejection — the upstream
+// may end its SSE stream with an error event (`error`, `response.failed`) or an
+// incomplete response, or answer with a bare JSON error object. Without this
+// scan such bodies are silently discarded and the only trace is "summary too
+// short (0 chars)" with no way to tell size-driven from systemic failures.
+function extractStreamError(o: Record<string, unknown>): string | null {
+    const t = typeof o.type === "string" ? o.type : undefined;
+    if (t === "error") {
+        const e = o.error;
+        if (e && typeof e === "object") {
+            const eo = e as Record<string, unknown>;
+            return `the upstream reported an in-stream error: ${typeof eo.message === "string" ? eo.message : JSON.stringify(eo).slice(0, 200)}`;
+        }
+        if (typeof o.message === "string") return `the upstream reported an in-stream error: ${o.message}`;
+        return "the upstream reported an in-stream error";
+    }
+    if (t === "response.failed" || t === "response.error") {
+        const resp = o.response;
+        if (resp && typeof resp === "object") {
+            const e = (resp as Record<string, unknown>).error;
+            if (e && typeof e === "object") {
+                const eo = e as Record<string, unknown>;
+                const code = typeof eo.code === "string" ? ` (${eo.code})` : "";
+                return `the upstream stream ended with a failed response${code}: ${typeof eo.message === "string" ? eo.message : JSON.stringify(eo).slice(0, 200)}`;
+            }
+        }
+        return "the upstream stream ended with a failed response";
+    }
+    if (t === "response.incomplete") {
+        const resp = (o.response ?? {}) as Record<string, unknown>;
+        const status = typeof resp.status === "string" ? resp.status : "unknown";
+        const e = resp.error as Record<string, unknown> | undefined;
+        const msg = e && typeof e.message === "string" ? ` (${e.message})` : "";
+        return `the upstream stream ended incomplete (status=${status}${msg})`;
+    }
+    if (!t && o.error && typeof o.error === "object") {
+        const eo = o.error as Record<string, unknown>;
+        return `the upstream reported an error: ${typeof eo.message === "string" ? eo.message : JSON.stringify(eo).slice(0, 200)}`;
+    }
+    return null;
+}
+
+export function diagnoseEmptySummary(text: string, json?: unknown): string {
+    if (json && typeof json === "object") {
+        const err = extractStreamError(json as Record<string, unknown>);
+        if (err) return err;
+    }
+    let sseEvents = 0;
+    let firstPayload = "";
+    for (const line of text.split("\n")) {
+        if (!line.startsWith("data:")) continue;
+        const payload = line.slice(5).trim();
+        if (!payload || payload === "[DONE]") continue;
+        if (!firstPayload) firstPayload = payload.slice(0, 200);
+        let obj: unknown;
+        try {
+            obj = JSON.parse(payload);
+        } catch {
+            continue;
+        }
+        if (!obj || typeof obj !== "object") continue;
+        sseEvents += 1;
+        const err = extractStreamError(obj as Record<string, unknown>);
+        if (err) return err;
+    }
+    if (sseEvents > 0) return `the upstream stream carried ${sseEvents} SSE event(s) but no summary text (first event: ${firstPayload})`;
+    const trimmed = text.trim();
+    if (!trimmed) return "the upstream returned an empty body";
+    return `the upstream returned a non-SSE body with no summary text (first 200 bytes: ${trimmed.slice(0, 200)})`;
+}
+
+async function summarizeRange(deps: PreflightDeps, content: string, startRef: string, endRef: string): Promise<SummaryOutcome> {
     const system =
         buildCompressSystemPrompt(deps.prompts) +
         `\n\nTASK: The conversation segment below (messages ${startRef}–${endRef}) must be compressed because the session context exceeds the current model's window. Write a tier-1 compression summary of the segment following every rule above. Output ONLY the summary text — no preamble, no closing remarks, no tool calls.`;
@@ -396,7 +482,7 @@ async function summarizeRange(deps: PreflightDeps, content: string, startRef: st
     }
 }
 
-async function requestSummary(deps: PreflightDeps, system: string, content: string, stream: boolean, includeMaxOutputTokens: boolean): Promise<string | null> {
+async function requestSummary(deps: PreflightDeps, system: string, content: string, stream: boolean, includeMaxOutputTokens: boolean): Promise<SummaryOutcome> {
     const { response, clearTimer } = await fetchWithRetry(
         deps.url,
         {
@@ -431,10 +517,11 @@ async function requestSummary(deps: PreflightDeps, system: string, content: stri
             deps.log("warn", `[preflight] summary response was not JSON: ${text.slice(0, 200)}`);
         }
         if (summary.length < MIN_SUMMARY_CHARS) {
-            deps.log("warn", `[preflight] summary too short (${summary.length} chars); skipping range`);
-            return null;
+            const diagnosis = diagnoseEmptySummary(text, json);
+            deps.log("warn", `[preflight] summary too short (${summary.length} chars): ${diagnosis}`);
+            return { unusable: diagnosis };
         }
-        return summary;
+        return { summary };
     } finally {
         clearTimer();
     }
@@ -486,6 +573,7 @@ export async function preflightCompress(deps: PreflightDeps, messages: CoreMessa
     let finalUpper = baselineKnown ? 0 : estimateCoreMessagesUpper(messages);
     let startTokens = -1;
     let failure: PreflightFailure | undefined;
+    let lastUnusableDetail: string | undefined;
     let activeConfig = deps.config;
     let relaxed = false;
     const relaxedExhaustedDetail =
@@ -581,13 +669,23 @@ export async function preflightCompress(deps: PreflightDeps, messages: CoreMessa
             // minUnits only in the char regime: with the optimistic token budget a
             // sub-minimum chunk is already rare, and keeping minUnits = 0 there
             // preserves the historical packing exactly.
-            for (const [cs, ce] of splitChunks(messages, startIdx, endIdx, budget, baselineKnown ? 0 : minChars, countText)) {
+            // #726: spans form a worklist instead of a flat pass. A chunk whose
+            // summary comes back unusable is halved (oldest half first) and
+            // retried down to a floor before the whole range is given up: the
+            // prime suspect for an empty summary is a CHUNK_FRACTION-sized chunk
+            // exceeding the upstream's real input cap, and halving recovers
+            // exactly those cases. Bounded by the per-regime call budget below.
+            const spans: Array<[number, number]> = splitChunks(messages, startIdx, endIdx, budget, baselineKnown ? 0 : minChars, countText).slice().reverse();
+            while (spans.length > 0) {
                 if (currentTokens < limit) break;
                 if (deps.signal?.aborted) {
                     failure = ABORTED_FAILURE;
                     break;
                 }
                 if (budgetHit) break;
+                const span = spans.pop();
+                if (!span) break;
+                const [cs, ce] = span;
                 const maps = refMaps(messages, deps.session.state);
                 const startRef = maps.idxToRef.get(cs);
                 const endRef = maps.idxToRef.get(ce);
@@ -600,9 +698,9 @@ export async function preflightCompress(deps: PreflightDeps, messages: CoreMessa
                     break;
                 }
                 summaryCalls += 1;
-                let summary: string | null;
+                let outcome: SummaryOutcome;
                 try {
-                    summary = await summarizeRange(deps, content, startRef, endRef);
+                    outcome = await summarizeRange(deps, content, startRef, endRef);
                 } catch (err) {
                     if (err instanceof UpstreamHttpError) {
                         failure = {
@@ -622,11 +720,21 @@ export async function preflightCompress(deps: PreflightDeps, messages: CoreMessa
                     }
                     break;
                 }
-                if (!summary) {
-                    deps.log("warn", `[preflight] range ${skipKey} produced no usable summary; skipping it`);
+                if ("unusable" in outcome) {
+                    lastUnusableDetail = outcome.unusable;
+                    const floorUnits = baselineKnown ? 2 * MIN_CHUNK_TOKENS : 2 * minChars;
+                    if (ce > cs && spanUnitsOf(messages, cs, ce, countText) >= floorUnits) {
+                        deps.log("warn", `[preflight] chunk ${startRef}:${endRef} produced no usable summary (${outcome.unusable}); retrying with smaller chunks`);
+                        const mid = Math.floor((cs + ce) / 2);
+                        spans.push([mid + 1, ce]);
+                        spans.push([cs, mid]);
+                        continue;
+                    }
+                    deps.log("warn", `[preflight] range ${skipKey} produced no usable summary even at minimum size (${outcome.unusable}); skipping it`);
                     skipSet.add(skipKey);
                     break;
                 }
+                const summary = outcome.summary;
                 const ctx: RewriteCtx = {
                     core: deps.core,
                     config: activeConfig,
@@ -659,14 +767,18 @@ export async function preflightCompress(deps: PreflightDeps, messages: CoreMessa
         if (appliedThisRound === 0) break;
     }
     if (currentTokens >= limit && !failure) {
+        // #726: carry the most recent unusable-summary diagnosis into the
+        // fail-fast message — "no range could be compressed" with no reason is
+        // undiagnosable from the client side.
+        const unusableNote = lastUnusableDetail ? ` Last unusable summary: ${lastUnusableDetail.slice(0, 300)}.` : "";
         if (budgetHit) {
-            failure = { kind: "exhausted", detail: `the preflight summarization budget (${MAX_SUMMARY_CALLS_PER_PREFLIGHT} calls per protection regime) was exhausted before the payload fit the window` };
+            failure = { kind: "exhausted", detail: `the preflight summarization budget (${MAX_SUMMARY_CALLS_PER_PREFLIGHT} calls per protection regime) was exhausted before the payload fit the window${unusableNote}` };
         } else if (relaxed && result.compressedRanges > 0) {
             failure = { kind: "exhausted", detail: relaxedExhaustedDetail };
         } else if (result.compressedRanges === 0) {
-            failure = { kind: "exhausted", detail: `no range could be compressed across ${rangesTried} viable range${rangesTried === 1 ? "" : "s"} (each was below minCompressRange, had an unusable summary, or failed to apply)` };
+            failure = { kind: "exhausted", detail: `no range could be compressed across ${rangesTried} viable range${rangesTried === 1 ? "" : "s"} (each was below minCompressRange, had an unusable summary, or failed to apply)${unusableNote}` };
         } else {
-            failure = { kind: "exhausted", detail: `the compress budget was exhausted after ${MAX_PREFLIGHT_ROUNDS} rounds` };
+            failure = { kind: "exhausted", detail: `the compress budget was exhausted after ${MAX_PREFLIGHT_ROUNDS} rounds${unusableNote}` };
         }
     }
     if (result.compressedRanges > 0) deps.session.stats.lastInputTokens = currentTokens;

--- a/src/server.ts
+++ b/src/server.ts
@@ -2972,6 +2972,23 @@ function preflightHoldGraceMs(): number {
     return Number.isFinite(v) && v >= 0 ? Math.floor(v) : PREFLIGHT_HOLD_GRACE_DEFAULT_MS;
 }
 
+// #726: a preflight that failed WITHOUT folding anything hit a deterministic
+// rejection under the current session state — a client that retries verbatim
+// (codex auto-retries every few seconds) re-runs the same doomed walk, burning
+// upstream quota on identical large summarization calls. Such failures arm a
+// per-session cooldown: matching requests fail fast with the cached diagnosis
+// and ZERO upstream calls until it expires. Any preflight outcome without a
+// failure clears the marker (the state changed — client shrank the
+// conversation, or the upstream recovered). Aborted failures never arm it.
+const PREFLIGHT_DEAD_END_COOLDOWN_DEFAULT_MS = 5 * 60_000;
+
+function preflightDeadEndCooldownMs(): number {
+    const raw = process.env.BILI_PREFLIGHT_DEAD_END_COOLDOWN_MS;
+    if (!raw) return PREFLIGHT_DEAD_END_COOLDOWN_DEFAULT_MS;
+    const v = Number(raw);
+    return Number.isFinite(v) && v >= 0 ? Math.floor(v) : PREFLIGHT_DEAD_END_COOLDOWN_DEFAULT_MS;
+}
+
 /** #568: commit the response early so a long preflight cannot lose the client
  *  to its header timeout. Streaming clients get an SSE stream with keep-alive
  *  comment lines (`: bili-preflight` — a spec-mandated no-op for every SSE
@@ -3058,6 +3075,17 @@ async function preflightCompressIfNeeded(
         ? estimateCoreMessagesUpper(prepared.processedMessages) + overheadEstimate + imageTokens
         : Math.max(session.stats.lastInputTokens, payloadEstimate);
     if (limit <= 0 || !model || tokenCount < limit) return prepared;
+    // #726: dead-end cooldown — an identical over-window state already failed
+    // preflight without folding anything, so re-running the walk is doomed; fail
+    // fast with the cached diagnosis and spend ZERO upstream summarization calls.
+    const deadEnd = session.metadata.preflightDeadEnd;
+    if (deadEnd && typeof deadEnd === "object") {
+        const de = deadEnd as Record<string, unknown>;
+        if (typeof de.key === "string" && de.key === `${model}\u0000${limit}` && typeof de.until === "number" && de.until > Date.now() && typeof de.message === "string") {
+            log("warn", `[${session.id}] preflight dead-end cooldown active (${Math.ceil((de.until - Date.now()) / 1000)}s left); failing fast without upstream calls (#726)`);
+            return { failFast: true, status: typeof de.status === "number" ? de.status : 502, message: de.message, retryable: false, respond: !res.writableEnded };
+        }
+    }
     // #496 forward-once-then-learn: the default image cost (base64/4) matches byte
     // relays (#488) but overestimates pixel-tile upstreams (a 400KB JPEG ≈ 1.6K real
     // tokens, not ~133K), so an image-dominated payload can clear the window on ESTIMATE
@@ -3155,6 +3183,9 @@ async function preflightCompressIfNeeded(
         clearTimeout(holdTimer);
         stopHold?.();
     }
+    // #726: a preflight that did not end in failure clears any dead-end marker
+    // — the state changed (conversation shrank, upstream recovered).
+    if (!result.failure) delete session.metadata.preflightDeadEnd;
     // #330: decide forward/fail on the payload actually forwarded, not
     // result.payloadEstimate — the preflight's relaxed-zone processTurn trims
     // that estimate more than the normal-config prepare does, which can turn a
@@ -3187,7 +3218,20 @@ async function preflightCompressIfNeeded(
         return { failFast: true, status: 0, message: f.detail, retryable: false, respond: false };
     }
     const status = f?.kind === "upstream" && f.status === 429 ? 503 : 502;
-    return failFast(status, f?.detail ?? "the payload still exceeds the window after preflight compression", status === 503);
+    const ff = failFast(status, f?.detail ?? "the payload still exceeds the window after preflight compression", status === 503);
+    // #726: zero-progress failure under unchanged state is a deterministic
+    // dead-end — arm the cooldown so client auto-retries stop re-burning
+    // upstream quota on the identical doomed summarization walk. Aborted
+    // failures never reach here.
+    if (f && result.compressedRanges === 0) {
+        const cooldownMs = preflightDeadEndCooldownMs();
+        if (cooldownMs > 0) {
+            ff.message += ` Preflight will not call the upstream again for the next ${Math.max(1, Math.round(cooldownMs / 60_000))}m while the context is unchanged (identical failure); restarting the session recovers immediately.`;
+            session.metadata.preflightDeadEnd = { key: `${model}\u0000${limit}`, until: Date.now() + cooldownMs, status: ff.status, message: ff.message };
+            markDirty(session);
+        }
+    }
+    return ff;
 }
 
 /** #604: arm the emergency shrink after an upstream failure that will never

--- a/src/server.ts
+++ b/src/server.ts
@@ -3075,17 +3075,6 @@ async function preflightCompressIfNeeded(
         ? estimateCoreMessagesUpper(prepared.processedMessages) + overheadEstimate + imageTokens
         : Math.max(session.stats.lastInputTokens, payloadEstimate);
     if (limit <= 0 || !model || tokenCount < limit) return prepared;
-    // #726: dead-end cooldown — an identical over-window state already failed
-    // preflight without folding anything, so re-running the walk is doomed; fail
-    // fast with the cached diagnosis and spend ZERO upstream summarization calls.
-    const deadEnd = session.metadata.preflightDeadEnd;
-    if (deadEnd && typeof deadEnd === "object") {
-        const de = deadEnd as Record<string, unknown>;
-        if (typeof de.key === "string" && de.key === `${model}\u0000${limit}` && typeof de.until === "number" && de.until > Date.now() && typeof de.message === "string") {
-            log("warn", `[${session.id}] preflight dead-end cooldown active (${Math.ceil((de.until - Date.now()) / 1000)}s left); failing fast without upstream calls (#726)`);
-            return { failFast: true, status: typeof de.status === "number" ? de.status : 502, message: de.message, retryable: false, respond: !res.writableEnded };
-        }
-    }
     // #496 forward-once-then-learn: the default image cost (base64/4) matches byte
     // relays (#488) but overestimates pixel-tile upstreams (a 400KB JPEG ≈ 1.6K real
     // tokens, not ~133K), so an image-dominated payload can clear the window on ESTIMATE
@@ -3136,6 +3125,21 @@ async function preflightCompressIfNeeded(
         // relax path (#330) folds the soft-protected recent zone when that is
         // the only foldable content, and its exhaustion detail carries the
         // operator remedy wording.
+    }
+    // #726: dead-end cooldown — an identical over-window state already failed
+    // preflight without folding anything, so re-running the walk is doomed; fail
+    // fast with the cached diagnosis and spend ZERO upstream summarization calls.
+    // Sits AFTER every safe-forward path above (#496 image arbitration, #300
+    // stale-baseline fit): those return without running the walk, so the
+    // cooldown must not convert a fitting payload into a false fail-fast while
+    // a marker from a larger earlier request is still warm.
+    const deadEnd = session.metadata.preflightDeadEnd;
+    if (deadEnd && typeof deadEnd === "object") {
+        const de = deadEnd as Record<string, unknown>;
+        if (typeof de.key === "string" && de.key === `${model}\u0000${limit}` && typeof de.until === "number" && de.until > Date.now() && typeof de.message === "string") {
+            log("warn", `[${session.id}] preflight dead-end cooldown active (${Math.ceil((de.until - Date.now()) / 1000)}s left); failing fast without upstream calls (#726)`);
+            return { failFast: true, status: typeof de.status === "number" ? de.status : 502, message: de.message, retryable: de.retryable === true, respond: !res.writableEnded };
+        }
     }
     // #330: the payload overflows the window (or nothing is foldable in the
     // normal pass but it doesn't fit). Let preflightCompress try to fold it —
@@ -3227,7 +3231,7 @@ async function preflightCompressIfNeeded(
         const cooldownMs = preflightDeadEndCooldownMs();
         if (cooldownMs > 0) {
             ff.message += ` Preflight will not call the upstream again for the next ${Math.max(1, Math.round(cooldownMs / 60_000))}m while the context is unchanged (identical failure); restarting the session recovers immediately.`;
-            session.metadata.preflightDeadEnd = { key: `${model}\u0000${limit}`, until: Date.now() + cooldownMs, status: ff.status, message: ff.message };
+            session.metadata.preflightDeadEnd = { key: `${model}\u0000${limit}`, until: Date.now() + cooldownMs, status: ff.status, retryable: ff.retryable, message: ff.message };
             markDirty(session);
         }
     }

--- a/tests/preflight-empty-summary.test.ts
+++ b/tests/preflight-empty-summary.test.ts
@@ -51,14 +51,14 @@ function okSummarySse(res: http.ServerResponse): void {
     res.end();
 }
 
-function forwardSse(res: http.ServerResponse): void {
+function forwardSse(res: http.ServerResponse, inputTokens = 800): void {
     res.write(sse("response.completed", {
         type: "response.completed",
         response: {
             id: "resp_fwd",
             status: "completed",
             output: [{ type: "message", role: "assistant", content: [{ type: "output_text", text: "ok" }] }],
-            usage: { input_tokens: 800, output_tokens: 4 },
+            usage: { input_tokens: inputTokens, output_tokens: 4 },
         },
     }));
     res.end();
@@ -84,7 +84,7 @@ function inputContentChars(parsed: ParsedBody): number {
     return typeof c === "string" ? c.length : 0;
 }
 
-function makeUpstream(calls: Call[], failAboveChars: number): http.Server {
+function makeUpstream(calls: Call[], failAboveChars: number, forwardInputTokens = 800): http.Server {
     return http.createServer((req, res) => {
         const chunks: Buffer[] = [];
         req.on("data", (c: Buffer) => chunks.push(c));
@@ -107,7 +107,7 @@ function makeUpstream(calls: Call[], failAboveChars: number): http.Server {
                 res.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache" });
                 okSummarySse(res);
             } else {
-                forwardSse(res);
+                forwardSse(res, forwardInputTokens);
             }
         });
     });
@@ -236,6 +236,46 @@ test("#726 systemic empty summary: diagnosis surfaced, bounded calls, cooldown b
         const r3 = await driveResponses(proxyPort, upstreamPort, "s726-deadend", "gpt-7-sol", longResponsesInput(12));
         assert.equal(r3.status, 502, `post-expiry retry must fail again, got ${r3.status}`);
         assert.ok(calls.length > callsBeforeExpire, "after the cooldown expires the walk must run again");
+    } finally {
+        proxy.close();
+        upstream.close();
+        await new Promise<void>((resolve, reject) => {
+            void Promise.allSettled([once(proxy, "close"), once(upstream, "close")]).then(() => resolve(), reject);
+        });
+    }
+});
+
+test("#726 dead-end cooldown must not block safe-forwards: fitting payload under a warm marker still goes out", async () => {
+    const calls: Call[] = [];
+    // failAboveChars=0 → every summary call fails; forwardInputTokens=15_000 lets
+    // a successful turn seed a stale-high usage baseline above the 10_000 window (#300 shape).
+    const upstream = makeUpstream(calls, 0, 15_000);
+    upstream.listen(0, "127.0.0.1");
+    await once(upstream, "listening");
+    const upstreamPort = (upstream.address() as { port: number }).port;
+
+    const proxy = await startProxy(upstreamPort, { "gpt-7-sol": { context: 10_000 } });
+    await once(proxy, "listening");
+    const proxyPort = (proxy.address() as { port: number }).port;
+
+    try {
+        const seed = await driveResponses(proxyPort, upstreamPort, "s726-stale", "gpt-7-sol", longResponsesInput(1));
+        assert.equal(seed.status, 200, `seed request must forward, got ${seed.status}`);
+        let sess = listSessions().find((s) => s.id.includes("s726-stale"));
+        assert.ok(sess && sess.stats.lastInputTokens >= 10_000, `seed must leave a high baseline, got ${sess?.stats.lastInputTokens}`);
+
+        const r1 = await driveResponses(proxyPort, upstreamPort, "s726-stale", "gpt-7-sol", longResponsesInput(12));
+        assert.equal(r1.status, 502, `systemic failure must fail-fast, got ${r1.status}`);
+        sess = listSessions().find((s) => s.id.includes("s726-stale"));
+        assert.ok(sess?.metadata?.preflightDeadEnd, "zero-progress failure must arm the dead-end marker");
+
+        // Same session, smaller payload: its own estimate fits the window; only
+        // the stale baseline trips the trigger. The cooldown suppresses the
+        // doomed walk — it must not convert this safe forward into a false 502.
+        const callsBeforeSmall = calls.length;
+        const r2 = await driveResponses(proxyPort, upstreamPort, "s726-stale", "gpt-7-sol", [{ type: "message", role: "user", content: "small follow-up" }]);
+        assert.equal(r2.status, 200, `fitting payload under a warm marker must still forward, got ${r2.status}`);
+        assert.ok(calls.length > callsBeforeSmall && calls[calls.length - 1].summary === false, "the small payload was forwarded to the upstream");
     } finally {
         proxy.close();
         upstream.close();

--- a/tests/preflight-empty-summary.test.ts
+++ b/tests/preflight-empty-summary.test.ts
@@ -1,0 +1,274 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import { once } from "node:events";
+import test from "node:test";
+
+process.env.NODE_ENV = "test";
+// Fail fast on 4xx retries so the stream-learn path exercises immediately.
+process.env.BILI_REPLAY_RETRY_MAX = "1";
+// Short dead-end cooldown so the expiry leg of the #726 test stays fast.
+process.env.BILI_PREFLIGHT_DEAD_END_COOLDOWN_MS = "400";
+
+import { defaultConfig } from "acp-kernel";
+import { startServer, type ProxyOptions } from "../src/server.ts";
+import { SessionStore, _setStoreForTest } from "../src/persist.ts";
+import { _setForTest as setRegistryForTest } from "../src/registry.ts";
+import { listSessions } from "../src/session.ts";
+import { diagnoseEmptySummary } from "../src/preflight.ts";
+
+// #726 regression: after the #626/#663 compatibility retries, a ChatGPT-backend
+// summarization call can return HTTP 200 SSE carrying NO summary text (an
+// in-stream error event / truncated stream). The proxy must (a) surface WHAT
+// the body said instead of a bare "summary too short", (b) retry the failing
+// chunk at smaller sizes before giving up on the range, and (c) stop client
+// auto-retries from re-burning upstream quota on the identical doomed walk
+// (per-session dead-end cooldown).
+
+const SUMMARY_TEXT =
+    "EMPTY-SUMMARY TEST SUMMARY: the segment held a deterministic load-growth payload across several turns; every raw marker is derivable from the seed, so the folded view loses nothing of value.";
+
+const FAIL_ABOVE_CHARS = 16_000;
+
+type Call = { stream: boolean; summary: boolean; contentChars: number; failed: boolean };
+
+function sse(event: string, data: unknown): string {
+    return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+function failedSummarySse(res: http.ServerResponse): void {
+    res.write(sse("response.failed", {
+        type: "response.failed",
+        response: { id: "resp_fail", status: "failed", error: { code: "context_length_exceeded", message: "Input is too long for this model." } },
+    }));
+    res.end();
+}
+
+function okSummarySse(res: http.ServerResponse): void {
+    for (const part of [SUMMARY_TEXT.slice(0, 40), SUMMARY_TEXT.slice(40)]) {
+        res.write(sse("response.output_text.delta", { type: "response.output_text.delta", delta: part }));
+    }
+    res.write(sse("response.completed", { type: "response.completed", response: { id: "resp_sum", status: "completed", output: [], usage: { input_tokens: 100, output_tokens: 5 } } }));
+    res.end();
+}
+
+function forwardSse(res: http.ServerResponse): void {
+    res.write(sse("response.completed", {
+        type: "response.completed",
+        response: {
+            id: "resp_fwd",
+            status: "completed",
+            output: [{ type: "message", role: "assistant", content: [{ type: "output_text", text: "ok" }] }],
+            usage: { input_tokens: 800, output_tokens: 4 },
+        },
+    }));
+    res.end();
+}
+
+type ParsedBody = { stream?: boolean; instructions?: unknown; input?: unknown; model?: string };
+
+function parseBody(raw: string): ParsedBody {
+    try {
+        return JSON.parse(raw) as ParsedBody;
+    } catch {
+        return {};
+    }
+}
+
+function isSummaryCall(parsed: ParsedBody): boolean {
+    return typeof parsed.instructions === "string" && Array.isArray(parsed.input) && parsed.input.length === 1;
+}
+
+function inputContentChars(parsed: ParsedBody): number {
+    const first = Array.isArray(parsed.input) ? parsed.input[0] : undefined;
+    const c = first && typeof first === "object" ? (first as Record<string, unknown>).content : undefined;
+    return typeof c === "string" ? c.length : 0;
+}
+
+function makeUpstream(calls: Call[], failAboveChars: number): http.Server {
+    return http.createServer((req, res) => {
+        const chunks: Buffer[] = [];
+        req.on("data", (c: Buffer) => chunks.push(c));
+        req.on("end", () => {
+            const parsed = parseBody(Buffer.concat(chunks).toString("utf8"));
+            const contentChars = isSummaryCall(parsed) ? inputContentChars(parsed) : 0;
+            const failed = isSummaryCall(parsed) && contentChars > failAboveChars;
+            calls.push({ stream: parsed.stream === true, summary: isSummaryCall(parsed), contentChars, failed });
+            if (isSummaryCall(parsed) && parsed.stream !== true) {
+                res.writeHead(400, { "content-type": "application/json" });
+                res.end(JSON.stringify({ detail: "Stream must be set to true" }));
+                return;
+            }
+            if (failed) {
+                res.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache" });
+                failedSummarySse(res);
+                return;
+            }
+            if (isSummaryCall(parsed)) {
+                res.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache" });
+                okSummarySse(res);
+            } else {
+                forwardSse(res);
+            }
+        });
+    });
+}
+
+function longResponsesInput(count: number) {
+    const input: { type: string; role: string; content: string }[] = [];
+    for (let i = 0; i < count; i++) {
+        input.push({ type: "message", role: i % 2 === 0 ? "user" : "assistant", content: `Message ${i} of the long conversation. ` + `MARKER_${i}_content_`.repeat(250) });
+    }
+    return input;
+}
+
+function startProxy(upstreamPort: number, models: Record<string, { context: number }>): Promise<http.Server> {
+    _setStoreForTest(new SessionStore({ enabled: false }));
+    setRegistryForTest({});
+    return startServer({
+        port: 0,
+        host: "127.0.0.1",
+        upstream: "http://127.0.0.1",
+        routes: { [`http://127.0.0.1:${upstreamPort}`]: { models } },
+        modelContextLimit: 10_000,
+        kernelConfig: defaultConfig(10_000),
+        compress: { injectTool: true, injectNudge: true },
+        promptCache: { routing: "auto" },
+        sessionHeader: "x-acp-session",
+        log: false,
+        debug: false,
+        passthrough: false,
+        autoUpdate: false,
+        mitm: { enabled: false, domains: [] },
+    } as ProxyOptions);
+}
+
+async function driveResponses(proxyPort: number, upstreamPort: number, session: string, model: string, input: unknown): Promise<Response> {
+    return await fetch(`http://127.0.0.1:${proxyPort}/bili/http://127.0.0.1:${upstreamPort}/responses`, {
+        method: "POST",
+        headers: { "content-type": "application/json", "x-acp-session": session },
+        body: JSON.stringify({ model, stream: true, input }),
+    });
+}
+
+test("#726 size-driven empty summary: oversized chunk fails, halved chunk recovers, session continues", async () => {
+    const calls: Call[] = [];
+    const upstream = makeUpstream(calls, FAIL_ABOVE_CHARS);
+    upstream.listen(0, "127.0.0.1");
+    await once(upstream, "listening");
+    const upstreamPort = (upstream.address() as { port: number }).port;
+
+    const proxy = await startProxy(upstreamPort, { "gpt-7-sol": { context: 10_000 } });
+    await once(proxy, "listening");
+    const proxyPort = (proxy.address() as { port: number }).port;
+
+    try {
+        const r = await driveResponses(proxyPort, upstreamPort, "s726-recover", "gpt-7-sol", longResponsesInput(12));
+        assert.equal(r.status, 200, `request must recover via smaller chunks, got ${r.status}`);
+
+        const summaries = calls.filter((c) => c.summary);
+        const failed = summaries.filter((c) => c.failed);
+        const succeeded = summaries.filter((c) => !c.failed);
+        assert.ok(failed.length >= 1, `expected at least one oversized failed summary, got ${JSON.stringify(summaries)}`);
+        assert.ok(failed.every((c) => c.contentChars > FAIL_ABOVE_CHARS), "only oversized chunks may fail");
+        assert.ok(succeeded.length >= 1, `expected a recovered smaller summary, got ${JSON.stringify(summaries)}`);
+        // The first failure must precede the recovery — halving walks oldest-first.
+        assert.ok(
+            summaries.indexOf(failed[0]) < summaries.indexOf(succeeded.find((c) => c.stream)!),
+            `halved retry must follow the failed chunk, got ${JSON.stringify(summaries)}`,
+        );
+        assert.ok(calls.some((c) => !c.summary), "the folded payload was forwarded");
+
+        const sess = listSessions().find((s) => s.id.includes("s726-recover"));
+        assert.ok(sess, "session recorded");
+        assert.equal(sess?.metadata?.preflightDeadEnd, undefined, "successful preflight must not leave a dead-end marker");
+    } finally {
+        proxy.close();
+        upstream.close();
+        await new Promise<void>((resolve, reject) => {
+            void Promise.allSettled([once(proxy, "close"), once(upstream, "close")]).then(() => resolve(), reject);
+        });
+    }
+});
+
+test("#726 systemic empty summary: diagnosis surfaced, bounded calls, cooldown blocks retries, expiry re-runs", async () => {
+    const calls: Call[] = [];
+    const upstream = makeUpstream(calls, 0);
+    upstream.listen(0, "127.0.0.1");
+    await once(upstream, "listening");
+    const upstreamPort = (upstream.address() as { port: number }).port;
+
+    const proxy = await startProxy(upstreamPort, { "gpt-7-sol": { context: 10_000 } });
+    await once(proxy, "listening");
+    const proxyPort = (proxy.address() as { port: number }).port;
+
+    try {
+        const r1 = await driveResponses(proxyPort, upstreamPort, "s726-deadend", "gpt-7-sol", longResponsesInput(12));
+        assert.equal(r1.status, 502, `systemic failure must fail-fast, got ${r1.status}`);
+        const j1 = (await r1.json()) as { error?: { code?: string; message?: string } };
+        assert.equal(j1.error?.code, "preflight_compress_failed");
+        assert.ok(
+            j1.error?.message?.includes("the upstream stream ended with a failed response (context_length_exceeded)"),
+            `fail-fast message must carry the upstream diagnosis, got: ${j1.error?.message}`,
+        );
+        assert.ok(
+            j1.error?.message?.includes("restarting the session recovers immediately"),
+            `fail-fast message must carry the recovery hint, got: ${j1.error?.message}`,
+        );
+        const summaries1 = calls.filter((c) => c.summary);
+        assert.ok(summaries1.length >= 2 && summaries1.length <= 9, `summary calls must be bounded, got ${summaries1.length}: ${JSON.stringify(summaries1)}`);
+        assert.ok(!calls.some((c) => !c.summary), "nothing may be forwarded on failure");
+
+        const sess = listSessions().find((s) => s.id.includes("s726-deadend"));
+        const marker = sess?.metadata?.preflightDeadEnd as Record<string, unknown> | undefined;
+        assert.ok(marker && typeof marker === "object", "zero-progress failure must arm the dead-end marker");
+        assert.equal(marker?.key, "gpt-7-sol\u000010000", "marker scoped to model + window");
+
+        const callsBeforeRetry = calls.length;
+        const r2 = await driveResponses(proxyPort, upstreamPort, "s726-deadend", "gpt-7-sol", longResponsesInput(12));
+        assert.equal(r2.status, 502, `cooldown must fail fast, got ${r2.status}`);
+        const j2 = (await r2.json()) as { error?: { code?: string; message?: string } };
+        assert.equal(j2.error?.code, "preflight_compress_failed");
+        assert.equal(j2.error?.message, j1.error?.message, "cooldown replays the cached diagnosis");
+        assert.equal(calls.length, callsBeforeRetry, "cooldown must spend ZERO upstream calls");
+
+        await new Promise((resolve) => setTimeout(resolve, 450));
+        const callsBeforeExpire = calls.length;
+        const r3 = await driveResponses(proxyPort, upstreamPort, "s726-deadend", "gpt-7-sol", longResponsesInput(12));
+        assert.equal(r3.status, 502, `post-expiry retry must fail again, got ${r3.status}`);
+        assert.ok(calls.length > callsBeforeExpire, "after the cooldown expires the walk must run again");
+    } finally {
+        proxy.close();
+        upstream.close();
+        await new Promise<void>((resolve, reject) => {
+            void Promise.allSettled([once(proxy, "close"), once(upstream, "close")]).then(() => resolve(), reject);
+        });
+    }
+});
+
+test("#726 diagnoseEmptySummary: extracts terminal error signals from 200 bodies", () => {
+    assert.match(
+        diagnoseEmptySummary(sse("response.failed", { type: "response.failed", response: { status: "failed", error: { code: "context_length_exceeded", message: "Input is too long." } } })),
+        /failed response \(context_length_exceeded\): Input is too long\./,
+    );
+    assert.match(
+        diagnoseEmptySummary(sse("error", { type: "error", error: { message: "boom" } })),
+        /in-stream error: boom/,
+    );
+    assert.match(
+        diagnoseEmptySummary(sse("response.incomplete", { type: "response.incomplete", response: { status: "incomplete", error: { message: "cut off" } } })),
+        /incomplete \(status=incomplete \(cut off\)\)/,
+    );
+    assert.match(
+        diagnoseEmptySummary("", { error: { message: "bare json error" } }),
+        /reported an error: bare json error/,
+    );
+    assert.equal(diagnoseEmptySummary(""), "the upstream returned an empty body");
+    assert.match(
+        diagnoseEmptySummary(sse("response.created", { type: "response.created", response: { id: "r1" } })),
+        /carried 1 SSE event\(s\) but no summary text/,
+    );
+    assert.match(
+        diagnoseEmptySummary('{"unrelated":"body"}'),
+        /non-SSE body with no summary text/,
+    );
+});


### PR DESCRIPTION
Fixes #726

## Problem

After the #626 (stream) and #663 (max_output_tokens) compatibility retries, a ChatGPT-backend summarization call can still return **HTTP 200 SSE with zero extractable summary text** — an in-stream error event or truncated stream that `extractSummaryFromSse` silently discarded. The only trace was `summary too short (0 chars)`, one viable range got skipped whole, and every codex auto-retry re-ran the identical doomed walk (~8 large summary calls per retry), producing the stable `502 retryable=false` loop from #726.

## Changes

**`src/preflight.ts`**

1. **Diagnose empty summaries** — new `diagnoseEmptySummary(text, json?)` scans a no-text body for terminal error signals: SSE `error` / `response.failed` / `response.error` events (`response.error.code` + `message`), `response.incomplete` (status + optional message), bare JSON `{error: {...}}`, plus fallbacks for empty bodies, event-carrying streams without text, and non-SSE bodies. The diagnosis goes into the warn log and is threaded into the fail-fast 502 message (`Last unusable summary: …`), so the operator/client finally sees WHY the summary was empty.
2. **Shrink-and-retry** — the chunk pass became a worklist: a chunk whose summary comes back unusable is halved (oldest half first) and retried down to a floor (`2×MIN_CHUNK_TOKENS` tokens / `2×minCompressRange` chars) before the range is skipped. This recovers size-driven rejections — the prime suspect in #726, where the first chunk was `CHUNK_FRACTION × window` ≈ 630K tokens of summarization input — while staying bounded by the existing `MAX_SUMMARY_CALLS_PER_PREFLIGHT` budget. Skip-on-exhaustion semantics for genuinely unsalvageable ranges are preserved.

**`src/server.ts`**

3. **Dead-end cooldown** — when preflight fails with `compressedRanges === 0` (zero progress under unchanged state = deterministic dead-end), the failure fingerprint (`model\u0000limit`) + status + full message is cached in `session.metadata.preflightDeadEnd` for a cooldown (default 5 min, `BILI_PREFLIGHT_DEAD_END_COOLDOWN_MS`). Matching requests fail fast with the cached diagnosis and **zero upstream calls**; any non-failure outcome clears the marker; aborted failures never arm it. The 502 message gains a recovery hint (restart the session). This stops the quota-burning retry loop from the issue's logs (8 identical walks in 48s).

**`tests/preflight-empty-summary.test.ts`** (new)

- Size-driven recovery: oversized chunk → 200 SSE `response.failed`; halved chunk succeeds → request 200, payload forwarded, no dead-end marker left behind.
- Systemic failure: diagnosis present in the 502 message, bounded summary calls, nothing forwarded, cooldown blocks the immediate retry with zero upstream calls, expiry re-runs the walk.
- Unit coverage for `diagnoseEmptySummary` across all signal shapes.

## Pre-flight

- `npm run typecheck` ✅
- `npm test` — 1422 pass / 0 fail / 2 skipped (gated e2e) ✅
- `npm run build` ✅
- `E2E_CHECK=1` e2e preflight ✅. Full `ACP_TEST_E2E=1` run not possible in this environment: the default local upstream (`http://127.0.0.1:8199/v1`) is down here (proxy log shows only ECONNREFUSED to it); please dispatch `.github/workflows/ci-e2e.yml` before merging since this touches the request pipeline.

## Out of scope (separate issue filed)

The deeper blind spot — nudge never fires when the upstream never reports usage (`usage=0%` in #726's logs), letting context grow to 1.32M without any incremental compression — is kernel-layered and needs its own design discussion. Filed separately with this issue as source.