### PR TITLE
fix: name the operator-shrunk window in preflight fail-fast errors

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -3131,8 +3131,14 @@ async function preflightCompressIfNeeded(
             : "";
         // #736: when the wall is bili's own shrunken window, say so — "raise the
         // model context window" otherwise sends operators to the upstream when
-        // their compress.modelContextLimit is the actual ceiling.
-        const shrinkNote = resolvedNativeWindow !== undefined && limit < resolvedNativeWindow
+        // their compress.modelContextLimit is the actual ceiling. Gate on
+        // windowShrinkReason (set ONLY by the operator-override and codex-align
+        // paths) — NOT just on limit < resolvedNativeWindow: the per-request
+        // output-headroom reservation (reserveOutputHeadroom) also lowers
+        // reqConfig.modelContextLimit below native for every non-Anthropic turn
+        // with a max_tokens, so comparing alone would emit this note for a
+        // setting the operator never touched (#737 review).
+        const shrinkNote = windowShrinkReason !== undefined && resolvedNativeWindow !== undefined && limit < resolvedNativeWindow
             ? ` Note: bili's effective window ${limit} is below the model's full window ${resolvedNativeWindow} — ` +
                 (windowShrinkReason === "codex"
                     ? `it was aligned down to codex's own window perception; set compress.modelContextLimit explicitly if your upstream serves the larger window.`

--- a/src/server.ts
+++ b/src/server.ts
@@ -1086,6 +1086,12 @@ async function handle(
     // absolute number, a "70%" string of the native window, or unset → native)
     // overrides the table.
     let reqConfig = config;
+    // #736: the resolved NATIVE window (before the compress.modelContextLimit
+    // override and the codex align) plus what shrank the effective window below
+    // it — threaded into preflightCompressIfNeeded so a fail-fast can tell the
+    // operator that their own setting, not the upstream, is the wall they hit.
+    let resolvedNativeWindow: number | undefined;
+    let windowShrinkReason: "operator" | "codex" | undefined;
     // True when the resolved native window came from a low-confidence fallback
     // (built-in table / env default) instead of an authoritative source — such
     // windows get an effective-floor after output-headroom reservation (see
@@ -1156,6 +1162,7 @@ async function handle(
                     log("info", `[window] model=${model} source=${wsSource} native=${native ?? "none"} effective=${reqConfig.modelContextLimit} launcher=${launcherWindow ?? "none"} configured=${configuredWindow ?? "none"} peek=${peekWindow ?? "none"} fallback=${nativeFromFallback}`);
                 }
             }
+            resolvedNativeWindow = native;
             // #321 PR-E1: a codex client carries its OWN window perception
             // (bundled model table + 272K unknown-model fallback) and
             // auto-compacts at 90% of it. If bili's budget exceeds what codex
@@ -1173,7 +1180,10 @@ async function handle(
                 const before = reqConfig.modelContextLimit;
                 reqConfig = { ...reqConfig, modelContextLimit: aligned.limit };
                 nativeFromFallback = false;
+                windowShrinkReason = "codex";
                 log("info", `[codex] effective window clamped ${before} → ${aligned.limit} (codex's own perception for model=${model}; ACP now compresses before codex's native auto-compact)`);
+            } else if (operatorWindowTuned && native !== undefined && reqConfig.modelContextLimit < native) {
+                windowShrinkReason = "operator";
             }
             const compressCfg = resolveCompress(opts.routes, embeddedUrl, model, opts.compress);
             reqPrompts = resolveCompressPrompts(compressCfg);
@@ -1642,6 +1652,8 @@ async function handle(
                         core,
                         reqConfig,
                         (parsed as { model?: string }).model,
+                        resolvedNativeWindow,
+                        windowShrinkReason,
                         route,
                         affinity,
                         anonAffinity !== null,
@@ -3054,6 +3066,8 @@ async function preflightCompressIfNeeded(
     core: CompressionCore,
     config: Config,
     model: string | undefined,
+    resolvedNativeWindow: number | undefined,
+    windowShrinkReason: "operator" | "codex" | undefined,
     route: ReturnType<typeof resolveUpstream>,
     affinity: string | undefined,
     anonymous: boolean,
@@ -3115,10 +3129,20 @@ async function preflightCompressIfNeeded(
         const imageNote = imageTokens >= limit
             ? ` Images alone account for ~${imageTokens} tokens (≥ window ${limit}); compression cannot remove them — shrink or remove the images, or raise the window.`
             : "";
+        // #736: when the wall is bili's own shrunken window, say so — "raise the
+        // model context window" otherwise sends operators to the upstream when
+        // their compress.modelContextLimit is the actual ceiling.
+        const shrinkNote = resolvedNativeWindow !== undefined && limit < resolvedNativeWindow
+            ? ` Note: bili's effective window ${limit} is below the model's full window ${resolvedNativeWindow} — ` +
+                (windowShrinkReason === "codex"
+                    ? `it was aligned down to codex's own window perception; set compress.modelContextLimit explicitly if your upstream serves the larger window.`
+                    : `your compress.modelContextLimit setting overrides it; if the upstream actually serves the larger window, raise or remove that setting (hot-reloaded, no session restart needed).`)
+            : "";
         const message =
             `context ~${tokenCount} tokens exceeds the model window ${limit} (model=${model}) ` +
-            `and preflight compression could not bring it under: ${detail}.` +
+            `and preflight compression could not bring it under: ${detail.replace(/\.\s*$/, "")}.` +
             imageNote +
+            shrinkNote +
             ` The over-window payload was NOT forwarded.`;
         log("error", `[${session.id}] preflight fail-fast ${status} (retryable=${retryable}): ${message}`);
         return { failFast: true, status, message, retryable, respond: !res.writableEnded };

--- a/tests/preflight-fail-fast.test.ts
+++ b/tests/preflight-fail-fast.test.ts
@@ -10,6 +10,7 @@ process.env.BILI_REPLAY_RETRY_MAX = "1";
 
 import { defaultConfig, type Config } from "acp-kernel";
 import { startServer, type ProxyOptions } from "../src/server.ts";
+import { type CompressSettings } from "../src/config.ts";
 import { SessionStore, _setStoreForTest } from "../src/persist.ts";
 import { _setForTest as setRegistryForTest } from "../src/registry.ts";
 
@@ -87,7 +88,7 @@ function makeUpstreamOk(calls?: Call[]): http.Server {
     });
 }
 
-function startProxy(upstreamPort: number, models: Record<string, { context: number }>, kernelOverrides?: Partial<Config>): Promise<http.Server> {
+function startProxy(upstreamPort: number, models: Record<string, { context: number }>, kernelOverrides?: Partial<Config>, compressOverrides?: Partial<CompressSettings>): Promise<http.Server> {
     _setStoreForTest(new SessionStore({ enabled: false }));
     setRegistryForTest({});
     return startServer({
@@ -97,7 +98,7 @@ function startProxy(upstreamPort: number, models: Record<string, { context: numb
         routes: { [`http://127.0.0.1:${upstreamPort}`]: { models } },
         modelContextLimit: 400_000,
         kernelConfig: defaultConfig(400_000, kernelOverrides),
-        compress: { injectTool: true, injectNudge: true },
+        compress: { injectTool: true, injectNudge: true, ...compressOverrides },
         promptCache: { routing: "auto" },
         sessionHeader: "x-acp-session",
         log: false,
@@ -348,6 +349,78 @@ test("e2e #470: system + tools overhead counts in the preflight trigger — text
         assert.equal(calls.filter((c) => c.stream).length, 1, "the folded payload was forwarded upstream");
         const forwarded = calls.find((c) => c.stream)?.body ?? "";
         assert.ok(!forwarded.includes("A".repeat(100)), "the folded big message did NOT ride the forwarded payload");
+    } finally {
+        proxy.close();
+        await once(proxy, "close");
+        upstream.close();
+        await once(upstream, "close");
+    }
+});
+
+test("e2e #736: operator-shrunk window (compress.modelContextLimit below the model's declared window) → fail-fast names the setting", async () => {
+    const calls: Call[] = [];
+    const upstream = makeUpstream429(calls);
+    upstream.listen(0, "127.0.0.1");
+    await once(upstream, "listening");
+    const upstreamPort = upstream.address().port;
+
+    // Same incompressible-payload shape as the #301 exhausted test, but the
+    // 4k window is an OPERATOR override of the model's declared 10k — the
+    // fail-fast must point at compress.modelContextLimit, not just say
+    // "raise the model context window" (which sends operators to the upstream).
+    const proxy = await startProxy(upstreamPort, { "claude-small": { context: 10_000 } }, { protectedTools: ["bash"] }, { modelContextLimit: 4_000 });
+    await once(proxy, "listening");
+    const proxyPort = proxy.address().port;
+
+    try {
+        const filler = "FILLER_".repeat(7000);
+        const r = await fetch(`http://127.0.0.1:${proxyPort}/bili/http://127.0.0.1:${upstreamPort}/v1/messages`, {
+            method: "POST",
+            headers: { "content-type": "application/json", "x-acp-session": "preflight-shrink-sess" },
+            body: JSON.stringify({
+                model: "claude-small",
+                max_tokens: 1024,
+                stream: true,
+                messages: [
+                    { role: "assistant", content: [{ type: "tool_use", id: "call_1", name: "bash", input: { command: "echo hi" } }] },
+                    { role: "user", content: [{ type: "tool_result", tool_use_id: "call_1", content: filler }] },
+                ],
+            }),
+        });
+        assert.equal(r.status, 502, "fail-fast 502 when nothing is compressible under the shrunken window");
+        const json = JSON.parse(await r.text()) as { error?: { code?: string; message?: string } };
+        assert.equal(json.error?.code, "preflight_compress_failed");
+        const msg = json.error?.message ?? "";
+        assert.ok(msg.includes("NOT forwarded"), `payload withheld (got: ${msg})`);
+        assert.ok(msg.includes("effective window 4000"), `names the shrunken effective window (got: ${msg})`);
+        assert.ok(msg.includes("full window 10000"), `names the model's full window (got: ${msg})`);
+        assert.ok(msg.includes("compress.modelContextLimit"), `points at the operator setting (got: ${msg})`);
+        assert.ok(!/\.\./.test(msg), `no doubled period (got: ${msg})`);
+        assert.equal(calls.length, 0, "no upstream call was spent on an incompressible payload");
+
+        // Negative control: the same payload with NO operator override must not
+        // carry the shrink note (effective === full window).
+        const proxyPlain = await startProxy(upstreamPort, { "claude-small": { context: 10_000 } }, { protectedTools: ["bash"] });
+        await once(proxyPlain, "listening");
+        const plainPort = proxyPlain.address().port;
+        const r2 = await fetch(`http://127.0.0.1:${plainPort}/bili/http://127.0.0.1:${upstreamPort}/v1/messages`, {
+            method: "POST",
+            headers: { "content-type": "application/json", "x-acp-session": "preflight-shrink-plain-sess" },
+            body: JSON.stringify({
+                model: "claude-small",
+                max_tokens: 1024,
+                stream: true,
+                messages: [
+                    { role: "assistant", content: [{ type: "tool_use", id: "call_1", name: "bash", input: { command: "echo hi" } }] },
+                    { role: "user", content: [{ type: "tool_result", tool_use_id: "call_1", content: filler }] },
+                ],
+            }),
+        });
+        assert.equal(r2.status, 502);
+        const msg2 = (JSON.parse(await r2.text()) as { error?: { message?: string } }).error?.message ?? "";
+        assert.ok(!msg2.includes("full window"), `no shrink note when the window was not operator-shrunk (got: ${msg2})`);
+        proxyPlain.close();
+        await once(proxyPlain, "close");
     } finally {
         proxy.close();
         await once(proxy, "close");

--- a/tests/preflight-fail-fast.test.ts
+++ b/tests/preflight-fail-fast.test.ts
@@ -428,3 +428,62 @@ test("e2e #736: operator-shrunk window (compress.modelContextLimit below the mod
         await once(upstream, "close");
     }
 });
+
+// #737 review: the shrink note must fire ONLY when bili deliberately shrank the
+// window (operator override / codex align). On a NON-Anthropic turn the per-request
+// output-headroom reservation (reserveOutputHeadroom = window - max_tokens) ALSO
+// lowers reqConfig.modelContextLimit below the resolved native window — with no
+// operator setting involved. Gating the note on `limit < resolvedNativeWindow` alone
+// (the pre-fix logic) therefore blamed compress.modelContextLimit for a reduction
+// the operator never made. This guards that path: an OpenAI-chat incompressible
+// payload under a headroom-shrunk window must NOT carry the shrink note.
+test("e2e #737: output-headroom-shrunk window (non-Anthropic, no operator override) → fail-fast does NOT name compress.modelContextLimit", async () => {
+    const calls: Call[] = [];
+    const upstream = makeUpstream429(calls);
+    upstream.listen(0, "127.0.0.1");
+    await once(upstream, "listening");
+    const upstreamPort = upstream.address().port;
+
+    // Model declares a 10k window (registry table), NO operator override. The
+    // OpenAI-chat endpoint reserves output headroom: max_tokens 4000 shrinks the
+    // effective window 10000 -> 6000. A ~12k incompressible (hard-protected bash)
+    // tool result overflows 6000 → fail-fast.
+    const proxy = await startProxy(upstreamPort, { "gpt-small": { context: 10_000 } }, { protectedTools: ["bash"] });
+    await once(proxy, "listening");
+    const proxyPort = proxy.address().port;
+
+    try {
+        const filler = "FILLER_".repeat(7000);
+        const r = await fetch(`http://127.0.0.1:${proxyPort}/bili/http://127.0.0.1:${upstreamPort}/v1/chat/completions`, {
+            method: "POST",
+            headers: { "content-type": "application/json", "x-acp-session": "preflight-headroom-sess" },
+            body: JSON.stringify({
+                model: "gpt-small",
+                max_tokens: 4_000,
+                stream: true,
+                messages: [
+                    { role: "assistant", content: null, tool_calls: [{ id: "call_1", type: "function", function: { name: "bash", arguments: JSON.stringify({ command: "echo hi" }) } }] },
+                    { role: "tool", tool_call_id: "call_1", content: filler },
+                ],
+            }),
+        });
+        assert.equal(r.status, 502, "fail-fast 502 when nothing is compressible under the headroom-shrunk window");
+        const json = JSON.parse(await r.text()) as { error?: { code?: string; message?: string } };
+        assert.equal(json.error?.code, "preflight_compress_failed");
+        const msg = json.error?.message ?? "";
+        assert.ok(msg.includes("NOT forwarded"), `payload withheld (got: ${msg})`);
+        // Proves the headroom path was exercised: the reported window is the
+        // reserved 6000, not the declared 10000.
+        assert.ok(msg.includes("model window 6000"), `effective window reflects headroom reservation (got: ${msg})`);
+        // Regression guard: the reduction here came from output-headroom, NOT an
+        // operator setting — the shrink note must stay silent.
+        assert.ok(!msg.includes("full window"), `no shrink note for a headroom-shrunk window (got: ${msg})`);
+        assert.ok(!msg.includes("compress.modelContextLimit"), `does not blame an untouched operator setting (got: ${msg})`);
+        assert.equal(calls.length, 0, "no upstream call was spent on an incompressible payload");
+    } finally {
+        proxy.close();
+        await once(proxy, "close");
+        upstream.close();
+        await once(upstream, "close");
+    }
+});


### PR DESCRIPTION
## What

When preflight compression cannot bring an over-window payload under the window, the fail-fast error ends with "Raise the model context window or restart the session to recover." — which sends operators to the upstream when the actual wall is bili's own `compress.modelContextLimit` setting.

#736 is exactly that misdirection in the wild: the log shows `[window] source=table-or-registry native=128000 effective=16000` — the model's registered window is 128K and the local upstream demonstrably served it (an earlier turn of the same session reported 82022 input tokens; a sibling session was billed at 16589) — yet every fail-fast only ever said "raise the model context window", while the ceiling was a `compress.modelContextLimit: 16000`-style override edited into the web UI minutes before the brick.

This change threads the resolved native window + shrink reason (`operator` / `codex`) from the per-request window-resolution block into `preflightCompressIfNeeded`, and when `effective < native` the fail-fast message now adds:

- operator case: "Note: bili's effective window 16000 is below the model's full window 128000 — your compress.modelContextLimit setting overrides it; if the upstream actually serves the larger window, raise or remove that setting (hot-reloaded, no session restart needed)."
- codex case: the note names the codex align instead, with the explicit-opt-out pointer.

Also normalizes the doubled period at the detail seam (`...recover..` → `...recover.`), visible verbatim in the #736 log.

## Why not just docs

The message is the only surface an operator sees at the moment of failure; the #736 thread shows how far "raise the model context window" leads when the registry already knows the true window. The hint is emitted only when bili itself shrank the window below the resolved native value, so it can never point at a setting that isn't the cause (output-headroom reservation and self-heal paths leave `windowShrinkReason` unset → no note).

## Tests

New e2e in `tests/preflight-fail-fast.test.ts`: incompressible payload under an operator-shrunk 4k window (model declares 10k) → 502 message names both numbers and `compress.modelContextLimit`; negative control without the override asserts no note. Harness `startProxy` gained an optional compress-overrides param.

Pre-flight: `npm run typecheck` clean · `npm test` 1430 pass / 0 fail / 2 skipped (E2E-gated) · `npm run build` OK.

Fixes #736