### PR TITLE
feat(compress): promptPack — kernel pack resolution wired through all three wire paths

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -293,6 +293,13 @@ For each request, the proxy resolves the settings by longest-URL-prefix match (t
 - **Status:** ACTIVE
 - **Description:** Must be `true` for `prompts` overrides to take effect. Setting it acknowledges the summary-quality risk documented above.
 
+#### `promptPack`
+
+- **Type:** `string` (pack name, e.g. `"lean"`)
+- **Default:** *(unset — identity surface, kernel defaults everywhere)*
+- **Status:** ACTIVE
+- **Description:** Select a named prompt pack — a curated surface preset covering tool descriptions, compress system-prompt sections, and nudge sections — resolved from the kernel's pack chain: **project** `./.billion-context/packs/<name>.json` → **user** `<configDir>/packs/<name>.json` → **builtin** (`default`, `lean`). Built-in `lean` swaps the four ACP tool descriptions for one-liners (no snippet/guideline chrome) while keeping the compression rules default. Unknown names fall back to the identity surface with a one-time warning. Same three-level merge as the other fields; a pack's `prompts` overrides are subject to `acknowledgePromptsRisk` only when applied via `compress.prompts` — pack-surface sections (tool/section overrides) apply directly. Requires `acp-kernel` >= 0.0.66.
+
 #### `absorb`
 
 - **Type:** `object` (`{ enabled?, minToolTokens?, contextThresholdPct?, excludeTools?, toolName? }`)

--- a/CONFIGURATION.zh-CN.md
+++ b/CONFIGURATION.zh-CN.md
@@ -289,6 +289,14 @@
 - **类型：** `boolean`
 - **默认值：** `false`
 - **状态：** ACTIVE
+- **说明：** 必须为 `true`，`prompts` 覆盖才生效。设置它即表示知悉上述摘要质量风险。
+
+#### `promptPack`
+
+- **类型：** `string`（包名，如 `"lean"`）
+- **默认值：** *（未设置 —— 恒等表面，全部使用内核默认值）*
+- **状态：** ACTIVE
+- **说明：** 选择一个具名 prompt pack —— 一套策划好的表面预设，覆盖工具描述、压缩系统提示词段落、nudge 段落 —— 从内核的包解析链解析：**项目** `./.billion-context/packs/<name>.json` → **用户** `<configDir>/packs/<name>.json` → **内置**（`default`、`lean`）。内置 `lean` 把四个 ACP 工具描述换成单行版（无 snippet/guideline 包装），压缩规则保持默认。未知包名回退到恒等表面并记录一次警告。与其他字段一样三级级联合并；包的表面覆盖（工具/段落）直接生效，不经 `acknowledgePromptsRisk` 门控（该门控只管 `compress.prompts` 的规则文本覆盖）。需要 `acp-kernel` >= 0.0.66。
 - **说明：** 必须为 `true`，`prompts` 覆盖才会生效。设置它即表示知悉上文所述的摘要质量风险。
 
 #### `absorb`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billion-context",
-  "version": "0.1.106",
+  "version": "0.1.107",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billion-context",
-      "version": "0.1.106",
+      "version": "0.1.107",
       "license": "MIT",
       "bin": {
         "bili": "dist/index.js",
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@types/node": "^22.0.0",
         "@types/node-forge": "^1.3.14",
-        "acp-kernel": "0.0.64",
+        "acp-kernel": "0.0.66",
         "fzstd": "0.1.1",
         "node-forge": "^1.4.0",
         "tar": "^7.5.22",
@@ -946,9 +946,9 @@
       }
     },
     "node_modules/acp-kernel": {
-      "version": "0.0.64",
-      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.64.tgz",
-      "integrity": "sha512-zmxYKbK2qBD6sq321Y+FwuVAwNWAEgOaiL0lFAAH3pHD6iXGRhlvcFUiHuGCDfAMTfo3v8WnEFZ+PICwYa6Lsw==",
+      "version": "0.0.66",
+      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.66.tgz",
+      "integrity": "sha512-zEg9KV9S6DFl6JNn3IPo9zDahjXESgZxw/Bx0Zgbj5syIGmH3GLvyGoq1HIQWGSDKlFE8vD1PRzrnhqnHo985g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/node-forge": "^1.3.14",
-    "acp-kernel": "0.0.64",
+    "acp-kernel": "0.0.66",
     "fzstd": "0.1.1",
     "node-forge": "^1.4.0",
     "tar": "^7.5.22",

--- a/src/compress-settings.ts
+++ b/src/compress-settings.ts
@@ -1,5 +1,7 @@
-import { DEFAULT_ABSORB_CONFIG, defaultPrompts, resolvePrompts, type AbsorbConfig, type Config, type Prompts } from "acp-kernel";
+import { DEFAULT_ABSORB_CONFIG, defaultPrompts, resolvePrompts, createPackResolver, defaultPackSources, isValidPackName, type AbsorbConfig, type Config, type PackSurface, type Prompts } from "acp-kernel";
+import * as path from "node:path";
 import { findRoute, type CompressSettings, type ProviderRoutes } from "./config.js";
+import { configDir } from "./paths.js";
 import { log as loggerLog } from "./logger.js";
 
 /** Resolve a raw `contextLimit` value to an absolute token count.
@@ -71,6 +73,7 @@ stripImages: pick("stripImages"),
         // exactly like `absorb`/`prompts`: a model-level `threshold` must not
         // discard a provider-level `drop: false`.
         reasoning: reasoningLevels.length > 0 ? Object.assign({}, ...reasoningLevels) : undefined,
+        promptPack: pick("promptPack"),
     };
 }
 
@@ -110,6 +113,37 @@ export function resolveCompressPrompts(s: CompressSettings): Prompts {
     } catch {
         return defaultPrompts;
     }
+}
+
+let warnedUnknownPack = new Set<string>();
+
+/** Resolve the pack surface for one request: `promptPack` names a pack in the
+ *  kernel's resolver chain [project `./.billion-context/packs` > user
+ *  `<configDir>/packs` > builtin registry]. Unknown names fall back to the
+ *  identity surface ({} — kernel defaults everywhere) with a one-time-per-name
+ *  warning, so a typo never degrades the compression prompts. Directory
+ *  layout is host policy; resolution/sanitization is the kernel's. */
+export function resolveCompressSurface(
+    s: CompressSettings,
+    dirs?: { projectDir?: string; userDirs?: readonly string[] },
+): PackSurface {
+    const name = s.promptPack;
+    if (typeof name !== "string" || name === "default" || !isValidPackName(name)) return {};
+    const resolver = createPackResolver(
+        defaultPackSources({
+            projectDir: dirs?.projectDir ?? path.join(process.cwd(), ".billion-context", "packs"),
+            userDirs: dirs?.userDirs ?? [path.join(configDir(), "packs")],
+        }),
+    );
+    const pack = resolver.resolve(name);
+    if (!pack) {
+        if (!warnedUnknownPack.has(name)) {
+            warnedUnknownPack.add(name);
+            loggerLog("warn", `[compress] promptPack "${name}" not found (project/user/builtin); using default surface`);
+        }
+        return {};
+    }
+    return pack.surface;
 }
 
 /** True when a CompressSettings carries at least one configured field (i.e. it

--- a/src/config.ts
+++ b/src/config.ts
@@ -131,6 +131,12 @@ export type CompressSettings = {
     /** Must be true for `prompts` overrides to take effect. Acknowledges the
      *  summary-quality risk documented on `prompts`. */
     acknowledgePromptsRisk?: boolean;
+    /** Named prompt pack (kernel pack registry): a curated surface preset —
+     *  tool descriptions, system-prompt sections, nudge sections — resolved
+     *  from [project `./.billion-context/packs` > user `<configDir>/packs` >
+     *  builtin (`default`, `lean`)]. Deepest-wins like every other field;
+     *  unknown names fall back to the identity surface. Kernel >= 0.0.66. */
+    promptPack?: string;
     /** Instant tool-result absorption (kernel absorb API, acp-kernel >= 0.0.54).
      *  When `enabled`, eligible large tool results carry a forced [ACP absorb]
      *  instruction and the model distills them via the injected `absorb` tool;
@@ -688,6 +694,10 @@ export function parseCompressSettings(v: unknown): (CompressSettings & { injectT
             }
             if (ok) out.prompts = cleaned;
         }
+    }
+    if ("promptPack" in obj && obj.promptPack !== undefined) {
+        if (typeof obj.promptPack !== "string" || obj.promptPack.trim().length === 0) ok = false;
+        else out.promptPack = obj.promptPack.trim();
     }
     if (!ok) return undefined;
     return out;

--- a/src/preflight.ts
+++ b/src/preflight.ts
@@ -5,6 +5,7 @@ import {
     type Config,
     type CoreMessage,
     type Prompts,
+    type PackSurface,
 } from "acp-kernel";
 import { buildCompressSystemPrompt, parseCompressInput } from "./compress-tool.js";
 import { applyAbsorbView } from "./absorb.js";
@@ -39,6 +40,7 @@ export interface PreflightDeps {
     session: Session;
     config: Config;
     prompts: Prompts;
+    surface?: PackSurface;
     protocol: PreflightProtocol;
     url: string;
     headers: Record<string, string>;
@@ -447,7 +449,7 @@ export function diagnoseEmptySummary(text: string, json?: unknown): string {
 
 async function summarizeRange(deps: PreflightDeps, content: string, startRef: string, endRef: string): Promise<SummaryOutcome> {
     const system =
-        buildCompressSystemPrompt(deps.prompts) +
+        buildCompressSystemPrompt(deps.prompts, deps.surface?.promptSections) +
         `\n\nTASK: The conversation segment below (messages ${startRef}–${endRef}) must be compressed because the session context exceeds the current model's window. Write a tier-1 compression summary of the segment following every rule above. Output ONLY the summary text — no preamble, no closing remarks, no tool calls.`;
     // #626: the session remembers upstreams that require stream:true, so the
     // extra 400 round-trip is paid at most once per session (persisted with

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,8 +1,8 @@
 import http from "node:http";
 import fs from "node:fs";
 import { randomUUID } from "node:crypto";
-import { createCore, type CompressionCore, type CompressionState, type Config, type CoreMessage, type NudgeDecision, type Prompts, defaultPrompts, defaultCountTokens, estimateTokensFast, renderNudgeText, deactivateBlock, viableRanges } from "acp-kernel";
-import { resolveCompress, resolveCompressPrompts, resolveRequestConfig } from "./compress-settings.js";
+import { createCore, type CompressionCore, type CompressionState, type Config, type CoreMessage, type NudgeDecision, type Prompts, type PackSurface, type ToolPrompts, applyAcpToolOverrides, defaultPrompts, defaultCountTokens, estimateTokensFast, renderNudgeText, deactivateBlock, viableRanges } from "acp-kernel";
+import { resolveCompress, resolveCompressPrompts, resolveCompressSurface, resolveRequestConfig } from "./compress-settings.js";
 import { dropCompressReasoning, type CompressReasoningConfig } from "./reasoning-drop.js";
 import { DEFAULT_STRIP_IMAGES_KEEP_RECENT, stripHistoricalImages } from "./strip-images.js";
 import type { ProxyOptions } from "./config.js";
@@ -625,6 +625,10 @@ type Prepared = {
       *  in forward() rebuilds the SAME system prompt the request was prepared
       *  with. */
     prompts?: Prompts;
+    /** Effective pack surface (promptPack) for this request: tool prompts,
+      *  system-prompt sections, nudge sections. Same carrying rationale as
+      *  prompts — the compress loop must rebuild the identical surface. */
+    surface?: PackSurface;
     /** #388: side request (title-gen etc.) — transport with render-tag strip
      *  only. Skips preflight (handle() returns before it), the fake-completion
      *  retry wrapper, the compress loop, and every usage-sniffing pipe; the
@@ -1094,6 +1098,7 @@ async function handle(
     // and the compress-loop system prompt all use one consistent Prompts set
     // (kernel contract: renderNudgeText and the adapter prompt must match).
     let reqPrompts: Prompts = defaultPrompts;
+    let reqSurface: PackSurface = {};
     if (parsed && typeof parsed === "object") {
         const model = (parsed as { model?: string }).model;
         if (model) {
@@ -1170,7 +1175,9 @@ async function handle(
                 nativeFromFallback = false;
                 log("info", `[codex] effective window clamped ${before} → ${aligned.limit} (codex's own perception for model=${model}; ACP now compresses before codex's native auto-compact)`);
             }
-            reqPrompts = resolveCompressPrompts(resolveCompress(opts.routes, embeddedUrl, model, opts.compress));
+            const compressCfg = resolveCompress(opts.routes, embeddedUrl, model, opts.compress);
+            reqPrompts = resolveCompressPrompts(compressCfg);
+            reqSurface = resolveCompressSurface(compressCfg);
         }
     }
     let prepared: Prepared | null = null;
@@ -1587,16 +1594,16 @@ async function handle(
                     return countTokens
                         ? prepareCountTokens(work as AnthropicRequestBody, core, reqConfig, log, session)
                         : protocol === "anthropic"
-                          ? prepareAnthropic(work as AnthropicRequestBody, req, opts, core, reqConfig, reqPrompts, log, session, pluginMode, upstreamOrigin, reasoningCfg)
+                          ? prepareAnthropic(work as AnthropicRequestBody, req, opts, core, reqConfig, reqPrompts, reqSurface, log, session, pluginMode, upstreamOrigin, reasoningCfg)
                           : protocol === "openai"
-                             ? prepareOpenai(work as OpenAIRequestBody, req, opts, core, reqConfig, reqPrompts, log, session, pluginMode, upstreamOrigin, nativeWindow, reasoningCfg)
+                             ? prepareOpenai(work as OpenAIRequestBody, req, opts, core, reqConfig, reqPrompts, reqSurface, log, session, pluginMode, upstreamOrigin, nativeWindow, reasoningCfg)
                              : responsesCompact
                                 // #618 review nit: when no bili compaction item is present,
                                 // prepareResponsesCompact falls back to the raw bodyBuffer — forward
                                 // the re-serialized post-strip work instead so dropped images don't
                                 // ride along. Unchanged bodies keep the original buffer byte-identical.
                                 ? prepareResponsesCompact(stripped.removed > 0 ? Buffer.from(JSON.stringify(work)) : bodyBuffer, work as ResponsesRequestBody, session, req, core, reqConfig, log)
-                               : prepareResponses(work as ResponsesRequestBody, req, opts, core, reqConfig, reqPrompts, log, session, responsesIdentity!, pluginMode, upstreamOrigin, nativeWindow, reasoningCfg);
+                               : prepareResponses(work as ResponsesRequestBody, req, opts, core, reqConfig, reqPrompts, reqSurface, log, session, responsesIdentity!, pluginMode, upstreamOrigin, nativeWindow, reasoningCfg);
                 };
                 // #332: codex's native remote-compaction request (trigger form)
                 // is dispatched BEFORE prepare/preflight. When it is not
@@ -1944,6 +1951,7 @@ function prepareAnthropic(
     core: CompressionCore,
     config: Config,
     prompts: Prompts,
+    surface: PackSurface,
     log: (level: string, msg: string) => void,
     session: Session,
     pluginMode: boolean,
@@ -1958,7 +1966,7 @@ function prepareAnthropic(
 
     if (isAutoModeClassifier(parsed)) {
         log("info", `[${sessionId}] auto-mode classifier passthrough (skipping compress injection)`);
-        return { body: JSON.stringify(parsed), session, processedMessages: [], originalMessages: [], anthropicSystem: parsed.system, protocol: "anthropic", stream, compressInjected: false, pluginMode, nudge: undefined, prompts } as Prepared;
+        return { body: JSON.stringify(parsed), session, processedMessages: [], originalMessages: [], anthropicSystem: parsed.system, protocol: "anthropic", stream, compressInjected: false, pluginMode, nudge: undefined, prompts, surface } as Prepared;
     }
 
     let processedMessages: CoreMessage[] = [];
@@ -2038,7 +2046,7 @@ function prepareAnthropic(
         // agent's re-sent history, safe for the prefix-cache anchor.
         if (willInjectNudge && turn.nudge) {
             try {
-                const rendered = renderNudgeText(turn.nudge, prompts);
+                const rendered = renderNudgeText(turn.nudge, prompts, surface?.nudgeSections);
                 if (rendered.text) {
                     rebuiltMessages = [...rebuiltMessages, { role: "user", content: withMarkerIntegrityNote(withStagedCompressGuidance(rendered.text)) }];
                 }
@@ -2062,7 +2070,7 @@ function prepareAnthropic(
     // identity chain (#268), not part of the Anthropic Messages API — strip it
     // so the real upstream never sees a field it doesn't know.
     delete (rebuilt as Record<string, unknown>).prompt_cache_key;
-    return { body: JSON.stringify(rebuilt), session, processedMessages, originalMessages, anthropicSystem: parsed.system, protocol: "anthropic", stream, compressInjected: injectTools, pluginMode, nudge, prompts, renderTags: "text-only" } as Prepared;
+    return { body: JSON.stringify(rebuilt), session, processedMessages, originalMessages, anthropicSystem: parsed.system, protocol: "anthropic", stream, compressInjected: injectTools, pluginMode, nudge, prompts, surface, renderTags: "text-only" } as Prepared;
 }
 
 // #453 hard backstop: cap the forwarded output budget so input+output can never
@@ -2180,6 +2188,7 @@ function prepareOpenai(
     core: CompressionCore,
     config: Config,
     prompts: Prompts,
+    surface: PackSurface,
     log: (level: string, msg: string) => void,
     session: Session,
     pluginMode: boolean,
@@ -2266,7 +2275,7 @@ function prepareOpenai(
         // would invalidate the cache every turn.
         const sysParts: string[] = [];
         if (systemText) sysParts.push(systemText);
-        if (shouldInject) sysParts.push(withMarkerIntegrityNote(buildCompressSystemPrompt(prompts)));
+        if (shouldInject) sysParts.push(withMarkerIntegrityNote(buildCompressSystemPrompt(prompts, surface?.promptSections)));
         if (absorbActive) sysParts.push(buildAbsorbSystemPrompt(absorbToolName(config)));
         rebuiltMessages = injectOpenaiSystem(rebuiltMessages, sysParts);
         // #532: capture what bili injects outside the fold space (client system
@@ -2285,7 +2294,7 @@ function prepareOpenai(
         // prefix-cache-anchor safe.
         if (willInjectNudge && turn.nudge) {
             try {
-                const rendered = renderNudgeText(turn.nudge, prompts);
+                const rendered = renderNudgeText(turn.nudge, prompts, surface?.nudgeSections);
                 if (rendered.text) {
                     rebuiltMessages = [...rebuiltMessages, { role: "user", content: withMarkerIntegrityNote(withStagedCompressGuidance(rendered.text)) }];
                 }
@@ -2324,7 +2333,7 @@ function prepareOpenai(
     }
     snapshotMessages(session, originalMessages);
     markDirty(session);
-    return { body: JSON.stringify(rebuilt), session, processedMessages, originalMessages, protocol: "openai", stream, compressInjected: injectTools, pluginMode, nudge, prompts, openaiSystemText, renderTags: "text-only" } as Prepared;
+    return { body: JSON.stringify(rebuilt), session, processedMessages, originalMessages, protocol: "openai", stream, compressInjected: injectTools, pluginMode, nudge, prompts, surface, openaiSystemText, renderTags: "text-only" } as Prepared;
 }
 
 function prepareResponses(
@@ -2334,6 +2343,7 @@ function prepareResponses(
     core: CompressionCore,
     config: Config,
     prompts: Prompts,
+    surface: PackSurface,
     log: (level: string, msg: string) => void,
     session: Session,
     identity: ConversationIdentity,
@@ -2456,7 +2466,7 @@ function prepareResponses(
             ? []
             : (session.metadata.codexForgedSummaries as string[] | undefined) ?? [];
         if (shouldInject && !isCompactionTrigger && !process.env.ACP_NO_COMPRESS_PROMPT) {
-            const prompt = withMarkerIntegrityNote(responsesTextProtocol ? buildCompressHybridSystemPrompt(prompts) : buildCompressSystemPrompt(prompts));
+            const prompt = withMarkerIntegrityNote(responsesTextProtocol ? buildCompressHybridSystemPrompt(prompts, surface?.promptSections) : buildCompressSystemPrompt(prompts, surface?.promptSections));
             const devParts = [...projection.systemParts, ...forgedSummaries, prompt];
             if (absorbActive) devParts.push(buildAbsorbSystemPrompt(absorbToolName(config)));
             const devContent = devParts.join("\n\n---\n\n");
@@ -2481,7 +2491,7 @@ function prepareResponses(
         // message — not persisted, prefix-cache-anchor safe.
         if (willInjectNudge && turn.nudge) {
             try {
-                const rendered = renderNudgeText(turn.nudge, prompts);
+                const rendered = renderNudgeText(turn.nudge, prompts, surface?.nudgeSections);
                 if (rendered.text) {
                     const inputItems: ResponseInputItem[] = typeof rebuiltInput === "string"
                         ? [{ type: "message", role: "user", content: rebuiltInput }]
@@ -2594,6 +2604,7 @@ function prepareResponses(
         responsesTextProtocol,
         nudge,
         prompts,
+        surface,
         renderTags,
         resetAfterSuccess: isCompactionTrigger,
         codexForge,
@@ -2783,6 +2794,7 @@ function injectSystem(
     opts: ProxyOptions,
     prompts: Prompts = defaultPrompts,
     config: Config,
+    surface?: PackSurface,
 ): string | AnthropicRequestBody["system"] {
     // ONLY the static compress prompt goes into the system block — it is the
     // prefix-cache anchor and must stay byte-stable across turns. The nudge
@@ -2790,30 +2802,32 @@ function injectSystem(
     // the caller (prepareAnthropic), never merged into system.
     const baseText = extractSystem(parsed.system);
     const parts: string[] = [];
-    if (opts.compress.injectTool) parts.push(withMarkerIntegrityNote(buildCompressSystemPrompt(prompts)));
+    if (opts.compress.injectTool) parts.push(withMarkerIntegrityNote(buildCompressSystemPrompt(prompts, surface?.promptSections)));
     if (opts.compress.injectTool && absorbEnabled(config)) parts.push(buildAbsorbSystemPrompt(absorbToolName(config)));
     if (parts.length === 0) return parsed.system;
     const full = baseText ? `${baseText}\n\n---\n\n${parts.join("\n\n")}` : parts.join("\n\n");
     return buildSystem(full, parsed.system);
 }
 
-function injectTool(tools: unknown[] | undefined, extra?: { name: string }): unknown[] {
-    if (!Array.isArray(tools)) return extra ? [...ACP_TOOLS_ANTHROPIC, extra] : [...ACP_TOOLS_ANTHROPIC];
+function injectTool(tools: unknown[] | undefined, extra?: { name: string }, toolPrompts?: ToolPrompts): unknown[] {
+    const acp = applyAcpToolOverrides(ACP_TOOLS_ANTHROPIC, toolPrompts);
+    if (!Array.isArray(tools)) return extra ? [...acp, extra] : [...acp];
     const names = new Set(tools.map((t) => (t as { name?: string })?.name));
-    const missing = ACP_TOOLS_ANTHROPIC.filter((t) => !names.has(t.name));
+    const missing = acp.filter((t) => !names.has(t.name));
     const extraMissing = extra && !names.has(extra.name);
     if (missing.length === 0 && !extraMissing) return tools;
     return [...tools, ...missing, ...(extraMissing ? [extra] : [])];
 }
 
-function injectOpenaiTool(tools: OpenAITool[] | undefined, extra?: OpenAITool): OpenAITool[] {
-    if (!Array.isArray(tools)) return extra ? [...ACP_TOOLS_OPENAI, extra] as OpenAITool[] : ([...ACP_TOOLS_OPENAI] as OpenAITool[]);
+function injectOpenaiTool(tools: OpenAITool[] | undefined, extra?: OpenAITool, toolPrompts?: ToolPrompts): OpenAITool[] {
+    const acp = applyAcpToolOverrides(ACP_TOOLS_OPENAI, toolPrompts) as OpenAITool[];
+    if (!Array.isArray(tools)) return extra ? [...acp, extra] : ([...acp] as OpenAITool[]);
     const present = new Set(
         tools
             .map((t) => t?.function?.name)
             .filter((n): n is string => typeof n === "string"),
     );
-    const additions = ACP_TOOLS_OPENAI.filter((t) => !present.has(t.function.name));
+    const additions = acp.filter((t) => !present.has(t.function.name));
     const out = [...tools, ...(additions as OpenAITool[])];
     if (extra && !out.some((t) => t?.function?.name === extra.function?.name)) out.push(extra);
     return out;
@@ -2828,14 +2842,15 @@ const FORCE_TEXT_PROTOCOL = process.env.ACP_COMPRESS_PROTOCOL === "text";
 /** Inject all ACP tools (compress/decompress/search_context/acp_status) in
  *  Responses API flat format, matching the PROXY_TOOL_NAMES set the compress
  *  loop dispatches on. Idempotent. */
-function injectResponsesTool(tools: unknown[] | undefined, toolsToAdd: readonly { name: string }[] = ACP_TOOLS_RESPONSES): unknown[] {
-    if (!Array.isArray(tools)) return [...toolsToAdd];
+function injectResponsesTool(tools: unknown[] | undefined, toolsToAdd: readonly { name: string }[] = ACP_TOOLS_RESPONSES, toolPrompts?: ToolPrompts): unknown[] {
+    const base = applyAcpToolOverrides(toolsToAdd, toolPrompts);
+    if (!Array.isArray(tools)) return [...base];
     const present = new Set(
         tools
             .map((t) => (t as { name?: string })?.name)
             .filter((n): n is string => typeof n === "string"),
     );
-    const additions = toolsToAdd.filter((t) => !present.has(t.name));
+    const additions = base.filter((t) => !present.has(t.name));
     return [...tools, ...additions];
 }
 
@@ -3170,6 +3185,7 @@ async function preflightCompressIfNeeded(
                 session,
                 config,
                 prompts: prepared.prompts ?? defaultPrompts,
+                surface: prepared.surface,
                 protocol: prepared.protocol,
                 url: upstreamUrl,
                 headers,
@@ -3897,7 +3913,7 @@ async function forward(
             const absorbSection = absorbActive
                 ? `\n\n---\n\n${buildAbsorbSystemPrompt(absorbToolName(loopConfig))}`
                 : "";
-            const systemPrompt = withMarkerIntegrityNote(textProtocol ? buildCompressHybridSystemPrompt(prepared.prompts ?? defaultPrompts) : buildCompressSystemPrompt(prepared.prompts ?? defaultPrompts)) + absorbSection;
+            const systemPrompt = withMarkerIntegrityNote(textProtocol ? buildCompressHybridSystemPrompt(prepared.prompts ?? defaultPrompts, prepared.surface?.promptSections) : buildCompressSystemPrompt(prepared.prompts ?? defaultPrompts, prepared.surface?.promptSections)) + absorbSection;
             const adapter = pickAdapter(prepared.protocol, parsedReq, textProtocol, prepared.responsesProjection, prepared.anthropicSystem, prepared.openaiSystemText, absorbActive ? absorbToolName(loopConfig) : undefined);
             const refreshFolded = (current: CoreMessage[]): CoreMessage[] => {
                 // #422: mirror the prepare's fold with the post-compress state so

--- a/tests/compress-prompt-pack.test.ts
+++ b/tests/compress-prompt-pack.test.ts
@@ -1,0 +1,77 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { defaultPrompts, buildCompressSystemPrompt, ACP_TOOLS_OPENAI, applyAcpToolOverrides } from "acp-kernel";
+import { mergeCompress, resolveCompressSurface } from "../src/compress-settings.js";
+
+test("promptPack merges deepest-wins like every other field", () => {
+    const merged = mergeCompress(
+        { promptPack: "lean" },
+        { promptPack: "team" },
+        { promptPack: "default" },
+    );
+    assert.equal(merged.promptPack, "default");
+    assert.equal(mergeCompress({ promptPack: "lean" }).promptPack, "lean");
+    assert.equal(mergeCompress(undefined, { promptPack: "team" }).promptPack, "team");
+    assert.equal(mergeCompress().promptPack, undefined);
+});
+
+test("resolveCompressSurface: unset / default / invalid names yield the identity surface", () => {
+    assert.deepEqual(resolveCompressSurface({}), {});
+    assert.deepEqual(resolveCompressSurface({ promptPack: "default" }), {});
+    assert.deepEqual(resolveCompressSurface({ promptPack: "../etc/passwd" }), {});
+    assert.deepEqual(resolveCompressSurface({ promptPack: "" }), {});
+});
+
+test("resolveCompressSurface: builtin lean resolves from the kernel registry", () => {
+    const surface = resolveCompressSurface({ promptPack: "lean" });
+    assert.equal(
+        surface.toolPrompts?.compress?.description,
+        "Replace consumed conversation ranges with self-contained summaries using mNNNNN or bN refs.",
+    );
+    assert.equal(surface.prompts, undefined);
+    const tools = applyAcpToolOverrides(ACP_TOOLS_OPENAI, surface.toolPrompts);
+    const compress = tools.find((t) => t.function.name === "compress");
+    assert.ok(compress);
+    assert.equal(compress.function.description, surface.toolPrompts?.compress?.description);
+});
+
+test("resolveCompressSurface: unknown names fall back to identity", () => {
+    assert.deepEqual(resolveCompressSurface({ promptPack: "no-such-pack" }), {});
+});
+
+test("resolveCompressSurface: file packs load from project dir, shadowing builtin", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "bili-pack-"));
+    try {
+        writeFileSync(
+            path.join(dir, "lean.json"),
+            JSON.stringify({ name: "lean", toolPrompts: { acp_status: { description: "project lean" } } }),
+        );
+        const surface = resolveCompressSurface({ promptPack: "lean" }, { projectDir: dir });
+        assert.equal(surface.toolPrompts?.acp_status?.description, "project lean");
+        assert.equal(surface.toolPrompts?.compress?.description, undefined);
+    } finally {
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+test("resolveCompressSurface: nudge/prompt section overrides flow into the kernel builders", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "bili-pack2-"));
+    try {
+        writeFileSync(
+            path.join(dir, "quiet.json"),
+            JSON.stringify({
+                promptSections: { summariesInContext: null, acpTags: "QUIET-TAGS" },
+                nudgeSections: { efficiencyNote: null },
+            }),
+        );
+        const surface = resolveCompressSurface({ promptPack: "quiet" }, { projectDir: dir });
+        const prompt = buildCompressSystemPrompt(defaultPrompts, surface.promptSections);
+        assert.ok(prompt.includes("QUIET-TAGS"));
+        assert.ok(!prompt.includes("COMPRESSION SUMMARIES IN CONTEXT"));
+    } finally {
+        rmSync(dir, { recursive: true, force: true });
+    }
+});


### PR DESCRIPTION
Closes #729. Depends on acp-kernel 0.0.66 (PR #260, live on npm).

## What

`compress.promptPack` selects a named surface preset resolved via the kernel's pack chain: **project** `./.billion-context/packs/<name>.json` → **user** `<configDir>/packs/<name>.json` → **builtin** (`default`, `lean`). Unknown names fall back to the identity surface with a one-time-per-name warning. Same three-level cascade (global → provider → model, deepest-wins) as every other compress field.

The resolved `PackSurface` threads through:

- **Tool injection** (all three wire paths): `injectTool` / `injectOpenaiTool` / `injectResponsesTool` now apply `applyAcpToolOverrides` to the ACP tool arrays they add — pack tool descriptions + paramDescriptions land in anthropic/openai/responses tool defs
- **System prompt**: `injectSystem` (anthropic), openai sysParts, responses dev-content, the forward() compress-loop rebuild (#422 fold-refresh consistency), and preflight — all pass `surface.promptSections` into `buildCompressSystemPrompt` / `buildCompressHybridSystemPrompt`
- **Nudges**: all three `renderNudgeText` sites pass `surface.nudgeSections` (kernel contract: adapter prompt and nudge text must match)
- `Prepared.surface` carried alongside `Prepared.prompts` so the compress loop rebuilds the identical surface

## Config + docs

- `promptPack?: string` in CompressSettings, sanitized (non-empty trimmed string)
- CONFIGURATION.md / CONFIGURATION.zh-CN.md: `#### promptPack` sections

## Tests

6 new in `tests/compress-prompt-pack.test.ts`: deepest-wins merge, identity-surface fallbacks (unset/default/invalid/unknown), builtin lean resolution + wire-tool application, project file pack shadowing builtin, promptSections → builder flow.

Full suite vs merged kernel master (real npm 0.0.66): **1431 tests, 0 fail** (2 skipped; one earlier single-fail run was a network-flake, three consecutive clean runs since). typecheck clean, build green.

Note: the lean recall rules in shipped kernel 0.0.66 are already aligned with pre-lean semantics (summary as primary carrier, decompress-centric on-demand recall, search_context as locator only).